### PR TITLE
Clean up sources that arm edition will not need

### DIFF
--- a/alpine/packages/Makefile
+++ b/alpine/packages/Makefile
@@ -12,14 +12,9 @@ all:
 	$(MAKE) -C iptables OS=linux
 
 arm:
-	$(MAKE) -C transfused OS=linux ARCH=arm
 	$(MAKE) -C docker arm OS=Linux ARCH=arm
 	# Not cross building at present (C code)
-	# $(MAKE) -C tap-vsockd OS=linux ARCH=arm
 	# $(MAKE) -C diagnostics OS=linux ARCH=arm
-	# $(MAKE) -C proxy OS=linux ARCH=arm
-	# $(MAKE) -C nc-vsock OS=linux ARCH=arm
-	# $(MAKE) -C vsudd OS=linux ARCH=arm
 
 clean:
 	$(MAKE) -C proxy clean


### PR DESCRIPTION
As arm will not be a desktop edition, we will not need to
try to fix these. We do need `diagnostics` though, the
vsock code however is not cross building, needs to be fixed
or made conditional.

Signed-off-by: Justin Cormack justin.cormack@docker.com
