### PR TITLE
Hyper-V: mount the filesystem from the default gateway via eth0

### DIFF
--- a/alpine/packages/hvtools/src/hv_kvp_daemon.c
+++ b/alpine/packages/hvtools/src/hv_kvp_daemon.c
@@ -377,7 +377,7 @@ static int kvp_cifs_mount(const char *value)
 	char *t;
 
 	char gw[256];
-	char gwcmd[] = "ip route show | awk '/default/ {print $3 }'";
+	char gwcmd[] = "ip route show | grep 'eth0' | awk '/default/ {print $3 }'";
 
 	int i, count;
 


### PR DESCRIPTION
When running in VPN mode eth0 and eth1 have default routes, but
eth1 has the lowest metric. However the host CIFS server can
only be contacted via eth0, so always use the eth0 address.

Signed-off-by: David Scott dave.scott@docker.com
