### PR TITLE
Bind aside original var log

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -54,7 +54,11 @@ start()
 	if cat /proc/cmdline | grep -q 'com.docker.driverDir'
 	then
 		DRIVERDIR="/Mac$(cat /proc/cmdline | sed -e 's/.*com.docker.driverDir="//' -e 's/".*//')"
-		grep -q "osxfs on /var/log" /proc/mounts || mount --bind "${DRIVERDIR}/log" /var/log
+		if ! grep -q "osxfs on /var/log" /proc/mounts ; then
+			mkdir /run/log
+			mount -o bind /var/log /run/log
+			mount --bind "${DRIVERDIR}/log" /var/log
+		fi
 	fi
 
 	# same default ulimit as boot2docker; if you want more can set at docker run time


### PR DESCRIPTION
This makes the original `/var/log` (the one on the virtio device) available as /run/log prior to mounting the tranfused based thing over it. That can be handy if you want/need to look into the early logging while debugging (typically there isn't much of interest here, but still...).

Also fixed up a stray use of /etc/mtab while I was in the neighbourhood.
