### PR TITLE
transfused: add mknod reg file event actuation message

### DIFF
--- a/alpine/packages/transfused/transfused.c
+++ b/alpine/packages/transfused/transfused.c
@@ -624,6 +624,11 @@ void perform_syscall(connection_t * conn, uint8_t syscall, char path[]) {
     r = symlink(".",path);
     break;
 
+  case MKNOD_REG_SYSCALL:
+    name = "mknod";
+    r = mknod(path, 0600, 0);
+    break;
+
   case TRUNCATE_SYSCALL:
     name = "truncate";
     r = truncate(path, 0);

--- a/alpine/packages/transfused/transfused.h
+++ b/alpine/packages/transfused/transfused.h
@@ -48,6 +48,7 @@ void write_exactly(char * descr, int fd, void * buf, size_t nbyte);
 #define SYMLINK_SYSCALL  3
 #define TRUNCATE_SYSCALL 4
 #define CHMOD_SYSCALL    5
+#define MKNOD_REG_SYSCALL 6
 // these could be turned into an enum probably but... C standard nausea
 
 #define MOUNT_SUITABILITY_REQUEST 1


### PR DESCRIPTION
This is the required client side change to resolve docker/pinata#3876 which occurs due to the Linux VFS node table retaining file kind information about inodes. Previously, we would actuate file creation from osxfs with a `symlink` call which would create the node but with the wrong type. If the next action on that node had a kind dependence, this would cause Linux to become confused and (understandably) fail. This event type now allows us to create regular files without taking a file handle.
