### PR TITLE
Prevent DNS on eth1

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -114,6 +114,9 @@ RUN \
 RUN \
   sed -i 's@/etc/init.d/syslog --quiet restart@@' /sbin/setup-disk
 
+# Prevent DNS setup on eth1 (private network) so eth0 is preferred
+RUN echo "NO_DNS=eth1" > /etc/udhcpc/udhcpc.conf
+
 COPY init /
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
When using multiple interfaces, typically eth0 is the primary interface,
and eth1 is the secondary/private interface.  On some hypervisors, they
do run DNS on isolated networks so VMs can find eachother, but they block
outbound DNS lookups.  This causes docker (e.g., pulls from hub) to break
because eth1 gets set up after eth0, and the resolv.conf winds up pointing
to the isolated DNS server not the public one on the eth0 network.
