### PR TITLE
transfused service delay start until mounts are ready

### DIFF
--- a/alpine/packages/transfused/etc/init.d/transfused
+++ b/alpine/packages/transfused/etc/init.d/transfused
@@ -8,18 +8,8 @@ start()
 
 	mkdir -p /Mac
 
-        if cat /proc/cmdline | grep -q 'com.docker.driverDir'
-        then
-                DRIVERDIR="/Mac$(cat /proc/cmdline | sed -e 's/.*com.docker.driverDir="//' -e 's/".*//')"
-                RUNTIME_LOGFILE=${DRIVERDIR}/log/transfused.log
-        else
-                ID=$(LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)
-                RUNTIME_LOGFILE="/Mac/private/tmp/transfused_${ID}.log"
-        fi
-
         PIDFILE=/var/run/transfused.pid
         STARTUP_LOGFILE=/var/transfused_start.log
-        MOUNT_TRIGGER=/Mac
 
 	start-stop-daemon --start --quiet \
 		--background \


### PR DESCRIPTION
This prevents a race between other services and `osxfs` bringing up all of the user's mounts. 2 seconds should be enough time...

The other commit cleans up some useless cruft.
