### PR TITLE
Mount /run as shared

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -1,7 +1,7 @@
 all:	initrd.img.gz mobylinux-efi.iso
 
 ETCFILES=etc/issue etc/motd etc/network/interfaces
-ETCFILES+=etc/inittab
+ETCFILES+=etc/inittab etc/fstab
 
 initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	rm -f initrd.img

--- a/alpine/etc/fstab
+++ b/alpine/etc/fstab
@@ -1,0 +1,1 @@
+tmpfs	/run	tmpfs	defaults,nodev,relatime,size=10%,mode=755,shared 0 0


### PR DESCRIPTION
This is needed for volume drivers as they will mount their
volumes under here, and if they are running in a container
docker on the host will need to see these.

Also provide our own fstab, removes the media devices that were
there previously.

Signed-off-by: Justin Cormack justin.cormack@docker.com
