### PR TITLE
Fix shared mount of /run

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM justincormack/moby-alpine-base:c31ad889c44f78974e8e04a5d489be3a07e77536
+FROM justincormack/moby-alpine-base:ac8b97858e93f51dff9a2a2229be551638aff1b2
 
 ENV ARCH=x86_64
 

--- a/alpine/base/Dockerfile
+++ b/alpine/base/Dockerfile
@@ -22,4 +22,5 @@ RUN \
   e2fsprogs-extra \
   openssl \
   jq \
+  util-linux \
   && rm -rf /var/cache/apk/*

--- a/alpine/etc/fstab
+++ b/alpine/etc/fstab
@@ -1,2 +1,1 @@
 tmpfs	/run	tmpfs	defaults,nodev,relatime,size=10%,mode=755 0 0
-tmpfs	/run	tmpfs	remount,bind,shared 0 0

--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -13,6 +13,9 @@ start()
 
 	pidfile="/run/docker.pid"
 
+	# mount /run shared eg for volume drivers
+	mount -o remount,bind,shared /run
+
 	# create cgroups mount for systemd containers
 	if [ ! -d /sys/fs/cgroup/systemd ]
 	then


### PR DESCRIPTION
Needs util-linux for now, see https://github.com/docker/moby/issues/424

Signed-off-by: Justin Cormack justin.cormack@docker.com
