### PR TITLE
Remove util-linux

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM justincormack/moby-alpine-base:0d79ff85d10a7d86067a3893e8a1f52ff3a073da
+FROM justincormack/moby-alpine-base:c31ad889c44f78974e8e04a5d489be3a07e77536
 
 ENV ARCH=x86_64
 

--- a/alpine/base/Dockerfile
+++ b/alpine/base/Dockerfile
@@ -18,7 +18,6 @@ RUN \
   openssh-client \
   strace \
   fuse \
-  util-linux \
   cifs-utils \
   e2fsprogs-extra \
   openssl \


### PR DESCRIPTION
This was added in #87 to support Kubernetes, but they no longer
support install via Docker so can remove.

Hopefully we have not started requiring this for anything else.

Signed-off-by: Justin Cormack justin@specialbusservice.com
