### PR TITLE
Remove syslinux from base image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-base:f457f4814b887126ded4930e93a9bd9749d4f540
+FROM mobylinux/alpine-base:550f9068f98000a9134b08217cde767fa732e6e0
 
 ENV ARCH=x86_64
 

--- a/alpine/base/alpine-base/Dockerfile
+++ b/alpine/base/alpine-base/Dockerfile
@@ -29,7 +29,6 @@ RUN \
   sfdisk \
   strace \
   sysklogd \
-  syslinux \
   tar \
   xz \
   && true

--- a/alpine/base/alpine-base/packages
+++ b/alpine/base/alpine-base/packages
@@ -1,17 +1,14 @@
-acct 6.6.2-r0
 alpine-baselayout 3.0.3-r0
 alpine-conf 3.4.1-r2
 alpine-keys 1.1-r0
 apk-tools 2.6.7-r0
 bind-libs 9.10.4_p2-r0
 bind-tools 9.10.4_p2-r0
-blkid 2.28-r3
 busybox 1.24.2-r11
 busybox-initscripts 3.0-r3
 ca-certificates 20160104-r4
 chrony 2.3-r1
 cifs-utils 6.5-r0
-cryptsetup-libs 1.7.1-r0
 curl 7.50.3-r0
 device-mapper 2.02.154-r0
 dhcpcd 6.10.3-r1
@@ -25,10 +22,8 @@ hvtools 4.4.15-r0
 iptables 1.6.0-r0
 jq 1.5-r1
 keyutils-libs 1.5.9-r1
-kmod 22-r0
 krb5-conf 1.0-r1
 krb5-libs 1.14.3-r0
-lddtree 1.25-r2
 libblkid 2.28-r3
 libc-utils 0.7-r0
 libcap 2.25-r0
@@ -47,8 +42,6 @@ libverto 0.2.5-r0
 lvm2 2.02.154-r0
 lvm2-libs 2.02.154-r0
 make 4.1-r1
-mkinitfs 3.0.5-r1
-mtools 4.0.18-r1
 musl 1.1.14-r12
 musl-utils 1.1.14-r12
 openrc 0.21-r2
@@ -62,7 +55,6 @@ scanelf 1.1.6-r0
 sfdisk 2.28-r3
 strace 4.11-r2
 sysklogd 1.5.1-r0
-syslinux 6.03-r4
 talloc 2.1.7-r0
 tar 1.29-r0
 xz 5.2.2-r1


### PR DESCRIPTION
I don't believe we need this at runtime, and it appears on the
vulnerability scanner. We still have it in the build images.

Signed-off-by: Justin Cormack justin.cormack@docker.com
