### PR TITLE
improve kernel build makefile

### DIFF
--- a/alpine/kernel/.gitignore
+++ b/alpine/kernel/.gitignore
@@ -4,3 +4,5 @@ aufs-utils.tar
 kernel-patches.tar
 kernel-modules.tar
 kernel-source-info
+mobykernel-build
+mobyarmkernel-build

--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -1,24 +1,25 @@
 all:	vmlinuz64
 
-vmlinuz64: kernel_config Dockerfile
+mobykernel-build: Dockerfile kernel_config
 	docker build -t mobykernel:build .
-	docker run --rm mobykernel:build cat /linux/arch/x86_64/boot/bzImage > $@
-	docker run --rm mobykernel:build cat /aufs-utils.tar > aufs-utils.tar
-	docker run --rm mobykernel:build cat /kernel-source-info > kernel-source-info
-	docker run --rm mobykernel:build cat /kernel-patches.tar > kernel-patches.tar
-	docker run --rm mobykernel:build cat /kernel-modules.tar > kernel-modules.tar
+	touch $@
+
+mobyarmkernel-build: Dockerfile kernel_config.arm
+	docker build --build-arg ARCH=arm -t mobyarmkernel:build .
+	touch $@
+
+aufs-utils.tar kernel-source-info kernel-patches.tar kernel-modules.tar: mobykernel-build
+	docker run --rm mobykernel:build cat /$@ > $@ || ! rm $@
+
+vmlinuz64: aufs-utils.tar kernel-source-info kernel-patches.tar kernel-modules.tar mobykernel-build
+	docker run --rm mobykernel:build cat /linux/arch/x86_64/boot/bzImage > $@ || ! rm $@
 
 arm: zImage
 
-zImage: kernel_config.arm Dockerfile
-	docker build --build-arg ARCH=arm -t mobyarmkernel:build .
+zImage: mobyarmkernel-build aufs-utils.tar kernel-source-info kernel-patches.tar kernel-modules.tar
 	docker run --rm mobyarmkernel:build cat /linux/arch/arm/boot/zImage > $@
-	docker run --rm mobyarmkernel:build cat /aufs-utils.tar > aufs-utils.tar
-	docker run --rm mobyarmkernel:build cat /kernel-source-info > kernel-source-info
-	docker run --rm mobyarmkernel:build cat /kernel-patches.tar > kernel-patches.tar
-	docker run --rm mobyarmkernel:build cat /kernel-modules.tar > kernel-modules.tar
 
 clean:
-	rm -f zImage vmlinuz64 aufs-utils.tar kernel-source-info kernel-patches.tar
+	rm -f zImage vmlinuz64 aufs-utils.tar kernel-source-info kernel-patches.tar mobykernel-build mobyarmkernel-build
 	docker images -q mobykernel:build | xargs docker rmi -f || true
 	docker images -q mobyarmkernel:build | xargs docker rmi -f || true


### PR DESCRIPTION
- create an empty dummy file to indicate that docker image is built
- reuse same make rule to extract the different files from docker image
- make sure that we remove empty files on failure

This makes build more robust and improves parallelism.

Signed-off-by: Natanael Copa natanael.copa@docker.com
