### PR TITLE
Add a system containerd

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -76,6 +76,7 @@ COPY packages/test/etc /etc
 COPY packages/test/mobytest /usr/bin
 COPY packages/sysctl/etc /etc
 COPY packages/iptables/iptables /usr/local/sbin/iptables
+COPY packages/containerd/etc /etc/
 
 RUN \
   rc-update add swap boot && \
@@ -112,10 +113,17 @@ RUN \
   rc-update add hv_vss_daemon default && \
   rc-update add oom default && \
   rc-update add test default && \
+  rc-update add containerd default && \
   true
 
 COPY init /
 
 RUN adduser -D -H -s /sbin/nologin dockremap
+
+RUN cd /usr/bin && \
+  ln -s docker-runc runc && \
+  ln -s docker-containerd-shim containerd-shim && \
+  ln -s docker-containerd-ctr containerd-ctr && \
+  ln -s docker-containerd containerd
 
 CMD ["/bin/sh"]

--- a/alpine/packages/containerd/etc/init.d/containerd
+++ b/alpine/packages/containerd/etc/init.d/containerd
@@ -1,0 +1,17 @@
+#!/sbin/openrc-run
+
+depend()
+{
+	after docker
+}
+
+start()
+{
+	ebegin "Running system containerd"
+
+	# set ulimits as high as possible
+	ulimit -n 1048576
+	ulimit -p unlimited
+
+	/usr/bin/containerd &
+}

--- a/alpine/packages/diagnostics/diagnostics
+++ b/alpine/packages/diagnostics/diagnostics
@@ -28,5 +28,9 @@ DOCKERPS=$(docker ps 2>&1)
 [ $? -eq 0 ] && printf "✓ Docker daemon working\n" || printf "✗ Docker ps failed: $DOCKERPS\n"
 DIAGNOSTICS=$(ps -eo args | grep '/usr/bin/diagnostics-server$')
 [ $? -eq 0 ] && printf "✓ Diagnostics server running: $DIAGNOSTICS\n" || printf "✗ No diagnostics server\n"
+CONTAINERD=$(ps -eo args | grep '/usr/bin/containerd$')
+[ $? -eq 0 ] && printf "✓ System containerd server running: $DIAGNOSTICS\n" || printf "✗ No containerd server\n"
+CONTAINERPS=$(containerd-ctr containers 2>&1)
+[ $? -eq 0 ] && printf "✓ System containerd working\n" || printf "✗ containerd failed: $CONTAINERPS\n"
 
 exit 0

--- a/alpine/packages/diagnostics/etc/init.d/diagnostics
+++ b/alpine/packages/diagnostics/etc/init.d/diagnostics
@@ -2,7 +2,7 @@
 
 depend()
 {
-	after docker
+	after docker containerd
 }
 
 start()


### PR DESCRIPTION
This adds an independent system containerd for running internal
containers.

Signed-off-by: Justin Cormack justin.cormack@docker.com
