### PR TITLE
On Hyper-V, mount the database 9P filesystem

### DIFF
--- a/alpine/packages/mobyconfig/mobyconfig
+++ b/alpine/packages/mobyconfig/mobyconfig
@@ -12,16 +12,15 @@ then
   exit 1
 fi
 
-if ! cat /proc/cmdline | grep -q 'com.docker.database'
-then
-  printf "Could not find database configuration information\n" 1>&2
-  exit 1
-fi
-
 if [ ! -d /Database ]
 then
   mkdir -p /Database
-  mount -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 db /Database
+  if [ -d /sys/bus/vmbus ]; then
+    # Running on a Hyper-V hypervisor
+    /sbin/9pmount-vsock listen db /Database
+  else
+    mount -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 db /Database
+  fi
   if [ $? -ne 0 ]
   then
     rm -rf /Database
@@ -30,7 +29,7 @@ then
   fi
 fi
 
-DATABASE="$(cat /proc/cmdline | sed -e 's/.*com.docker.database="//' -e 's/".*//')"
+DATABASE="com.docker.driver.amd64-linux"
 BASE="/Database/branch/master/ro/${DATABASE}"
 
 KEY=$(echo $2 | sed 's@^/@@')


### PR DESCRIPTION
If we are running on Hyper-V (inferred by the presence of `/sys/bus/vmbus`) then run `/sbin/9pmount-vsock` which establishes a connection with the db on the host and then execs `/bin/mount` with the magic options `trans=fd,rfdno=<fd>,rfdno=<fd>`.

Since this depends on the database, the database process should be merged and started first.
