### PR TITLE
Added ability to make ami-clean-mount to clean up AMI volume mount

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -55,6 +55,9 @@ ami: common
 	docker-compose run --rm -T ami clean
 	docker-compose run --rm -T ami bake
 
+ami-clean-mount: common
+	docker-compose run --rm -T ami clean-mount
+
 azure: common
 	docker-compose build azure
 	docker-compose run --rm -T azure makeraw


### PR DESCRIPTION
When you do a make ami, it will leave the volume mount on the EC2 host when complete. This isn't ideal, I have added a new make target `ami-clean-mount` which will clean up the mount on the host. This is helpful when you want to do multiple AMI runs and not remove the old AMI's (cs release, vs OSS release)

Signed-off-by: Ken Cochrane KenCochrane@gmail.com
