### PR TITLE
Point chronyd at gateway when ntp=gateway is given on the kernel cmdl…

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -50,7 +50,6 @@ COPY packages/diagnostics/diagnostics /usr/bin/
 COPY packages/diagnostics/diagnostics-server /usr/bin/
 COPY packages/diagnostics/etc /etc/
 COPY packages/automount/etc /etc/
-COPY packages/ntp15m/etc /etc/
 COPY packages/binfmt_misc/etc /etc/
 COPY packages/dnsfix/etc /etc/
 COPY packages/hostsettings/etc /etc/
@@ -84,7 +83,6 @@ RUN \
   rc-update add networking boot && \
   rc-update add acpid default && \
   rc-update add chronyd default && \
-  rc-update add crond default && \
   rc-update add savecache shutdown && \
   rc-update add killprocs shutdown && \
   rc-update add mount-ro shutdown && \

--- a/alpine/packages/chronyd/etc/chrony/chrony.conf
+++ b/alpine/packages/chronyd/etc/chrony/chrony.conf
@@ -1,0 +1,6 @@
+# default config
+
+server pool.ntp.org iburst minpoll 2
+makestep 0.5 -1
+keyfile /etc/chrony/chrony.keys
+driftfile /var/lib/chrony/chrony.drift

--- a/alpine/packages/chronyd/etc/udhcpc/post-bound/chronyd
+++ b/alpine/packages/chronyd/etc/udhcpc/post-bound/chronyd
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ "x$interface" != "xeth0" ] ; then exit 0 ; fi
+
+if cat /proc/cmdline | grep -q '\bntp=gateway\b' ; then
+    server=$(ip -4 route list type unicast dev eth0 exact 0/0 | awk '/^default/ { print $3 }')
+    server="$server trust"
+else
+    # TODO: consult $router
+    exit 0
+fi
+
+sed -i -e "s/^server [^ ]\+/server $server/g" /etc/chrony/chrony.conf
+
+logger -t udhcpc "Restarting chronyd with server $server"
+service -q chronyd conditionalrestart

--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -3,7 +3,6 @@
 depend()
 {
 	after transfused
-	before chronyd
 }
 
 start()

--- a/alpine/packages/ntp15m/etc/periodic/15min/ntp
+++ b/alpine/packages/ntp15m/etc/periodic/15min/ntp
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-ntpd -n -q -p pool.ntp.org


### PR DESCRIPTION
…ine.

Reconfigure chronyd in a udhcpc post-bound hook and restart it, but use
conditionalrestart so it is not started if it isn't running, which is the case
during boot when this hook happens from init.d/networking via ifup, running
"service ... start" in that context results in the daemon running but the
service db saying it isn't.

Doing it in the udhcpc hook leaves a nice hole where support for getting the
NTP server via DHCP can fit in once it is available.

This also switches from using "initstepslew" to "makestep", the former was
responsible for the long delay starting chronyd (meaning we can now drop
"before chronyd" from Docker's init dependencies), while the later will force a
step if the time is out by more than the configured amount (half a second
here), meaning it will be corrected on resume. The rest of the time it chrony
will do the usual slewing to keep the clock accurate. Passing -1 as the limit
to "makestep" ensures the step will always occur, if it were positive it would
only be done that number of times.

We add "iburst" and "minpoll 2" to the default configuration file to speed up
initial sync and resync after sleep respectively, resync after sleep happens in
a couple of seconds. In "ntp=gateway" mode we also patch in "trust", this isn't
in the default config file since we won't be so sure about DHCP provided
servers, but when talking to a host provided NTP we want to use its time (for
sync accross host mounts) even if it has a crazy idea about what the time is.

With this we can also remove the 15min ntp sync, which in turn gets rid of the
need for cron.

Signed-off-by: Ian Campbell ian.campbell@docker.com
