### PR TITLE
Remove unneeded console=/dev/hvc0

### DIFF
--- a/alpine/cloud/aws/syslinux.cfg
+++ b/alpine/cloud/aws/syslinux.cfg
@@ -4,4 +4,4 @@ PROMPT 0
 LABEL linux
     KERNEL /vmlinuz64
     INITRD /initrd.img
-    APPEND root=/dev/xvdb1 console=hvc0 console=tty0 console=tty1 console=ttyS0 mobyplatform=aws
+    APPEND root=/dev/xvdb1 console=tty0 console=tty1 console=ttyS0 mobyplatform=aws


### PR DESCRIPTION
@justincormack 

Logs complain about not being able to find this device in AWS so it seems not needed.  `/dev/ttyS0` is the main magic device I think.

Signed-off-by: Nathan LeClaire nathan.leclaire@gmail.com
