### PR TITLE
transfused: use find rather than rm+glob to clean up /tmp

### DIFF
--- a/alpine/packages/transfused/etc/init.d/transfused
+++ b/alpine/packages/transfused/etc/init.d/transfused
@@ -7,7 +7,7 @@ start()
 	ebegin "Starting FUSE socket passthrough"
 
 	mkdir -p /Mac
-	rm -rf /tmp/* /tmp/.*
+	find /tmp -mindepth 1 -delete
 
 	PIDFILE=/var/run/transfused.pid
 	STARTUP_LOGFILE=/var/transfused_start.log


### PR DESCRIPTION
This avoids annoying error messages about `.` and `..`.
