### PR TITLE
Added licensing zip from container to prevent user login leak

### DIFF
--- a/licensing/Makefile
+++ b/licensing/Makefile
@@ -8,7 +8,6 @@ run: license
 	rm -rf output
 	docker run -it -v /etc:/hostetc -v /usr:/hostusr -v /lib:/lib -v $(PWD)/output:/output license
 	docker run -it --rm -v $(PWD):/licensing debian sh -c "cd /licensing/output && tar --numeric-owner -zcvf /licensing/License.tar.gz *"
-	mv License.tar.gz ~/Desktop/
 
 clean:
 	rm -rf output


### PR DESCRIPTION
Small tweak to the makefile for Licensing. Output is like:

```
-rw-r--r--  0 0      0      571091 Sep 13 11:07 zlib-1.2.8/zlib-1.2.8.tar.gz
```

instead of adding my user login:

```
-rw-r--r--  0 frenchben frenchben      571091 Sep 13 11:07 zlib-1.2.8/zlib-1.2.8.tar.gz
```
