### PR TITLE
No log driver for large copies

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -33,16 +33,16 @@ initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	  -C packages/azure etc -C ../.. \
 	  | \
 	  docker build -t moby-initrd:build -
-	docker run --net=none --rm moby-initrd:build > $@
+	docker run --net=none --log-driver=none --rm moby-initrd:build > $@
 
 mobylinux-efi.iso: Dockerfile.efi initrd.img kernel/x86_64/vmlinuz64
 	tar cf - $^ | docker build -t moby-efi:build -f Dockerfile.efi -
-	docker run --net=none --rm --cap-add sys_admin moby-efi:build cat /tmp/efi/mobylinux.efi > mobylinux.efi
-	docker run --net=none --rm --cap-add sys_admin moby-efi:build cat /tmp/efi/mobylinux-efi.iso > $@
+	docker run --net=none --log-driver=none --rm --cap-add sys_admin moby-efi:build cat /tmp/efi/mobylinux.efi > mobylinux.efi
+	docker run --net=none --log-driver=none --rm --cap-add sys_admin moby-efi:build cat /tmp/efi/mobylinux-efi.iso > $@
 
 mobylinux-bios.iso: Dockerfile.bios initrd.img kernel/x86_64/vmlinuz64 isolinux.cfg
 	tar cf - $^ | docker build -t moby-bios:build -f Dockerfile.bios -
-	docker run --net=none --rm moby-bios:build cat /tmp/mobylinux-bios.iso > $@
+	docker run --net=none --log-driver=none --rm moby-bios:build cat /tmp/mobylinux-bios.iso > $@
 
 ami: initrd.img
 	docker-compose build ami

--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -5,10 +5,10 @@ all:	x86_64/vmlinuz64
 x86_64/vmlinuz64: Dockerfile kernel_config
 	mkdir -p x86_64 etc
 	docker build --build-arg DEBUG=$(DEBUG) -t mobykernel:build .
-	docker run --rm --net=none mobykernel:build cat /kernel-modules.tar | tar xf -
-	docker run --rm --net=none mobykernel:build cat /aufs-utils.tar | tar xf -
-	docker run --rm --net=none mobykernel:build cat /kernel-source-info > etc/kernel-source-info
-	docker run --rm --net=none mobykernel:build cat /linux/arch/x86_64/boot/bzImage > $@
+	docker run --rm --net=none --log-driver=none mobykernel:build cat /kernel-modules.tar | tar xf -
+	docker run --rm --net=none --log-driver=none mobykernel:build cat /aufs-utils.tar | tar xf -
+	docker run --rm --net=none --log-driver=none mobykernel:build cat /kernel-source-info > etc/kernel-source-info
+	docker run --rm --net=none --log-driver=none mobykernel:build cat /linux/arch/x86_64/boot/bzImage > $@
 	cp -a patches etc/kernel-patches
 
 clean:


### PR DESCRIPTION
Takes 75% of the time without logs.

Signed-off-by: Justin Cormack justin.cormack@docker.com
