### PR TITLE
kernel: Fix Null pointer de-reference in af_hvsock code

### DIFF
--- a/alpine/kernel/patches/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
+++ b/alpine/kernel/patches/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
@@ -1,7 +1,7 @@
-From 4eb420ca189539397da818a6f0dab9f187693681 Mon Sep 17 00:00:00 2001
+From 31adb74f5668e7e44615a2854742f8726a818533 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 17 Dec 2015 16:53:43 +0800
-Subject: [PATCH 01/27] virtio: make find_vqs() checkpatch.pl-friendly
+Subject: [PATCH 01/28] virtio: make find_vqs() checkpatch.pl-friendly
 
 checkpatch.pl wants arrays of strings declared as follows:
 

--- a/alpine/kernel/patches/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
+++ b/alpine/kernel/patches/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
@@ -1,7 +1,7 @@
-From 55b1d9c5700491a520e9f62db00813153949038e Mon Sep 17 00:00:00 2001
+From 4b274b13e7dfe4ac54072f324738c487a36b78b8 Mon Sep 17 00:00:00 2001
 From: Julia Lawall <julia.lawall@lip6.fr>
 Date: Sat, 21 Nov 2015 18:39:17 +0100
-Subject: [PATCH 02/27] VSOCK: constify vmci_transport_notify_ops structures
+Subject: [PATCH 02/28] VSOCK: constify vmci_transport_notify_ops structures
 
 The vmci_transport_notify_ops structures are never modified, so declare
 them as const.

--- a/alpine/kernel/patches/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
+++ b/alpine/kernel/patches/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
@@ -1,7 +1,7 @@
-From 7344b208b2e3dc6283addd17ac444d0e6f086b3c Mon Sep 17 00:00:00 2001
+From 31fb7962193b46e8f7e24ac350e3efc486f0fd90 Mon Sep 17 00:00:00 2001
 From: Claudio Imbrenda <imbrenda@linux.vnet.ibm.com>
 Date: Tue, 22 Mar 2016 17:05:52 +0100
-Subject: [PATCH 03/27] AF_VSOCK: Shrink the area influenced by prepare_to_wait
+Subject: [PATCH 03/28] AF_VSOCK: Shrink the area influenced by prepare_to_wait
 
 When a thread is prepared for waiting by calling prepare_to_wait, sleeping
 is not allowed until either the wait has taken place or finish_wait has

--- a/alpine/kernel/patches/0004-VSOCK-transport-specific-vsock_transport-functions.patch
+++ b/alpine/kernel/patches/0004-VSOCK-transport-specific-vsock_transport-functions.patch
@@ -1,7 +1,7 @@
-From 0397651ccfc37e24cc6c9ef3c6356e269e9e961f Mon Sep 17 00:00:00 2001
+From 891b9c6111fc77750b261cc03f8ac7a80441701a Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 17 Dec 2015 11:10:21 +0800
-Subject: [PATCH 04/27] VSOCK: transport-specific vsock_transport functions
+Subject: [PATCH 04/28] VSOCK: transport-specific vsock_transport functions
 
 struct vsock_transport contains function pointers called by AF_VSOCK
 core code.  The transport may want its own transport-specific function

--- a/alpine/kernel/patches/0005-VSOCK-Introduce-virtio_vsock_common.ko.patch
+++ b/alpine/kernel/patches/0005-VSOCK-Introduce-virtio_vsock_common.ko.patch
@@ -1,7 +1,7 @@
-From 397a1c318aa57643a35b048ae9e9df10fb7c46cf Mon Sep 17 00:00:00 2001
+From a27fee87d915bfb9edf720f9068c3aed6649aa0c Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 13 Jun 2013 18:27:00 +0800
-Subject: [PATCH 05/27] VSOCK: Introduce virtio_vsock_common.ko
+Subject: [PATCH 05/28] VSOCK: Introduce virtio_vsock_common.ko
 
 This module contains the common code and header files for the following
 virtio_transporto and vhost_vsock kernel modules.

--- a/alpine/kernel/patches/0006-VSOCK-Introduce-virtio_transport.ko.patch
+++ b/alpine/kernel/patches/0006-VSOCK-Introduce-virtio_transport.ko.patch
@@ -1,7 +1,7 @@
-From bfa67b1c19a075f4fbb89fd393e9c368ad156416 Mon Sep 17 00:00:00 2001
+From 19cfdea4fa3fa9136c234ac695f628fce73b40c2 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 13 Jun 2013 18:28:48 +0800
-Subject: [PATCH 06/27] VSOCK: Introduce virtio_transport.ko
+Subject: [PATCH 06/28] VSOCK: Introduce virtio_transport.ko
 
 VM sockets virtio transport implementation.  This driver runs in the
 guest.

--- a/alpine/kernel/patches/0007-VSOCK-Introduce-vhost_vsock.ko.patch
+++ b/alpine/kernel/patches/0007-VSOCK-Introduce-vhost_vsock.ko.patch
@@ -1,7 +1,7 @@
-From a40b8961e92a5cfea634685e0e3aff9227a0fdd5 Mon Sep 17 00:00:00 2001
+From fd467c3335938b8eca0489008c390ad16a01aee7 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 13 Jun 2013 18:29:21 +0800
-Subject: [PATCH 07/27] VSOCK: Introduce vhost_vsock.ko
+Subject: [PATCH 07/28] VSOCK: Introduce vhost_vsock.ko
 
 VM sockets vhost transport implementation.  This driver runs on the
 host.

--- a/alpine/kernel/patches/0008-VSOCK-Add-Makefile-and-Kconfig.patch
+++ b/alpine/kernel/patches/0008-VSOCK-Add-Makefile-and-Kconfig.patch
@@ -1,7 +1,7 @@
-From f0c236fefc57085cb6de93b4af6a97f794d86944 Mon Sep 17 00:00:00 2001
+From 5d2849bde15e969b8cf1eb2f5e818b62ec2181ec Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 13 Jun 2013 18:30:19 +0800
-Subject: [PATCH 08/27] VSOCK: Add Makefile and Kconfig
+Subject: [PATCH 08/28] VSOCK: Add Makefile and Kconfig
 
 Enable virtio-vsock and vhost-vsock.
 

--- a/alpine/kernel/patches/0009-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/alpine/kernel/patches/0009-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,7 +1,7 @@
-From bb208cf070af4f831073ded2ae58e624ee965105 Mon Sep 17 00:00:00 2001
+From 81b78a051aa8c61743abcc266eb9c7511dd19a62 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
-Subject: [PATCH 09/27] VSOCK: Only allow host network namespace to use
+Subject: [PATCH 09/28] VSOCK: Only allow host network namespace to use
  AF_VSOCK.
 
 The VSOCK addressing schema does not really lend itself to simply creating an

--- a/alpine/kernel/patches/0010-Drivers-hv-vmbus-serialize-process_chn_event-and-vmb.patch
+++ b/alpine/kernel/patches/0010-Drivers-hv-vmbus-serialize-process_chn_event-and-vmb.patch
@@ -1,7 +1,7 @@
-From c30350ee4aaaf29604fc6f3f3f9bdcef2f4fdb2a Mon Sep 17 00:00:00 2001
+From c4795172e48b3229b24b3816c4c0d822c2cd2b88 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:47 -0800
-Subject: [PATCH 10/27] Drivers: hv: vmbus: serialize process_chn_event() and
+Subject: [PATCH 10/28] Drivers: hv: vmbus: serialize process_chn_event() and
  vmbus_close_internal()
 
 process_chn_event(), running in the tasklet, can race with

--- a/alpine/kernel/patches/0011-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
+++ b/alpine/kernel/patches/0011-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
@@ -1,7 +1,7 @@
-From 3aeadb59ed3d6216976648b3aee9b1db2c64c752 Mon Sep 17 00:00:00 2001
+From db7c4decfd08e194c3fe7647ebc0903c5fee33b7 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:48 -0800
-Subject: [PATCH 11/27] Drivers: hv: vmbus: do sanity check of channel state in
+Subject: [PATCH 11/28] Drivers: hv: vmbus: do sanity check of channel state in
  vmbus_close_internal()
 
 This fixes an incorrect assumption of channel state in the function.

--- a/alpine/kernel/patches/0012-Drivers-hv-vmbus-fix-rescind-offer-handling-for-devi.patch
+++ b/alpine/kernel/patches/0012-Drivers-hv-vmbus-fix-rescind-offer-handling-for-devi.patch
@@ -1,7 +1,7 @@
-From c1709827403ac4f3858b2ae0a9ee23733054b896 Mon Sep 17 00:00:00 2001
+From 92aa99cab10f5beb241635eee20fd1709fb63196 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:49 -0800
-Subject: [PATCH 12/27] Drivers: hv: vmbus: fix rescind-offer handling for
+Subject: [PATCH 12/28] Drivers: hv: vmbus: fix rescind-offer handling for
  device without a driver
 
 In the path vmbus_onoffer_rescind() -> vmbus_device_unregister()  ->

--- a/alpine/kernel/patches/0013-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
+++ b/alpine/kernel/patches/0013-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
@@ -1,7 +1,7 @@
-From 84a3cd7026e12d7bd88f9b896df40148236af875 Mon Sep 17 00:00:00 2001
+From c0e232b85b7cf4387788962085fed314e01b5e8c Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:50 -0800
-Subject: [PATCH 13/27] Drivers: hv: vmbus: release relid on error in
+Subject: [PATCH 13/28] Drivers: hv: vmbus: release relid on error in
  vmbus_process_offer()
 
 We want to simplify vmbus_onoffer_rescind() by not invoking

--- a/alpine/kernel/patches/0014-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
+++ b/alpine/kernel/patches/0014-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
@@ -1,7 +1,7 @@
-From 567b486c7ee1eddf6aee005103b801cd9508057f Mon Sep 17 00:00:00 2001
+From 2991041546570f369440c4837ae5ef0518e4d839 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:51 -0800
-Subject: [PATCH 14/27] Drivers: hv: vmbus: channge
+Subject: [PATCH 14/28] Drivers: hv: vmbus: channge
  vmbus_connection.channel_lock to mutex
 
 spinlock is unnecessary here.

--- a/alpine/kernel/patches/0015-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
+++ b/alpine/kernel/patches/0015-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
@@ -1,7 +1,7 @@
-From fa129d6856d2fb887a124bb17ac88f18e3fb639f Mon Sep 17 00:00:00 2001
+From 38bad476ce53b8b305d5629cfa5fe013c82f5a97 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:37 -0800
-Subject: [PATCH 15/27] Drivers: hv: vmbus: add a helper function to set a
+Subject: [PATCH 15/28] Drivers: hv: vmbus: add a helper function to set a
  channel's pending send size
 
 This will be used by the coming net/hvsock driver.

--- a/alpine/kernel/patches/0016-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
+++ b/alpine/kernel/patches/0016-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
@@ -1,7 +1,7 @@
-From 14c27d35657e10990f6b428460ef9d5fc81ffca4 Mon Sep 17 00:00:00 2001
+From 34e3731c0ba650cc5e7c15517da15f76e438b031 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:38 -0800
-Subject: [PATCH 16/27] Drivers: hv: vmbus: define the new offer type for
+Subject: [PATCH 16/28] Drivers: hv: vmbus: define the new offer type for
  Hyper-V socket (hvsock)
 
 A helper function is also added.

--- a/alpine/kernel/patches/0017-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
+++ b/alpine/kernel/patches/0017-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
@@ -1,7 +1,7 @@
-From ff94799688f8090c70cdca2158a8c0ca7a9f676c Mon Sep 17 00:00:00 2001
+From 53e57822a7f9d6c6fc221c21cfbbe9da2965c059 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:39 -0800
-Subject: [PATCH 17/27] Drivers: hv: vmbus: vmbus_sendpacket_ctl: hvsock: avoid
+Subject: [PATCH 17/28] Drivers: hv: vmbus: vmbus_sendpacket_ctl: hvsock: avoid
  unnecessary signaling
 
 When the hvsock channel's outbound ringbuffer is full (i.e.,

--- a/alpine/kernel/patches/0018-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
+++ b/alpine/kernel/patches/0018-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
@@ -1,7 +1,7 @@
-From 91c41d9e85f67881be5523d544508c08ca9926e3 Mon Sep 17 00:00:00 2001
+From 7e8defd74db9d20fc2c1b98946f5f1e5ad96e33c Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:40 -0800
-Subject: [PATCH 18/27] Drivers: hv: vmbus: define a new VMBus message type for
+Subject: [PATCH 18/28] Drivers: hv: vmbus: define a new VMBus message type for
  hvsock
 
 A function to send the type of message is also added.

--- a/alpine/kernel/patches/0019-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
+++ b/alpine/kernel/patches/0019-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
@@ -1,7 +1,7 @@
-From 22631e9eff59670c7cef5f91979375a2144189dd Mon Sep 17 00:00:00 2001
+From 1d19451adec149cefc135c442b4cb2241d87607a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:41 -0800
-Subject: [PATCH 19/27] Drivers: hv: vmbus: add a hvsock flag in struct
+Subject: [PATCH 19/28] Drivers: hv: vmbus: add a hvsock flag in struct
  hv_driver
 
 Only the coming hv_sock driver has a "true" value for this flag.

--- a/alpine/kernel/patches/0020-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
+++ b/alpine/kernel/patches/0020-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
@@ -1,7 +1,7 @@
-From 220aa4002752a3ce9d8b7a8010c64d8a9c3e1654 Mon Sep 17 00:00:00 2001
+From 14935b1d81d62a8aee055d8b762a745338e445b2 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:42 -0800
-Subject: [PATCH 20/27] Drivers: hv: vmbus: add a per-channel rescind callback
+Subject: [PATCH 20/28] Drivers: hv: vmbus: add a per-channel rescind callback
 
 This will be used by the coming hv_sock driver.
 

--- a/alpine/kernel/patches/0021-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
+++ b/alpine/kernel/patches/0021-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
@@ -1,7 +1,7 @@
-From 8cdace7efd0cba254c7183e302d97e2018d61840 Mon Sep 17 00:00:00 2001
+From 080b343d4e73684e9c261350703a48771eeda231 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:43 -0800
-Subject: [PATCH 21/27] Drivers: hv: vmbus: add an API
+Subject: [PATCH 21/28] Drivers: hv: vmbus: add an API
  vmbus_hvsock_device_unregister()
 
 The hvsock driver needs this API to release all the resources related

--- a/alpine/kernel/patches/0022-kcm-Kernel-Connection-Multiplexor-module.patch
+++ b/alpine/kernel/patches/0022-kcm-Kernel-Connection-Multiplexor-module.patch
@@ -1,7 +1,7 @@
-From d2dabcfdbf46a4c78f87d1a6b56822a3ed10499a Mon Sep 17 00:00:00 2001
+From 7f7ff16a50fdab9cf540ba469dd4fd9dc1c36ce8 Mon Sep 17 00:00:00 2001
 From: Tom Herbert <tom@herbertland.com>
 Date: Mon, 7 Mar 2016 14:11:06 -0800
-Subject: [PATCH 22/27] kcm: Kernel Connection Multiplexor module
+Subject: [PATCH 22/28] kcm: Kernel Connection Multiplexor module
 
 This module implements the Kernel Connection Multiplexor.
 

--- a/alpine/kernel/patches/0023-net-add-the-AF_KCM-entries-to-family-name-tables.patch
+++ b/alpine/kernel/patches/0023-net-add-the-AF_KCM-entries-to-family-name-tables.patch
@@ -1,7 +1,7 @@
-From 5df30f620de871e80745c25687dbcb5af4c532e5 Mon Sep 17 00:00:00 2001
+From 0f2c256a5c2d11572adb078202575c85472c23dd Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:51:09 -0700
-Subject: [PATCH 23/27] net: add the AF_KCM entries to family name tables
+Subject: [PATCH 23/28] net: add the AF_KCM entries to family name tables
 
 This is for the recent kcm driver, which introduces AF_KCM(41) in
 b7ac4eb(kcm: Kernel Connection Multiplexor module).

--- a/alpine/kernel/patches/0024-net-Add-Qualcomm-IPC-router.patch
+++ b/alpine/kernel/patches/0024-net-Add-Qualcomm-IPC-router.patch
@@ -1,7 +1,7 @@
-From daaab04e678f6e0b64de7d12ac87183ae6581a3e Mon Sep 17 00:00:00 2001
+From ff301a551f581af1f7a5b44e531f24f6706ff8a1 Mon Sep 17 00:00:00 2001
 From: Courtney Cavin <courtney.cavin@sonymobile.com>
 Date: Wed, 27 Apr 2016 12:13:03 -0700
-Subject: [PATCH 24/27] net: Add Qualcomm IPC router
+Subject: [PATCH 24/28] net: Add Qualcomm IPC router
 
 Add an implementation of Qualcomm's IPC router protocol, used to
 communicate with service providing remote processors.

--- a/alpine/kernel/patches/0025-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/alpine/kernel/patches/0025-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,7 +1,7 @@
-From 20eefd65c0ddcc93c8de196ee4d21b3dacc24c37 Mon Sep 17 00:00:00 2001
+From f94eeafa1082af0972a429ca973da5230e21c5c9 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 11 May 2016 10:52:37 -0700
-Subject: [PATCH 25/27] hv_sock: introduce Hyper-V Sockets
+Subject: [PATCH 25/28] hv_sock: introduce Hyper-V Sockets
 
 Hyper-V Sockets (hv_sock) supplies a byte-stream based communication
 mechanism between the host and the guest. It's somewhat like TCP over

--- a/alpine/kernel/patches/0026-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
+++ b/alpine/kernel/patches/0026-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
@@ -1,7 +1,7 @@
-From 9e6fe61e17afc54313f2fd8216c1c8aa150f97e7 Mon Sep 17 00:00:00 2001
+From 2cffe53eda5ea0b90968867317149b57eb6d5b13 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:53:08 -0700
-Subject: [PATCH 26/27] net: add the AF_HYPERV entries to family name tables
+Subject: [PATCH 26/28] net: add the AF_HYPERV entries to family name tables
 
 This is for the hv_sock driver, which introduces AF_HYPERV(42).
 

--- a/alpine/kernel/patches/0027-VSOCK-do-not-disconnect-socket-when-peer-has-shutdow.patch
+++ b/alpine/kernel/patches/0027-VSOCK-do-not-disconnect-socket-when-peer-has-shutdow.patch
@@ -1,7 +1,7 @@
-From 637d86f5133f5c0a446dcce0d1dd6006bc9a3b4d Mon Sep 17 00:00:00 2001
+From 6d6ad94bf42ceff0785f28382ba2c4a2cc6725d3 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Wed, 4 May 2016 14:21:53 +0100
-Subject: [PATCH 27/27] VSOCK: do not disconnect socket when peer has shutdown
+Subject: [PATCH 27/28] VSOCK: do not disconnect socket when peer has shutdown
  SEND only
 
 The peer may be expecting a reply having sent a request and then done a

--- a/alpine/kernel/patches/0028-hv_sock-Don-t-touch-the-socket-state-when-the-other-.patch
+++ b/alpine/kernel/patches/0028-hv_sock-Don-t-touch-the-socket-state-when-the-other-.patch
@@ -1,0 +1,29 @@
+From 89a360504f1683d1be642506a14c9f59ea2c9771 Mon Sep 17 00:00:00 2001
+From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
+Date: Sun, 15 May 2016 10:56:16 +0100
+Subject: [PATCH 28/28] hv_sock: Don't touch the socket state when the other
+ end closes
+
+This cause a NULL pointer de-reference when the client closes the connection
+before accept() is called by the server.
+
+Signed-off-by: Rolf Neugebauer <rolf.neugebauer@gmail.com>
+---
+ net/hv_sock/af_hvsock.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/net/hv_sock/af_hvsock.c b/net/hv_sock/af_hvsock.c
+index 013d684..0b7ab8a 100644
+--- a/net/hv_sock/af_hvsock.c
++++ b/net/hv_sock/af_hvsock.c
+@@ -616,7 +616,6 @@ static void hvsock_close_connection(struct vmbus_channel *channel)
+ 	if (!sk)
+ 		goto out;
+ 
+-	sk->sk_socket->state = SS_UNCONNECTED;
+ 	sk->sk_state = SS_UNCONNECTED;
+ 	sock_set_flag(sk, SOCK_DONE);
+ 
+-- 
+2.8.2
+


### PR DESCRIPTION
The Hyper-V socket patch has a bug which was triggered by a race condition when
the client connected and then immediately closed the connection before the
server would call accept(). This caused a kernel crash.

This patch was discussed with Dexuan Cui decui@microsoft.com, the original
author of the Hyper-V socket support.

Signed-off-by: Rolf Neugebauer rolf.neugebauer@docker.com
