### PR TITLE
Append CA certificates from the host to the global certificate bundle

### DIFF
--- a/alpine/packages/hostsettings/etc/init.d/hostsettings
+++ b/alpine/packages/hostsettings/etc/init.d/hostsettings
@@ -32,6 +32,8 @@ start() {
 	     echo "    gateway ${GW}"      >> /etc/network/interfaces
 	     echo "    metric  200"        >> /etc/network/interfaces
 	fi
+	
+	mobyconfig exists etc/ssl/certs/ca-certificates.crt && mobyconfig get etc/ssl/certs/ca-certificates.crt >> /etc/ssl/certs/ca-certificates.crt 
 
 	eend 0
 }


### PR DESCRIPTION
Signed-off-by: Simon Ferquel simon.ferquel@docker.com
