### PR TITLE
9pudc: add `defer conn.Close()` for the connection to docker

### DIFF
--- a/alpine/packages/9pudc/main.go
+++ b/alpine/packages/9pudc/main.go
@@ -90,6 +90,8 @@ func handleOne(id int) {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+	defer conn.Close()
+
 	if err != nil {
 		// If the forwarding program has broken then close and continue
 		log.Println("Failed to connect to Unix domain socket after 10s", sock, err)


### PR DESCRIPTION
Before this patch we were using `conn.CloseRead()` and `conn.CloseWrite()`
to flush and signal EOF properly in the proxy, but we forgot to actually
close the file descriptor. As a result we leaked one fd per request,
until the GC came along and closed them for us. This could explain why
the process appeared to block: new connections could not be accepted
because we were out of fds, but once the GC had happened (or we closed
some 9P fds as a result of the client on the host closing its connection)
then the process would unwedge.

This doesn't explain why the 9P filesystem itself would occasionally become
unresponsive in Linux, although apparently still processing requests normally
if you connect to it directly over the host-side socket.

Signed-off-by: David Scott dave.scott@docker.com
