### PR TITLE
docker init: remove fixed host export mounts

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -42,13 +42,6 @@ start()
 		export no_proxy="$(mobyconfig get proxy/exclude)"
 	fi
 
-	grep -q "osxfs /tmp" /proc/mounts || ( [ -d /Mac/tmp ] && mount --bind /Mac/tmp /tmp )
-
-	for d in Users Volumes private
-	do
-		[ -d /Mac/$d ] && [ ! -d $d ] && mkdir -p /$d && mount --bind /Mac/$d /$d
-	done
-
 	# shift logs onto host before docker starts
 	# busybox reopens its log files every second
 	if cat /proc/cmdline | grep -q 'com.docker.driverDir'


### PR DESCRIPTION
`transfused` does not complete its startup until the `osxfs` server sends it a completion notification after all of the user's exports are mounted. This mechanism replaces the fixed set of bind mounts configured in `/etc/init.d/docker`.
