### PR TITLE
Use alpine to do raw2vhd

### DIFF
--- a/alpine/base/alpine-base/Makefile
+++ b/alpine/base/alpine-base/Makefile
@@ -5,9 +5,9 @@ IMAGE=alpine-base
 
 default: push
 
-hash:
+hash: Dockerfile repositories
 	docker pull $(BASE)
-	tar cf - Dockerfile repositories | docker build --no-cache -t $(IMAGE):build -
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm $(IMAGE):build sha1sum /lib/apk/db/installed | sed 's/ .*//' > hash
 
 push: hash

--- a/alpine/base/alpine-qemu/Dockerfile
+++ b/alpine/base/alpine-qemu/Dockerfile
@@ -1,9 +1,11 @@
 FROM alpine:3.4
 
+COPY repositories /etc/apk/
+
 RUN \
   apk update && apk upgrade && \
-  apk add \
-  qemu-img \
-  qemu-system-arm \
-  qemu-system-x86_64 \
-  && rm -rf /var/cache/apk/*
+  apk add --no-cache \
+  qemu-img@edge \
+  qemu-system-arm@edge \
+  qemu-system-x86_64@edge \
+  && true

--- a/alpine/base/alpine-qemu/Makefile
+++ b/alpine/base/alpine-qemu/Makefile
@@ -5,9 +5,9 @@ IMAGE=alpine-qemu
 
 default: push
 
-hash:
+hash: Dockerfile repositories
 	docker pull $(BASE)
-	tar cf - Dockerfile | docker build --no-cache -t $(IMAGE):build -
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm $(IMAGE):build sha1sum /lib/apk/db/installed | sed 's/ .*//' > hash
 
 push: hash

--- a/alpine/base/alpine-qemu/repositories
+++ b/alpine/base/alpine-qemu/repositories
@@ -1,0 +1,2 @@
+http://dl-cdn.alpinelinux.org/alpine/v3.4/main
+@edge http://dl-cdn.alpinelinux.org/alpine/edge/main

--- a/alpine/cloud/Dockerfile.raw2vhd
+++ b/alpine/cloud/Dockerfile.raw2vhd
@@ -1,17 +1,5 @@
-FROM debian:jessie
+FROM mobylinux/alpine-qemu:0e5f8a908e7976c3a6ab725b7267ab725e89c6ae
 
-# Why bother with this whole song and dance?  qemu-img versions >=2.2.1 have a
-# "bug" which causes the generated VHD files to be improperly formatted for
-# running on Azure: https://bugs.launchpad.net/qemu/+bug/1490611
-# 
-# Since Alpine has only qemu-img >= 2.4.1 in its apk index, we cannot use
-# Alpine.
-RUN apt-get update && \
-    apt-get install -y qemu-utils
-
-# If version changes in distributed packages, this build is busted.  Sanity check.
-RUN qemu-img --version
-RUN qemu-img --version | awk '{ if ($3 != "2.1.2,") exit 1; }'
 COPY ./cloud/azure/raw2vhd.sh /raw2vhd.sh
 
 VOLUME ["/tmp"]

--- a/alpine/cloud/azure/raw2vhd.sh
+++ b/alpine/cloud/azure/raw2vhd.sh
@@ -3,5 +3,5 @@
 set -e
 
 >&2 echo "Converting raw image file to VHD..."
-qemu-img convert -f raw -O vpc -o subformat=fixed /tmp/mobylinux.img /tmp/mobylinux.vhd 1>&2
+qemu-img convert -f raw -O vpc -o subformat=fixed,force_size /tmp/mobylinux.img /tmp/mobylinux.vhd 1>&2
 >&2 echo "Done converting to VHD."


### PR DESCRIPTION
Force late enough version of qemu from alpine edge.

Signed-off-by: Justin Cormack justin.cormack@docker.com

Replaces #494

fix #457
