### PR TITLE
Separate services into edition-specific runlevels

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -75,41 +75,79 @@ COPY packages/gummiboot/gummiboot.tar.gz /usr/share/src/
 COPY packages/oom/etc /etc
 COPY packages/9pmount-vsock/9pmount-vsock /sbin
 
-RUN \
-  rc-update add swap boot && \
-  rc-update add sysctl boot && \
-  rc-update add bootmisc boot && \
-  rc-update add urandom boot && \
-  rc-update add hostname boot && \
-  rc-update add vsudd boot && \
-  rc-update add syslog boot && \
-  rc-update add hwclock boot && \
-  rc-update add networking boot && \
-  rc-update add acpid default && \
-  rc-update add chronyd default && \
-  rc-update add savecache shutdown && \
-  rc-update add killprocs shutdown && \
-  rc-update add mount-ro shutdown && \
-  rc-update add dmesg sysinit && \
-  rc-update add devfs sysinit && \
-  rc-update add hwdrivers sysinit && \
-  rc-update add sysfs && \
-  rc-update add fsck && \
-  rc-update add root && \
-  rc-update add localmount && \
-  rc-update add docker default && \
-  rc-update add proxy default && \
-  rc-update add transfused default && \
-  rc-update add llmnrd default && \
-  rc-update add automount boot && \
-  rc-update add diagnostics default && \
-  rc-update add binfmt_misc default && \
-  rc-update add dnsfix boot && \
-  rc-update add hostsettings boot && \
-  rc-update add hv_kvp_daemon default && \
-  rc-update add hv_vss_daemon default && \
-  rc-update add oom default && \
-  true
+# Create different runlevels for various D4X platforms, each stacked on top of
+# default runlevel.
+RUN mkdir -p /etc/runlevels/windows && \
+    mkdir -p /etc/runlevels/mac && \
+    mkdir -p /etc/runlevels/localvirt && \
+    mkdir -p /etc/runlevels/azure && \
+    mkdir -p /etc/runlevels/aws
+
+# Set up shutdown, boot, sysvinit, and default services
+RUN rc-update add savecache shutdown && \
+    rc-update add killprocs shutdown && \
+    rc-update add mount-ro shutdown && \
+    rc-update add swap boot && \
+    rc-update add sysctl boot && \
+    rc-update add bootmisc boot && \
+    rc-update add urandom boot && \
+    rc-update add hostname boot && \
+    rc-update add syslog boot && \
+    rc-update add hwclock boot && \
+    rc-update add networking boot && \
+    rc-update add automount boot && \
+    rc-update add dnsfix boot && \
+    rc-update add hostsettings boot && \
+    rc-update add sysfs && \
+    rc-update add fsck && \
+    rc-update add root && \
+    rc-update add localmount && \
+    rc-update add dmesg sysinit && \
+    rc-update add devfs sysinit && \
+    rc-update add hwdrivers sysinit
+
+# Common ('default') services
+RUN rc-update add docker default && \
+    rc-update add diagnostics default && \
+    rc-update add acpid default && \
+    rc-update add oom default && \
+    rc-update add chronyd default
+
+# Services only for local virtualization editions
+RUN rc-update add proxy localvirt && \
+    rc-update add transfused localvirt && \
+    rc-update add binfmt_misc localvirt && \
+    rc-update add vsudd localvirt
+
+# Define runlevel inheritance.  A runlevel to boot into can be defined using
+# bootflag 'softlevel'.
+# e.g.:
+#
+# default
+# |-- aws
+# |-- azure
+# `-- localvirt
+#     |-- mac
+#     `-- windows
+RUN rc-update --stack add default localvirt && \
+    rc-update --stack add localvirt windows && \
+    rc-update --stack add localvirt mac && \
+    rc-update --stack add default aws && \
+    rc-update --stack add default azure
+
+# Services only for Docker for Mac
+# TODO?
+
+# Services only for Docker for Windows
+RUN rc-update add hv_kvp_daemon windows && \
+    rc-update add llmnrd windows && \
+    rc-update add hv_vss_daemon windows
+
+# Services only for Docker for Azure
+# RUN TODO
+
+# Services only for Docker for AWS
+# RUN TODO
 
 # we do not need to restart syslog, as probably not running
 RUN \


### PR DESCRIPTION
cc @justincormack @kencochrane @mavenugo 

**tl;dr** With this change Moby will not run cloud-specific services in Pinata or vice versa.

This change begins the update of Moby to support different "runlevels" to ensure that services intended to be started per-platform do not run on the others.  It uses stacked runlevel configuration (https://wiki.gentoo.org/wiki/OpenRC#Stacked_runlevels) to provide service inheritance (as shown below, each provider-specific service inherits from the `default` service).

Thanks to @rneugeba for this document which was quite helpful here: https://docs.google.com/spreadsheets/d/1wMqg2LmWuK27rNrYiZDjV04st1C-0dacYIfDrEdCe1Q/edit#gid=0

It's not the end of resolving this issue, but it should a good start.  This would allow me to remove the nasty `bootflag` hack.

**IMPORTANT**: It will require that each edition sets a `softlevel=foo` (where `foo` is the provider runlevel) flag in boot but then the rest of decisions about whether to run the code in each level are handled by OpenRC automatically.  I am happy to add this if desired but haven't gotten around to it yet.

Rolph does have some good points that we still need to account for services that _do_ need to be started on multiple platforms, just with different parameters (e.g. `docker`).  My idea for this use case is that we could maybe use [`conf.d`](https://github.com/OpenRC/openrc/blob/master/guide.md#the-magic-of-confd), or just check `RC_RUNLEVEL` (http://manpages.ubuntu.com/manpages/wily/man8/openrc-run.8.html) in the shared scripts we have?  Hopefully we can probably figure something out once we know the various use cases.

BTW Rolph, having runlevels should not prevent you from doing `before networking` in a service, no? All services should have access to `networking` (it's a "virtual service" I think?).  And runlevels if I understand correct do not affect service ordering.  They simply decide the "big bag" of all possible services that OpenRC grabs from to build and execute the dependency graph.

Check it out, Pinata specific services don't get run unless needed:

``` console
moby:~# rc-update
                acpid |                default
            automount |           boot
          binfmt_misc |                        localvirt
             bootmisc |           boot
              chronyd |                default
                devfs |                                                         sysinit
          diagnostics |                default
                dmesg |                                                         sysinit
               dnsfix |           boot
               docker |                default
                 fsck |                                                         sysinit
             hostname |           boot
         hostsettings |           boot
        hv_kvp_daemon |                                                                 windows
        hv_vss_daemon |                                                                 windows
              hwclock |           boot
            hwdrivers |                                                         sysinit
            killprocs |                                                shutdown
               llmnrd |                                                                 windows
           localmount |                                                         sysinit
             mount-ro |                                                shutdown
           networking |           boot
                  oom |                default
                proxy |                        localvirt
                 root |                                                         sysinit
            savecache |                                                shutdown
                 swap |           boot
               sysctl |           boot
                sysfs |                                                         sysinit
               syslog |           boot
           transfused |                        localvirt
              urandom |           boot
                vsudd |                        localvirt
moby:~# rc-status
Runlevel: default
 docker
 [  started  ]
 oom
 [  started  ]
 acpid
 [  started  ]
 diagnostics
 [  started  ]
 chronyd
 [  started  ]
Dynamic Runlevel: hotplugged
Dynamic Runlevel: needed/wanted
 mdev
 [  started  ]
 klogd
 [  started  ]
Dynamic Runlevel: manual
```

Signed-off-by: Nathan LeClaire nathan.leclaire@gmail.com
