### PR TITLE
Avoid brace expansion which is a bashism.

### DIFF
--- a/alpine/packages/docker/Makefile
+++ b/alpine/packages/docker/Makefile
@@ -9,8 +9,11 @@ bin: docker.git
 	(cd docker.git && git fetch origin --tags && git checkout moby-$(DOCKER_VERSION))
 	DOCKER_EXPERIMENTAL=$(EXPERIMENTAL) BIND_DIR=$(shell pwd) make -C docker.git binary
 	mkdir -p bin
-	cp docker.git/bundles/latest/binary-daemon/{dockerd,docker-runc} bin/
-	cp docker.git/bundles/latest/binary-daemon/{docker-containerd,docker-containerd-shim,docker-containerd-ctr} bin/
+	cp docker.git/bundles/latest/binary-daemon/dockerd bin/
+	cp docker.git/bundles/latest/binary-daemon/docker-runc bin/
+	cp docker.git/bundles/latest/binary-daemon/docker-containerd bin/
+	cp docker.git/bundles/latest/binary-daemon/docker-containerd-shim bin/
+	cp docker.git/bundles/latest/binary-daemon/docker-containerd-ctr bin/
 	cp docker.git/bundles/latest/binary-daemon/docker-proxy bin/
 	cp docker.git/bundles/latest/binary-client/docker bin/
 


### PR DESCRIPTION
Building on Debian where /bin/sh is dash:

make[1]: Leaving directory '/home/ijc/development/Docker/moby.git/alpine/packages/docker/docker.git'
mkdir -p bin
cp docker.git/bundles/latest/binary-daemon/{dockerd,docker-runc} bin/
cp: cannot stat 'docker.git/bundles/latest/binary-daemon/{dockerd,docker-runc}': No such file or directory
Makefile:9: recipe for target 'bin' failed

Pasting the construct into a file and running checkbashsisms:
possible bashism in foo line 2 (brace expansion):
cp docker.git/bundles/latest/binary-daemon/{dockerd,docker-runc} bin/

Signed-off-by: Ian Campbell ian.campbell@docker.com
