### PR TITLE
Use build container id rather than tagging builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,10 @@ qemu-iso: Dockerfile.qemuiso alpine/mobylinux-bios.iso
 
 test: Dockerfile.test alpine/initrd.img alpine/kernel/x86_64/vmlinuz64
 	$(MAKE) -C alpine
-	tar cf - $^ | docker build -f Dockerfile.test -t mobytest:build -
-	touch test.log
-	docker run --rm mobytest:build 2>&1 | tee -a test.log
+	BUILD=$$( tar cf - $^ | docker build -f Dockerfile.test -q - ) && [ -n "$$BUILD" ] && \
+	touch test.log && \
+	docker run --rm $$BUILD 2>&1 | tee -a test.log && \
+	docker rmi --no-prune $$BUILD
 	@cat test.log | grep -q 'Moby test suite PASSED'
 
 TAG=$(shell git rev-parse HEAD)

--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -5,7 +5,7 @@ ETCFILES=$(shell find etc)
 initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	$(MAKE) -C kernel
 	$(MAKE) -j -C packages
-	tar cf - \
+	BUILD=$$( tar cf - \
 	  Dockerfile etc usr init mkinitrd.sh \
 	  -C kernel usr etc sbin lib -C .. \
 	  -C packages/proxy usr sbin etc -C ../.. \
@@ -30,13 +30,15 @@ initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	  -C packages/aws etc -C ../.. \
 	  -C packages/azure etc -C ../.. \
 	  | \
-	  docker build -t moby-initrd:build -
-	docker run --net=none --log-driver=none --rm moby-initrd:build > $@
+	  docker build -q - ) && [ -n "$$BUILD" ] && \
+	docker run --net=none --log-driver=none --rm $$BUILD > $@ && \
+	docker rmi --no-prune $$BUILD
 
 mobylinux-efi.iso: Dockerfile.efi initrd.img kernel/x86_64/vmlinuz64
-	tar cf - $^ | docker build -t moby-efi:build -f Dockerfile.efi -
-	docker run --net=none --log-driver=none --rm --cap-add sys_admin moby-efi:build cat /tmp/efi/mobylinux.efi > mobylinux.efi
-	docker run --net=none --log-driver=none --rm --cap-add sys_admin moby-efi:build cat /tmp/efi/mobylinux-efi.iso > $@
+	BUILD=$$( tar cf - $^ | docker build -q -f Dockerfile.efi - ) && [ -n "$$BUILD" ] && \
+	docker run --net=none --log-driver=none --rm --cap-add sys_admin $$BUILD cat /tmp/efi/mobylinux.efi > mobylinux.efi && \
+	docker run --net=none --log-driver=none --rm --cap-add sys_admin $$BUILD cat /tmp/efi/mobylinux-efi.iso > $@ && \
+	docker rmi --no-prune $$BUILD
 
 mobylinux-bios.iso: initrd.img kernel/x86_64/vmlinuz64
 	tar cf - initrd.img -C kernel/x86_64 vmlinuz64 | \

--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -4,11 +4,12 @@ all:	x86_64/vmlinuz64
 
 x86_64/vmlinuz64: Dockerfile kernel_config
 	mkdir -p x86_64 etc
-	docker build --build-arg DEBUG=$(DEBUG) -t mobykernel:build .
-	docker run --rm --net=none --log-driver=none mobykernel:build cat /kernel-modules.tar | tar xf -
-	docker run --rm --net=none --log-driver=none mobykernel:build cat /aufs-utils.tar | tar xf -
-	docker run --rm --net=none --log-driver=none mobykernel:build cat /kernel-source-info > etc/kernel-source-info
-	docker run --rm --net=none --log-driver=none mobykernel:build cat /linux/arch/x86_64/boot/bzImage > $@
+	BUILD=$$( docker build --build-arg DEBUG=$(DEBUG) -q . ) && [ -n "$$BUILD" ] && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-modules.tar | tar xf - && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat /aufs-utils.tar | tar xf - && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-source-info > etc/kernel-source-info && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat /linux/arch/x86_64/boot/bzImage > $@ && \
+	docker rmi --no-prune $$BUILD
 	cp -a patches etc/kernel-patches
 
 clean:

--- a/alpine/packages/9pmount-vsock/Makefile
+++ b/alpine/packages/9pmount-vsock/Makefile
@@ -2,8 +2,9 @@ DEPS=Dockerfile $(wildcard *.c *.h)
 
 9pmount-vsock: $(DEPS)
 	mkdir -p sbin
-	tar cf - $(DEPS) | docker build -t 9pmount-vsock:build -
-	docker run --rm --net=none 9pmount-vsock:build | tar xf - -C sbin
+	BUILD=$$( tar cf - $(DEPS) | docker build -q - ) && [ -n "$$BUILD" ] && \
+	docker run --rm --net=none $$BUILD | tar xf - -C sbin && \
+	docker rmi --no-prune $$BUILD
 
 clean:
 	rm -rf sbin

--- a/alpine/packages/diagnostics/Makefile
+++ b/alpine/packages/diagnostics/Makefile
@@ -3,8 +3,9 @@ all: usr/bin/diagnostics-server
 DEPS=Dockerfile $(wildcard *.go)
 
 usr/bin/diagnostics-server: $(DEPS) ../vendor/manifest
-	tar cf - $(DEPS) -C .. vendor | docker build -t diagnostics-server:build -
-	docker run --rm --net=none diagnostics-server:build | tar xf - -C usr/bin
+	BUILD=$$( tar cf - $(DEPS) -C .. vendor | docker build -q - ) && [ -n "$$BUILD" ] && \
+	docker run --rm --net=none $$BUILD | tar xf - -C usr/bin && \
+	docker rmi --no-prune $$BUILD
 
 clean:
 	rm -f usr/bin/diagnostics-server

--- a/alpine/packages/iptables/Makefile
+++ b/alpine/packages/iptables/Makefile
@@ -2,8 +2,9 @@ all: usr/local/sbin/iptables
 
 usr/local/sbin/iptables: Dockerfile main.ml
 	mkdir -p usr/local/sbin
-	docker build -t iptables:build .
-	docker run --rm iptables:build | tar xf - -C usr/local/sbin
+	BUILD=$$( docker build -q . ) && [ -n "$$BUILD" ] && \
+	docker run --rm $$BUILD | tar xf - -C usr/local/sbin && \
+	docker rmi --no-prune $$BUILD
 
 clean:
 	rm -rf usr

--- a/alpine/packages/nc-vsock/Makefile
+++ b/alpine/packages/nc-vsock/Makefile
@@ -2,8 +2,9 @@ DEPS=Dockerfile $(wildcard *.c *.h)
 
 usr/bin/nc-vsock: $(DEPS)
 	mkdir -p usr/bin
-	tar cf - $(DEPS) | docker build -t nc-vsock:build -
-	docker run --rm --net=none nc-vsock:build | tar xf - -C usr/bin
+	BUILD=$$( tar cf - $(DEPS) | docker build -q - ) && [ -n "$$BUILD" ] && \
+	docker run --rm --net=none $$BUILD | tar xf - -C usr/bin && \
+	docker rmi --no-prune $$BUILD
 
 clean:
 	rm -rf usr

--- a/alpine/packages/proxy/Makefile
+++ b/alpine/packages/proxy/Makefile
@@ -3,8 +3,9 @@ all: usr/bin/slirp-proxy sbin/proxy-vsockd
 DEPS=Dockerfile $(wildcard *.go libproxy/*.go)
 
 proxy: $(DEPS) ../vendor/manifest
-	tar cf - $(DEPS) -C .. vendor | docker build -t proxy:build -
-	docker run --rm --net=none proxy:build | tar xf -
+	BUILD=$$( tar cf - $(DEPS) -C .. vendor | docker build -q - ) && [ -n "$$BUILD" ] && \
+	docker run --rm --net=none $$BUILD | tar xf - && \
+	docker rmi --no-prune $$BUILD
 
 usr/bin/slirp-proxy: proxy
 	mkdir -p usr/bin

--- a/alpine/packages/tap-vsockd/Makefile
+++ b/alpine/packages/tap-vsockd/Makefile
@@ -2,8 +2,9 @@ DEPS=Dockerfile $(wildcard *.c *.h)
 
 sbin/tap-vsockd: $(DEPS)
 	mkdir -p sbin
-	tar cf - $(DEPS) | docker build -t tap-vsockd:build -
-	docker run --rm --net=none tap-vsockd:build | tar xf - -C sbin
+	BUILD=$$( tar cf - $(DEPS) | docker build -q - ) && [ -n "$$BUILD" ] && \
+	docker run --rm --net=none $$BUILD | tar xf - -C sbin && \
+	docker rmi --no-prune $$BUILD
 
 clean:
 	rm -rf sbin

--- a/alpine/packages/transfused/Makefile
+++ b/alpine/packages/transfused/Makefile
@@ -2,8 +2,9 @@ DEPS=Dockerfile $(wildcard *.c *.h)
 
 sbin/transfused: $(DEPS)
 	mkdir -p sbin
-	tar cf - $(DEPS) | docker build -t transfused:build -
-	docker run --rm --net=none transfused:build | tar xf - -C sbin
+	BUILD=$$( tar cf - $(DEPS) | docker build -q - ) && [ -n "$$BUILD" ] && \
+	docker run --rm --net=none $$BUILD | tar xf - -C sbin && \
+	docker rmi --no-prune $$BUILD
 
 clean:
 	rm -rf sbin

--- a/alpine/packages/vsudd/Makefile
+++ b/alpine/packages/vsudd/Makefile
@@ -4,8 +4,9 @@ DEPS=Dockerfile $(wildcard *.go)
 
 vsudd: $(DEPS) ../vendor/manifest
 	mkdir -p sbin
-	tar cf - $(DEPS) -C .. vendor | docker build -t vsudd:build -
-	docker run --rm --net=none vsudd:build | tar xf - -C sbin
+	BUILD=$$( tar cf - $(DEPS) -C .. vendor | docker build -q - ) && [ -n "$$BUILD" ] && \
+	docker run --rm --net=none $$BUILD | tar xf - -C sbin && \
+	docker rmi --no-prune $$BUILD
 
 clean:
 	rm -rf sbin


### PR DESCRIPTION
This means that multiple builds will not conflict, so we can
remove the lock from the CI. Also quieter when no errors.

Some still left to do, only done the ones used in build and CI
initially. Some of the others will be cleaned up anyway later.

Signed-off-by: Justin Cormack justin.cormack@docker.com

Thanks to @thaJeztah for pointing out the `-q` build option...
