### PR TITLE
Add `|| true` to the `docker rmi` invocations in the clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,5 @@ qemu-arm: Dockerfile.qemu.armhf arm
 clean:
 	$(MAKE) -C alpine clean
 	$(MAKE) -C xhyve clean
-	docker images -q mobyqemu:build | xargs docker rmi -f
-	docker images -q justincormack/remora | xargs docker rmi -f
+	docker images -q mobyqemu:build | xargs docker rmi -f || true
+	docker images -q justincormack/remora | xargs docker rmi -f || true

--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -18,5 +18,5 @@ zImage: kernel_config.arm Dockerfile
 
 clean:
 	rm -f zImage vmlinuz64 aufs-utils.tar kernel-source-info kernel-patches.tar
-	docker images -q mobykernel:build | xargs docker rmi -f
-	docker images -q mobyarmkernel:build | xargs docker rmi -f
+	docker images -q mobykernel:build | xargs docker rmi -f || true
+	docker images -q mobyarmkernel:build | xargs docker rmi -f || true

--- a/alpine/packages/9pmount-vsock/Makefile
+++ b/alpine/packages/9pmount-vsock/Makefile
@@ -18,4 +18,4 @@ hvsock.o: hvsock.c hvsock.h
 
 clean:
 	rm -f 9pmount-vsock
-	docker images -q 9pmount-vsock:build | xargs docker rmi -f
+	docker images -q 9pmount-vsock:build | xargs docker rmi -f || true

--- a/alpine/packages/diagnostics/Makefile
+++ b/alpine/packages/diagnostics/Makefile
@@ -12,4 +12,4 @@ diagnostics-server: Dockerfile main.go vendor
 
 clean:
 	rm -rf diagnostics-server vendor
-	docker images -q diagnostics:build | xargs docker rmi -f
+	docker images -q diagnostics:build | xargs docker rmi -f || true

--- a/alpine/packages/gummiboot/Makefile
+++ b/alpine/packages/gummiboot/Makefile
@@ -8,4 +8,4 @@ linuxx64.efi.stub: Dockerfile gummiboot/*
 
 clean:
 	rm -f linuxx64.efi.stub gummiboot.tar.gz
-	docker images -q gummiboot:build | xargs docker rmi -f
+	docker images -q gummiboot:build | xargs docker rmi -f || true

--- a/alpine/packages/hvtools/Makefile
+++ b/alpine/packages/hvtools/Makefile
@@ -10,4 +10,4 @@ hvtools: Dockerfile src/*
 
 clean:
 	rm -f hv_fcopy_daemon hv_kvp_daemon hv_vss_daemon
-	docker images -q hvtools:build | xargs docker rmi -f
+	docker images -q hvtools:build | xargs docker rmi -f || true

--- a/alpine/packages/llmnrd/Makefile
+++ b/alpine/packages/llmnrd/Makefile
@@ -8,4 +8,4 @@ llmnrd: Dockerfile src/*
 
 clean:
 	rm -f llmnrd llmnrd.tar.gz
-	docker images -q llmnrd:build | xargs docker rmi -f
+	docker images -q llmnrd:build | xargs docker rmi -f || true

--- a/alpine/packages/nc-vsock/Makefile
+++ b/alpine/packages/nc-vsock/Makefile
@@ -12,4 +12,4 @@ nc-vsock: $(DEPS)
 
 clean:
 	rm -f nc-vsock
-	docker images -q nc-vsock:build | xargs docker rmi -f
+	docker images -q nc-vsock:build | xargs docker rmi -f || true

--- a/alpine/packages/proxy/Makefile
+++ b/alpine/packages/proxy/Makefile
@@ -12,4 +12,4 @@ proxy: Dockerfile main.go proxy.go vendor
 
 clean:
 	rm -rf proxy vendor
-	docker images -q proxy:build | xargs docker rmi -f
+	docker images -q proxy:build | xargs docker rmi -f || true

--- a/alpine/packages/tap-vsockd/Makefile
+++ b/alpine/packages/tap-vsockd/Makefile
@@ -21,4 +21,4 @@ tap-vsockd.o: tap-vsockd.c hvsock.h
 
 clean:
 	rm -f tap-vsockd
-	docker images -q tap-vsockd:build | xargs docker rmi -f
+	docker images -q tap-vsockd:build | xargs docker rmi -f || true

--- a/alpine/packages/transfused/Makefile
+++ b/alpine/packages/transfused/Makefile
@@ -15,4 +15,4 @@ transfused: $(DEPS)
 
 clean:
 	rm -f transfused
-	docker images -q transfused:build | xargs docker rmi -f
+	docker images -q transfused:build | xargs docker rmi -f || true

--- a/alpine/packages/vsudd/Makefile
+++ b/alpine/packages/vsudd/Makefile
@@ -12,4 +12,4 @@ vsudd: Dockerfile main.go vendor
 
 clean:
 	rm -rf vsudd vendor
-	docker images -q vsudd:build | xargs docker rmi -f
+	docker images -q vsudd:build | xargs docker rmi -f || true


### PR DESCRIPTION
Linux xargs calls the command with no arguments if it gets no inputs, which
`docker rmi` complains about. It provides -r / --no-run-if-empty to prevent
this but unfortunately this isn't supported on OSX.

Ignore errors from `docker rmi` so that `make clean` will keep going and clean
up later stuff.

Signed-off-by: Ian Campbell ian.campbell@docker.com
