### PR TITLE
[DO NOT MERGE (yet)] config: overwrite resolv.conf and interfaces from database

### DIFF
--- a/alpine/etc/network/interfaces.template
+++ b/alpine/etc/network/interfaces.template
@@ -1,0 +1,9 @@
+auto lo
+iface lo inet loopback
+
+auto eth1
+iface eth1 inet dhcp
+    udhcpc_opts -T 1 -A 3
+    metric 199
+    pre-up service tap-vsockd start
+    post-down service tap-vsockd stop

--- a/alpine/packages/hostsettings/etc/init.d/hostsettings
+++ b/alpine/packages/hostsettings/etc/init.d/hostsettings
@@ -3,7 +3,7 @@
 description="Configuring settings from database."
 
 depend() {
-	before sysctl
+	before sysctl net
 }
 
 start() {
@@ -19,5 +19,24 @@ start() {
 		mount --bind "${DRIVERDIR}/log" /var/log
 	fi
 
-        eend 0
+	mobyconfig exists etc/resolv.conf && mobyconfig get etc/resolv.conf > /etc/resolv.conf
+
+	# handle static network config if configured
+	mobyconfig exists net/config && NETCONFIG=`mobyconfig get net/config`
+	if [ "${NETCONFIG}" = "static" ]; then
+	     # assume that the other configsDB entries exist
+	     IP=`mobyconfig get net/address`
+	     MASK=`mobyconfig get net/netmask`
+	     GW=`mobyconfig get net/gateway`
+
+	     cp /etc/network/interfaces.template /etc/network/interfaces
+	     echo                          >> /etc/network/interfaces
+	     echo "auto eth0"              >> /etc/network/interfaces
+	     echo "iface eth0 inet static" >> /etc/network/interfaces
+	     echo "    address ${IP}"      >> /etc/network/interfaces
+	     echo "    netmask ${MASK}"    >> /etc/network/interfaces
+	     echo "    gateway ${GW}"      >> /etc/network/interfaces
+	fi
+
+	eend 0
 }


### PR DESCRIPTION
Allow the host to configure a static IP address for eth0 by setting the
following DB keys:
- net/config: "static" (default or not set -> dhcp)
- net/address: IP address
- net/netmask: netmask in dot notation
- net/gateway: default gateway

Also allow overwriting/setting "/etc/resolve.conf" by writing to
the "etc/resolv.conf" key.

Signed-off-by: Rolf Neugebauer rolf.neugebauer@docker.com
