### PR TITLE
moby: revert #126. setup-disk -m depends on syslinux for now

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -14,6 +14,8 @@ RUN \
   xz \
   iptables \
   sfdisk \
+  lvm2 \
+  syslinux \
   openrc \
   busybox-initscripts \
   alpine-conf \


### PR DESCRIPTION
Signed-off-by: Rolf Neugebauer rolf.neugebauer@docker.com
