### PR TITLE
initrd: don't include /mnt in the initrd

### DIFF
--- a/alpine/mkinitrd.sh
+++ b/alpine/mkinitrd.sh
@@ -4,7 +4,7 @@ set -e
 
 rm -rf /tmp/*
 
-for f in $(ls | grep -vE 'dev|sys|proc|tmp|export')
+for f in $(ls | grep -vE 'dev|sys|proc|tmp|export|mnt')
 do
   cp -a $f /tmp
 done


### PR DESCRIPTION
With the move to compose/volume mounts this now includes the current
directory. Noticed it when my initrds were getting bigger and bigger.

Signed-off-by: Rolf Neugebauer rolf.neugebauer@docker.com
