### PR TITLE
transfused: change protocol to support events, add syslog logging

### DIFF
--- a/alpine/packages/transfused/Makefile
+++ b/alpine/packages/transfused/Makefile
@@ -1,6 +1,9 @@
 .PHONY: all
 
-DEPS=transfused.c
+HDR=transfused.h transfused_log.h
+SRC=transfused.c transfused_log.c
+DEPS=$(HDR) $(SRC)
+
 
 all: Dockerfile $(DEPS)
 	docker build -t transfused:build .
@@ -8,7 +11,7 @@ all: Dockerfile $(DEPS)
 	chmod 755 transfused
 
 transfused: $(DEPS)
-	gcc -g -static -Wall -Werror -o transfused transfused.c
+	gcc -g -static -Wall -Werror -o transfused $(SRC)
 
 clean:
 	rm -f transfused

--- a/alpine/packages/transfused/etc/init.d/transfused
+++ b/alpine/packages/transfused/etc/init.d/transfused
@@ -13,16 +13,28 @@ start()
 
 	ebegin "Starting FUSE socket passthrough"
 
-	PIDFILE=/var/run/transfused.pid
-	LOGFILE=/var/log/transfused.log
+        if cat /proc/cmdline | grep -q 'com.docker.driverDir'
+        then
+                DRIVERDIR="/Mac$(cat /proc/cmdline | sed -e 's/.*com.docker.driverDir="//' -e 's/".*//')"
+                RUNTIME_LOGFILE=${DRIVERDIR}/log/transfused.log
+        else
+                ID=$(LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)
+                RUNTIME_LOGFILE="/Mac/private/tmp/transfused_${ID}.log"
+        fi
+
+        PIDFILE=/var/run/transfused.pid
+        STARTUP_LOGFILE=/var/transfused_start.log
+        MOUNT_TRIGGER=/Mac
 
 	start-stop-daemon --start --quiet \
 		--background \
 		--exec /sbin/transfused \
 		--pidfile ${PIDFILE} \
-		--stderr "${LOGFILE}" \
-		--stdout "${LOGFILE}" \
-		-- -p "${PIDFILE}"
+		-- \
+                -p "${PIDFILE}" \
+                -l "${STARTUP_LOGFILE}" \
+                -m "${MOUNT_TRIGGER}" \
+                -t "${RUNTIME_LOGFILE}"
 
 	eend $? "Failed to start transfused"
 }

--- a/alpine/packages/transfused/transfused.h
+++ b/alpine/packages/transfused/transfused.h
@@ -1,0 +1,22 @@
+#include <pthread.h>
+
+typedef struct {
+  char * socket9p_root;
+  char * fusermount;
+  char * pidfile;
+  char * logfile;
+  char * mount_trigger;
+  char * trigger_log;
+  pthread_mutex_t fd_lock;
+  int logfile_fd;
+  int trigger_fd;
+} parameters;
+
+typedef struct {
+  parameters * params;
+  long id;
+} connection_t;
+
+void lock(char *const descr, pthread_mutex_t * mutex);
+
+void unlock(char *const descr, pthread_mutex_t * mutex);

--- a/alpine/packages/transfused/transfused_log.c
+++ b/alpine/packages/transfused/transfused_log.c
@@ -1,0 +1,117 @@
+#include <errno.h>
+#include <string.h>
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <pthread.h>
+
+#include <syslog.h>
+
+#include <sys/time.h>
+#include <time.h>
+#include <math.h>
+
+#include "transfused.h"
+
+void log_timestamp(int fd) {
+  char timestamp[26];
+  int msec;
+  struct tm* tm_info;
+  struct timeval tv;
+
+  gettimeofday(&tv, NULL);
+
+  msec = lrint(tv.tv_usec/1000.0);
+  if (msec >= 1000) {
+    msec -= 1000;
+    tv.tv_sec++;
+  }
+
+  tm_info = localtime(&tv.tv_sec);
+
+  strftime(timestamp, 26, "%Y-%m-%d %H:%M:%S", tm_info);
+  dprintf(fd, "%s.%03d ", timestamp, msec);
+}
+
+void die(int exit_code, const char * perror_arg, const char * fmt, ...) {
+  va_list argp;
+  int in_errno = errno;
+  va_start(argp, fmt);
+  vsyslog(LOG_CRIT, fmt, argp);
+  va_end(argp);
+  if (perror_arg != NULL) {
+    if (*perror_arg != 0)
+      syslog(LOG_CRIT, "%s: %s", perror_arg, strerror(in_errno));
+    else
+      syslog(LOG_CRIT, "%s", strerror(in_errno));
+  }
+  exit(exit_code);
+}
+
+void vlog_locked(connection_t * conn, const char * fmt, va_list args) {
+  int fd = conn->params->trigger_fd;
+  if (fd != 0) {
+    vdprintf(fd, fmt, args);
+  } else {
+    vsyslog(LOG_INFO, fmt, args);
+    fd = conn->params->logfile_fd;
+    if (fd != 0) {
+      vdprintf(fd, fmt, args);
+    }
+  }  
+}
+
+void vlog_time_locked(connection_t * conn, const char * fmt, va_list args) {
+  int fd = conn->params->trigger_fd;
+  if (fd != 0) log_timestamp(fd);
+  else {
+    fd = conn->params->logfile_fd;
+    if (fd != 0) log_timestamp(fd);
+  }
+  vlog_locked(conn, fmt, args);
+}
+
+void log_time_locked(connection_t * connection, const char * fmt, ...) {
+  va_list args;
+
+  va_start(args, fmt);
+
+  vlog_time_locked(connection, fmt, args);
+
+  va_end(args);
+}
+
+void log_time(connection_t * connection, const char * fmt, ...) {
+  va_list args;
+
+  va_start(args, fmt);
+
+  lock("log_time fd_lock", &connection->params->fd_lock);
+  vlog_time_locked(connection, fmt, args);
+  unlock("log_time fd_lock", &connection->params->fd_lock);
+
+  va_end(args);
+}
+
+void log_continue_locked(connection_t * connection, const char * fmt, ...) {
+  va_list args;
+
+  va_start(args, fmt);
+
+  vlog_locked(connection, fmt, args);
+
+  va_end(args);
+}
+
+void log_continue(connection_t * connection, const char * fmt, ...) {
+  va_list args;
+
+  va_start(args, fmt);
+
+  lock("log_continue fd_lock", &connection->params->fd_lock);
+  vlog_locked(connection, fmt, args);
+  unlock("log_continue fd_lock", &connection->params->fd_lock);
+
+  va_end(args);
+}

--- a/alpine/packages/transfused/transfused_log.h
+++ b/alpine/packages/transfused/transfused_log.h
@@ -1,0 +1,15 @@
+#include "transfused.h"
+
+void die(int exit_code, const char * perror_arg, const char * fmt, ...);
+
+void vlog_locked(connection_t * conn, const char * fmt, va_list args);
+
+void vlog_time_locked(connection_t * conn, const char * fmt, va_list args);
+
+void log_time_locked(connection_t * connection, const char * fmt, ...);
+
+void log_time(connection_t * connection, const char * fmt, ...);
+
+void log_continue_locked(connection_t * connection, const char * fmt, ...);
+
+void log_continue(connection_t * connection, const char * fmt, ...);


### PR DESCRIPTION
The event string in the 9p socket file system now contains a 1 byte
channel type immediately preceding the connection ID. This channel type
determines which protocol will be used on the channel -- m for FUSE
protocol, e for events. The event messages are host-initiated and have
the following structure:

  2 bytes for total length
  2 bytes for path length + NUL (x)
  x bytes for path
  1 byte  for syscall

stderr logging was also changed to syslog-based logging in this patch.

Signed-off-by: David Sheets david.sheets@docker.com
