### PR TITLE
Allow longer for Docker to shut down

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -94,7 +94,7 @@ stop()
 	# stop docker
 	einfo "Stopping docker"
 	pidfile="/run/docker.pid"
-	start-stop-daemon --stop --quiet --pidfile ${pidfile}
+	start-stop-daemon --stop --quiet --pidfile ${pidfile} --retry 15
 
 	# taken from localmount stop script
 	# XXX fix more cleanly see #35


### PR DESCRIPTION
Docker needs 10s at least for containers to be allowed to shut down,
so allow 15s maximum between SIGTERM and SIGKILL.

Signed-off-by: Justin Cormack justin.cormack@docker.com
