### PR TITLE
Populate /lib/modules/`uname -r`

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -34,6 +34,7 @@ ADD kernel/aufs-utils.tar /
 COPY mkinitrd.sh /bin/
 COPY kernel/kernel-source-info /etc/
 ADD kernel/kernel-patches.tar /etc/kernel-patches
+ADD kernel/kernel-modules.tar /
 
 COPY packages/proxy/slirp-proxy /usr/bin/
 COPY packages/proxy/slirp-proxy /sbin/proxy-vsockd

--- a/alpine/kernel/.gitignore
+++ b/alpine/kernel/.gitignore
@@ -2,4 +2,5 @@ vmlinuz64
 zImage
 aufs-utils.tar
 kernel-patches.tar
+kernel-modules.tar
 kernel-source-info

--- a/alpine/kernel/Dockerfile
+++ b/alpine/kernel/Dockerfile
@@ -74,6 +74,8 @@ RUN jobs=$(nproc); \
     make ARCH=$ARCH defconfig && \
     make ARCH=$ARCH oldconfig && \
     make ARCH=$ARCH -j ${jobs} && \
+    make ARCH=$ARCH INSTALL_MOD_PATH=/tmp/kernel-modules modules_install && \
+    ( cd /tmp/kernel-modules && tar cf /kernel-modules.tar . ) && \
     make ARCH=$ARCH INSTALL_HDR_PATH=/tmp/kernel-headers headers_install
 
 # Build aufs tools, do this here as they need kernel headers and to match aufs

--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -6,6 +6,7 @@ vmlinuz64: kernel_config Dockerfile
 	docker run --rm mobykernel:build cat /aufs-utils.tar > aufs-utils.tar
 	docker run --rm mobykernel:build cat /kernel-source-info > kernel-source-info
 	docker run --rm mobykernel:build cat /kernel-patches.tar > kernel-patches.tar
+	docker run --rm mobykernel:build cat /kernel-modules.tar > kernel-modules.tar
 
 arm: zImage
 
@@ -15,6 +16,7 @@ zImage: kernel_config.arm Dockerfile
 	docker run --rm mobyarmkernel:build cat /aufs-utils.tar > aufs-utils.tar
 	docker run --rm mobyarmkernel:build cat /kernel-source-info > kernel-source-info
 	docker run --rm mobyarmkernel:build cat /kernel-patches.tar > kernel-patches.tar
+	docker run --rm mobyarmkernel:build cat /kernel-modules.tar > kernel-modules.tar
 
 clean:
 	rm -f zImage vmlinuz64 aufs-utils.tar kernel-source-info kernel-patches.tar


### PR DESCRIPTION
This is less to do with installing modules (which we generally don't expect to
use in Moby) but to populate /lib/modules/`uname -r`/modules.builtin which
turns:

```
moby:~# modprobe ip_vs
modprobe: FATAL: Module ip_vs not found in directory /lib/modules/4.4.14-moby
moby:~# modprobe nf_nat
modprobe: FATAL: Module nf_nat not found in directory /lib/modules/4.4.14-moby
moby:~#
```

into:

```
moby:~# modprobe ip_vs
moby:~# modprobe nf_nat
moby:~#
```

which reduces the amount noise in the logs, e.g. in docker.log:

time="2016-07-04T11:21:58Z" level=warning msg="Running modprobe nf_nat failed with message: `modprobe: WARNING: Module nf_nat not found in directory /lib/modules/4.4.14-moby`, error: exit status 1"

A fair number of these appear in the logs.

This also stops various tools logging about /lib/modules/`uname -r` not
existing (there was one in the boot log until recently I think)

Signed-off-by: Ian Campbell ian.campbell@docker.com
