### PR TITLE
Make the diagnostics download more reliable

### DIFF
--- a/alpine/packages/diagnostics/diagnostics-download
+++ b/alpine/packages/diagnostics/diagnostics-download
@@ -8,27 +8,27 @@ mkdir $TEMP/moby
 cd $TEMP/moby
 
 # gather diagnostic data
-date > "date"
-uname -a > "uname -a"
-ps uax > "ps -aux"
-netstat -tulpn > "netstat -tulpn"
-iptables-save > "iptables-save"
-ifconfig -a > "ifconfig -a"
-route -n > "route -n"
-brctl show > "brctl show"
-dmesg > dmesg
+timeout -t 2 date > "date"
+timeout -t 2 uname -a > "uname -a"
+timeout -t 2 ps uax > "ps -aux"
+timeout -t 2 netstat -tulpn > "netstat -tulpn"
+timeout -t 2 iptables-save > "iptables-save"
+timeout -t 2 ifconfig -a > "ifconfig -a"
+timeout -t 2 route -n > "route -n"
+timeout -t 2 brctl show > "brctl show"
+timeout -t 2 dmesg > dmesg
 timeout -t 2 docker ps > "docker ps"
-tail /var/log/docker.log > "docker.log"
-mount > "mount"
-df > "df"
-ls -l /var &> "ls -l var"
-ls -l /var/lib &> "ls -l var_lib"
-ls -l /var/lib/docker &> "ls -l var_lib_docker"
-/usr/bin/diagnostics > "diagnostics"
-ping -w 5 8.8.8.8 &> "ping -w 5 8.8.8.8"
-cp /etc/resolv.conf .
-dig docker.com > "dig docker.com"
-wget -O - http://www.docker.com/ &> "wget docker.com"
+timeout -t 2 tail /var/log/docker.log > "docker.log"
+timeout -t 2 mount > "mount"
+timeout -t 2 df > "df"
+timeout -t 2 ls -l /var &> "ls -l var"
+timeout -t 2 ls -l /var/lib &> "ls -l var_lib"
+timeout -t 2 ls -l /var/lib/docker &> "ls -l var_lib_docker"
+timeout -t 2 /usr/bin/diagnostics > "diagnostics"
+timeout -t 2 ping -w 5 8.8.8.8 &> "ping -w 5 8.8.8.8"
+timeout -t 2 cp /etc/resolv.conf .
+timeout -t 2 dig docker.com > "dig docker.com"
+timeout -t 2 wget -O - http://www.docker.com/ &> "wget docker.com"
 
 # send everything to the client
 cd ..


### PR DESCRIPTION
- include the `iptables-save` output which is hopefully complete
- wrap every command in a fairly low timeout, which should help particularly when the network is down and so DNS is blocking/timing out slowly
