### PR TITLE
Add curl to base

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-base:be37f68d6da073bab6b0d82ff3669ee0ae41aac8
+FROM mobylinux/alpine-base:1b684f4d3178e95649fbc3ecbca28834048fd3eb
 
 ENV ARCH=x86_64
 

--- a/alpine/base/alpine-base/Dockerfile
+++ b/alpine/base/alpine-base/Dockerfile
@@ -10,6 +10,7 @@ RUN \
   busybox-initscripts \
   chrony \
   cifs-utils \
+  curl \
   e2fsprogs \
   e2fsprogs-extra \
   fuse \


### PR DESCRIPTION
We need this to self host if you specify a custom version of Docker.

Signed-off-by: Justin Cormack justin.cormack@docker.com
