### PR TITLE
Add weekly cron job to TRIM drive

### DIFF
--- a/alpine/etc/periodic/weekly/trim
+++ b/alpine/etc/periodic/weekly/trim
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# TODO check with hdparm if supports TRIM
+/sbin/fstrim /var || true


### PR DESCRIPTION
See #536

This is the recommended frequency. For desktop this might be less
suitable, so we may want to adjust

Signed-off-by: Justin Cormack justin.cormack@docker.com
