### PR TITLE
[RFC] [PoC] Allow overriding docker binaries

### DIFF
--- a/alpine/etc/conf.d/docker
+++ b/alpine/etc/conf.d/docker
@@ -1,0 +1,5 @@
+# allow overriding the installed docker version
+# by putting alternative docker binaries in
+# /usr/local/docker
+PATH=/usr/local/docker:$PATH
+DOCKER_BINARY="dockerd"


### PR DESCRIPTION
This allows overriding the docker binaries with a different version by sharing '/usr/local/docker/' from the host.

It's not perfect, because the symlinks on OS X are hard-coded, so still point to the regular binaries, but opening this for discussion (and probably better ways to do this).

I looked for more "standard" paths to use for this, but `/usr/local/sbin` was blocked from the preference pane, and `/usr/local/bin` on OS X contains many binaries by default, so would mess up Moby :smile:

With this patch, simply:
- download static binaries for docker (e.g. the [docker 1.12.1-rc1 binaries](https://experimental.docker.com/builds/Linux/x86_64/docker-1.12.1-rc1.tgz)
- extract them to `/usr/local/docker` on OS X
- remove the `docker-proxy` binary (so that the "special" version inside moby is still used)
- share `/usr/local/docker`:

<img width="380" alt="screen shot 2016-08-13 at 20 31 51" src="https://cloud.githubusercontent.com/assets/1804568/17645012/f8d2efc6-6198-11e6-84fc-f68250809b0d.png">
- restart the docker service (because Moby resets the filesystem, I had to manually apply this path, and restart the service from a screen session, but I assume with this patch, it's possible to simply "apply and restart docker"), et voila:

```
Client:
 Version:      1.12.0
 API version:  1.24
 Go version:   go1.6.3
 Git commit:   8eab29e
 Built:        Thu Jul 28 21:04:48 2016
 OS/Arch:      darwin/amd64
 Experimental: true

Server:
 Version:      1.12.1-rc1
 API version:  1.24
 Go version:   go1.6.3
 Git commit:   7889dc7
 Built:        Fri Aug 12 18:35:53 2016
 OS/Arch:      linux/amd64
 Experimental: true
```

Questions;
- better way to do this (different path?)
- how to make sure the "moby" `docker-proxy` is always used? perhaps put it in a location that's earlier in the path?
- how to fix the symlinks? (Not sure where/when they are created; possibly recreating them on restart with the correct path would work)

ping @justincormack this is what we were discussing; it's just a hack, but possibly something we can do (given a better implementation than this dirty hack)
