### PR TITLE
kernel: enable SCSI disk support

### DIFF
--- a/alpine/kernel/kernel_config
+++ b/alpine/kernel/kernel_config
@@ -1348,12 +1348,12 @@ CONFIG_SCSI=y
 CONFIG_SCSI_DMA=y
 # CONFIG_SCSI_NETLINK is not set
 # CONFIG_SCSI_MQ_DEFAULT is not set
-# CONFIG_SCSI_PROC_FS is not set
+CONFIG_SCSI_PROC_FS=y
 
 #
 # SCSI support type (disk, tape, CD-ROM)
 #
-# CONFIG_BLK_DEV_SD is not set
+CONFIG_BLK_DEV_SD=y
 # CONFIG_CHR_DEV_ST is not set
 # CONFIG_CHR_DEV_OSST is not set
 # CONFIG_BLK_DEV_SR is not set


### PR DESCRIPTION
This is needed the get HD access in a Hyper-V VM

Successfully booted MobyLinux on HyperV with virtual hard disk
