### PR TITLE
default to unknown platform if not specified in command line

### DIFF
--- a/alpine/packages/mobyplatform/mobyplatform
+++ b/alpine/packages/mobyplatform/mobyplatform
@@ -16,4 +16,6 @@ awk -v flag=$1 '{
 }' /proc/cmdline
 }
 
-kvpair mobyplatform
+PLATFORM=$(kvpair mobyplatform)
+
+[ -z ${PLATFORM} ] && printf unknown || printf ${PLATFORM}


### PR DESCRIPTION
Signed-off-by: Justin Cormack justin.cormack@docker.com
