### PR TITLE
Add 'bootflag' script to check kernel flags

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -73,6 +73,7 @@ COPY packages/userns/useradd /usr/sbin
 COPY packages/vsudd/vsudd /sbin
 COPY packages/vsudd/etc /etc
 COPY packages/mobyconfig/mobyconfig /usr/bin
+COPY packages/bootflag/bootflag /usr/bin
 COPY packages/gummiboot/gummiboot.tar.gz /usr/share/src/
 COPY packages/oom/etc /etc
 COPY packages/9pmount-vsock/9pmount-vsock /sbin

--- a/alpine/packages/bootflag/bootflag
+++ b/alpine/packages/bootflag/bootflag
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Script to print values of arbitrary kvpairs the kernel was passed as command
+# line parameters on boot.
+# 
+# e.g. if kernel booted with cloud_provider=azure, 'bootflag cloud_provider'
+# will return 'azure'.
+# 
+# If multiple flags have the same key, it will return only the first one found.
+
+if [ $# -ne 1 ]; then
+    echo "Usage: bootflag [key]"
+    exit 1
+fi
+
+awk -v flag=$1 '{
+    for(i = 1; i <= NF; i++) {
+        split($i, kvpair, "=");
+        if(kvpair[1] == flag) {
+            print kvpair[2];
+            break;
+        }
+    }
+}' /proc/cmdline


### PR DESCRIPTION
@justincormack @rneugeba WDYT?

I would like to use it to skip the AWS init (we'll need one for Azure and others as well) if not specified explicitly in boot.  Otherwise we will try to contact metadata endpoints which don't exist on Pinata etc...

Trying to determine which provider we're on in the init scripts itself seems error prone.

Open as always to better suggestions if you have them.

Usage:

``` console
$ bootflag console
hvc0

$ [ "$(bootflag cloud_provider)" == "aws" ] && echo "Let's bootstrap a Swarm!"
```

etc.

Signed-off-by: Nathan LeClaire nathan.leclaire@gmail.com
