### PR TITLE
fsck filesystem before mount

### DIFF
--- a/alpine/packages/automount/etc/init.d/automount
+++ b/alpine/packages/automount/etc/init.d/automount
@@ -45,7 +45,7 @@ start()
 			ERASE_DISKS="${DRIVE}" setup-disk -m data ${DRIVE}
 			blockdev --rereadpt "${DRIVE}" 2> /dev/null
 		else
-			( mount "${DATA}" /var && ([ -z "${SWAP}" ] || swapon "${SWAP}") ) || \
+			( e2fsck -p "${DATA}" && mount "${DATA}" /var && ([ -z "${SWAP}" ] || swapon "${SWAP}") ) || \
 			  ( ERASE_DISKS="${DRIVE}" setup-disk -m data ${DRIVE}; blockdev --rereadpt ${DRIVE} 2> /dev/null )
 		fi
 		# boot2docker compat, has /var and /tmp on partition


### PR DESCRIPTION
Use `fsck -p` to fix errors that are fixable.

Note this will recreate the filesystem on fatal errors.

Fix #665

Signed-off-by: Justin Cormack <justin.cormack@docker.com>