### PR TITLE
fix #212 do not let chronyd listen on a port for commands

### DIFF
--- a/alpine/packages/chronyd/etc/chrony/chrony.conf
+++ b/alpine/packages/chronyd/etc/chrony/chrony.conf
@@ -1,6 +1,5 @@
-# default config
-
 server pool.ntp.org iburst minpoll 2
 makestep 0.5 -1
 keyfile /etc/chrony/chrony.keys
 driftfile /var/lib/chrony/chrony.drift
+cmdport 0


### PR DESCRIPTION
Signed-off-by: Justin Cormack justin.cormack@docker.com
