### PR TITLE
also bindmount /tmp once

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -49,7 +49,9 @@ start()
 		export no_proxy="$(mobyconfig get proxy/exclude)"
 	fi
 
-	for d in Users Volumes tmp private
+	grep "osxfs /tmp" /etc/mtab -q || mount --bind /Mac/tmp /tmp
+
+	for d in Users Volumes private
 	do
 		[ -d /Mac/$d ] && [ ! -d $d ] && mkdir -p /$d && mount --bind /Mac/$d /$d
 	done


### PR DESCRIPTION
After #165 /tmp would not be mounted as the directory already exists. This checks if /tmp is already mounted in mtab and mounts it if it isn't.

Signed-off-by: Magnus Skjegstad magnus@skjegstad.com
