### PR TITLE
add random-seed database key

### DIFF
--- a/alpine/packages/hostsettings/etc/init.d/hostsettings
+++ b/alpine/packages/hostsettings/etc/init.d/hostsettings
@@ -12,6 +12,7 @@ start() {
 	mobyconfig exists etc/sysctl.conf && mobyconfig get etc/sysctl.conf > /etc/sysctl.conf
 	mobyconfig exists etc/sysfs.conf && mobyconfig get etc/sysfs.conf > /etc/sysfs.conf
 	mobyconfig exists etc/resolv.conf && mobyconfig get etc/resolv.conf > /etc/resolv.conf
+	mobyconfig exists random-seed && mobyconfig get random-seed > /dev/urandom
 
 	mobyconfig exists etc/hosts && mobyconfig get etc/hosts >> /etc/hosts
 


### PR DESCRIPTION
Signed-off-by: Justin Cormack justin.cormack@docker.com

See #183

Cloud editions should populate this, via cloud init equivalent.
