### PR TITLE
hvtools: Enable CIFS mount/unmount via KVP writes

### DIFF
--- a/alpine/packages/hvtools/etc/init.d/hv_kvp_daemon
+++ b/alpine/packages/hvtools/etc/init.d/hv_kvp_daemon
@@ -14,6 +14,9 @@ start()
 
         ebegin "Starting Hyper-V Daemon: ${HV_DAEMON}"
 
+        # Delete the existing store
+        rm -rf /var/lib/hyperv
+
         [ -n "${PIDFILE}" ] || PIDFILE=/var/run/${HV_DAEMON}.pid
 
         start-stop-daemon --start --quiet \


### PR DESCRIPTION
- Trigger a CIFS mount by writing to the "cifsmount" key.
- The value has the format: <mountpoint>;<alias mountpoint>;<options>
  with <options> containing username, password and optional domain
- The key is not stored in the KV store (aka the 'registry')
- Trigger an unmount by writing to the cifsumount" key.
- The value has the format: <mountpoint>;<alias mountpoint>
- The 'registry' is also wiped on reboot

Signed-off-by: Rolf Neugebauer rolf.neugebauer@docker.com
