### PR TITLE
sysctl: set a large fs.inotify.max_user_watches limit

### DIFF
--- a/alpine/packages/sysctl/etc/sysctl.d/01-moby.conf
+++ b/alpine/packages/sysctl/etc/sysctl.d/01-moby.conf
@@ -1,2 +1,3 @@
 vm.max_map_count = 262144
 net.core.somaxconn = 1024
+fs.inotify.max_user_watches = 524288


### PR DESCRIPTION
Needed by Ruby `guard` and Dropbox.

See https://forums.docker.com/t/running-guard-with-docker-compose-fails-due-to-inotify-limit/17096.
