### PR TITLE
Use a container for doing gzip compression

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -11,7 +11,7 @@ initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	docker-compose run --rm -T moby /bin/mkinitrd.sh
 
 initrd.img.gz: initrd.img
-	cat initrd.img | gzip -9 > initrd.img.gz
+	cat initrd.img | docker run -i justincormack/gzip -9 > initrd.img.gz
 
 mobylinux-efi.iso: initrd.img.gz Dockerfile.efi
 	docker-compose build efi
@@ -68,3 +68,5 @@ clean:
 	rm -f mobylinux-bios.iso mobylinux-efi.iso mobylinux.efi
 	$(MAKE) -C packages clean
 	$(MAKE) -C kernel clean
+
+.DELETE_ON_ERROR:


### PR DESCRIPTION
The CI uses Alpine with busybox and that version is not good
at compression.

ALso use `.DELETE_ON_ERROR` so empty files are not created on failure.

Signed-off-by: Justin Cormack justin.cormack@docker.com
