### PR TITLE
Switch to dhcpcd

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-base:0661b14ac943eacde2662a2c0e3be6dae297ce73
+FROM mobylinux/alpine-base:0f9607c16aaa5073e0cfd01c0cbbb718acbde8bf
 
 ENV ARCH=x86_64
 
@@ -22,6 +22,7 @@ RUN \
   rc-update add hwclock boot && \
   rc-update add tap-vsockd boot && \
   rc-update add networking boot && \
+  rc-update add dhcpcd boot && \
   rc-update add acpid default && \
   rc-update add chronyd default && \
   rc-update add savecache shutdown && \

--- a/alpine/base/alpine-base/Dockerfile
+++ b/alpine/base/alpine-base/Dockerfile
@@ -11,6 +11,7 @@ RUN \
   chrony \
   cifs-utils \
   curl \
+  dhcpcd \
   e2fsprogs \
   e2fsprogs-extra \
   fuse \

--- a/alpine/base/alpine-base/packages
+++ b/alpine/base/alpine-base/packages
@@ -14,6 +14,7 @@ cifs-utils 6.5-r0
 cryptsetup-libs 1.7.1-r0
 curl 7.50.3-r0
 device-mapper 2.02.154-r0
+dhcpcd 6.10.3-r1
 e2fsprogs 1.43-r0
 e2fsprogs-extra 1.43-r0
 e2fsprogs-libs 1.43-r0

--- a/alpine/etc/dhcpcd.conf
+++ b/alpine/etc/dhcpcd.conf
@@ -1,0 +1,46 @@
+# Moby dhcpcd config
+
+# Only configure standard external ethernet
+allowinterfaces eth*
+
+# Inform the DHCP server of our hostname for DDNS.
+hostname
+
+# Use the hardware address of the interface for the Client ID.
+clientid
+# or
+# Use the same DUID + IAID as set in DHCPv6 for DHCPv4 ClientID as per RFC4361.
+# Some non-RFC compliant DHCP servers do not reply with this set.
+# In this case, comment out duid and enable clientid above.
+#duid
+
+# Persist interface configuration when dhcpcd exits.
+persistent
+
+# Rapid commit support.
+# Safe to enable by default because it requires the equivalent option set
+# on the server to actually work.
+option rapid_commit
+
+# A list of options to request from the DHCP server.
+option domain_name_servers, domain_name, domain_search, host_name
+option classless_static_routes
+# Most distributions have NTP support.
+option ntp_servers
+# Respect the network MTU. This is applied to DHCP routes.
+option interface_mtu
+
+# A ServerID is required by RFC2131.
+require dhcp_server_identifier
+
+# Generate Stable Private IPv6 Addresses instead of hardware based ones
+slaac private
+
+# Do not wait
+nodelay
+
+# Do not arp to check IP
+noarp
+
+# Only fork when we have ipv4
+waitip 4

--- a/alpine/etc/network/interfaces
+++ b/alpine/etc/network/interfaces
@@ -1,6 +1,2 @@
 auto lo
 iface lo inet loopback
-
-auto eth0
-iface eth0 inet dhcp
-    udhcpc_opts -T 3 -A 3 -t 20 -O search

--- a/alpine/packages/azure/etc/init.d/azure
+++ b/alpine/packages/azure/etc/init.d/azure
@@ -5,7 +5,7 @@ description="Bootstrap procedure if running on Docker Azure edition"
 depend()
 {
 	need docker
-	need networking
+	need net
 }
 
 start()

--- a/alpine/packages/tap-vsockd/etc/init.d/tap-vsockd
+++ b/alpine/packages/tap-vsockd/etc/init.d/tap-vsockd
@@ -4,7 +4,7 @@ description="VPN proxy"
 
 depend()
 {
-	before networking
+	before net
 }
 
 start()

--- a/alpine/packages/test/usr/bin/mobytest
+++ b/alpine/packages/test/usr/bin/mobytest
@@ -2,6 +2,7 @@
 
 set -ex
 
+ifconfig
 docker info
 docker ps
 docker pull alpine


### PR DESCRIPTION
Should fix issue with not sending hostname which Azure needs.

This should be requesting all the dhcp features we currently use.

Signed-off-by: Justin Cormack justin.cormack@docker.com

Replaces #483
