### PR TITLE
proxy-vsockd: bump the max number of file descriptors

### DIFF
--- a/alpine/packages/proxy/etc/init.d/proxy
+++ b/alpine/packages/proxy/etc/init.d/proxy
@@ -19,6 +19,7 @@ start()
 	[ -n "${PIDFILE}" ] || PIDFILE=/var/run/proxy-vsockd.pid
 	[ -n "${LOGFILE}" ] || LOGFILE=/var/log/proxy-vsockd.log
 
+	ulimit -n 1048576
 	start-stop-daemon --start --quiet \
 		--background \
 		--exec /sbin/proxy-vsockd \


### PR DESCRIPTION
Signed-off-by: David Scott dave.scott@docker.com
