### PR TITLE
remove "alpha" from motd

### DIFF
--- a/alpine/etc/motd
+++ b/alpine/etc/motd
@@ -1,1 +1,1 @@
-Welcome to the Moby alpha, based on Alpine Linux.
+Welcome to Moby, based on Alpine Linux.


### PR DESCRIPTION
commit 3eae35d77b9abf56a335a007bdec40b215ae4b7d (https://github.com/docker/moby/pull/408) removed
"alpha" from "issue", but missed removing it here.

ping @justincormack ptal
