### PR TITLE
add trailing / to COPY

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:edge
 
 MAINTAINER Justin Cormack <justin.cormack@unikernel.com>
 
-COPY repositories /etc/apk
+COPY repositories /etc/apk/
 
 RUN apk update && apk upgrade && apk add e2fsprogs docker chrony blkid
 


### PR DESCRIPTION
else I seem to get errors of the form `stat /mnt/sda1/var/lib/docker/aufs/mnt/e2729aae6cfdd93d3b2581a6cc403ccd198cdc21d063b66a362a6fde35e51618/etc/apk/repositories: not a directory`
