### PR TITLE
Cleanup script moby

### DIFF
--- a/scripts/moby.sh
+++ b/scripts/moby.sh
@@ -4,13 +4,20 @@ set -e
 
 mobydir=/Applications/Docker.app/Contents/Resources/moby
 
+backup_once() {
+	if ! [ -e "$1"- ]
+	then
+		cp "$1" "$1"-
+	fi
+}
+
 if [ "$1" = "undo" ]
 then
 	cp "$mobydir"/initrd.img- "$mobydir"/initrd.img
 	cp "$mobydir"/vmlinuz64- "$mobydir"/vmlinuz64
 else
-	cp "$mobydir"/initrd.img "$mobydir"/initrd.img-
-	cp "$mobydir"/vmlinuz64 "$mobydir"/vmlinuz64-
+	backup_once "$mobydir"/initrd.img
+	backup_once "$mobydir"/vmlinuz64
 	cp alpine/initrd.img "$mobydir"/initrd.img
 	cp alpine/kernel/x86_64/vmlinuz64 "$mobydir"/vmlinuz64
 fi


### PR DESCRIPTION
minor cleanups of `scripts/moby.sh`

First patch is only to improve readability.

Second will change the behavior so that it will only create a backup of `vmlinuz64` and `initrd` if they don't already exist. The idea behind this is that we save the version we get from the docker update instead of the last version we tried. This lets us keep the "safe" version as backup instead of the last successfully built.
