### PR TITLE
diagnostics: Add daemon.json to the diagnistics tarball

### DIFF
--- a/alpine/packages/diagnostics/main.go
+++ b/alpine/packages/diagnostics/main.go
@@ -102,6 +102,7 @@ func capture(w *tar.Writer) {
 	run(t, w, "/bin/ls", "-l", "/var/lib/docker")
 	run(t, w, "/usr/bin/diagnostics")
 	run(t, w, "/bin/ping", "-w", "5", "8.8.8.8")
+	run(t, w, "/bin/cat", "/etc/docker/daemon.json")
 	run(t, w, "/bin/cat", "/etc/network/interfaces")
 	run(t, w, "/bin/cat", "/etc/resolv.conf")
 	run(t, w, "/bin/cat", "/etc/sysctl.conf")


### PR DESCRIPTION
With #186 we are now using /etc/docker/daemon.json again.
Add it to the tarball.

Signed-off-by: Rolf Neugebauer rolf.neugebauer@docker.com
