### PR TITLE
Use mobyplatform not vmbus for tap-vsock

### DIFF
--- a/alpine/packages/diagnostics/diagnostics
+++ b/alpine/packages/diagnostics/diagnostics
@@ -12,7 +12,7 @@ then
 	FUSE=$(ps -eo args | grep '^/sbin/transfused')
 	[ $? -eq 0 ] && printf "✓ Process transfused running\n" || printf "✗ No transfused process\n"
 fi
-if [ -d /sys/bus/vmbus ]
+if [ [ "$(mobyplatform)" = "windows" ]  ]
 then
 	TAPVS=$(ps -eo args | grep '^/sbin/tap-vsockd')
 	[ $? -eq 0 ] && printf "✓ Process tap-vsockd running\n" || printf "✗ No tap-vsockd process\n"

--- a/alpine/packages/tap-vsockd/etc/init.d/tap-vsockd
+++ b/alpine/packages/tap-vsockd/etc/init.d/tap-vsockd
@@ -9,37 +9,30 @@ depend()
 
 start()
 {
-	if [ ! -d /sys/bus/vmbus ]; then
-		# skip if not on Hyper-V
-		exit 0
-	fi
-        if mobyconfig exists network
-        then
-                NETWORK_MODE="$(mobyconfig get network | tr -d '[[:space:]]')"
-                if [ "${NETWORK_MODE}" = "hybrid" ]; then
+	[ "$(mobyplatform)" != "windows" ] && exit 0
 
-			ebegin "Starting VPN proxy"
+	mobyconfig exists network || exit 0
+	NETWORK_MODE="$(mobyconfig get network | tr -d '[[:space:]]')"
+	[ "${NETWORK_MODE}" = "hybrid" ] || exit 0
 
-			PIDFILE=/var/run/tap-vsockd.pid
-			start-stop-daemon --start \
-				--exec /sbin/tap-vsockd \
-				--background \
-				--pidfile ${PIDFILE} \
-				-- \
-				--pidfile "${PIDFILE}" \
-				--listen
+	ebegin "Starting VPN proxy"
 
-			eend $? "Failed to start VPN proxy"
-		fi
-	fi
+	PIDFILE=/var/run/tap-vsockd.pid
+	start-stop-daemon --start \
+		--exec /sbin/tap-vsockd \
+		--background \
+		--pidfile ${PIDFILE} \
+		-- \
+		--pidfile "${PIDFILE}" \
+		--listen
+
+	eend $? "Failed to start VPN proxy"
 }
 
 stop()
 {
-	if [ ! -d /sys/bus/vmbus ]; then
-		# skip if not on Hyper-V
-		exit 0
-	fi
+	[ "$(mobyplatform)" != "windows" ] && exit 0
+
 	ebegin "Stopping VPN proxy"
 
 	PIDFILE=/var/run/tap-vsockd.pid


### PR DESCRIPTION
Plus cleanup for less indentation. No functional change.

Signed-off-by: Justin Cormack justin.cormack@docker.com
