### PR TITLE
Increase default memlock ulimit

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -107,6 +107,8 @@ start()
 	# set ulimits as high as possible
 	ulimit -n 1048576
 	ulimit -p unlimited
+	# set locked memory higher for varnish
+	ulimit -l 82000
 
 	DOCKER_LOGFILE="/var/log/docker.log"
 


### PR DESCRIPTION
Fix #610

Users can override, but the default is low.

Signed-off-by: Justin Cormack justin.cormack@docker.com
