### PR TITLE
proxy: keep the fd open to the control file

### DIFF
--- a/alpine/packages/proxy/main.go
+++ b/alpine/packages/proxy/main.go
@@ -63,9 +63,8 @@ func exposePort(host net.Addr, port int) error {
 		log.Printf("Failed to read from /port/%s/ctl: %#v\n", name, err)
 		return err
 	}
-	// TODO: consider whether close/clunk of ctl would be a better tear down
-	// signal
-	ctl.Close()
+	// We deliberately keep the control file open since 9P clunk
+	// will trigger a shutdown on the host side.
 
 	response := string(results[0:count])
 	if strings.HasPrefix(response, "ERROR ") {


### PR DESCRIPTION
A future version of the 9P server will shutdown the forward on 9P
clunk, so if this process crashes the forward will be cleaned up
properly.

In the meantime, it's safe to keep 1 extra fd open while running the proxy.
