### PR TITLE
kernel: update kernel patches

### DIFF
--- a/alpine/kernel/patches/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
+++ b/alpine/kernel/patches/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
@@ -1,7 +1,7 @@
-From 56b578ba91efa05a2b860cbe167748911d7e8b31 Mon Sep 17 00:00:00 2001
+From 076de0d8086f75b10632476ad8f128095adde73c Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 17 Dec 2015 16:53:43 +0800
-Subject: [PATCH 01/40] virtio: make find_vqs() checkpatch.pl-friendly
+Subject: [PATCH 01/41] virtio: make find_vqs() checkpatch.pl-friendly
 
 checkpatch.pl wants arrays of strings declared as follows:
 

--- a/alpine/kernel/patches/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
+++ b/alpine/kernel/patches/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
@@ -1,7 +1,7 @@
-From 92c249101049a990d9246d13dd1b6ba1fde358eb Mon Sep 17 00:00:00 2001
+From 2155678736173e6ad2f5f5ec9ce4a49cf689457c Mon Sep 17 00:00:00 2001
 From: Julia Lawall <julia.lawall@lip6.fr>
 Date: Sat, 21 Nov 2015 18:39:17 +0100
-Subject: [PATCH 02/40] VSOCK: constify vmci_transport_notify_ops structures
+Subject: [PATCH 02/41] VSOCK: constify vmci_transport_notify_ops structures
 
 The vmci_transport_notify_ops structures are never modified, so declare
 them as const.

--- a/alpine/kernel/patches/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
+++ b/alpine/kernel/patches/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
@@ -1,7 +1,7 @@
-From d984039a518dc75da313fe5697c1c10085f85a86 Mon Sep 17 00:00:00 2001
+From 9d5b17e645e9ccddfc2a6ab112ae69739da32ae6 Mon Sep 17 00:00:00 2001
 From: Claudio Imbrenda <imbrenda@linux.vnet.ibm.com>
 Date: Tue, 22 Mar 2016 17:05:52 +0100
-Subject: [PATCH 03/40] AF_VSOCK: Shrink the area influenced by prepare_to_wait
+Subject: [PATCH 03/41] AF_VSOCK: Shrink the area influenced by prepare_to_wait
 
 When a thread is prepared for waiting by calling prepare_to_wait, sleeping
 is not allowed until either the wait has taken place or finish_wait has

--- a/alpine/kernel/patches/0004-VSOCK-transport-specific-vsock_transport-functions.patch
+++ b/alpine/kernel/patches/0004-VSOCK-transport-specific-vsock_transport-functions.patch
@@ -1,7 +1,7 @@
-From c91678f538e550f93bd1a692862cdb2e3198d8c2 Mon Sep 17 00:00:00 2001
+From 17665d95bdc4e922e45e5d7abca3de9b0b65e1f9 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 17 Dec 2015 11:10:21 +0800
-Subject: [PATCH 04/40] VSOCK: transport-specific vsock_transport functions
+Subject: [PATCH 04/41] VSOCK: transport-specific vsock_transport functions
 
 struct vsock_transport contains function pointers called by AF_VSOCK
 core code.  The transport may want its own transport-specific function

--- a/alpine/kernel/patches/0005-VSOCK-Introduce-virtio_vsock_common.ko.patch
+++ b/alpine/kernel/patches/0005-VSOCK-Introduce-virtio_vsock_common.ko.patch
@@ -1,7 +1,7 @@
-From 1e4aa76446e62fc0d54225b52eed755c39bf3041 Mon Sep 17 00:00:00 2001
+From 6d9a53a79d1794f8863c6ed37c290c3bf04ef931 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 13 Jun 2013 18:27:00 +0800
-Subject: [PATCH 05/40] VSOCK: Introduce virtio_vsock_common.ko
+Subject: [PATCH 05/41] VSOCK: Introduce virtio_vsock_common.ko
 
 This module contains the common code and header files for the following
 virtio_transporto and vhost_vsock kernel modules.

--- a/alpine/kernel/patches/0006-VSOCK-Introduce-virtio_transport.ko.patch
+++ b/alpine/kernel/patches/0006-VSOCK-Introduce-virtio_transport.ko.patch
@@ -1,7 +1,7 @@
-From 699fe71d8522b674a38e066c204907a8d3b91b2d Mon Sep 17 00:00:00 2001
+From edffb28d3dc83885096529fbe0e7cd720d58be8e Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 13 Jun 2013 18:28:48 +0800
-Subject: [PATCH 06/40] VSOCK: Introduce virtio_transport.ko
+Subject: [PATCH 06/41] VSOCK: Introduce virtio_transport.ko
 
 VM sockets virtio transport implementation.  This driver runs in the
 guest.

--- a/alpine/kernel/patches/0007-VSOCK-Introduce-vhost_vsock.ko.patch
+++ b/alpine/kernel/patches/0007-VSOCK-Introduce-vhost_vsock.ko.patch
@@ -1,7 +1,7 @@
-From 737df2ecc7b83e6e0d66acbc2f8eb9e7b1fdfc11 Mon Sep 17 00:00:00 2001
+From 16f7572f518eafec12136aa081f4c35d6355f19b Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 13 Jun 2013 18:29:21 +0800
-Subject: [PATCH 07/40] VSOCK: Introduce vhost_vsock.ko
+Subject: [PATCH 07/41] VSOCK: Introduce vhost_vsock.ko
 
 VM sockets vhost transport implementation.  This driver runs on the
 host.

--- a/alpine/kernel/patches/0008-VSOCK-Add-Makefile-and-Kconfig.patch
+++ b/alpine/kernel/patches/0008-VSOCK-Add-Makefile-and-Kconfig.patch
@@ -1,7 +1,7 @@
-From c072cd43aac2c8fa0c18f5169ba0f20dd0f2d8a3 Mon Sep 17 00:00:00 2001
+From bc5ebf61ea082b6f7562bd43d9f343cc7edc491d Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 13 Jun 2013 18:30:19 +0800
-Subject: [PATCH 08/40] VSOCK: Add Makefile and Kconfig
+Subject: [PATCH 08/41] VSOCK: Add Makefile and Kconfig
 
 Enable virtio-vsock and vhost-vsock.
 

--- a/alpine/kernel/patches/0009-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/alpine/kernel/patches/0009-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,7 +1,7 @@
-From 4987973de34f9db2a750cb1bace20e0abdb25ea0 Mon Sep 17 00:00:00 2001
+From 9024e2d916d191281c6deda22eed41c886f9120b Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
-Subject: [PATCH 09/40] VSOCK: Only allow host network namespace to use
+Subject: [PATCH 09/41] VSOCK: Only allow host network namespace to use
  AF_VSOCK.
 
 The VSOCK addressing schema does not really lend itself to simply creating an

--- a/alpine/kernel/patches/0010-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
+++ b/alpine/kernel/patches/0010-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
@@ -1,7 +1,7 @@
-From 098d92d569163aa8a058e6db91b9e8f6a4fb5352 Mon Sep 17 00:00:00 2001
+From 87b1f78685e31082a8b3844ab8a1500cd486fc98 Mon Sep 17 00:00:00 2001
 From: Jake Oshins <jakeo@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:41 -0800
-Subject: [PATCH 10/40] drivers:hv: Define the channel type for Hyper-V PCI
+Subject: [PATCH 10/41] drivers:hv: Define the channel type for Hyper-V PCI
  Express pass-through
 
 This defines the channel type for PCI front-ends in Hyper-V VMs.

--- a/alpine/kernel/patches/0011-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
+++ b/alpine/kernel/patches/0011-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
@@ -1,7 +1,7 @@
-From f5035c8690926b8ae70948892c7e559705c89760 Mon Sep 17 00:00:00 2001
+From acfa2b1d85d80d256f2e02bb03ee0107bd998c13 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:43 -0800
-Subject: [PATCH 11/40] Drivers: hv: vmbus: Use uuid_le type consistently
+Subject: [PATCH 11/41] Drivers: hv: vmbus: Use uuid_le type consistently
 
 Consistently use uuid_le type in the Hyper-V driver code.
 

--- a/alpine/kernel/patches/0012-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
+++ b/alpine/kernel/patches/0012-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
@@ -1,7 +1,7 @@
-From 256f7a915de76e35dd58b1d4c9397b6062c60d40 Mon Sep 17 00:00:00 2001
+From 3b6bcb030c01863b075ce19559e6134b77b09b8b Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:44 -0800
-Subject: [PATCH 12/40] Drivers: hv: vmbus: Use uuid_le_cmp() for comparing
+Subject: [PATCH 12/41] Drivers: hv: vmbus: Use uuid_le_cmp() for comparing
  GUIDs
 
 Use uuid_le_cmp() for comparing GUIDs.

--- a/alpine/kernel/patches/0013-Drivers-hv-vmbus-serialize-process_chn_event-and-vmb.patch
+++ b/alpine/kernel/patches/0013-Drivers-hv-vmbus-serialize-process_chn_event-and-vmb.patch
@@ -1,7 +1,7 @@
-From ced355716f3043f7ac42753e117c0dd6cefd6eb2 Mon Sep 17 00:00:00 2001
+From e843982a50538584d46295cdbccc584374dcfd6c Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:47 -0800
-Subject: [PATCH 13/40] Drivers: hv: vmbus: serialize process_chn_event() and
+Subject: [PATCH 13/41] Drivers: hv: vmbus: serialize process_chn_event() and
  vmbus_close_internal()
 
 process_chn_event(), running in the tasklet, can race with

--- a/alpine/kernel/patches/0014-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
+++ b/alpine/kernel/patches/0014-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
@@ -1,7 +1,7 @@
-From 3c73ef56248ec7b090c6c94df0904923da0959d0 Mon Sep 17 00:00:00 2001
+From a5eb33883eff6c75ffe084674b7550d2a7bca2d2 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:48 -0800
-Subject: [PATCH 14/40] Drivers: hv: vmbus: do sanity check of channel state in
+Subject: [PATCH 14/41] Drivers: hv: vmbus: do sanity check of channel state in
  vmbus_close_internal()
 
 This fixes an incorrect assumption of channel state in the function.

--- a/alpine/kernel/patches/0015-Drivers-hv-vmbus-fix-rescind-offer-handling-for-devi.patch
+++ b/alpine/kernel/patches/0015-Drivers-hv-vmbus-fix-rescind-offer-handling-for-devi.patch
@@ -1,7 +1,7 @@
-From 69bac0d6604e0c2bd3bbef8b13a17c877040e0ee Mon Sep 17 00:00:00 2001
+From fe74981d0e068abb7502fc52dffdea5e89f89fc2 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:49 -0800
-Subject: [PATCH 15/40] Drivers: hv: vmbus: fix rescind-offer handling for
+Subject: [PATCH 15/41] Drivers: hv: vmbus: fix rescind-offer handling for
  device without a driver
 
 In the path vmbus_onoffer_rescind() -> vmbus_device_unregister()  ->

--- a/alpine/kernel/patches/0016-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
+++ b/alpine/kernel/patches/0016-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
@@ -1,7 +1,7 @@
-From d9c917c73bbcd9602202fa8037d0bfc79d29bc4b Mon Sep 17 00:00:00 2001
+From 202e5b6d1aa80448d661657f3bf38ef1741ccd00 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:50 -0800
-Subject: [PATCH 16/40] Drivers: hv: vmbus: release relid on error in
+Subject: [PATCH 16/41] Drivers: hv: vmbus: release relid on error in
  vmbus_process_offer()
 
 We want to simplify vmbus_onoffer_rescind() by not invoking

--- a/alpine/kernel/patches/0017-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
+++ b/alpine/kernel/patches/0017-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
@@ -1,7 +1,7 @@
-From 6f4f7d2455717a60752058d73bdca1636e09a824 Mon Sep 17 00:00:00 2001
+From 7b79c52f3e8d783b98915fc6066daf9c4394f929 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:51 -0800
-Subject: [PATCH 17/40] Drivers: hv: vmbus: channge
+Subject: [PATCH 17/41] Drivers: hv: vmbus: channge
  vmbus_connection.channel_lock to mutex
 
 spinlock is unnecessary here.

--- a/alpine/kernel/patches/0018-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
+++ b/alpine/kernel/patches/0018-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
@@ -1,7 +1,7 @@
-From 2d1c04320920e2250e964b11cd21d374b055ed45 Mon Sep 17 00:00:00 2001
+From 1f0c4d3c51b91e7efe8cda63ff471e5e20ce59a3 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Mon, 14 Dec 2015 19:02:00 -0800
-Subject: [PATCH 18/40] Drivers: hv: remove code duplication between
+Subject: [PATCH 18/41] Drivers: hv: remove code duplication between
  vmbus_recvpacket()/vmbus_recvpacket_raw()
 
 vmbus_recvpacket() and vmbus_recvpacket_raw() are almost identical but

--- a/alpine/kernel/patches/0019-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
+++ b/alpine/kernel/patches/0019-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
@@ -1,7 +1,7 @@
-From 6d6ffadf6e2a8a8cfd7afb259df4d928407b40c0 Mon Sep 17 00:00:00 2001
+From 9e1ad22e913564dac402f93eb2a1101d9e199758 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Dec 2015 12:21:22 -0800
-Subject: [PATCH 19/40] Drivers: hv: vmbus: fix the building warning with
+Subject: [PATCH 19/41] Drivers: hv: vmbus: fix the building warning with
  hyperv-keyboard
 
 With the recent change af3ff643ea91ba64dd8d0b1cbed54d44512f96cd

--- a/alpine/kernel/patches/0020-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
+++ b/alpine/kernel/patches/0020-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
@@ -1,7 +1,7 @@
-From 384ccf1bbf62722d579d3cfec7b209e034a11d60 Mon Sep 17 00:00:00 2001
+From 02adc9f995f59194291bde782062a2aa38201ab9 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Tue, 15 Dec 2015 16:27:27 -0800
-Subject: [PATCH 20/40] Drivers: hv: vmbus: Treat Fibre Channel devices as
+Subject: [PATCH 20/41] Drivers: hv: vmbus: Treat Fibre Channel devices as
  performance critical
 
 For performance critical devices, we distribute the incoming

--- a/alpine/kernel/patches/0021-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
+++ b/alpine/kernel/patches/0021-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
@@ -1,7 +1,7 @@
-From 0e5cc03371ae2817286d5b14a0554e4315503dbe Mon Sep 17 00:00:00 2001
+From 4607194c4f3d351c7967a03f6dd8a6590be10cab Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Fri, 25 Dec 2015 20:00:30 -0800
-Subject: [PATCH 21/40] Drivers: hv: vmbus: Add vendor and device atttributes
+Subject: [PATCH 21/41] Drivers: hv: vmbus: Add vendor and device atttributes
 
 Add vendor and device attributes to VMBUS devices. These will be used
 by Hyper-V tools as well user-level RDMA libraries that will use the

--- a/alpine/kernel/patches/0022-Drivers-hv-vmbus-avoid-infinite-loop-in-init_vp_inde.patch
+++ b/alpine/kernel/patches/0022-Drivers-hv-vmbus-avoid-infinite-loop-in-init_vp_inde.patch
@@ -1,7 +1,7 @@
-From 7c34ef7f365248b5c34e3dbd07ffa2a549e1d048 Mon Sep 17 00:00:00 2001
+From 32a9ade9656d3ce93efd9e429eca714ccc90c53e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Wed, 27 Jan 2016 22:29:34 -0800
-Subject: [PATCH 22/40] Drivers: hv: vmbus: avoid infinite loop in
+Subject: [PATCH 22/41] Drivers: hv: vmbus: avoid infinite loop in
  init_vp_index()
 
 When we pick a CPU to use for a new subchannel we try find a non-used one

--- a/alpine/kernel/patches/0023-Drivers-hv-vmbus-avoid-scheduling-in-interrupt-conte.patch
+++ b/alpine/kernel/patches/0023-Drivers-hv-vmbus-avoid-scheduling-in-interrupt-conte.patch
@@ -1,7 +1,7 @@
-From 2d6cab80cbbcc7b94e538a0a1d32a5584c166169 Mon Sep 17 00:00:00 2001
+From ddf2482b26c0381ab579ed3c4769249ea0f5aacb Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Wed, 27 Jan 2016 22:29:35 -0800
-Subject: [PATCH 23/40] Drivers: hv: vmbus: avoid scheduling in interrupt
+Subject: [PATCH 23/41] Drivers: hv: vmbus: avoid scheduling in interrupt
  context in vmbus_initiate_unload()
 
 We have to call vmbus_initiate_unload() on crash to make kdump work but

--- a/alpine/kernel/patches/0024-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
+++ b/alpine/kernel/patches/0024-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
@@ -1,7 +1,7 @@
-From 449c8f899575afc7af1aa6e559750074ad17b99d Mon Sep 17 00:00:00 2001
+From 6821345c611268ced9be1e9116ed3a5de98194bf Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:37 -0800
-Subject: [PATCH 24/40] Drivers: hv: vmbus: add a helper function to set a
+Subject: [PATCH 24/41] Drivers: hv: vmbus: add a helper function to set a
  channel's pending send size
 
 This will be used by the coming net/hvsock driver.

--- a/alpine/kernel/patches/0025-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
+++ b/alpine/kernel/patches/0025-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
@@ -1,7 +1,7 @@
-From 3e9764b49994095527e0b6e0d5cb0280cf522cf0 Mon Sep 17 00:00:00 2001
+From f8302883a3723113f63e2361968f303cdcbcf0f9 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:38 -0800
-Subject: [PATCH 25/40] Drivers: hv: vmbus: define the new offer type for
+Subject: [PATCH 25/41] Drivers: hv: vmbus: define the new offer type for
  Hyper-V socket (hvsock)
 
 A helper function is also added.

--- a/alpine/kernel/patches/0026-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
+++ b/alpine/kernel/patches/0026-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
@@ -1,7 +1,7 @@
-From 5acc7c6742ee5651f5ac9e920804976c2859bbf5 Mon Sep 17 00:00:00 2001
+From 4023630c2a63f60d82ff894cfbfd0072c2f43f74 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:39 -0800
-Subject: [PATCH 26/40] Drivers: hv: vmbus: vmbus_sendpacket_ctl: hvsock: avoid
+Subject: [PATCH 26/41] Drivers: hv: vmbus: vmbus_sendpacket_ctl: hvsock: avoid
  unnecessary signaling
 
 When the hvsock channel's outbound ringbuffer is full (i.e.,

--- a/alpine/kernel/patches/0027-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
+++ b/alpine/kernel/patches/0027-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
@@ -1,7 +1,7 @@
-From 8ffc572cbd086612e786c50411e60d9fe9ea16bf Mon Sep 17 00:00:00 2001
+From a43b42887324604cf976d6dde10d5e4b4d411a14 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:40 -0800
-Subject: [PATCH 27/40] Drivers: hv: vmbus: define a new VMBus message type for
+Subject: [PATCH 27/41] Drivers: hv: vmbus: define a new VMBus message type for
  hvsock
 
 A function to send the type of message is also added.

--- a/alpine/kernel/patches/0028-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
+++ b/alpine/kernel/patches/0028-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
@@ -1,7 +1,7 @@
-From 9fe203d7a24278ca2d9311edd64276233903b4c9 Mon Sep 17 00:00:00 2001
+From 7c82782252605f2cc287780166ee10442d10e978 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:41 -0800
-Subject: [PATCH 28/40] Drivers: hv: vmbus: add a hvsock flag in struct
+Subject: [PATCH 28/41] Drivers: hv: vmbus: add a hvsock flag in struct
  hv_driver
 
 Only the coming hv_sock driver has a "true" value for this flag.

--- a/alpine/kernel/patches/0029-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
+++ b/alpine/kernel/patches/0029-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
@@ -1,7 +1,7 @@
-From 8db632a31ce18f1dcadce4ac934419e20903370d Mon Sep 17 00:00:00 2001
+From 844324cce7cf8caf3b86795637bd9afddfbbc390 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:42 -0800
-Subject: [PATCH 29/40] Drivers: hv: vmbus: add a per-channel rescind callback
+Subject: [PATCH 29/41] Drivers: hv: vmbus: add a per-channel rescind callback
 
 This will be used by the coming hv_sock driver.
 

--- a/alpine/kernel/patches/0030-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
+++ b/alpine/kernel/patches/0030-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
@@ -1,7 +1,7 @@
-From 748b793b0bb200124a4547546384b6083393eb4d Mon Sep 17 00:00:00 2001
+From 0f2be5d95acaac8d4391c6f7918f77ada0885f48 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:43 -0800
-Subject: [PATCH 30/40] Drivers: hv: vmbus: add an API
+Subject: [PATCH 30/41] Drivers: hv: vmbus: add an API
  vmbus_hvsock_device_unregister()
 
 The hvsock driver needs this API to release all the resources related

--- a/alpine/kernel/patches/0031-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
+++ b/alpine/kernel/patches/0031-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
@@ -1,7 +1,7 @@
-From b28445573c0d9eb82556b22a8feef62681e9bfc7 Mon Sep 17 00:00:00 2001
+From c3244e29d0e58c3de56f23075ae22f9d47ba9d0f Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:45 -0800
-Subject: [PATCH 31/40] Drivers: hv: vmbus: Give control over how the ring
+Subject: [PATCH 31/41] Drivers: hv: vmbus: Give control over how the ring
  access is serialized
 
 On the channel send side, many of the VMBUS

--- a/alpine/kernel/patches/0032-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
+++ b/alpine/kernel/patches/0032-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
@@ -1,7 +1,7 @@
-From 7dd0f1293f17f73c424300ce4dbeaea4fc21db1f Mon Sep 17 00:00:00 2001
+From 3269a14134d8c0ccc6e50e5336142e8f65226da2 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:16 -0800
-Subject: [PATCH 32/40] Drivers: hv: vmbus: avoid wait_for_completion() on
+Subject: [PATCH 32/41] Drivers: hv: vmbus: avoid wait_for_completion() on
  crash
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/alpine/kernel/patches/0033-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
+++ b/alpine/kernel/patches/0033-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
@@ -1,7 +1,7 @@
-From 07d088bcb47d39a5edfdce1d1a88491262e55908 Mon Sep 17 00:00:00 2001
+From 3d4dcde731d52d41491301a3430ea84324331b4e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:18 -0800
-Subject: [PATCH 33/40] Drivers: hv: vmbus: avoid unneeded compiler
+Subject: [PATCH 33/41] Drivers: hv: vmbus: avoid unneeded compiler
  optimizations in vmbus_wait_for_unload()
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/alpine/kernel/patches/0034-kcm-Kernel-Connection-Multiplexor-module.patch
+++ b/alpine/kernel/patches/0034-kcm-Kernel-Connection-Multiplexor-module.patch
@@ -1,7 +1,7 @@
-From 14657505a252117919d7689d808344f9010d1cca Mon Sep 17 00:00:00 2001
+From 92afb1396d3e35cf6b87248ded174db0c9699e1e Mon Sep 17 00:00:00 2001
 From: Tom Herbert <tom@herbertland.com>
 Date: Mon, 7 Mar 2016 14:11:06 -0800
-Subject: [PATCH 34/40] kcm: Kernel Connection Multiplexor module
+Subject: [PATCH 34/41] kcm: Kernel Connection Multiplexor module
 
 This module implements the Kernel Connection Multiplexor.
 

--- a/alpine/kernel/patches/0035-net-add-the-AF_KCM-entries-to-family-name-tables.patch
+++ b/alpine/kernel/patches/0035-net-add-the-AF_KCM-entries-to-family-name-tables.patch
@@ -1,7 +1,7 @@
-From d8538313990d2d0dffca96608b181f4e0328b9aa Mon Sep 17 00:00:00 2001
+From c6e4e04e17788c1fe4c9ba68f2c0ca52b0786be0 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:51:09 -0700
-Subject: [PATCH 35/40] net: add the AF_KCM entries to family name tables
+Subject: [PATCH 35/41] net: add the AF_KCM entries to family name tables
 
 This is for the recent kcm driver, which introduces AF_KCM(41) in
 b7ac4eb(kcm: Kernel Connection Multiplexor module).

--- a/alpine/kernel/patches/0036-net-Add-Qualcomm-IPC-router.patch
+++ b/alpine/kernel/patches/0036-net-Add-Qualcomm-IPC-router.patch
@@ -1,7 +1,7 @@
-From 81dba561b9dce770d4c981fac66b9dbb09be2802 Mon Sep 17 00:00:00 2001
+From ef5406e1c37f0f3a2cfaf4be867639d5d882c3bb Mon Sep 17 00:00:00 2001
 From: Courtney Cavin <courtney.cavin@sonymobile.com>
 Date: Wed, 27 Apr 2016 12:13:03 -0700
-Subject: [PATCH 36/40] net: Add Qualcomm IPC router
+Subject: [PATCH 36/41] net: Add Qualcomm IPC router
 
 Add an implementation of Qualcomm's IPC router protocol, used to
 communicate with service providing remote processors.

--- a/alpine/kernel/patches/0037-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/alpine/kernel/patches/0037-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,7 +1,7 @@
-From 0fea0056631e409950b21d0fc4f80ee5c42777cc Mon Sep 17 00:00:00 2001
+From 07e2f075c89ac3ec1dd2ac47078e1ea7b376ba88 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 15 May 2016 09:53:11 -0700
-Subject: [PATCH 37/40] hv_sock: introduce Hyper-V Sockets
+Subject: [PATCH 37/41] hv_sock: introduce Hyper-V Sockets
 
 Hyper-V Sockets (hv_sock) supplies a byte-stream based communication
 mechanism between the host and the guest. It's somewhat like TCP over

--- a/alpine/kernel/patches/0038-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
+++ b/alpine/kernel/patches/0038-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
@@ -1,7 +1,7 @@
-From 5ae29368847275f23f58d9f8e858d011e213ee03 Mon Sep 17 00:00:00 2001
+From 5a28294f62717b7eca4d5a014ed43acef3d5667a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:53:08 -0700
-Subject: [PATCH 38/40] net: add the AF_HYPERV entries to family name tables
+Subject: [PATCH 38/41] net: add the AF_HYPERV entries to family name tables
 
 This is for the hv_sock driver, which introduces AF_HYPERV(42).
 

--- a/alpine/kernel/patches/0039-VSOCK-do-not-disconnect-socket-when-peer-has-shutdow.patch
+++ b/alpine/kernel/patches/0039-VSOCK-do-not-disconnect-socket-when-peer-has-shutdow.patch
@@ -1,7 +1,7 @@
-From 146004c055da70f40db59e25d25844201d21fbf0 Mon Sep 17 00:00:00 2001
+From 248a6f77e4a373960892595a5ab500af8ce38343 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Wed, 4 May 2016 14:21:53 +0100
-Subject: [PATCH 39/40] VSOCK: do not disconnect socket when peer has shutdown
+Subject: [PATCH 39/41] VSOCK: do not disconnect socket when peer has shutdown
  SEND only
 
 The peer may be expecting a reply having sent a request and then done a

--- a/alpine/kernel/patches/0040-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
+++ b/alpine/kernel/patches/0040-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
@@ -1,7 +1,7 @@
-From b4a79d74e88c82a7b83de21df5281a124b3a921a Mon Sep 17 00:00:00 2001
+From 6b78cb6d1a476bc91ad5a7f9754db29c4e566bc2 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 21 May 2016 16:55:50 +0800
-Subject: [PATCH 40/40] Drivers: hv: vmbus: fix the race when querying &
+Subject: [PATCH 40/41] Drivers: hv: vmbus: fix the race when querying &
  updating the percpu list
 
 There is a rare race when we remove an entry from the global list

--- a/alpine/kernel/patches/0041-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/alpine/kernel/patches/0041-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,0 +1,30 @@
+From 02e36dc741646dd93f2958378c87f22e6815a400 Mon Sep 17 00:00:00 2001
+From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
+Date: Mon, 23 May 2016 18:55:45 +0100
+Subject: [PATCH 41/41] vmbus: Don't spam the logs with unknown GUIDs
+
+With Hyper-V sockets device types are introduced on the fly. The pr_info()
+then prints a message on every connection, which is way too verbose.  Since
+there doesn't seem to be an easy way to check for registered services,
+disable the pr_info() completely.
+
+Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
+---
+ drivers/hv/channel_mgmt.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/hv/channel_mgmt.c b/drivers/hv/channel_mgmt.c
+index 0a54317..120ee22 100644
+--- a/drivers/hv/channel_mgmt.c
++++ b/drivers/hv/channel_mgmt.c
+@@ -147,7 +147,6 @@ static u16 hv_get_dev_type(const uuid_le *guid)
+ 		if (!uuid_le_cmp(*guid, vmbus_devs[i].guid))
+ 			return i;
+ 	}
+-	pr_info("Unknown GUID: %pUl\n", guid);
+ 	return i;
+ }
+ 
+-- 
+2.8.2
+


### PR DESCRIPTION
Added a patch to reduce verbosity of vmbus for unknown GUIDs.
Thes happen on every Hyper-V socket connection.

Signed-off-by: Rolf Neugebauer rolf.neugebauer@docker.com
