### PR TITLE
Wait for docker to finish starting up before terminateing init script

### DIFF
--- a/alpine/packages/diagnostics/diagnostics
+++ b/alpine/packages/diagnostics/diagnostics
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# now start very soon after docker, let containerd start
-sleep 1
-
 printf '\n'
 DEV=$(ls /dev | grep '[sxv]da$')
 [ $? -eq 0 ] && printf "✓ Drive found: $DEV\n" || printf "✗ No drive found\n"

--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -75,6 +75,8 @@ start()
 		--stdout "${DOCKER_LOGFILE}" \
 		-- --pidfile=${pidfile} ${DOCKER_OPTS}
 
+	ewaitfile 20 ${pidfile} /var/run/docker.sock /var/run/docker/libcontainerd/docker-containerd.sock
+
 	eend $? "Failed to start docker"
 }
 


### PR DESCRIPTION
This means dependent services can rely on docker being up.

Signed-off-by: Justin Cormack justin.cormack@docker.com
