### PR TITLE
Use RDRAND/RDSEED to add randomness to Linux pool

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -16,6 +16,7 @@ RUN \
   rc-update add sysctl boot && \
   rc-update add bootmisc boot && \
   rc-update add urandom boot && \
+  rc-update add random boot && \
   rc-update add hostname boot && \
   rc-update add vsudd boot && \
   rc-update add sysklogd boot && \

--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -31,6 +31,7 @@ initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	  -C packages/containerd etc -C ../.. \
 	  -C packages/aws etc -C ../.. \
 	  -C packages/azure etc -C ../.. \
+	  -C packages/random etc sbin -C ../.. \
 	  | \
 	  docker build -t moby-initrd:build -
 	docker run --net=none --log-driver=none --rm moby-initrd:build > $@

--- a/alpine/packages/Makefile
+++ b/alpine/packages/Makefile
@@ -1,4 +1,4 @@
-DEPS=proxy diagnostics transfused tap-vsockd hvtools docker nc-vsock vsudd 9pmount-vsock iptables
+DEPS=proxy diagnostics transfused tap-vsockd hvtools docker nc-vsock vsudd 9pmount-vsock iptables random
 .PHONY: clean $(DEPS)
 
 default: $(DEPS)

--- a/alpine/packages/random/Dockerfile
+++ b/alpine/packages/random/Dockerfile
@@ -1,0 +1,9 @@
+FROM mobylinux/alpine-build-c:1ea690a7438cdd8a5965eaa034e0a0c521d9cb40
+
+COPY . /random
+
+WORKDIR /random
+
+RUN cc -g -static -Wall -Werror -o add-random rdrand.c rdseed.c main.c
+
+CMD ["tar", "cf", "-", "add-random"]

--- a/alpine/packages/random/Makefile
+++ b/alpine/packages/random/Makefile
@@ -1,0 +1,9 @@
+DEPS=Dockerfile $(wildcard *.c *.h)
+
+sbin/add-random: $(DEPS)
+	mkdir -p sbin
+	tar cf - $(DEPS) | docker build -t random:build -
+	docker run --rm --net=none random:build | tar xf - -C sbin
+
+clean:
+	rm -rf sbin

--- a/alpine/packages/random/drng.h
+++ b/alpine/packages/random/drng.h
@@ -1,0 +1,330 @@
+/* Copyright © 2015, Intel Corporation.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+-       Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+-       Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+-       Neither the name of Intel Corporation nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE. */
+
+/*! \file drng.h
+*  \brief Public header for libdrng.
+*
+* This is the public header for libdrng.
+*/
+
+#ifndef DRNG_H
+#define DRNG_H
+
+/* Windows Specific */
+#ifdef _WIN32
+
+#if __STDC_VERSION__ >= 199901L
+#include <stdint.h>
+#else
+/* MSVC specific */
+typedef unsigned __int16 uint16_t;
+typedef unsigned __int32 uint32_t;
+typedef unsigned __int64 uint64_t;
+#endif
+
+#endif /* Windows */
+
+/* GNUC Specific */
+#ifdef __GNUC__
+
+#define HAVE_RDRAND_IN_GCC 1
+
+#include <inttypes.h>
+#ifdef _MSC_VER
+/* MSVC specific */
+typedef unsigned __int16 uint16_t;
+typedef unsigned __int32 uint32_t;
+typedef unsigned __int64 uint64_t;
+#endif
+
+#endif /* GNUC */
+
+#if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(_WIN64)
+# define _NOT_WIN32
+#endif
+
+/*! \def DRNG_SUCCESS
+*   The rdseed/rdrand call was successful, the hardware was ready, and a random
+*   number was returned.
+*/
+#define DRNG_SUCCESS 1
+
+/*! \def DRNG_NOT_READY
+*  The rdseed/rdrand call was unsuccessful, the hardware was not ready, and a
+*  random number was not returned.
+*/
+#define DRNG_NOT_READY -1
+
+/*! \def DRNG_SUPPORTED
+* The rdseed/rdrand instruction is supported by the host hardware.
+*/
+#define DRNG_SUPPORTED -2
+
+/*! \def DRNG_UNSUPPORTED
+* The rdseed/rdrand instruction is unsupported by the host hardware.
+*/
+#define DRNG_UNSUPPORTED -3
+
+/*! \def DRNG_SUPPORT_UNKNOWN
+* Whether or not the hardware supports the rdseed/rdrand instruction is unknown
+*/
+#define DRNG_SUPPORT_UNKNOWN -4
+
+
+/*! \brief Determines whether or not rdrand is supported by the CPU
+*
+* This function calls cpuid to determine rdrand support and caches the
+* result in a static variable. This prevents calling cpuid on subsequent invocations.
+*
+* \return bool/int of whether or not rdrand is supported
+*/
+int RdRand_isSupported();
+
+
+/*! \brief Determines whether or not rdseed is supported by the CPU
+*
+* This function calls cpuid to determine rdseed support and caches the
+* result in a static variable. This prevents calling cpuid on subsequent invocations.
+*
+* \return bool/int of whether or not rdseed is supported
+*/
+int RdSeed_isSupported();
+
+
+/*! \brief Calls rdseed for a 16-bit result.
+*
+* This function calls rdseed requesting a 16-bit result. By default, it will
+* perform only a single call to rdseed, returning success or failure. On
+* success the data is written to memory pointed to by x.  On failure an error
+* is returned unless the int retry_count is non-zero, in which case the function
+* will retry rdseed until a successful result is obtained, or until the set number of
+* retries occurs.
+*
+* This function also ensures that rdseed is supported by the cpu or fails gracefully.
+*
+* \param x pointer to memory to store the random result
+* \param retry_count int to determine how many rdseed retries should be attempted
+*
+* \return whether or not the call was successful, or supported at all
+*/
+int rdseed_16(uint16_t* x, int retry_count);
+
+/*! \brief Calls rdrand for a 16-bit result.
+*
+* This function calls rdrand requesting a 16-bit result. By default, it will
+* perform only a single call to rdrand, returning success or failure. On
+* success, the data is written to memory pointed to by x. On failure an error
+* is returned unless the int retry is true (non-zero), in which case the function
+* will retry rdrand up to 10 times for a successful result before returning an error.
+*
+* This function also ensures that rdrand is supported by the cpu or fails
+* gracefully.
+*
+* \param x pointer to memory to store the random result
+* \param retry int to determine whether or not to loop until rdrand succeeds
+*		  or until 10 failed attempts
+*
+* \return whether or not the call was successful, or supported at all
+*/
+int rdrand_16(uint16_t* x, int retry);
+
+/*! \brief Calls rdseed for a 32-bit result.
+*
+* This function calls rdseed requesting a 32-bit result. By default, it will
+* perform only a single call to rdseed, returning success or failure. On
+* success the data is written to memory pointed to by x.  On failure an error
+* is returned unless the int retry_count is non-zero, in which case the function
+* will retry rdseed until a successful result is obtained, or until the set number of
+* retries occurs.
+*
+* This function also ensures that rdseed is supported by the cpu or fails gracefully.
+*
+* \param x pointer to memory to store the random result
+* \param retry_count int to determine how many rdseed retries should be attempted
+*
+* \return whether or not the call was successful, or supported at all
+*/
+int rdseed_32(uint32_t* x, int retry_count);
+
+/*! \brief Calls rdrand for a 32-bit result.
+*
+* This function calls rdrand requesting a 32-bit result. By default, it will
+* perform only a single call to rdrand, returning success or failure. On
+* success, the data is written to memory pointed to by x. On failure an error
+* is returned unless the int retry is true (non-zero), in which case the function
+* will retry rdrand up to 10 times for a successful result before returning an error.
+*
+* This function also ensures that rdrand is supported by the cpu or fails
+* gracefully.
+*
+* \param x pointer to memory to store the random result
+* \param retry int to determine whether or not to loop until rdrand succeeds
+*		  or until 10 failed attempts
+*
+* \return whether or not the call was successful, or supported at all
+*/
+int rdrand_32(uint32_t* x, int retry);
+
+/*! \brief Calls rdseed for a 64-bit result.
+*
+* This function calls rdseed requesting a 64-bit result. By default, it will
+* perform only a single call to rdseed, returning success or failure. On
+* success the data is written to memory pointed to by x.  On failure an error
+* is returned unless the int retry_count is non-zero, in which case the function
+* will retry rdseed until a successful result is obtained, or until the set number of
+* retries occurs.
+*
+* This function also ensures that rdseed is supported by the cpu or fails gracefully.
+*
+* \param x pointer to memory to store the random result
+* \param retry_count int to determine how many rdseed retries should be attempted
+*
+* \return whether or not the call was successful, or supported at all
+*/
+int rdseed_64(uint64_t* x, int retry_count);
+
+/*! \brief Calls rdrand for a 64-bits result.
+*
+* This function calls rdrand requesting a 64-bit result. By default, it will
+* perform only a single call to rdrand, returning success or failure. On
+* success, the data is written to memory pointed to by x. On failure an error
+* is returned unless the int retry is true (non-zero), in which case the function
+* will retry rdrand up to 10 times for a successful result before returning an error.
+*
+* This function also ensures that rdrand is supported by the cpu or fails
+* gracefully.
+*
+* \param x pointer to memory to store the random result
+* \param retry int to determine whether or not to loop until rdrand succeeds
+*		  or until 10 failed attempts
+*
+* \return whether or not the call was successful, or supported at all
+*/
+int rdrand_64(uint64_t* x, int retry);
+
+/*! \brief Calls rdseed to obtain multiple 64-byte results.
+*
+* This function calls rdseed requesting multiple 64-bit results. On
+* success, the data is written to memory pointed to by x. If a call to rdseed
+* fails to return a value this function will retry it if int max_retries is non-zero,
+* but if the total retry count exceeds max_retries then it will return the total
+* number of the 64-bit results it was able to generate.
+*
+* The int skip parameter is provided as a convenience to the user to resume 
+* filling the buffer where it left off if a previous operation did not complete.
+* If it is set, the function will appended (n - skip) values to the end of
+* the partially-filled buffer pointed to by x.
+*
+* \param n total number of 64-bit random seeds to generate
+* \param x pointer to memory buffer to fill with 64-bit random seeds
+* \param max_retries total number of retries that will be made by multiple rdseed_64 call
+* \param skip int to determine index of array to start from
+* \return total number of results generated or error number
+*/
+int rdseed_get_n_64(unsigned int n, uint64_t* x, unsigned int skip, unsigned int max_retries);
+
+/*! \brief Calls rdrand to obtain multiple 64-byte results.
+*
+* This function calls rdrand requesting multiple 64-byte results. On
+* success, the data is written to memory pointed to by x. This function
+* calls rdrand_64 and if any of those invocations fail, this function
+* fails. It returns the same values as rdrand_64.
+*
+* \param n total number of 64-bit random values to generate
+* \param x pointer to memory buffer to fill with 64-bit random values
+*/
+int rdrand_get_n_64(unsigned int n, uint64_t* x);
+
+/*! \brief Calls rdseed to obtain multiple 32-byte results.
+*
+* This function calls rdseed requesting multiple 32-bit results. On
+* success, the data is written to memory pointed to by x. If a call to rdseed
+* fails to return a value this function will retry it if int max_retries is non-zero,
+* but if the total retry count exceeds max_retries then it will return the total
+* number of the 32-bit results it was able to generate.
+*
+* The int skip parameter is provided as a convenience to the user to resume 
+* filling the buffer where it left off if a previous operation did not complete.
+* If it is set, the function will appended (n - skip) values to the end of
+* the partially-filled buffer pointed to by x.
+*
+* \param n total number of 32-bit random seeds to generate
+* \param x pointer to memory buffer to fill with 32-bit random seeds
+* \param max_retries total number of retries that will be made by multiple rdseed_32 call
+* \param skip int to determine index of array to start from
+* \return total number of results generated or error number
+*/
+int rdseed_get_n_32(unsigned int n, uint32_t* x, unsigned int skip, unsigned int max_retries);
+
+
+/*! \brief Calls rdrand to obtain multiple 32-byte results.
+*
+* This function calls rdrand requesting multiple 32-byte results. On
+* success, the data is written to memory pointed to by x. This function
+* calls rdrand_32 and if any of those invocations fail, this function
+* fails. It returns the same values as rdrand_32.
+*
+* \param n total number of 32-bit random values to generate
+* \param x pointer to memory buffer to fill with 32-bit random values
+*/
+int rdrand_get_n_32(unsigned int n, uint32_t* x);
+
+/*! \brief Calls rdseed to fill a buffer of arbitrary size with random bytes.
+*
+* This function calls rdseed requesting multiple 64- or 32-bit results to
+* fill a buffer of arbitrary size. If a call to rdseed
+* fails to return a value this function will retry it if int max_retries is non-zero,
+* but if the total retry count exceeds max_retries then it will return the total
+* number of the bytes written to the buffer pointed to be x.
+*
+* The int skip parameter is provided as a convenience to the user to resume 
+* filling the buffer where it left off if a previous operation did not complete.
+* If it is set, the function will appended (n - skip) bytes to the end of
+* the partially-filled buffer pointed to by x.
+*
+* \param n size of the buffer to fill with random bytes
+* \param buffer pointer to memory to store the random result
+* \param skip int to determine index of array to start from, to make the code re-entrant
+* \param max_retries total number of retries that will be made by multiple rdseed_32 call
+*
+* \return total number or bytes generated if rdseed is supported
+*/
+
+int rdseed_get_bytes(unsigned int n, unsigned char *buffer, unsigned int skip, unsigned int max_retries);
+
+/*! \brief Calls rdrand to fill a buffer of arbitrary size with random bytes.
+*
+* This function calls rdrand requesting multiple 64- or 32-bit results to
+* fill a buffer of arbitrary size.
+*
+* \param n size of the buffer to fill with random bytes
+* \param buffer pointer to memory to store the random result
+*
+* \return whether or not the call was successful, or supported at all
+*/
+
+int rdrand_get_bytes(unsigned int n, unsigned char *buffer);
+
+#endif // DRNG_H

--- a/alpine/packages/random/etc/init.d/random
+++ b/alpine/packages/random/etc/init.d/random
@@ -1,0 +1,10 @@
+#!/sbin/openrc-run
+
+start()
+{
+	ebegin "Adding to random seed"
+
+	/sbin/add-random
+
+	eend $? "Failed to add randomness"
+}

--- a/alpine/packages/random/etc/periodic/15m/random
+++ b/alpine/packages/random/etc/periodic/15m/random
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/sbin/add-random

--- a/alpine/packages/random/main.c
+++ b/alpine/packages/random/main.c
@@ -1,0 +1,47 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <linux/random.h>
+
+#include "drng.h"
+
+#define BUFSIZE 1024
+#define MAX_RETRY_LIMIT 10
+
+int main() {
+	struct rand_pool_info *info = malloc(sizeof(struct rand_pool_info) + BUFSIZE);
+	unsigned char *buffer = (unsigned char *)info->buf;
+	int fd, ret, r;
+	int entropy_count = 0;
+
+	if (! info)
+		return 1;
+
+	fd = open("/dev/random", O_RDWR);
+	if (fd == -1)
+		return 1;
+
+	if (RdSeed_isSupported()) {
+		r = rdseed_get_bytes(BUFSIZE, buffer, 0, MAX_RETRY_LIMIT);
+		if (r <= 0)
+			return 1;
+		entropy_count = r * 8; /* number of bits produced */
+	} else if (RdRand_isSupported()) {
+		r = rdrand_get_bytes(BUFSIZE, buffer);
+		if (r != DRNG_SUCCESS)
+			return 1;
+		r = BUFSIZE; /* always provides amount requested on success */
+		entropy_count = r / 64; /* uses PRNG so underlying there are fewer bits */
+	} else {
+		return 1;
+	}
+
+	info->entropy_count = entropy_count;
+	info->buf_size = r;
+	ret = ioctl(fd, RNDADDENTROPY, &info);
+	if (ret != 0)
+		return 1;
+}

--- a/alpine/packages/random/rdrand.c
+++ b/alpine/packages/random/rdrand.c
@@ -1,0 +1,397 @@
+/* Copyright © 2015, Intel Corporation.  All rights reserved. 
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+-       Redistributions of source code must retain the above copyright notice,
+		this list of conditions and the following disclaimer.
+-       Redistributions in binary form must reproduce the above copyright 
+		notice, this list of conditions and the following disclaimer in the
+		documentation and/or other materials provided with the distribution.
+-       Neither the name of Intel Corporation nor the names of its contributors
+		may be used to endorse or promote products derived from this software
+		without specific prior written permission.
+ 
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE. */
+
+/*! \file rdrand.c
+*  \brief APIs for rdrand functions
+*
+* This is the rdrand library file which exposes 
+* different APIs for 32- and 64-bit systems.
+*/
+
+#include "drng.h"
+
+/* Windows Specific */
+#ifdef _WIN32
+#include <immintrin.h>
+#include <string.h>
+#endif /* Windows */
+
+/* GNUC Specific */
+#ifdef __GNUC__
+#ifdef __INTEL_COMPILER
+# include <immintrin.h>
+#endif
+#include <stdint.h>
+#include <string.h>
+#endif /* GNUC */
+
+#if defined(_WIN64)||defined(_LP64)
+# define _IS64BIT
+#endif
+
+#ifdef _IS64BIT
+typedef uint64_t _wordlen_t;
+#else
+typedef uint32_t _wordlen_t;
+#endif
+
+
+/*! \def RDRAND_MASK
+*    The bit mask used to examine the ecx register returned by cpuid. The 
+ *   30th bit is set.
+ */
+#define RDRAND_MASK	0x40000000
+
+#define RETRY_LIMIT 10
+
+/* Global variable to keep the rdrand support value in cache */
+int rdrand_support_cache = DRNG_SUPPORT_UNKNOWN;
+
+/* GNU Specific */
+
+#ifdef __GNUC__
+
+/* Mimic the Intel compiler's intrinsics as best we can if we are using gcc */
+
+# define __cpuid(x,y,z) asm volatile("cpuid":"=a"(x[0]),"=b"(x[1]),"=c"(x[2]),"=d"(x[3]):"a"(y),"c"(z))
+
+/* RDRAND isn't a supported instruction until gcc 4.6 */
+
+# ifdef HAVE_RDRAND_IN_GCC
+
+#  define _rdrand_step(x) ({ unsigned char err; asm volatile("rdrand %0; setc %1":"=r"(*x), "=qm"(err)); err; })
+
+#  define _rdrand16_step(x) _rdrand_step(x)
+#  define _rdrand32_step(x) _rdrand_step(x)
+
+# else
+
+/* Our version of gcc is too old, so we need to use byte code */
+
+#  define _rdrand16_step(x) ({ unsigned char err; asm volatile(".byte 0x66; .byte 0x0f; .byte 0xc7; .byte 0xf0; setc %1":"=a"(*x), "=qm"(err)); err; })
+#  define _rdrand32_step(x) ({ unsigned char err; asm volatile(".byte 0x0f; .byte 0xc7; .byte 0xf0; setc %1":"=a"(*x), "=qm"(err)); err; })
+
+# endif
+
+#ifdef _IS64BIT
+
+# ifdef HAVE_RDRAND_IN_GCC
+#  define _rdrand64_step(x) _rdrand_step(x)
+# else
+
+/* Our version of gcc is too old, so we need to use byte code */
+
+#  define _rdrand64_step(x) ({ unsigned char err; asm volatile(".byte 0x48; .byte 0x0f; .byte 0xc7; .byte 0xf0; setc %1":"=a"(*x), "=qm"(err)); err; })
+
+# endif
+
+#else
+
+/*
+*   The Intel compiler intrinsic for generating a 64-bit rand on a 32-bit
+*   system maps to two 32-bit RDRAND instructions. 
+*
+*   Note that this isn't very efficient.  If you need 64-bit values
+*   you should really be on a 64-bit system.
+*/
+
+int _rdrand64_step(uint64_t *x);
+
+int _rdrand64_step(uint64_t *x)
+{
+	uint32_t xlow, xhigh;
+	int rv;
+
+	if ((rv = _rdrand32_step(&xlow)) != DRNG_SUCCESS) return rv;
+	if ((rv = _rdrand32_step(&xhigh)) != DRNG_SUCCESS) return rv;
+
+	*x = (uint64_t)xlow | ((uint64_t)xhigh << 32);
+
+	return DRNG_SUCCESS;
+}
+
+# endif
+
+#endif /* GNUC */
+
+/*! \brief Queries cpuid to see if rdrand is supported and caches the result
+ *
+ * rdrand support in a CPU is determined by examining the 30th bit of the ecx
+ * register after calling cpuid.
+ * 
+ * \return bool of whether or not rdrand is supported
+ */
+int RdRand_cpuid()
+{
+	unsigned int info[4] = {-1, -1, -1, -1};
+
+	/* Are we on an Intel processor? */
+
+#ifdef _WIN32
+	__cpuid(info, /*feature bits*/0);
+#endif
+
+#ifdef __GNUC__
+	__cpuid(info, /*feature bits*/0, 0);
+#endif
+	if ( memcmp((void *) &info[1], (void *) "Genu", 4) != 0 ||
+		 memcmp((void *) &info[3], (void *) "ineI", 4) != 0 ||
+		 memcmp((void *) &info[2], (void *) "ntel", 4) != 0 ) {
+
+		return 0;
+	}
+
+	/* Do we have RDRAND? */
+	
+#ifdef _WIN32
+	__cpuid(info, /*feature bits*/1);
+#endif
+
+#ifdef __GNUC__
+	__cpuid(info, /*feature bits*/1, 0);
+#endif
+	 
+
+	 unsigned int ecx = info[2];
+	 if ((ecx & RDRAND_MASK) == RDRAND_MASK)
+		 return 1;
+	 else
+		 return 0;
+}
+
+int RdRand_isSupported()
+{
+	int supported = rdrand_support_cache;
+
+	if (supported == DRNG_SUPPORT_UNKNOWN)
+	{
+
+		if (RdRand_cpuid())
+			supported = DRNG_SUPPORTED;
+		else
+			supported = DRNG_UNSUPPORTED;
+
+		rdrand_support_cache = supported;
+	}
+	
+	return (supported == DRNG_SUPPORTED) ? 1 : 0;
+}
+
+int rdrand_16(uint16_t* x, int retry)
+{
+	unsigned int i;
+	if (RdRand_isSupported())
+	{
+		if (retry)
+		{
+			for (i = 0; i < RETRY_LIMIT; i++)
+			{		
+				if (_rdrand16_step(x))
+					return DRNG_SUCCESS;
+			}
+
+			return DRNG_NOT_READY;
+		}
+		else
+		{
+				if (_rdrand16_step(x))
+					return DRNG_SUCCESS;
+				else
+					return DRNG_NOT_READY;
+		}
+	}
+	else
+	{
+		return DRNG_UNSUPPORTED;
+	}
+}
+
+int rdrand_32(uint32_t* x, int retry)
+{
+	unsigned int i;
+	if (RdRand_isSupported())
+	{
+		if (retry)
+		{
+			for (i = 0; i < RETRY_LIMIT; i++)
+			{		
+				if (_rdrand32_step(x))
+					return DRNG_SUCCESS;
+			}
+
+			return DRNG_NOT_READY;
+		}
+		else
+		{
+				if (_rdrand32_step(x))
+					return DRNG_SUCCESS;
+				else
+					return DRNG_NOT_READY;
+		}
+	}
+	else
+	{
+		return DRNG_UNSUPPORTED;
+	}
+}
+
+#ifdef _NOT_WIN32
+
+int rdrand_64(uint64_t* x, int retry)
+{
+	unsigned int i;
+	if (RdRand_isSupported())
+	{
+		if (retry)
+		{
+			for (i = 0; i < RETRY_LIMIT; i++)
+			{		
+				if (_rdrand64_step(x))
+					return DRNG_SUCCESS;
+			}
+
+			return DRNG_NOT_READY;
+		}
+		else
+		{
+				if (_rdrand64_step(x))
+					return DRNG_SUCCESS;
+				else
+					return DRNG_NOT_READY;
+		}
+	}
+	else
+	{
+		return DRNG_UNSUPPORTED;
+	}
+}
+
+int rdrand_get_n_64(unsigned int n, uint64_t *dest)
+{
+	int success;
+	unsigned int i;
+
+	for (i=0; i<n; i++)
+	{
+	    success= rdrand_64(dest, 1);
+		if (success != DRNG_SUCCESS) return success;
+		dest= &(dest[1]);
+	}
+	return DRNG_SUCCESS; 
+}
+ 
+#endif
+
+int rdrand_get_n_32(unsigned int n, uint32_t *dest)
+{
+	int success;
+	unsigned int i;
+
+	for (i=0; i<n; i++)
+	{
+	    success= rdrand_32(dest, 1);
+		if (success != DRNG_SUCCESS) return success;
+		dest= &(dest[1]);
+	}
+	return DRNG_SUCCESS; 
+}
+
+int rdrand_get_bytes(unsigned int n, unsigned char *dest)
+{
+	unsigned char *start;
+	unsigned char *residualstart;
+	_wordlen_t *blockstart;
+	_wordlen_t i, temprand;
+	unsigned int count;
+	unsigned int residual;
+	unsigned int startlen;
+	unsigned int length;
+	int success;
+
+	/* Compute the address of the first 32- or 64- bit aligned block in the destination buffer, depending on whether we are in 32- or 64-bit mode */
+	start = dest;
+	if (((_wordlen_t)start % (_wordlen_t) sizeof(_wordlen_t)) == 0)
+	{
+		blockstart = (_wordlen_t *)start;
+		count = n;
+		startlen = 0;
+	}
+	else
+	{
+		blockstart = (_wordlen_t *)(((_wordlen_t)start & ~(_wordlen_t) (sizeof(_wordlen_t)-1) )+(_wordlen_t)sizeof(_wordlen_t));
+		count = n - (sizeof(_wordlen_t) - (unsigned int)((_wordlen_t)start % sizeof(_wordlen_t)));
+		startlen = (unsigned int)((_wordlen_t)blockstart - (_wordlen_t)start);
+	}
+
+	/* Compute the number of 32- or 64- bit blocks and the remaining number of bytes */
+	residual = count % sizeof(_wordlen_t);
+	length = count/sizeof(_wordlen_t);
+	if (residual != 0)
+	{
+		residualstart = (unsigned char *)(blockstart + length);
+	}
+
+	/* Get a temporary random number for use in the residuals. Failout if retry fails */
+	if (startlen > 0)
+	{
+#ifdef _IS64BIT
+		if ( (success= rdrand_64((uint64_t *) &temprand, 1)) != DRNG_SUCCESS) return success;
+#else
+		if ( (success= rdrand_32((uint32_t *) &temprand, 1)) != DRNG_SUCCESS) return success;
+#endif
+	}
+
+	/* populate the starting misaligned block */
+	for (i = 0; i<startlen; i++)
+	{
+		start[i] = (unsigned char)(temprand & 0xff);
+		temprand = temprand >> 8;
+	}
+
+	/* populate the central aligned block. Fail out if retry fails */
+
+#ifdef _IS64BIT
+	if ( (success= rdrand_get_n_64(length, (uint64_t *)(blockstart))) != DRNG_SUCCESS) return success;
+#else
+	if ( (success= rdrand_get_n_32(length, (uint32_t *)(blockstart))) != DRNG_SUCCESS) return success;
+#endif
+	/* populate the final misaligned block */
+	if (residual > 0)
+	{
+#ifdef _IS64BIT
+		if ((success= rdrand_64((uint64_t *)&temprand, 1)) != DRNG_SUCCESS) return success;
+#else
+		if ((success= rdrand_32((uint32_t *)&temprand, 1)) != DRNG_SUCCESS) return success;
+#endif
+
+		for (i = 0; i<residual; i++)
+		{
+			residualstart[i] = (unsigned char)(temprand & 0xff);
+			temprand = temprand >> 8;
+		}
+	}
+
+    return DRNG_SUCCESS;
+}

--- a/alpine/packages/random/rdseed.c
+++ b/alpine/packages/random/rdseed.c
@@ -1,0 +1,434 @@
+/* Copyright © 2015, Intel Corporation.  All rights reserved. 
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+-       Redistributions of source code must retain the above copyright notice,
+		this list of conditions and the following disclaimer.
+-       Redistributions in binary form must reproduce the above copyright 
+		notice, this list of conditions and the following disclaimer in the
+		documentation and/or other materials provided with the distribution.
+-       Neither the name of Intel Corporation nor the names of its contributors
+		may be used to endorse or promote products derived from this software
+		without specific prior written permission.
+ 
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE. */
+
+/*! \file rdseed.c
+*  \brief APIs for rdseed library.
+*
+* This is the rdseed library file which exposes
+* different APIs for 32bit and 64bit system.
+*/
+
+#include "drng.h"
+/* Windows Specific */
+#ifdef _WIN32
+#include <immintrin.h>
+#include <string.h>
+#endif /* Windows */
+
+/* Linux Specific */
+#ifdef __GNUC__
+#ifdef __INTEL_COMPILER
+# include <immintrin.h>
+#endif
+#include <stdint.h>
+#include <string.h>
+#endif /* Linux */
+
+/*! \def RDSEED_MASK
+*    The bit mask used to examine the ebx register returned by cpuid. The 
+*   18th bit is set.
+*/
+#define RDSEED_MASK	0x40000
+
+/*! \def rdseed_support_cache
+*   Global variable to keep the drng support value in cache
+*/
+int rdseed_support_cache = DRNG_SUPPORT_UNKNOWN;
+
+/*! \def retry_counter
+*	Global variable to keep track of number of rdseed retries 
+*/
+unsigned int retry_counter = 0;
+
+
+#if defined(_WIN64)||defined(_LP64)
+# define _IS64BIT
+#endif
+
+#ifdef _IS64BIT
+typedef uint64_t _wordlen_t;
+#else
+typedef uint32_t _wordlen_t;
+#endif
+
+
+/* Linux Specific */
+
+/* Mimic the Intel compiler's intrinsics as best we can if we are using gcc */
+
+#ifdef __GNUC__
+
+# define __cpuid(x,y,z) asm volatile("cpuid":"=a"(x[0]),"=b"(x[1]),"=c"(x[2]),"=d"(x[3]):"a"(y),"c"(z))
+
+/* RDSEED isn't a supported instruction until gcc 4.6 */
+
+# ifdef HAVE_RDSEED_IN_GCC
+
+#  define _rdseed_step(x) ({ unsigned char err; asm volatile("rdseed %0; setc %1":"=r"(*x), "=qm"(err)); err; })
+
+#  define _rdseed16_step(x) _rdseed_step(x)
+#  define _rdseed32_step(x) _rdseed_step(x)
+
+# else
+
+/* Our version of gcc is too old, so we need to use byte code */
+
+#  define _rdseed16_step(x) ({ unsigned char err; asm volatile(".byte 0x66; .byte 0x0f; .byte 0xc7; .byte 0xf8; setc %1":"=a"(*x), "=qm"(err)); err; })
+#  define _rdseed32_step(x) ({ unsigned char err; asm volatile(".byte 0x0f; .byte 0xc7; .byte 0xf8; setc %1":"=a"(*x), "=qm"(err)); err; })
+
+# endif
+
+#ifdef _IS64BIT
+
+# ifdef HAVE_RDSEED_IN_GCC
+#  define _rdseed64_step(x) _rdseed_step(x)
+# else
+
+/* Our version of gcc is too old, so we need to use byte code */
+
+#  define _rdseed64_step(x) ({ unsigned char err; asm volatile(".byte 0x48; .byte 0x0f; .byte 0xc7; .byte 0xf8; setc %1":"=a"(*x), "=qm"(err)); err; })
+
+# endif
+
+#else
+
+/*
+*   The Intel compiler intrinsic for generating a 64-bit rand on a 32-bit 
+*   system maps to two 32-bit RDSEED instructions. Because of the way
+*   the way the DRNG is implemented you can do this up to a 128-bit value
+*   (for crypto purposes) before you no longer have multiplicative 
+*   prediction resistance.
+*  
+*   Note that this isn't very efficient.  If you need 64-bit values
+*   you should really be on a 64-bit system.
+*/
+
+int _rdseed64_step (uint64_t *x);
+
+int _rdseed64_step (uint64_t *x) 
+{
+	uint32_t xlow, xhigh;
+	int rv;
+
+	if ( (rv= _rdseed32_step(&xlow)) != DRNG_SUCCESS ) return rv;
+	if ( (rv= _rdseed32_step(&xhigh)) != DRNG_SUCCESS ) return rv;
+
+	*x= (uint64_t) xlow | ((uint64_t)xhigh<<32);
+
+	return DRNG_SUCCESS;
+}
+
+# endif
+
+#endif /* GNUC */
+
+/*! \brief Queries cpuid to see if rdseed is supported and caches the result
+ *
+ * rdseed support in a CPU is determined by examining the 18th bit of the ebx
+ * register after calling cpuid.
+ * 
+ * \return bool of whether or not rdseed is supported
+ */
+int RdSeed_cpuid()
+{
+	/* Are we on an Intel processor? */
+	unsigned int info[4] = { -1, -1, -1, -1 };
+
+#ifdef _WIN32
+	__cpuid(info, /*feature bits*/0);
+#endif
+
+#ifdef __GNUC__
+	__cpuid(info, /*feature bits*/0, 0);
+#endif
+	if (memcmp((void *)&info[1], (void *) "Genu", 4) != 0 ||
+		memcmp((void *)&info[3], (void *) "ineI", 4) != 0 ||
+		memcmp((void *)&info[2], (void *) "ntel", 4) != 0) {
+		return 0;
+	}
+
+	
+	/* Do we have RDSEED? */
+
+	unsigned int info_rdseed[4] = { -1, -1, -1, -1 };
+
+#ifdef _WIN32
+	__cpuid(info_rdseed, /*feature bits*/7);
+#endif
+
+#ifdef __GNUC__
+	__cpuid(info_rdseed, /*feature bits*/7, 0);
+#endif
+
+	unsigned int ebx = info_rdseed[1];
+	if ((ebx & RDSEED_MASK) == RDSEED_MASK)
+		return 1;
+	else
+		return 0;
+}
+
+
+int RdSeed_isSupported()
+{
+	int supported = rdseed_support_cache;
+
+	if (supported == DRNG_SUPPORT_UNKNOWN)
+	{
+
+		if (RdSeed_cpuid())
+			supported = DRNG_SUPPORTED;
+		else
+			supported = DRNG_UNSUPPORTED;
+
+		rdseed_support_cache = supported;
+
+	}
+	
+	return (supported == DRNG_SUPPORTED) ? 1 : 0;
+}
+
+int rdseed_16(uint16_t* x, int retry_count)
+{
+	if (RdSeed_isSupported())
+	{
+
+		if (_rdseed16_step(x))
+			return DRNG_SUCCESS;
+		else
+		{
+			retry_counter = retry_count;
+			while (retry_counter > 0)
+			{
+				retry_counter--;
+				if (_rdseed16_step(x))
+					return DRNG_SUCCESS;
+			}
+
+			return DRNG_NOT_READY;
+		}
+	}
+	else
+		return RdSeed_isSupported();
+}
+
+
+int rdseed_32(uint32_t* x, int retry_count)
+{
+	if (RdSeed_isSupported())
+	{
+
+		if (_rdseed32_step(x))
+			return DRNG_SUCCESS;
+		else
+		{
+			retry_counter = retry_count;
+			while (retry_counter > 0)
+			{
+				retry_counter--;
+				if (_rdseed32_step(x))
+					return DRNG_SUCCESS;
+			}
+
+			return DRNG_NOT_READY;
+		}
+	}
+	else
+		return RdSeed_isSupported();
+}
+
+#ifdef _NOT_WIN32
+
+int rdseed_64(uint64_t* x, int retry_count)
+{
+	if (RdSeed_isSupported())
+	{
+
+		if (_rdseed64_step(x))
+			return DRNG_SUCCESS;
+		else
+		{
+			retry_counter = retry_count;
+			while (retry_counter > 0)
+			{
+				retry_counter--;
+				if (_rdseed64_step(x))
+					return DRNG_SUCCESS;
+			}
+
+			return DRNG_NOT_READY;
+		}
+	}
+	else
+		return RdSeed_isSupported();
+}
+
+int rdseed_get_n_64(unsigned int n, uint64_t *dest, unsigned int skip, unsigned int max_retries)
+{
+	int success;
+	unsigned int i;
+	unsigned int success_count = 0;
+	retry_counter = max_retries;
+
+	if (skip)
+	{
+		n = n - skip;
+		dest = &(dest[skip]);
+		success_count = skip;
+	}
+
+	for (i = 0; i<n; i++)
+	{
+		success = rdseed_64(dest, retry_counter);
+		if (success != DRNG_SUCCESS) return ((success == DRNG_UNSUPPORTED) ? success : success_count);
+		dest = &(dest[1]);
+		success_count++;
+	}
+	return success_count;
+}
+ 
+#endif
+
+int rdseed_get_n_32(unsigned int n, uint32_t *dest, unsigned int skip, unsigned int max_retries)
+{
+	int success;
+	unsigned int i;
+	unsigned int success_count = 0;
+	retry_counter = max_retries;
+
+	if (skip)
+	{
+		n = n - skip;
+		dest = &(dest[skip]);
+		success_count = skip;
+	}
+
+
+	for (i = 0; i<n; i++)
+	{
+		success = rdseed_32(dest, retry_counter);
+		if (success != DRNG_SUCCESS) return ((success == DRNG_UNSUPPORTED) ? success : success_count);
+		dest = &(dest[1]);
+		success_count++;
+	}
+	return success_count;
+}
+
+int rdseed_get_bytes(unsigned int n, unsigned char *dest, unsigned int skip, unsigned int max_retries)
+{
+	unsigned char *start;
+	unsigned char *residualstart;
+	_wordlen_t *blockstart;
+	_wordlen_t i, temprand;
+	unsigned int count;
+	unsigned int residual;
+	unsigned int startlen;
+	unsigned int length;
+	int success;
+	unsigned int success_count = 0;
+	unsigned int buffsize = n;
+	retry_counter = max_retries;
+
+	if (skip)
+	{
+		n = n - skip;
+		dest = &(dest[skip]);
+		success_count = skip;
+	}
+
+	/* Compute the address of the first 32- or 64- bit aligned block in the destination buffer, depending on whether we are in 32- or 64-bit mode */
+	start = dest;
+	if (((_wordlen_t)start % (_wordlen_t) sizeof(_wordlen_t)) == 0)
+	{
+		blockstart = (_wordlen_t *)start;
+		count = n;
+		startlen = 0;
+	}
+	else
+	{
+		blockstart = (_wordlen_t *)(((_wordlen_t)start & ~(_wordlen_t) (sizeof(_wordlen_t)-1) )+(_wordlen_t)sizeof(_wordlen_t));
+		count = n - (sizeof(_wordlen_t) - (unsigned int)((_wordlen_t)start % sizeof(_wordlen_t)));
+		startlen = (unsigned int)((_wordlen_t)blockstart - (_wordlen_t)start);
+	}
+
+	/* Compute the number of 32- or 64- bit blocks and the remaining number of bytes */
+	residual = count % sizeof(_wordlen_t);
+	length = count/sizeof(_wordlen_t);
+	if (residual != 0)
+	{
+		residualstart = (unsigned char *)(blockstart + length);
+	}
+
+	/* Get a temporary random number for use in the residuals. Failout if retry fails */
+	if (startlen > 0)
+	{
+#ifdef _IS64BIT
+		if ((success = rdseed_64((uint64_t *)&temprand, retry_counter)) != DRNG_SUCCESS) return ((success == DRNG_UNSUPPORTED) ? success : success_count);
+#else
+		if ((success = rdseed_32((uint32_t *)&temprand, retry_counter)) != DRNG_SUCCESS) return ((success == DRNG_UNSUPPORTED) ? success : success_count);
+#endif
+	}
+
+	/* populate the starting misaligned block */
+	for (i = 0; i<startlen; i++)
+	{
+		start[i] = (unsigned char)(temprand & 0xff);
+		temprand = temprand >> 8;
+	}
+
+	/* populate the central aligned block. Fail out if retry fails */
+
+#ifdef _IS64BIT
+	if ( (success = rdseed_get_n_64(length, (uint64_t *)(blockstart), 0, retry_counter)) < length)
+	{
+		success_count += success * 8;
+		return success_count;
+	}
+
+#else
+	if ((success = rdseed_get_n_32(length, (uint32_t *)(blockstart), 0, retry_counter)) < length)
+	{
+		success_count += success * 4;
+		return success_count;
+	}
+
+#endif
+	/* populate the final misaligned block */
+	if (residual > 0)
+	{
+#ifdef _IS64BIT
+		if ((success = rdseed_64((uint64_t *)&temprand, retry_counter)) != DRNG_SUCCESS) return success_count;
+#else
+		if ((success = rdseed_32((uint32_t *)&temprand, retry_counter)) != DRNG_SUCCESS) return success_count;
+#endif
+
+		for (i = 0; i<residual; i++)
+		{
+			residualstart[i] = (unsigned char)(temprand & 0xff);
+			temprand = temprand >> 8;
+		}
+	}
+
+	return buffsize;
+}


### PR DESCRIPTION
Linux only uses RDRAND to mix with random numbers, not as a source
of its own, and it uses RDSEED very little, and it is ot always available.
Add a utility that uses RDSEED (preferably) or failing that RDRAND (which
is usually available) to feed the pool.

Fix #514
Fix #183

Signed-off-by: Justin Cormack justin.cormack@docker.com
