### PR TITLE
finish removal of llmnrd from #311

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -32,7 +32,6 @@ Dockerfile.armhf: Dockerfile
 	  sed '/hvtools/d' | \
 	  sed 's/syslinux//' | \
 	  sed '/proxy/d' | \
-	  sed '/llmnrd/d' | \
 	  sed '/diagnostics/d' | \
 	  sed '/nc-vsock/d' | \
 	  sed '/vsudd/d' | \

--- a/alpine/packages/Makefile
+++ b/alpine/packages/Makefile
@@ -7,7 +7,6 @@ all:
 	$(MAKE) -C docker OS=Linux
 	$(MAKE) -C nc-vsock OS=linux
 	$(MAKE) -C vsudd OS=linux
-	$(MAKE) -C llmnrd OS=linux
 	$(MAKE) -C gummiboot OS=linux
 	$(MAKE) -C 9pmount-vsock OS=linux
 	$(MAKE) -C iptables OS=linux
@@ -31,7 +30,6 @@ clean:
 	$(MAKE) -C hvtools clean
 	$(MAKE) -C nc-vsock clean
 	$(MAKE) -C vsudd clean
-	$(MAKE) -C llmnrd clean
 	$(MAKE) -C gummiboot clean
 	$(MAKE) -C 9pmount-vsock clean
 	$(MAKE) -C iptables clean


### PR DESCRIPTION
`initrd` doesn't build without this.
