### PR TITLE
Ensure /var/log is bind mounted after transfused starts

### DIFF
--- a/alpine/packages/hostsettings/etc/init.d/hostsettings
+++ b/alpine/packages/hostsettings/etc/init.d/hostsettings
@@ -3,6 +3,7 @@
 description="Configuring settings from database."
 
 depend() {
+	need transfused
 	before sysctl net
 }
 


### PR DESCRIPTION
Otherwise /Mac$DRIVERDIR does not yet exist.

Signed-off-by: Ian Campbell ian.campbell@docker.com
