### PR TITLE
docker: stop listening on 0.0.0.0:2375

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -14,9 +14,7 @@ start()
 
 	pidfile="/run/docker.pid"
 
-	# Start with networking on both Mac and Hyper-V, but in
-	# future change this to use a hypervisor socket.
-	DOCKER_OPTS="${DOCKER_OPTS} -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock"
+	DOCKER_OPTS="${DOCKER_OPTS} -H unix:///var/run/docker.sock"
 
 	# some config is always in /etc/docker cannot specify alternative eg certs
 	if mobyconfig exists etc/docker


### PR DESCRIPTION
Now that Docker for Mac and Docker for Windows are both using hypervisor
sockets to contact docker, we don't need to listen on 0.0.0.0:2375 any more.
