### PR TITLE
Stop including nc-vsock in the initrd

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -59,7 +59,7 @@ COPY packages/chronyd/etc /etc/
 COPY packages/userns/etc /etc/
 COPY packages/userns/groupadd /usr/sbin
 COPY packages/userns/useradd /usr/sbin
-COPY packages/nc-vsock/nc-vsock /usr/bin
+#COPY packages/nc-vsock/nc-vsock /usr/bin
 COPY packages/vsudd/vsudd /sbin
 COPY packages/vsudd/etc /etc
 COPY packages/mobyconfig/mobyconfig /usr/bin


### PR DESCRIPTION
`nc-vsock` is GPL (it has no explicit license header, but it originally came from a Linux kernel tree so that's my best guess).

It's not actually used anywhere in Piñata (including any automated tests) so just drop it from the initrd by removing the `COPY` line.

I've left it in the build so it is easy for anyone who needs it e.g. for dev testing to reenable it locally.

It might be nice to have `vsudd` listen on some undocumented additional ports instead e.g. echo, source and sink ports seem like they might be useful for testing. This would make it easier to write tests I think, since right now you have a racy `docker run` to start `nc-vsock` and then the client in the harness, so you need retry loops etc.
