### PR TITLE
build: Don't use the Host OS environment to set GOOS and GOARCH

### DIFF
--- a/alpine/packages/9pudc/Makefile
+++ b/alpine/packages/9pudc/Makefile
@@ -1,7 +1,7 @@
 all: 9pudc
 
 9pudc: Dockerfile main.go
-	docker build --build-arg GOOS=$(OS) --build-arg GOARCH=$(ARCH) -t 9pudc:build .
+	docker build --build-arg GOOS=linux --build-arg GOARCH=amd64 -t 9pudc:build .
 	docker run --rm 9pudc:build cat /go/bin/9pudc > 9pudc
 	chmod 755 9pudc
 

--- a/alpine/packages/hupper/Makefile
+++ b/alpine/packages/hupper/Makefile
@@ -1,7 +1,7 @@
 all: hupper
 
 hupper: Dockerfile main.go
-	docker build --build-arg GOOS=$(OS) --build-arg GOARCH=$(ARCH) -t hupper:build .
+	docker build --build-arg GOOS=linux --build-arg GOARCH=amd64 -t hupper:build .
 	docker run --rm hupper:build cat /go/bin/hupper > hupper
 	chmod 755 hupper
 

--- a/alpine/packages/mdnstool/Makefile
+++ b/alpine/packages/mdnstool/Makefile
@@ -1,7 +1,7 @@
 all: mdnstool
 
 mdnstool: Dockerfile mdnstool.go mdnsmon/mdnsmon.go
-	docker build --build-arg GOOS=$(OS) --build-arg GOARCH=$(ARCH) -t mdnstool:build .
+	docker build --build-arg GOOS=linux --build-arg GOARCH=amd64 -t mdnstool:build .
 	docker run --rm mdnstool:build cat /go/bin/mdnstool > mdnstool
 	chmod 755 mdnstool
 


### PR DESCRIPTION
The Host OS could be Windows or Darwin but we want to build for 64bit Linux

Signed-off-by: Rolf Neugebauer rolf.neugebauer@docker.com
