### PR TITLE
Use xargs -r in cleaning runes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ remora: Dockerfile.remora remora/do-kexec.sh
 clean:
 	$(MAKE) -C alpine clean
 	$(MAKE) -C xhyve clean
-	docker images -q mobyqemu:build | xargs docker rmi -f
-	docker images -q justincormack/remora | xargs docker rmi -f
+	docker images -q mobyqemu:build | xargs -r docker rmi -f
+	docker images -q justincormack/remora | xargs -r docker rmi -f

--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -15,5 +15,5 @@ zImage: kernel_config.arm Dockerfile
 
 clean:
 	rm -f zImage vmlinuz64 aufs-utils.tar
-	docker images -q mobykernel:build | xargs docker rmi -f
-	docker images -q mobyarmkernel:build | xargs docker rmi -f
+	docker images -q mobykernel:build | xargs -r docker rmi -f
+	docker images -q mobyarmkernel:build | xargs -r docker rmi -f

--- a/alpine/packages/9pudc/Makefile
+++ b/alpine/packages/9pudc/Makefile
@@ -7,4 +7,4 @@ all: 9pudc
 
 clean:
 	rm -f 9pudc
-	docker images -q 9pudc:build | xargs docker rmi -f
+	docker images -q 9pudc:build | xargs -r docker rmi -f

--- a/alpine/packages/hupper/Makefile
+++ b/alpine/packages/hupper/Makefile
@@ -7,4 +7,4 @@ hupper: Dockerfile main.go
 
 clean:
 	rm -f hupper
-	docker images -q hupper:build | xargs docker rmi -f
+	docker images -q hupper:build | xargs -r docker rmi -f

--- a/alpine/packages/hvtools/Makefile
+++ b/alpine/packages/hvtools/Makefile
@@ -9,4 +9,4 @@ hvtools: Dockerfile src/*
 
 clean:
 	rm -f hv_fcopy_daemon hv_kvp_daemon hv_vss_daemon
-	docker images -q hvtools:build | xargs docker rmi -f
+	docker images -q hvtools:build | xargs -r docker rmi -f

--- a/alpine/packages/mdnstool/Makefile
+++ b/alpine/packages/mdnstool/Makefile
@@ -7,4 +7,4 @@ mdnstool: Dockerfile mdnstool.go mdnsmon/mdnsmon.go
 
 clean:
 	rm -f mdnstool
-	docker images -q mdnstool:build | xargs docker rmi -f
+	docker images -q mdnstool:build | xargs -r docker rmi -f

--- a/alpine/packages/transfused/Makefile
+++ b/alpine/packages/transfused/Makefile
@@ -12,4 +12,4 @@ transfused: $(DEPS)
 
 clean:
 	rm -f transfused
-	docker images -q transfused:build | xargs docker rmi -f
+	docker images -q transfused:build | xargs -r docker rmi -f


### PR DESCRIPTION
-r is AKA --no-run-if-empty, without this clean can sometimes result in:

```
docker images -q mobyarmkernel:build | xargs docker rmi -f
docker: "rmi" requires a minimum of 1 argument.
See 'docker rmi --help'.

Usage:  docker rmi [OPTIONS] IMAGE [IMAGE...]

Remove one or more images
Makefile:17: recipe for target 'clean' failed
```
