### PR TITLE
Add support for running a development bundle of Docker

### DIFF
--- a/alpine/packages/diagnostics/usr/bin/diagnostics
+++ b/alpine/packages/diagnostics/usr/bin/diagnostics
@@ -22,7 +22,8 @@ DOCKER=$(ps -eo args | grep '^/usr/bin/dockerd')
 CONTAINERD=$(ps -eo args | grep '^docker-containerd')
 [ $? -eq 0 ] && printf "✓ Process containerd running: $CONTAINERD\n" || printf "✗ No containerd process\n"
 DOCKERPS=$(docker ps 2>&1)
-[ $? -eq 0 ] && printf "✓ Docker daemon working\n" || printf "✗ Docker ps failed: $DOCKERPS\n"
+DOCKERV=$(docker --version)
+[ $? -eq 0 ] && printf "✓ Docker daemon working: ${DOCKERV}\n" || printf "✗ Docker ps failed: $DOCKERPS\n"
 DIAGNOSTICS=$(ps -eo args | grep '^/usr/bin/diagnostics-server')
 [ $? -eq 0 ] && printf "✓ Diagnostics server running: $DIAGNOSTICS\n" || printf "✗ No diagnostics server\n"
 CONTAINERD=$(ps -eo args | grep '^/usr/bin/containerd')

--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -9,6 +9,18 @@ start()
 {
 	ebegin "Starting Docker"
 
+	# check if overriding Docker with a dev bundle
+	if mobyconfig exists bundle
+	then
+		bundle=$(mobyconfig get bundle)
+		[ -n "$bundle" -a -d "$bundle" -a -h "$bundle/binary-client/docker" ] && \
+		  # note we copy all the symlinks, in case layout changes
+		  cp -a $bundle/binary-client/* \
+		        $bundle/binary-daemon/* \
+		  /usr/bin
+		printf "Overriding Docker with provided bundle: $bundle\n"
+	fi
+
 	command="${DOCKER_BINARY:-/usr/bin/dockerd}"
 
 	pidfile="/run/docker.pid"


### PR DESCRIPTION
Add a database key `bundle` that contains a path to a Docker dev
bundle eg `/.../docker/bundles/1.13.0-dev` where the docker
binaries to run can be found. This will be paired with a script
in `docker/docker` to set this key, so users can easily help
contribute to Docker development.

The change will be permanent until the key is removed or a factory
reset is done, or the bundle cannot be found.

Signed-off-by: Justin Cormack justin.cormack@docker.com
