### PR TITLE
tap-vsockd: make sure the service daemonizes properly

### DIFF
--- a/alpine/packages/tap-vsockd/etc/init.d/tap-vsockd
+++ b/alpine/packages/tap-vsockd/etc/init.d/tap-vsockd
@@ -21,11 +21,11 @@ start()
 			ebegin "Starting VPN proxy"
 
 			PIDFILE=/var/run/tap-vsockd.pid
-			start-stop-daemon --start --quiet \
+			start-stop-daemon --start \
 				--exec /sbin/tap-vsockd \
+				--background \
 				--pidfile ${PIDFILE} \
 				-- \
-				--daemon \
 				--pidfile "${PIDFILE}" \
 				--listen
 


### PR DESCRIPTION
This tells start-stop-daemon to run tap-vsockd as a daemon, and tells
tap-vsockd not to daemonize itself. This seems to work more reliably
than when tap-vsockd self-daemonizes.

Signed-off-by: David Scott dave.scott@docker.com
