### PR TITLE
proxy: remove the dynamic vsock port allocation

### DIFF
--- a/alpine/packages/proxy/one.go
+++ b/alpine/packages/proxy/one.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/rneugeba/virtsock/go/vsock"
 	"log"
 	"net"
 	"os"
@@ -12,12 +11,8 @@ import (
 )
 
 func onePort() {
-	host, port, container := parseHostContainerAddrs()
+	host, _, container := parseHostContainerAddrs()
 
-	vsockP, err := libproxy.NewVsockProxy(&vsock.VsockAddr{Port: uint(port)}, container)
-	if err != nil {
-		sendError(err)
-	}
 	ipP, err := libproxy.NewIPProxy(host, container)
 	if err != nil {
 		sendError(err)
@@ -31,8 +26,7 @@ func onePort() {
 	go handleStopSignals(ipP)
 	// TODO: avoid this line if we are running in a TTY
 	sendOK()
-	go ipP.Run()
-	vsockP.Run()
+	ipP.Run()
 	ctl.Close() // ensure ctl remains alive and un-GCed until here
 	os.Exit(0)
 }


### PR DESCRIPTION
On both Mac and Windows we have one well-known port and a SOCKS-like
port to tunnel connections through it. This was necessary on Windows
where ports have well-known GUIDs, but we might as well do it the same
way on both platforms for consistency.

This patch removes the dynamic binding of vsock ports, which fails on
a Windows Moby anyway.

Signed-off-by: David Scott dave.scott@docker.com
