### PR TITLE
Add dependency to Makefile for Docker

### DIFF
--- a/alpine/packages/docker/Makefile
+++ b/alpine/packages/docker/Makefile
@@ -24,9 +24,9 @@ endif
 .PHONY: download hub cleanusr
 
 ifeq ($(DOCKER_BIN_URL)$(FORCE_CURL)$(RELEASE_CANDIDATE),)
-usr/bin/docker: hub
+usr/bin/docker: Makefile hub
 else
-usr/bin/docker: download
+usr/bin/docker: Makefile download
 endif
 
 cleanusr:


### PR DESCRIPTION
The Docker version is in the Makefile su always re-upload if changed.

Signed-off-by: Justin Cormack justin.cormack@docker.com
