### PR TITLE
fix #169 only do /tmp bind mount if /Mac/tmp exists

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -49,7 +49,7 @@ start()
 		export no_proxy="$(mobyconfig get proxy/exclude)"
 	fi
 
-	grep "osxfs /tmp" /etc/mtab -q || mount --bind /Mac/tmp /tmp
+	grep -q "osxfs /tmp" /etc/mtab || ( [ -d /Mac/tmp ] && mount --bind /Mac/tmp /tmp )
 
 	for d in Users Volumes private
 	do


### PR DESCRIPTION
Signed-off-by: Justin Cormack justin.cormack@docker.com
