### PR TITLE
Add rngd

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-base:1b684f4d3178e95649fbc3ecbca28834048fd3eb
+FROM mobylinux/alpine-base:e9f02e5109222e03566777f7041aee192a976a56
 
 ENV ARCH=x86_64
 
@@ -29,6 +29,7 @@ RUN \
   rc-update add dmesg sysinit && \
   rc-update add devfs sysinit && \
   rc-update add hwdrivers sysinit && \
+  rc-update add rngd && \
   rc-update add sysfs && \
   rc-update add sysfsconf && \
   rc-update add fsck && \

--- a/alpine/base/alpine-base/Dockerfile
+++ b/alpine/base/alpine-base/Dockerfile
@@ -4,7 +4,7 @@ COPY repositories /etc/apk/
 
 RUN \
   apk update && apk upgrade && \
-  apk add \
+  apk add --no-cache \
   alpine-conf \
   bind-tools \
   busybox-initscripts \
@@ -22,10 +22,11 @@ RUN \
   openrc \
   openssh-client \
   openssl \
+  rng-tools@edgecommunity \
   sfdisk \
   strace \
   sysklogd \
   syslinux \
   tar \
   xz \
-  && rm -rf /var/cache/apk/*
+  && true

--- a/alpine/base/alpine-base/repositories
+++ b/alpine/base/alpine-base/repositories
@@ -1,1 +1,2 @@
 http://dl-cdn.alpinelinux.org/alpine/v3.4/main
+@edgecommunity http://dl-cdn.alpinelinux.org/alpine/edge/community

--- a/alpine/etc/conf.d/rngd
+++ b/alpine/etc/conf.d/rngd
@@ -1,0 +1,1 @@
+RNGD_OPTS=""


### PR DESCRIPTION
Tweak the config to use RDSEED or (fallback) RDRAND. Makes sure
we have initial random seed in cases where there is no other
random source if these are supported.

The default config in Alpine currently disables these, which makes
it pretty useless, as there is no motherboard rng support any more.

Replaces #517
Fix #514
Fix #183

Signed-off-by: Justin Cormack justin.cormack@docker.com
