### PR TITLE
[Alpine 3.5] use alpine qemu for vhd

### DIFF
--- a/alpine/cloud/Dockerfile.raw2vhd
+++ b/alpine/cloud/Dockerfile.raw2vhd
@@ -1,16 +1,3 @@
-FROM debian:jessie
+FROM mobylinux/alpine-qemu:1f3de121e9dea39a198413344a72049839bea91b
 
-# Why bother with this whole song and dance?  qemu-img versions >=2.2.1 have a
-# "bug" which causes the generated VHD files to be improperly formatted for
-# running on Azure: https://bugs.launchpad.net/qemu/+bug/1490611
-# 
-# Since Alpine has only qemu-img >= 2.4.1 in its apk index, we cannot use
-# Alpine.
-RUN apt-get update && \
-    apt-get install -y qemu-utils
-
-# If version changes in distributed packages, this build is busted.  Sanity check.
-RUN qemu-img --version
-RUN qemu-img --version | awk '{ if ($3 != "2.1.2,") exit 1; }'
-
-ENTRYPOINT ["qemu-img", "convert", "-f", "raw", "-O", "vpc", "-o", "subformat=fixed"]
+ENTRYPOINT ["qemu-img", "convert", "-f", "raw", "-O", "vpc", "-o", "subformat=fixed,force-size"]


### PR DESCRIPTION
Alpine 3.4 should have a recent enough version of qemu to have the fix for this issue if the right option is used.

@nathanleclaire can you test this and see if it works?

Signed-off-by: Justin Cormack justin@specialbusservice.com
