### PR TITLE
Use "mkdir -p /run/log" in docker initfile

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -55,7 +55,7 @@ start()
 	then
 		DRIVERDIR="/Mac$(cat /proc/cmdline | sed -e 's/.*com.docker.driverDir="//' -e 's/".*//')"
 		if ! grep -q "osxfs on /var/log" /proc/mounts ; then
-			mkdir /run/log
+			mkdir -p /run/log
 			mount -o bind /var/log /run/log
 			mount --bind "${DRIVERDIR}/log" /var/log
 		fi


### PR DESCRIPTION
For the "no error if existing" rather than "make parents" affect. Otherwise:

moby:~# service docker restart
- Stopping docker
- Starting Docker ...
  mkdir: can't create directory '/run/log': File exists
  [ ok ]

Signed-off-by: Ian Campbell ian.campbell@docker.com
