### PR TITLE
Do not try to keep log files, fix #154

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -11,23 +11,10 @@ start()
 	ebegin "Starting Docker"
 
 	# shift logs onto host before docker starts
-	# try to keep initial log files, although there is a race
 	# busybox reopens its log files every second
 	if cat /proc/cmdline | grep -q 'com.docker.driverDir'
 	then
-		DRIVERDIR="/Mac$(cat /proc/cmdline | sed -e 's/.*com.docker.driverDir="//' -e 's/".*//')"
-		rm -rf /var/tmp/log
-		mkdir -p /var/tmp/log
-		for f in /var/log/*
-		do
-			cp -a $f /var/tmp/log/$(basename $f)
-		done
 		mount --bind "${DRIVERDIR}/log" /var/log
-		for f in /var/tmp/log/*
-		do
-			[ -f $f ] && cat $f >> /var/log/$(basename $f)
-		done
-		rm -rf /var/tmp/log
 	fi
 
 	command="${DOCKER_BINARY:-/usr/bin/docker}"


### PR DESCRIPTION
Stop trying to keep early boot log files on host, as it was causing log explosion.

Plan is to shift to syslog #74 which will enable keeping logs.

Signed-off-by: Justin Cormack justin.cormack@docker.com
