### PR TITLE
net: add metric to static IP address entries

### DIFF
--- a/alpine/packages/hostsettings/etc/init.d/hostsettings
+++ b/alpine/packages/hostsettings/etc/init.d/hostsettings
@@ -37,6 +37,7 @@ start() {
 	     echo "    address ${IP}"      >> /etc/network/interfaces
 	     echo "    netmask ${MASK}"    >> /etc/network/interfaces
 	     echo "    gateway ${GW}"      >> /etc/network/interfaces
+	     echo "    metric  200"        >> /etc/network/interfaces
 	fi
 
 	eend 0


### PR DESCRIPTION
The VPN interface is configure with a routing metric of 199. If VPN mode
is enabled and we have static IP address configured (which is what we do
on Windows) then all traffic would still go via eth0 and not, as expected,
via the VPN interface.

With this PR we set the metric for eth1 to 200, thus, if VPN mode enabled
traffic will be routed over the VPN interface.

This fix is a bit Uggh, but it's the simplest way to apply this late in the
release cycle without requiring re-run of all OS X tests.

We should fix this properly after this release.

Signed-off-by: Rolf Neugebauer rolf.neugebauer@docker.com
