### PR TITLE
Update docker to rc of rc3

### DIFF
--- a/alpine/packages/docker/Makefile
+++ b/alpine/packages/docker/Makefile
@@ -1,4 +1,4 @@
-DOCKER_VERSION=1.12.0-rc2
+DOCKER_VERSION=1.12-rc3-rc
 ARCH?=x86_64
 OS?=Linux
 EXPERIMENTAL?=1
@@ -18,7 +18,7 @@ bin: docker.git
 	cp docker.git/bundles/latest/binary-client/docker bin/
 
 docker.git:
-	git clone git://github.com/justincormack/docker.git docker.git
+	git clone git://github.com/djs55/docker.git docker.git
 
 arm:
 	mkdir -p bin


### PR DESCRIPTION
4949c95ba31f34f9883480261873208f21d5b29e at https://github.com/tiborvass/docker/commits/bump_v1.12.0

Signed-off-by: David Scott dave.scott@docker.com
