### PR TITLE
Explicitly set the apk repositories we use

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-base:5ee3744f0fbcdd3e9c6216322e1d023e4cdf9ee4
+FROM mobylinux/alpine-base:be37f68d6da073bab6b0d82ff3669ee0ae41aac8
 
 ENV ARCH=x86_64
 

--- a/alpine/base/alpine-base/Dockerfile
+++ b/alpine/base/alpine-base/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.4
 
+COPY repositories /etc/apk/
+
 RUN \
   apk update && apk upgrade && \
   apk add \

--- a/alpine/base/alpine-base/Makefile
+++ b/alpine/base/alpine-base/Makefile
@@ -7,7 +7,7 @@ default: push
 
 hash:
 	docker pull $(BASE)
-	tar cf - Dockerfile | docker build --no-cache -t $(IMAGE):build -
+	tar cf - Dockerfile repositories | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm $(IMAGE):build sha1sum /lib/apk/db/installed | sed 's/ .*//' > hash
 
 push: hash

--- a/alpine/base/alpine-base/repositories
+++ b/alpine/base/alpine-base/repositories
@@ -1,0 +1,1 @@
+http://dl-cdn.alpinelinux.org/alpine/v3.4/main


### PR DESCRIPTION
Previously we used the defaults (main and community) but we
currently only need main, but are likely to need some packages
from edge soon.

Signed-off-by: Justin Cormack justin.cormack@docker.com
