### PR TITLE
win: ensure that the KVP daemon starts early

### DIFF
--- a/alpine/packages/hvtools/etc/init.d/hv_kvp_daemon
+++ b/alpine/packages/hvtools/etc/init.d/hv_kvp_daemon
@@ -6,6 +6,7 @@ depend()
 {
         after dev
         need networking
+        before docker proxy vsudd diagnostics
 }
 
 start()


### PR DESCRIPTION
The Windows start script polls the VM for it's IP address before
initiating things like CIFS mounts.  Getting the IP config is
done via the KVP daemon.  Starting it earlier reduce the start up
delay, in particular if the VM is part of a swarm.

Signed-off-by: Rolf Neugebauer rolf.neugebauer@docker.com

related to: https://github.com/docker/pinata/issues/4016
