### PR TITLE
Remove /Mac in docker init and transfused init

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -44,9 +44,9 @@ start()
 
 	# shift logs onto host before docker starts
 	# busybox reopens its log files every second
-	if cat /proc/cmdline | grep -q 'com.docker.driverDir'
+	if cat /proc/cmdline | grep -q 'com.docker.driver'
 	then
-		DRIVERDIR="/Mac$(cat /proc/cmdline | sed -e 's/.*com.docker.driverDir="//' -e 's/".*//')"
+		DRIVERDIR="/host_docker_app/$(cat /proc/cmdline | sed -e 's/.*com.docker.driver="//' -e 's/".*//')"
 		if ! grep -q "osxfs on /var/log" /proc/mounts ; then
 			mkdir -p /run/log
 			mount -o bind /var/log /run/log

--- a/alpine/packages/transfused/etc/init.d/transfused
+++ b/alpine/packages/transfused/etc/init.d/transfused
@@ -6,7 +6,7 @@ start()
 {
 	ebegin "Starting FUSE socket passthrough"
 
-	mkdir -p /Mac
+	mkdir -p /host_docker_app
 	find /tmp -mindepth 1 -delete
 
 	PIDFILE=/var/run/transfused.pid


### PR DESCRIPTION
Replace `/Mac` with `/host_docker_app` and replace `driverDir` with just `driver`.

This is the Moby side of docker/pinata#4219.

`pinata-ga` received this patch in #259.
