### PR TITLE
virtsock: update vendored virtosck package

### DIFF
--- a/alpine/packages/go/vendor/github.com/rneugeba/virtsock/go/hvsock/hvsock.go
+++ b/alpine/packages/go/vendor/github.com/rneugeba/virtsock/go/hvsock/hvsock.go
@@ -34,8 +34,10 @@ import (
 // (without data), `shutdownrd` and 'shutdownwr' are used to used to
 // signal a shutdown to the other end.
 
+// On Windows 10 build 10586 larger maxMsgSize values work, but on
+// newer builds it fails. It is unclear what the cause is...
 const (
-	maxMsgSize = 32 * 1024 // Maximum message size
+	maxMsgSize = 4 * 1024 // Maximum message size
 )
 
 // Hypper-V sockets use GUIDs for addresses and "ports"

--- a/alpine/packages/go/vendor/manifest
+++ b/alpine/packages/go/vendor/manifest
@@ -5,7 +5,7 @@
 			"importpath": "github.com/rneugeba/virtsock/go",
 			"repository": "https://github.com/rneugeba/virtsock",
 			"vcs": "git",
-			"revision": "359bc27daab86588bfc7a304e78c6758b098d8e5",
+			"revision": "74097e05a883e89c70e6a27b342672c7fe6c846b",
 			"branch": "master",
 			"path": "/go",
 			"notests": true


### PR DESCRIPTION
This fixes a bug on WIndows build newer than 10586.

Signed-off-by: Rolf Neugebauer rolf.neugebauer@docker.com
