### PR TITLE
hostsettings: correctly install multiline /etc/sysctl.conf files

### DIFF
--- a/alpine/packages/hostsettings/etc/init.d/hostsettings
+++ b/alpine/packages/hostsettings/etc/init.d/hostsettings
@@ -10,7 +10,7 @@ start() {
 	ebegin "Configuring host settings from database"
 
 	mobyconfig exists etc/hostname && echo $(mobyconfig get etc/hostname) > /etc/hostname
-	mobyconfig exists etc/sysctl.conf && echo $(mobyconfig get etc/sysctl.conf) > /etc/sysctl.conf
+	mobyconfig exists etc/sysctl.conf && mobyconfig get etc/sysctl.conf > /etc/sysctl.conf
 
         eend 0
 }


### PR DESCRIPTION
`echo` will destroy newlines in arguments.
