### PR TITLE
Default to overlay2

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -62,6 +62,9 @@ start()
 			mobyconfig get $f > $f
 		done
 	fi
+
+	[ -f /etc/docker/daemon.json ] || printf '{}' > /etc/docker/daemon.json
+
 	if mobyconfig exists network
 	then
 		NETWORK_MODE="$(mobyconfig get network | tr -d '[[:space:]]')"
@@ -79,7 +82,15 @@ start()
 	fi
 
 	# Set Docker to debug debug if not specified in daemon.json
-	([ -f /etc/docker/daemon.json ] && cat /etc/docker/daemon.json | jq -e 'has("debug")' > /dev/null) || DOCKER_OPTS="${DOCKER_OPTS} --debug"
+	cat /etc/docker/daemon.json | jq -e 'has("debug")' > /dev/null || DOCKER_OPTS="${DOCKER_OPTS} --debug"
+
+	# choose storage driver
+	if ! $(cat /etc/docker/daemon.json | jq -e '."storage-driver"' > /dev/null)
+	then
+		STORAGE_DRIVER="overlay2"
+		[ -d /var/lib/docker/aufs ] && STORAGE_DRIVER="aufs"
+		DOCKER_OPTS="${DOCKER_OPTS} --storage-driver ${STORAGE_DRIVER}"
+	fi
 
 	# shift logs onto host before docker starts
 	# busybox reopens its log files every second


### PR DESCRIPTION
If there is no storage-driver set in daemon.json and no
aufs directory in the docker directory, use overlay2 as the storage
driver.

Signed-off-by: Justin Cormack justin.cormack@docker.com
