### PR TITLE
Disable oom killer for transfused entirely

### DIFF
--- a/alpine/packages/transfused/etc/init.d/transfused
+++ b/alpine/packages/transfused/etc/init.d/transfused
@@ -22,8 +22,10 @@ start()
 		-l "${STARTUP_LOGFILE}"
 
 	ewaitfile 2 ${PIDFILE}
-
-	eend $? "Failed to start transfused"
+	RETVAL=$?
+	# Disable oomkiller for transfused
+	echo "-1000" > /proc/${PIDFILE}/oom_score_adj
+	eend $RETVAL "Failed to start transfused"
 }
 
 stop()


### PR DESCRIPTION
See docker/for-mac#18 -- no good can ever come from killing our
filesystem daemon
