### PR TITLE
tap-vsockd: only try to start on Hyper-V

### DIFF
--- a/alpine/packages/tap-vsockd/etc/init.d/tap-vsockd
+++ b/alpine/packages/tap-vsockd/etc/init.d/tap-vsockd
@@ -9,6 +9,10 @@ depend()
 
 start()
 {
+	if [ ! -d /sys/bus/vmbus ]; then
+		# skip if not on Hyper-V
+		exit 0
+	fi
         if mobyconfig exists network
         then
                 NETWORK_MODE="$(mobyconfig get network | tr -d '[[:space:]]')"
@@ -32,6 +36,10 @@ start()
 
 stop()
 {
+	if [ ! -d /sys/bus/vmbus ]; then
+		# skip if not on Hyper-V
+		exit 0
+	fi
 	ebegin "Stopping VPN proxy"
 
 	PIDFILE=/var/run/tap-vsockd.pid


### PR DESCRIPTION
This avoids an unnecessary boot-up error on non-Hyper-V hosts.

From review comments on #130

Signed-off-by: David Scott dave.scott@docker.com
