### PR TITLE
use correct tty for bios, fixes lack of login on VMWare Fusion

### DIFF
--- a/alpine/isolinux.cfg
+++ b/alpine/isolinux.cfg
@@ -2,4 +2,4 @@ DEFAULT linux
 LABEL linux
     KERNEL /vmlinuz64
     INITRD /initrd.img
-    APPEND earlyprintk=serial console=ttyS0 console=tty0
+    APPEND earlyprintk=serial console=ttyS0 console=tty1


### PR DESCRIPTION
Signed-off-by: Justin Cormack justin.cormack@docker.com
