### PR TITLE
dhcp: request and use search domains (option 119)

### DIFF
--- a/alpine/etc/network/interfaces
+++ b/alpine/etc/network/interfaces
@@ -3,7 +3,7 @@ iface lo inet loopback
 
 auto eth0
 iface eth0 inet dhcp
-    udhcpc_opts -T 3 -A 3 -t 20
+    udhcpc_opts -T 3 -A 3 -t 20 -O search
 
 auto eth1
 iface eth1 inet dhcp


### PR DESCRIPTION
This configures `udhcpc` to request search domains (`-O search`) but it also has to make the following change to the default script in `busybox-initscripts` to actually use it. I'm not sure where this patch should really go:

```
--- default.script.orig 2016-08-25 10:26:13.000000000 +0100
+++ default.script      2016-08-25 10:12:43.000000000 +0100
@@ -84,7 +84,11 @@
            [ "$i" = "$interface" ] && return
        done
        echo -n > "$RESOLV_CONF"
-       [ -n "$domain" ] && echo "search $domain" >> "$RESOLV_CONF"
+       if [ -n "$search" ]; then
+           echo "search $search" >> "$RESOLV_CONF"
+       else
+           [ -n "$domain" ] && echo "search $domain" >> "$RESOLV_CONF"
+       fi
        for i in $dns; do
            echo "nameserver $i" >> "$RESOLV_CONF"
        done
```
