### PR TITLE
Add /etc/mke2fs.conf reenabling the uninit_bg feature

### DIFF
--- a/alpine/etc/mke2fs.conf
+++ b/alpine/etc/mke2fs.conf
@@ -1,0 +1,52 @@
+[defaults]
+	base_features = sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr
+	default_mntopts = acl,user_xattr
+	enable_periodic_fsck = 0
+	blocksize = 4096
+	inode_size = 256
+	inode_ratio = 16384
+
+[fs_types]
+	ext3 = {
+		features = has_journal
+	}
+	ext4 = {
+		features = has_journal,extent,huge_file,flex_bg,uninit_bg,64bit,dir_nlink,extra_isize
+		inode_size = 256
+	}
+	ext4dev = {
+		features = has_journal,extent,huge_file,flex_bg,inline_data,64bit,dir_nlink,extra_isize
+		inode_size = 256
+		options = test_fs=1
+	}
+	small = {
+		blocksize = 1024
+		inode_size = 128
+		inode_ratio = 4096
+	}
+	floppy = {
+		blocksize = 1024
+		inode_size = 128
+		inode_ratio = 8192
+	}
+	big = {
+		inode_ratio = 32768
+	}
+	huge = {
+		inode_ratio = 65536
+	}
+	news = {
+		inode_ratio = 4096
+	}
+	largefile = {
+		inode_ratio = 1048576
+		blocksize = -1
+	}
+	largefile4 = {
+		inode_ratio = 4194304
+		blocksize = -1
+	}
+	hurd = {
+	     blocksize = 4096
+	     inode_size = 128
+	}


### PR DESCRIPTION
Without this the mkfs.ext4 on Moby on a virtualised OSX goes from ~10s to ~90s.

Signed-off-by: Ian Campbell ian.campbell@docker.com
