### PR TITLE
clean up images built by compose to avoid cacheing

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -66,6 +66,12 @@ azure: common
 clean:
 	rm -f initrd.img initrd.img.gz initrd-arm.img Dockerfile.armhf mobylinux.vhd mobylinux.img
 	rm -f mobylinux-bios.iso mobylinux-efi.iso mobylinux.efi
+	docker images -q alpine_moby:latest | xargs docker rmi -f || true
+	docker images -q alpine_efi:latest | xargs docker rmi -f || true
+	docker images -q alpine_bios:latest | xargs docker rmi -f || true
+	docker images -q alpine_arm:latest | xargs docker rmi -f || true
+	docker images -q alpine_ami:latest | xargs docker rmi -f || true
+	docker images -q alpine_azure:latest | xargs docker rmi -f || true
 	$(MAKE) -C packages clean
 	$(MAKE) -C kernel clean
 


### PR DESCRIPTION
Signed-off-by: Justin Cormack justin.cormack@docker.com
