### PR TITLE
Increase default fs.aio-max-nr

### DIFF
--- a/alpine/etc/sysctl.d/01-moby.conf
+++ b/alpine/etc/sysctl.d/01-moby.conf
@@ -1,4 +1,5 @@
 vm.max_map_count = 262144
 net.core.somaxconn = 1024
+fs.aio-max-nr = 1048576
 fs.inotify.max_user_watches = 524288
 fs.file-max = 524288


### PR DESCRIPTION
As recommended by Oracle for MySQL.

Signed-off-by: Justin Cormack justin.cormack@docker.com
