### PR TITLE
fix qemu invocation for arm kernel

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -2,9 +2,10 @@ FROM ubuntu:15.10
 
 COPY alpine/initrd-arm.img .
 COPY alpine/kernel/zImage .
+COPY alpine/kernel/dtb .
 
 RUN apt-get update && apt-get install -y qemu-system-arm
 
 RUN gzip -9 initrd-arm.img
 
-ENTRYPOINT [ "qemu-system-arm", "-machine", "vexpress-a9", "-cpu", "cortex-a9", "-no-reboot", "-serial", "stdio", "-kernel", "zImage", "-initrd", "initrd-arm.img.gz", "-m", "256", "-append", "console=ttyAMA0", "-vnc", "none" ]
+ENTRYPOINT [ "qemu-system-arm", "-machine", "vexpress-a15", "-cpu", "cortex-a15", "-no-reboot", "-serial", "stdio", "-kernel", "zImage", "-initrd", "initrd-arm.img.gz", "-dtb", "dtb", "-m", "256", "-append", "console=ttyAMA0,38400n8", "-vnc", "none" ]

--- a/alpine/kernel/Dockerfile
+++ b/alpine/kernel/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
   gcc-arm-linux-gnueabihf
 
 ADD https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz .
+ADD https://d-i.debian.org/daily-images/armhf/daily/device-tree/vexpress-v2p-ca15-tc1.dtb /dtb
 
 RUN cat linux-${KERNEL_VERSION}.tar.xz | tar --absolute-names -xJ &&  mv /linux-${KERNEL_VERSION} /linux
 

--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -10,6 +10,7 @@ arm: zImage
 zImage: kernel_config.arm Dockerfile
 	docker build --build-arg ARCH=arm -t mobyarmkernel:build .
 	docker run mobyarmkernel:build cat /linux/arch/arm/boot/zImage > $@
+	docker run mobyarmkernel:build cat /dtb > dtb
 	docker run mobyarmkernel:build cat /aufs-utils.tar > aufs-utils.tar
 
 clean:


### PR DESCRIPTION
Download the correct dtb for vexpress-a15/cortex-a15 from debian when making a kernel and use it
when invoking qemu-system-arm.  Also, provide additional required serial parameters.
