### PR TITLE
docker init: remove fixed host export mounts

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -42,13 +42,6 @@ start()
 		export no_proxy="$(mobyconfig get proxy/exclude)"
 	fi
 
-	grep -q "osxfs /tmp" /proc/mounts || ( [ -d /Mac/tmp ] && mount --bind /Mac/tmp /tmp )
-
-	for d in Users Volumes private
-	do
-		[ -d /Mac/$d ] && [ ! -d $d ] && mkdir -p /$d && mount --bind /Mac/$d /$d
-	done
-
 	# shift logs onto host before docker starts
 	# busybox reopens its log files every second
 	if cat /proc/cmdline | grep -q 'com.docker.driverDir'


### PR DESCRIPTION
On the advice of @djs55, #239 should also be applied to `master`.
