### PR TITLE
Use IP rather than socket9p for the docker socket

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -6,15 +6,22 @@ command="${DOCKER_BINARY:-/usr/bin/docker}"
 
 pidfile="/run/docker.pid"
 
+# Start with networking on both Mac and Hyper-V, but in
+# future change this to use a hypervisor socket.
+DOCKER_OPTS="${DOCKER_OPTS} -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock"
+
+if cat /proc/cmdline | grep -q 'com.docker.driverDir'
+then
+	DRIVER="$(cat /proc/cmdline | sed -e 's/.*com.docker.driverDir="//' -e 's/".*//')"
+	INET=$(ifconfig eth0 2> /dev/null | grep 'inet addr' | cut -f 2 -d ":" | cut -f 1 -d " ")
+	echo $INET > "/Mac/$DRIVER/ip"
+fi
+
 if cat /proc/cmdline | grep -q 'com.docker.database'
 then
 	DATABASE="$(cat /proc/cmdline | sed -e 's/.*com.docker.database="//' -e 's/".*//')"
 	CONFIG_FILE="/Database/branch/master/ro/${DATABASE}/etc/docker/daemon.json"
 	[ -s ${CONFIG_FILE} ] && DOCKER_OPTS="${DOCKER_OPTS} --config-file ${CONFIG_FILE}"
-else
-        # If there is no database and we run on Hyper-V start daemon
-        # with networking for now. This will change in the future!
-        [ -d /sys/bus/vmbus ] && DOCKER_OPTS="${DOCKER_OPTS} -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock"
 fi
 
 


### PR DESCRIPTION
Before this patch, docker would only listen on 0.0.0.0:2375 if running
on Hyper-V. This patch makes it listen there on all hypervisors.

In the case of xhyve, it will listen on the host internal vmnet network
or the virtual slirp network. We should aim to replace this with a socket-
based transport instead.

Signed-off-by: David Scott dave.scott@docker.com
