### PR TITLE
move log mount to hostsettings not docker startup

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -10,13 +10,6 @@ start()
 {
 	ebegin "Starting Docker"
 
-	# shift logs onto host before docker starts
-	# busybox reopens its log files every second
-	if cat /proc/cmdline | grep -q 'com.docker.driverDir'
-	then
-		mount --bind "${DRIVERDIR}/log" /var/log
-	fi
-
 	command="${DOCKER_BINARY:-/usr/bin/docker}"
 
 	pidfile="/run/docker.pid"

--- a/alpine/packages/hostsettings/etc/init.d/hostsettings
+++ b/alpine/packages/hostsettings/etc/init.d/hostsettings
@@ -11,5 +11,12 @@ start() {
 
 	mobyconfig exists etc/sysctl.conf && mobyconfig get etc/sysctl.conf > /etc/sysctl.conf
 
+	# shift logs onto host before docker starts
+	# busybox reopens its log files every second
+	if cat /proc/cmdline | grep -q 'com.docker.driverDir'
+	then
+		mount --bind "${DRIVERDIR}/log" /var/log
+	fi
+
         eend 0
 }


### PR DESCRIPTION
This stops multiple mounts when docker restarted.

Signed-off-by: Justin Cormack justin.cormack@docker.com
