### PR TITLE
use build-base not alpine-sdk as smaller

### DIFF
--- a/alpine/packages/diagnostics/Dockerfile
+++ b/alpine/packages/diagnostics/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine
 
-RUN apk update && apk add alpine-sdk
+RUN apk update && apk add build-base
 
 RUN mkdir -p /go/src/diagnostics
 WORKDIR /go/src/diagnostics

--- a/alpine/packages/llmnrd/Dockerfile
+++ b/alpine/packages/llmnrd/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 
-RUN apk update && apk upgrade && apk add alpine-sdk linux-headers
+RUN apk update && apk upgrade && apk add build-base linux-headers
 
 RUN mkdir -p /llmnrd
 

--- a/alpine/packages/nc-vsock/Dockerfile
+++ b/alpine/packages/nc-vsock/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 
-RUN apk update && apk upgrade && apk add alpine-sdk util-linux-dev
+RUN apk update && apk upgrade && apk add build-base util-linux-dev
 
 RUN mkdir -p /nc-vsock
 WORKDIR /nc-vsock

--- a/alpine/packages/proxy/Dockerfile
+++ b/alpine/packages/proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine
 
-RUN apk update && apk add alpine-sdk
+RUN apk update && apk add build-base
 
 RUN mkdir -p /go/src/proxy
 WORKDIR /go/src/proxy

--- a/alpine/packages/vsudd/Dockerfile
+++ b/alpine/packages/vsudd/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine
 
-RUN apk update && apk add alpine-sdk
+RUN apk update && apk add build-base
 
 RUN mkdir -p /go/src/vsudd
 WORKDIR /go/src/vsudd


### PR DESCRIPTION
Signed-off-by: Justin Cormack justin.cormack@docker.com
