### PR TITLE
transfused: use vsock transport instead of 9p

### DIFF
--- a/alpine/packages/diagnostics/diagnostics
+++ b/alpine/packages/diagnostics/diagnostics
@@ -7,11 +7,8 @@ DEV=$(mount | grep '/dev/[sxv]da. on /var type')
 [ $? -eq 0 ] && printf "✓ Drive mounted: $DEV\n" || printf "✗ No drive mounted\n"
 INET=$(ifconfig eth0 2> /dev/null | grep 'inet addr')
 [ $? -eq 0 ] && printf "✓ Network connected: $INET\n" || printf "✗ No network connection\n"
-if [ -d /Transfuse ]
-then
-	FUSE=$(ps -eo args | grep '^/sbin/transfused')
-	[ $? -eq 0 ] && printf "✓ Process transfused running\n" || printf "✗ No transfused process\n"
-fi
+FUSE=$(ps -eo args | grep '^/sbin/transfused')
+[ $? -eq 0 ] && printf "✓ Process transfused running\n" || printf "✗ No transfused process\n"
 MDNS=$(ps -eo args | grep '^/sbin/mdnstool')
 [ $? -eq 0 ] && printf "✓ Process mdnstool running: $MDNS\n" || printf "✗ No mdnstool process\n"
 HUPPER=$(ps -eo args | grep '^/bin/hupper')

--- a/alpine/packages/transfused/Makefile
+++ b/alpine/packages/transfused/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all
 
-HDR=transfused.h transfused_log.h
-SRC=transfused.c transfused_log.c
+HDR=transfused.h transfused_log.h transfused_vsock.h
+SRC=transfused.c transfused_log.c transfused_vsock.c
 DEPS=$(HDR) $(SRC)
 
 

--- a/alpine/packages/transfused/etc/init.d/transfused
+++ b/alpine/packages/transfused/etc/init.d/transfused
@@ -6,9 +6,7 @@ start()
 {
 	ebegin "Starting FUSE socket passthrough"
 
-	mkdir -p /Transfuse
 	mkdir -p /Mac
-	mount -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000,msize=32768 fuse /Transfuse
 
         if cat /proc/cmdline | grep -q 'com.docker.driverDir'
         then
@@ -38,8 +36,6 @@ start()
 
 stop()
 {
-	[ -d /Transfuse ] || exit 0
-
 	ebegin "Stopping FUSE socket passthrough"
 
 	PIDFILE=/var/run/transfused.pid

--- a/alpine/packages/transfused/include/uapi/linux/vm_sockets.h
+++ b/alpine/packages/transfused/include/uapi/linux/vm_sockets.h
@@ -1,0 +1,161 @@
+/*
+ * VMware vSockets Driver
+ *
+ * Copyright (C) 2007-2013 VMware, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation version 2 and no later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#ifndef _UAPI_VM_SOCKETS_H
+#define _UAPI_VM_SOCKETS_H
+
+#ifdef __KERNEL__
+#include <linux/socket.h>
+#else
+#define __kernel_sa_family_t sa_family_t
+#include <sys/socket.h>
+#endif
+
+/* Option name for STREAM socket buffer size.  Use as the option name in
+ * setsockopt(3) or getsockopt(3) to set or get an unsigned long long that
+ * specifies the size of the buffer underlying a vSockets STREAM socket.
+ * Value is clamped to the MIN and MAX.
+ */
+
+#define SO_VM_SOCKETS_BUFFER_SIZE 0
+
+/* Option name for STREAM socket minimum buffer size.  Use as the option name
+ * in setsockopt(3) or getsockopt(3) to set or get an unsigned long long that
+ * specifies the minimum size allowed for the buffer underlying a vSockets
+ * STREAM socket.
+ */
+
+#define SO_VM_SOCKETS_BUFFER_MIN_SIZE 1
+
+/* Option name for STREAM socket maximum buffer size.  Use as the option name
+ * in setsockopt(3) or getsockopt(3) to set or get an unsigned long long
+ * that specifies the maximum size allowed for the buffer underlying a
+ * vSockets STREAM socket.
+ */
+
+#define SO_VM_SOCKETS_BUFFER_MAX_SIZE 2
+
+/* Option name for socket peer's host-specific VM ID.  Use as the option name
+ * in getsockopt(3) to get a host-specific identifier for the peer endpoint's
+ * VM.  The identifier is a signed integer.
+ * Only available for hypervisor endpoints.
+ */
+
+#define SO_VM_SOCKETS_PEER_HOST_VM_ID 3
+
+/* Option name for determining if a socket is trusted.  Use as the option name
+ * in getsockopt(3) to determine if a socket is trusted.  The value is a
+ * signed integer.
+ */
+
+#define SO_VM_SOCKETS_TRUSTED 5
+
+/* Option name for STREAM socket connection timeout.  Use as the option name
+ * in setsockopt(3) or getsockopt(3) to set or get the connection
+ * timeout for a STREAM socket.
+ */
+
+#define SO_VM_SOCKETS_CONNECT_TIMEOUT 6
+
+/* Option name for using non-blocking send/receive.  Use as the option name
+ * for setsockopt(3) or getsockopt(3) to set or get the non-blocking
+ * transmit/receive flag for a STREAM socket.  This flag determines whether
+ * send() and recv() can be called in non-blocking contexts for the given
+ * socket.  The value is a signed integer.
+ *
+ * This option is only relevant to kernel endpoints, where descheduling the
+ * thread of execution is not allowed, for example, while holding a spinlock.
+ * It is not to be confused with conventional non-blocking socket operations.
+ *
+ * Only available for hypervisor endpoints.
+ */
+
+#define SO_VM_SOCKETS_NONBLOCK_TXRX 7
+
+/* The vSocket equivalent of INADDR_ANY.  This works for the svm_cid field of
+ * sockaddr_vm and indicates the context ID of the current endpoint.
+ */
+
+#define VMADDR_CID_ANY -1U
+
+/* Bind to any available port.  Works for the svm_port field of
+ * sockaddr_vm.
+ */
+
+#define VMADDR_PORT_ANY -1U
+
+/* Use this as the destination CID in an address when referring to the
+ * hypervisor.  VMCI relies on it being 0, but this would be useful for other
+ * transports too.
+ */
+
+#define VMADDR_CID_HYPERVISOR 0
+
+/* This CID is specific to VMCI and can be considered reserved (even VMCI
+ * doesn't use it anymore, it's a legacy value from an older release).
+ */
+
+#define VMADDR_CID_RESERVED 1
+
+/* Use this as the destination CID in an address when referring to the host
+ * (any process other than the hypervisor).  VMCI relies on it being 2, but
+ * this would be useful for other transports too.
+ */
+
+#define VMADDR_CID_HOST 2
+
+/* Invalid vSockets version. */
+
+#define VM_SOCKETS_INVALID_VERSION -1U
+
+/* The epoch (first) component of the vSockets version.  A single byte
+ * representing the epoch component of the vSockets version.
+ */
+
+#define VM_SOCKETS_VERSION_EPOCH(_v) (((_v) & 0xFF000000) >> 24)
+
+/* The major (second) component of the vSockets version.   A single byte
+ * representing the major component of the vSockets version.  Typically
+ * changes for every major release of a product.
+ */
+
+#define VM_SOCKETS_VERSION_MAJOR(_v) (((_v) & 0x00FF0000) >> 16)
+
+/* The minor (third) component of the vSockets version.  Two bytes representing
+ * the minor component of the vSockets version.
+ */
+
+#define VM_SOCKETS_VERSION_MINOR(_v) (((_v) & 0x0000FFFF))
+
+/* Address structure for vSockets.   The address family should be set to
+ * AF_VSOCK.  The structure members should all align on their natural
+ * boundaries without resorting to compiler packing directives.  The total size
+ * of this structure should be exactly the same as that of struct sockaddr.
+ */
+
+struct sockaddr_vm {
+	__kernel_sa_family_t svm_family;
+	unsigned short svm_reserved1;
+	unsigned int svm_port;
+	unsigned int svm_cid;
+	unsigned char svm_zero[sizeof(struct sockaddr) -
+			       sizeof(sa_family_t) -
+			       sizeof(unsigned short) -
+			       sizeof(unsigned int) - sizeof(unsigned int)];
+};
+
+#define IOCTL_VM_SOCKETS_GET_LOCAL_CID		_IO(7, 0xb9)
+
+#endif /* _UAPI_VM_SOCKETS_H */

--- a/alpine/packages/transfused/transfused.h
+++ b/alpine/packages/transfused/transfused.h
@@ -1,12 +1,15 @@
 #include <pthread.h>
+#include <sys/socket.h>
 
 typedef struct {
-  char * socket9p_root;
+  char * server;
+  char * socket;
   char * fusermount;
   char * pidfile;
   char * logfile;
   char * mount_trigger;
   char * trigger_log;
+  int sock;
   pthread_mutex_t fd_lock;
   int logfile_fd;
   int trigger_fd;
@@ -14,8 +17,11 @@ typedef struct {
 
 typedef struct {
   parameters * params;
-  long id;
   char * type_descr;
+  char * mount_point;
+  struct sockaddr sa_client;
+  socklen_t socklen_client;
+  int sock;
 } connection_t;
 
 pthread_attr_t detached;

--- a/alpine/packages/transfused/transfused_log.c
+++ b/alpine/packages/transfused/transfused_log.c
@@ -129,8 +129,8 @@ void thread_log_time(connection_t * conn, const char * fmt, ...) {
   // log demand to be low.
 
   if ((errno = pthread_create(&logger, &detached, log_time_thread, log_state)))
-    die(1, "", "Couldn't create log thread for %s connection '%ld': ",
-        conn->type_descr, conn->id);
+    die(1, "", "Couldn't create log thread for %s connection %s: ",
+        conn->type_descr, conn->mount_point);
 }
 
 void log_continue_locked(connection_t * connection, const char * fmt, ...) {

--- a/alpine/packages/transfused/transfused_log.h
+++ b/alpine/packages/transfused/transfused_log.h
@@ -1,3 +1,5 @@
+#include <stdarg.h>
+
 #include "transfused.h"
 
 void die(int exit_code, const char * perror_arg, const char * fmt, ...);

--- a/alpine/packages/transfused/transfused_vsock.c
+++ b/alpine/packages/transfused/transfused_vsock.c
@@ -1,0 +1,99 @@
+#include <stddef.h>
+#include <stdlib.h>
+
+#include <sys/socket.h>
+
+#include "include/uapi/linux/vm_sockets.h"
+
+#include "transfused_log.h"
+
+long parse_cid(const char * address) {
+  char * end = NULL;
+  long cid = strtol(address, &end, 10);
+  if (address == end || *end != ':') {
+    *end = 0;
+    die(2, NULL, "Invalid vsock cid: %s", address);
+  }
+  return cid;
+}
+
+long parse_port(const char * port_str) {
+  char * end = NULL;
+  long port = strtol(port_str, &end, 10);
+  if (port_str == end || *end != '\0') {
+    *end = 0;
+    die(2, NULL, "Invalid vsock port: %s", port_str);
+  }
+  return port;
+}
+
+int find_colon(const char * address) {
+  int colon = 0;
+
+  while (address[colon] != '\0')
+    if (address[colon] == ':') break;
+    else colon++;
+
+  if (address[colon] == '\0')
+    die(2, NULL, "Missing port in vsock address %s", address);
+
+  return colon;
+}
+
+int bind_vsock(const char * address) {
+  long cid, port;
+  int colon;
+
+  struct sockaddr_vm sa_listen = {
+    .svm_family = AF_VSOCK,
+  };
+
+  int sock_fd;
+
+  colon = find_colon(address);
+
+  if (address[0] == '_' && colon == 1) cid = VMADDR_CID_ANY;
+  else cid = parse_cid(address);
+
+  port = parse_port(address + colon + 1);
+
+  sa_listen.svm_cid = cid;
+  sa_listen.svm_port = port;
+
+  sock_fd = socket(AF_VSOCK, SOCK_STREAM, 0);
+  if (sock_fd < 0)
+    die(1, "socket(AF_VSOCK)", "");
+
+  if (bind(sock_fd, (struct sockaddr *) &sa_listen, sizeof(sa_listen)))
+    die(1, "bind(AF_VSOCK)", "");
+
+  return sock_fd;
+}
+
+int connect_vsock(const char * address) {
+  long cid, port;
+  int colon;
+
+  struct sockaddr_vm sa_connect = {
+    .svm_family = AF_VSOCK,
+  };
+
+  int sock_fd;
+
+  colon = find_colon(address);
+
+  cid = parse_cid(address);
+  port = parse_port(address + colon + 1);
+
+  sa_connect.svm_cid = cid;
+  sa_connect.svm_port = port;
+
+  sock_fd = socket(AF_VSOCK, SOCK_STREAM, 0);
+  if (sock_fd < 0)
+    die(1, "socket(AF_VSOCK)", "");
+
+  if (connect(sock_fd, (struct sockaddr *) &sa_connect, sizeof(sa_connect)))
+    die(1, "connect(AF_VSOCK)", "");
+
+  return sock_fd;
+}

--- a/alpine/packages/transfused/transfused_vsock.h
+++ b/alpine/packages/transfused/transfused_vsock.h
@@ -1,0 +1,2 @@
+int bind_vsock(const char * address);
+int connect_vsock(const char * address);


### PR DESCRIPTION
Preliminary (unscientific) tests show that this may slightly slow throughput performance but should be more stable and more optimizable in the long-term.
