### PR TITLE
Restart syslog after mounting drive on /var

### DIFF
--- a/alpine/packages/automount/etc/init.d/automount
+++ b/alpine/packages/automount/etc/init.d/automount
@@ -35,6 +35,8 @@ start()
 		[ -d /var/var/lib/boot2docker/ ] && mount --bind /var/var /var
 	fi
 
+	killall -HUP syslogd
+
 	mount | grep -q "${DEV}. on /var type"
 
 	eend $? "Failed to mount block device"


### PR DESCRIPTION
Otherwise logs are lost if files not reopened.

Signed-off-by: Justin Cormack justin.cormack@docker.com
