### PR TITLE
Stop using container for gzip

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -11,7 +11,7 @@ initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	docker-compose run --rm -T moby /bin/mkinitrd.sh
 
 initrd.img.gz: initrd.img
-	cat initrd.img | docker run -i justincormack/gzip -9 > initrd.img.gz
+	cat initrd.img | gzip -9 > initrd.img.gz
 
 mobylinux-efi.iso: initrd.img.gz Dockerfile.efi
 	docker-compose build efi


### PR DESCRIPTION
Issue fixed in upstream alpine, gzip -9 now works correctly.

Reverts #382

Signed-off-by: Justin Cormack justin.cormack@docker.com
