### PR TITLE
Use platform to decide whether to run hv tools

### DIFF
--- a/alpine/packages/hvtools/etc/init.d/hv_kvp_daemon
+++ b/alpine/packages/hvtools/etc/init.d/hv_kvp_daemon
@@ -11,7 +11,7 @@ depend()
 
 start()
 {
-        [ ! -d /sys/bus/vmbus ] && exit 0
+        [ "$(mobyplatform)" != "windows" ] && exit 0
 
         ebegin "Starting Hyper-V Daemon: ${HV_DAEMON}"
 
@@ -30,7 +30,7 @@ start()
 
 stop()
 {
-        [ ! -d /sys/bus/vmbus ] && exit 0
+        [ "$(mobyplatform)" != "windows" ] && exit 0
 
         ebegin "Stopping Hyper-V Daemon: ${HV_DAEMON}"
 

--- a/alpine/packages/hvtools/etc/init.d/hv_vss_daemon
+++ b/alpine/packages/hvtools/etc/init.d/hv_vss_daemon
@@ -9,7 +9,7 @@ depend()
 
 start()
 {
-        [ ! -d /sys/bus/vmbus ] && exit 0
+        [ "$(mobyplatform)" != "windows" ] && exit 0
 
         ebegin "Starting Hyper-V Daemon: ${HV_DAEMON}"
 
@@ -25,7 +25,7 @@ start()
 
 stop()
 {
-        [ ! -d /sys/bus/vmbus ] && exit 0
+        [ "$(mobyplatform)" != "windows" ] && exit 0
 
         ebegin "Stopping Hyper-V Daemon: ${HV_DAEMON}"
 


### PR DESCRIPTION
Signed-off-by: Justin Cormack justin.cormack@docker.com

@nathanleclaire can you confirm you do not want this running for Azure, I assume it is running over vmbus and Azure does not use this, but currently it would be running/trying to run if you did not disable it...

cc @rneugeba 
