### PR TITLE
Use upstream /etc/securetty

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -1,7 +1,7 @@
 all:	initrd.img.gz mobylinux-efi.iso
 
 ETCFILES=etc/issue etc/motd etc/network/interfaces
-ETCFILES+=etc/securetty etc/inittab
+ETCFILES+=etc/inittab
 
 initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	rm -f initrd.img

--- a/alpine/etc/securetty
+++ b/alpine/etc/securetty
@@ -1,4 +1,0 @@
-console
-ttyS0
-ttyAMA0
-tty1


### PR DESCRIPTION
Now we modify the file if we use a different console, can use
upstream unmodified.

Signed-off-by: Justin Cormack justin.cormack@docker.com
