### PR TITLE
[Post Dockercon] Use $ntpsrv from DHCP to configure chrony

### DIFF
--- a/alpine/packages/chronyd/etc/udhcpc/post-bound/chronyd
+++ b/alpine/packages/chronyd/etc/udhcpc/post-bound/chronyd
@@ -3,10 +3,20 @@
 if [ "x$interface" != "xeth0" ] ; then exit 0 ; fi
 
 if cat /proc/cmdline | grep -q '\bntp=gateway\b' ; then
-    server=$(ip -4 route list type unicast dev eth0 exact 0/0 | awk '/^default/ { print $3 }')
-    server="$server trust"
-else
-    # TODO: consult $router
+    if [ -n "$router" ] ; then
+        logger -t udhcpc "ntp=gateway used, using \$router=$router as \$ntpsrv"
+        server="$router trust"
+    else
+        logger -t udhcpc "ntp=gateway used but \$router not provided"
+    fi
+elif [ -n "$ntpsrv" ] ; then
+    # Just take the first
+    set -- $ntpsrv
+    server="$1"
+fi
+
+if [ -z "$server" ] ; then
+    logger -t udhcpc "No NTP server via DHCP"
     exit 0
 fi
 


### PR DESCRIPTION
NB: This is for post DockerCon, the current stuff is good enough and there isn't enough benefit to this to justify changing.

The existing `ntp=gateway` cmdline support overrides this, but is largely
redundant now.

A DHCP derived server will not be given the "trust" directive in the
configuration file, since it is harder to argue that we know we should trust a
server which arrives this way since it depends on the context in which Moby is
running. It's not clear to me that it makes much difference anyway.

This only uses the first server in $ntpsrv, since Piñata will only provide one
and supporting more makes the sed quite a bit more complex.

If `ntp=gateway` is given then we now use $router instead of parsing IP output.

Signed-off-by: Ian Campbell ian.campbell@docker.com
