### PR TITLE
Add Hyper-V sockets to ethernet proxy

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -41,6 +41,7 @@ COPY packages/proxy/etc /etc/
 COPY packages/transfused/transfused /sbin/
 COPY packages/transfused/etc /etc/
 COPY packages/tap-vsockd/tap-vsockd /sbin/
+COPY packages/tap-vsockd/etc /etc/
 COPY packages/llmnrd/llmnrd /sbin/
 COPY packages/llmnrd/etc /etc/
 COPY packages/llmnrd/llmnrd.tar.gz /usr/share/src/

--- a/alpine/etc/network/interfaces
+++ b/alpine/etc/network/interfaces
@@ -9,3 +9,5 @@ auto eth1
 iface eth1 inet dhcp
     udhcpc_opts -T 1 -A 3
     metric 199
+    pre-up service tap-vsockd start
+    post-down service tap-vsockd stop

--- a/alpine/packages/tap-vsockd/etc/init.d/tap-vsockd
+++ b/alpine/packages/tap-vsockd/etc/init.d/tap-vsockd
@@ -1,0 +1,43 @@
+#!/sbin/openrc-run
+
+description="VPN proxy"
+
+depend()
+{
+	before networking
+}
+
+start()
+{
+        if mobyconfig exists network
+        then
+                NETWORK_MODE="$(mobyconfig get network | tr -d '[[:space:]]')"
+                if [ "${NETWORK_MODE}" = "hybrid" ]; then
+
+			ebegin "Starting VPN proxy"
+
+			PIDFILE=/var/run/tap-vsockd.pid
+			start-stop-daemon --start --quiet \
+				--exec /sbin/tap-vsockd \
+				--pidfile ${PIDFILE} \
+				-- \
+				--daemon \
+				--pidfile "${PIDFILE}" \
+				--listen
+
+			eend $? "Failed to start VPN proxy"
+		fi
+	fi
+}
+
+stop()
+{
+	ebegin "Stopping VPN proxy"
+
+	PIDFILE=/var/run/tap-vsockd.pid
+
+	start-stop-daemon --stop --quiet \
+		--pidfile "${PIDFILE}"
+
+	eend $? "Failed to stop VPN proxy"
+}


### PR DESCRIPTION
If the `network` type is set to `hybrid` in the database then start the `tap-vsockd` daemon. `tap-vsockd` is configured to `listen()` for incoming Hyper-V socket connections (ideally it would `connect()` to the host, but this code appears to be broken in the current kernel). The host `com.docker.slirp.exe` process connects into the VM, they negotiate and set up `eth1` as a virtual ethernet link.

This is currently a no-op on both Mac and Windows because
- on the Mac the `tap-vsockd` process fails to start because it can't make an `AF_HYPERV` socket
- on Windows the process isn't even launched because there is no database
