### PR TITLE
run qemu-system-x86_64 with 256M of memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN apk update && apk add qemu-system-x86_64
 
 RUN gzip -9 initrd.img
 
-ENTRYPOINT [ "qemu-system-x86_64", "-kernel", "vmlinuz64", "-initrd", "initrd.img.gz", "-m", "256", "-append", "earlyprintk=serial console=ttyS0", "-vnc", "none" ]
+ENTRYPOINT [ "qemu-system-x86_64", "-serial", "stdio", "-kernel", "vmlinuz64", "-initrd", "initrd.img.gz", "-m", "256", "-append", "earlyprintk=serial console=ttyS0", "-vnc", "none" ]


### PR DESCRIPTION
With the default 128M of memory in qemu-system-x86_64, the ramfs (which has a decompressed
size of ~82M) can't be completely accessed, resulting in missing chunks of filesystem (notably /etc and /sbin for me) on the emulated machine.  Asking for 256M at least gets us to some nice whale ASCII art and a console we can interact with.
