### PR TITLE
Enable local service

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -35,6 +35,7 @@ RUN \
   rc-update add fsck && \
   rc-update add root && \
   rc-update add crond && \
+  rc-update add local && \
   rc-update add localmount && \
   rc-update add docker default && \
   rc-update add proxy default && \


### PR DESCRIPTION
Files in `/etc/local.d/` will be executed:

If a file in this directory is executable and it has a .start extension,
it will be run when the local service is started. If a file is
executable and it has a .stop extension, it will be run when the local
service is stopped.

Signed-off-by: Justin Cormack justin.cormack@docker.com
