### PR TITLE
Fix up chronyd support for editions

### DIFF
--- a/alpine/packages/chronyd/etc/init.d/chronyd
+++ b/alpine/packages/chronyd/etc/init.d/chronyd
@@ -46,7 +46,11 @@ setxtrarg() {
 }
 
 start() {
-	[ -d /sys/bus/vmbus ] && exit 0
+	[ "$(mobyplatform)" = "windows" ] && exit 0
+
+	[ "$(mobyplatform)" = "aws" ] && \
+		sed -i -e "s/^server [^ ]\+/server 0.amazon.pool.ntp.org/g" /etc/chrony/chrony.conf
+
 	checkconfig || return $?
 	setxtrarg
 
@@ -61,7 +65,8 @@ start() {
 }
 
 stop() {
-	[ -d /sys/bus/vmbus ] && exit 0
+	[ "$(mobyplatform)" = "windows" ] && exit 0
+
 	checkconfig || return $?
 
 	[ -n "${PIDFILE}" ] || PIDFILE=/var/run/chronyd.pid


### PR DESCRIPTION
See #305 #301

This sets AWS to use the amazon ntp pool, windows to do nothing,
mac uses ntp it gets from DNS. Azure currently uses default pool,
this probably needs fixing.

Signed-off-by: Justin Cormack justin.cormack@docker.com
