### PR TITLE
transfused: clean up /tmp

### DIFF
--- a/alpine/packages/transfused/etc/init.d/transfused
+++ b/alpine/packages/transfused/etc/init.d/transfused
@@ -9,16 +9,16 @@ start()
 	mkdir -p /Mac
 	rm -rf /tmp/* /tmp/.*
 
-        PIDFILE=/var/run/transfused.pid
-        STARTUP_LOGFILE=/var/transfused_start.log
+	PIDFILE=/var/run/transfused.pid
+	STARTUP_LOGFILE=/var/transfused_start.log
 
 	start-stop-daemon --start --quiet \
 		--background \
 		--exec /sbin/transfused \
 		--pidfile ${PIDFILE} \
 		-- \
-                -p "${PIDFILE}" \
-                -l "${STARTUP_LOGFILE}"
+		-p "${PIDFILE}" \
+		-l "${STARTUP_LOGFILE}"
 
 	ewaitfile 2 ${PIDFILE}
 


### PR DESCRIPTION
The default mountpoint behavior is to refuse to overmount. We want to be able to mount `/tmp`. `/tmp` is often used by software as a temporary file scratch space. In some circumstances, e.g., `setup-disk` will create `alpine-install-diskmode.out` in `/tmp` which will cause the overmount check to fail. This removes everything in `/tmp` before starting `transfused`.
