### PR TITLE
vsudd: Reduce logging

### DIFF
--- a/alpine/packages/vsudd/main.go
+++ b/alpine/packages/vsudd/main.go
@@ -200,7 +200,6 @@ func handleOne(connid int, fd int) {
 	vsock := os.NewFile(uintptr(fd), fmt.Sprintf("vsock:%d", fd))
 
 	defer func() {
-		log.Println(connid, "Closing vsock", vsock)
 		if err := vsock.Close(); err != nil {
 			log.Println(connid, "Error closing", vsock, ":", err)
 		}
@@ -223,12 +222,10 @@ func handleOne(connid int, fd int) {
 		return
 	}
 	defer func() {
-		log.Println(connid, "Closing docker", docker)
 		if err := docker.Close(); err != nil {
 			log.Println(connid, "Error closing", docker, ":", err)
 		}
 	}()
-	log.Println(connid, "Connected to docker", docker)
 
 	w := make(chan int64)
 	go func() {
@@ -236,7 +233,6 @@ func handleOne(connid int, fd int) {
 		if err != nil {
 			log.Println(connid, "error copying from docker to vsock:", err)
 		}
-		log.Println(connid, "copying from docker to vsock: ", n, "bytes done")
 
 		err = docker.CloseRead()
 		if err != nil {
@@ -253,7 +249,6 @@ func handleOne(connid int, fd int) {
 	if err != nil {
 		log.Println(connid, "error copying from vsock to docker:", err)
 	}
-	log.Println(connid, "copying from vsock to docker: ", n, "bytes done")
 	totalRead := n
 
 	err = docker.CloseWrite()


### PR DESCRIPTION
Previously the logs for a single connection would be something like:

2016/05/04 12:44:41 171 Accepted connection on fd 5 from 00000002.00010006
2016/05/04 12:44:41 171 Connected to docker &{{0xc82008a5b0}}
2016/05/04 12:44:44 171 copying from vsock to docker:  4465 bytes done
2016/05/04 12:44:44 171 copying from docker to vsock:  1324 bytes done
2016/05/04 12:44:44 171 Done. read: 4465 written: 1324
2016/05/04 12:44:44 171 Closing docker &{{0xc82008a5b0}}
2016/05/04 12:44:44 171 Closing vsock &{0xc820086840}

The "Connected" and "Closing" lines are not useful now that it is debugged and
working well. The "copying..." lines are redundant with the "Done" line. Reduce
to just:

2016/05/04 14:00:41 4 Accepted connection on fd 10 from 00000002.00010003
2016/05/04 14:00:41 4 Done. read: 90 written: 145

Signed-off-by: Ian Campbell ian.campbell@docker.com
