### PR TITLE
transfused: distinguish export requests from mount requests (Pinata GA cherry-pick)

### DIFF
--- a/alpine/packages/transfused/transfused.h
+++ b/alpine/packages/transfused/transfused.h
@@ -51,6 +51,7 @@ void write_exactly(char * descr, int fd, void * buf, size_t nbyte);
 // these could be turned into an enum probably but... C standard nausea
 
 #define MOUNT_SUITABILITY_REQUEST 1
+#define EXPORT_SUITABILITY_REQUEST 2
 
 #define TRANSFUSE_LOG_ERROR 1
 #define TRANSFUSE_LOG_NOTICE 2


### PR DESCRIPTION
We distinguish export suitability requests from bind mount suitability
requests in the transfuse control protocol. This distinction allows us to
permit both bind mounts of empty directories and export mounts onto empty
directories. Addresses docker/pinata#4213.

Cherry-pick of #251.
