### PR TITLE
remove use of rm /var/cache/apk

### DIFF
--- a/alpine/Dockerfile.efi
+++ b/alpine/Dockerfile.efi
@@ -1,5 +1,5 @@
 # Create a EFI Bootable ISO
-FROM mobylinux/alpine-efi:2f8c8e9ecc4bfefaf1b5ca56bac5506baba301f2
+FROM mobylinux/alpine-efi:41ce281ca20186b8f5cae3b0fd05260189d6a3d2
 
 WORKDIR /tmp/efi
 

--- a/alpine/base/alpine-efi/Dockerfile
+++ b/alpine/base/alpine-efi/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:3.4
 
 RUN \
   apk update && apk upgrade && \
-  apk add \
+  apk add --no-cache \
   binutils \
+  gummiboot \
   mtools \
   xorriso \
-  gummiboot \
-  && rm -rf /var/cache/apk/*
+  && true


### PR DESCRIPTION
Signed-off-by: Justin Cormack justin.cormack@docker.com

fix #571
