### PR TITLE
Add symlink from certd.d to Datakit

### DIFF
--- a/alpine/packages/docker/etc/docker/certs.d
+++ b/alpine/packages/docker/etc/docker/certs.d
@@ -1,0 +1,1 @@
+/Database/branch/master/ro/com.docker.driver.amd64-linux/etc/docker/certs.d


### PR DESCRIPTION
This is needed for https://github.com/docker/pinata/issues/2047.

Note: this hard-codes amd64-linux as the database. Perhaps Moby exposes
this somewhere, e.g. a symlink to the correct branch? If so, we could
use that instead.

Signed-off-by: Thomas Leonard thomas.leonard@docker.com
