### PR TITLE
vsudd bugfixes

### DIFF
--- a/alpine/packages/vsudd/main.go
+++ b/alpine/packages/vsudd/main.go
@@ -107,9 +107,9 @@ func handleOne(connid int, fd int, cid, port uint) {
 	log.Printf("%d Accepted connection on fd %d from %08x.%08x", connid, fd, cid, port)
 
 	defer func() {
-		log.Println(connid, "Closing vsock", fd)
-		if err := syscall.Close(fd) ; err != nil {
-			log.Println(connid, "Error closing", fd ":", err)
+		log.Println(connid, "Closing vsock", vsock)
+		if err := vsock.Close() ; err != nil {
+			log.Println(connid, "Error closing", vsock, ":", err)
 		}
 	}()
 


### PR DESCRIPTION
Things appear to be functional and reliable now, can pass `make test`, `docker-proxy-socket` perf test and `docker-compose` on the example-voting-app.
