### PR TITLE
[WIP] Add ability for diagnostics to upload to S3 bucket

### DIFF
--- a/alpine/packages/diagnostics/http.go
+++ b/alpine/packages/diagnostics/http.go
@@ -2,16 +2,24 @@ package main
 
 import (
 	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
+	"time"
 )
 
 const (
-	dockerSock    = "/var/run/docker.sock"
-	lgtm          = "LGTM"
-	httpMagicPort = ":44554" // chosen arbitrarily due to IANA availability -- might change
+	dockerSock     = "/var/run/docker.sock"
+	lgtm           = "LGTM"
+	httpMagicPort  = ":44554" // chosen arbitrarily due to IANA availability -- might change
+	bucket         = "editionsdiagnostics"
+	sessionIDField = "session"
 )
 
 var (
@@ -41,24 +49,103 @@ func (h HTTPDiagnosticListener) Listen() {
 	})
 
 	http.HandleFunc("/diagnose", func(w http.ResponseWriter, r *http.Request) {
-		dir, err := ioutil.TempDir("", "diagnostics")
-		if err != nil {
-			log.Println("Error creating temp dir on diagnostic request:", err)
+		diagnosticsSessionID := r.FormValue(sessionIDField)
+
+		if diagnosticsSessionID == "" {
+			http.Error(w, "No 'session' field specified for diagnostics run", http.StatusBadRequest)
 			return
 		}
 
-		file, err := ioutil.TempFile(dir, "diagnostics")
+		hostname, err := os.Hostname()
 		if err != nil {
-			log.Println("Error creating temp file on diagnostic request:", err)
+			http.Error(w, "Error getting hostname:"+err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		tarWriter := tar.NewWriter(file)
+		// To keep URL cleaner
+		hostname = strings.Replace(hostname, ".", "-", -1)
 
-		Capture(tarWriter, cloudCaptures)
+		if _, err := w.Write([]byte("OK hostname=" + hostname + " session=" + diagnosticsSessionID + "\n")); err != nil {
+			http.Error(w, "Error writing: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
 
-		// TODO: upload written (and gzipped?) tar file to our S3
-		// bucket with specific path convention (per-user?  by date?)
+		// Do the actual capture and uplaod to S3 in the background.
+		// No need to make caller sit and wait for the result.  They
+		// probably have a lot of other things going on, like other
+		// servers to request diagnostics for.
+		//
+		// TODO(nathanleclaire): Potentially, endpoint to check the
+		// result of this capture and upload process as well.
+		go func() {
+			dir, err := ioutil.TempDir("", "diagnostics")
+			if err != nil {
+				log.Println("Error creating temp dir on diagnostic request:: ", err)
+				return
+			}
+
+			file, err := ioutil.TempFile(dir, "diagnostics")
+			if err != nil {
+				log.Println("Error creating temp file on diagnostic request:", err)
+				return
+			}
+
+			tarWriter := tar.NewWriter(file)
+
+			Capture(tarWriter, cloudCaptures)
+
+			if err := tarWriter.Close(); err != nil {
+				log.Println("Error closing archive writer: ", err)
+				return
+			}
+
+			if err := file.Close(); err != nil {
+				log.Println("Error closing file: ", err)
+				return
+			}
+
+			readFile, err := os.Open(file.Name())
+			if err != nil {
+				log.Println("Error opening report file to upload: ", err)
+				return
+			}
+			defer readFile.Close()
+
+			buf := &bytes.Buffer{}
+			contentLength, err := io.Copy(buf, readFile)
+			if err != nil {
+				log.Println("Error copying to buffer: ", err)
+				return
+			}
+
+			reportURI := fmt.Sprintf("https://%s.s3.amazonaws.com/%s-%s.tar", bucket, diagnosticsSessionID, hostname)
+
+			uploadReq, err := http.NewRequest("PUT", reportURI, buf)
+			if err != nil {
+				log.Println("Error getting bucket request: ", err)
+				return
+			}
+
+			uploadReq.Header.Set("x-amz-acl", "bucket-owner-full-control")
+			uploadReq.Header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
+			uploadReq.Header.Set("Content-Length", strconv.Itoa(int(contentLength)))
+
+			client := &http.Client{}
+
+			if uploadResp, err := client.Do(uploadReq); err != nil {
+				log.Println("Error writing: ", err)
+				body, err := ioutil.ReadAll(uploadResp.Body)
+				if err != nil {
+					log.Println("Error reading response body: ", err)
+				}
+				log.Println(string(body))
+				return
+			} else {
+				log.Println("No error sending S3 request")
+			}
+
+			log.Println("Diagnostics request finished")
+		}()
 	})
 
 	// Start HTTP server to indicate general Docker health.


### PR DESCRIPTION
This adds support for the HTTP diagnostics server to upload its results to a Docker-controlled append-only S3 bucket.

This is just a rough draft.  There are several issues, including unification with Pinata's bucket etc., which need to be resolved before merge.  However I've started designing it to be integrated directly with what Pinata has today without too much work.

Pinata could use this if they wanted to as well, and it would save the extra hops to retrieve the tar file over the socket and so on.  In our case I really wanted to make each node responsible for collecting and sending its own information since it seems more reliable to me to ping them all with one HTTP request and then have them take care of the gathering and upload on their own and not require transferring anything else from node-to-node.  Also it makes it easier to access information about hostname etc. in the same place you are doing the upload.

~~I noticed some issues with the generated tar archive (when I tried to access the files later) that I will elaborate on.~~ (I forgot to close tar writer 😵 ) Also for some reason the output of certain commands, e.g. `tail -100 /var/log/docker.log` is truncated completely.  We need to diagnose the diagnostics lol.

To hit the endpoint you can run something like:

``` console
$ curl -i -X POST -F "session=$(date +'%s')" <ip>:44554/diagnose
```

@justincormack @rneugeba PTAL

@avsm @dave-tucker , please also take a look and let me know what you think.  We should sync up and get Editions team (myself, @kencochrane, @FrenchBen and others) access to the bucket in question as well as make the user agent etc. is set properly and the archives are generated correctly.

Signed-off-by: Nathan LeClaire nathan.leclaire@gmail.com
