### PR TITLE
Include the Go binary in the hash of the go build base

### DIFF
--- a/alpine/base/alpine-build-go/Makefile
+++ b/alpine/base/alpine-build-go/Makefile
@@ -8,7 +8,7 @@ default: push
 hash:
 	docker pull $(BASE)
 	tar cf - Dockerfile | docker build --no-cache -t $(IMAGE):build -
-	docker run --rm $(IMAGE):build sha1sum /lib/apk/db/installed | sed 's/ .*//' > hash
+	docker run golang:alpine sh -c 'cat /usr/local/go/bin/go /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
 
 push: hash
 	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \

--- a/alpine/packages/diagnostics/Dockerfile
+++ b/alpine/packages/diagnostics/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-build-go:f87b7d1c1cdec779ed602bfa5eaaeb94896d612c
+FROM mobylinux/alpine-build-go:30067067003d565887d7efe533eba03ed46038d2
 
 RUN mkdir -p /go/src/diagnostics
 WORKDIR /go/src/diagnostics

--- a/alpine/packages/proxy/Dockerfile
+++ b/alpine/packages/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-build-go:f87b7d1c1cdec779ed602bfa5eaaeb94896d612c
+FROM mobylinux/alpine-build-go:30067067003d565887d7efe533eba03ed46038d2
 
 RUN mkdir -p /go/src/proxy
 WORKDIR /go/src/proxy

--- a/alpine/packages/vsudd/Dockerfile
+++ b/alpine/packages/vsudd/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-build-go:f87b7d1c1cdec779ed602bfa5eaaeb94896d612c
+FROM mobylinux/alpine-build-go:30067067003d565887d7efe533eba03ed46038d2
 
 RUN mkdir -p /go/src/vsudd
 WORKDIR /go/src/vsudd


### PR DESCRIPTION
As this is not installed via apk it was not being included in the
checksum.

Signed-off-by: Justin Cormack justin.cormack@docker.com
