### PR TITLE
Support make flags for Docker version and experimental

### DIFF
--- a/alpine/packages/docker/Makefile
+++ b/alpine/packages/docker/Makefile
@@ -1,12 +1,12 @@
-DOCKER_VERSION=1.12.0-rc4
+DOCKER_VERSION?=1.12.0-rc4
 ARCH?=x86_64
 OS?=Linux
-EXPERIMENTAL?=1
+DOCKER_EXPERIMENTAL?=1
 
 all: bin
 
-#DOCKER_HOST=$(shell if echo "$(DOCKER_VERSION)" | grep -q -- '-rc'; then echo "test.docker.com"; else echo "get.docker.com"; fi)
-DOCKER_HOST=experimental.docker.com
+TEST_HOST=$(shell if echo "$(DOCKER_VERSION)" | grep -q -- '-rc'; then echo "test.docker.com"; else echo "get.docker.com"; fi)
+DOCKER_HOST=$(shell [ "${DOCKER_EXPERIMENTAL}" -eq 1 ] && printf "experimental.docker.com" || printf "${TEST_HOST}")
 
 bin:
 	mkdir -p bin


### PR DESCRIPTION
Use `make DOCKER_VERSION=xxx` to override version. Note that
as install process and packaging may vary this may not work.

Use `make DOCKER_EXPERIMENTAL=0` to build from either release
binaries, if version is a final release or test binaries for
release candidates.

Building experimental is still the default.

Signed-off-by: Justin Cormack justin.cormack@docker.com
