### PR TITLE
Split out Windows network config from hostsettings

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -45,7 +45,8 @@ RUN \
   rc-update add automount boot && \
   rc-update add diagnostics default && \
   rc-update add binfmt_misc default && \
-  rc-update add hostsettings boot && \
+  rc-update add hostsettings default && \
+  rc-update add windowsnet boot && \
   rc-update add hv_kvp_daemon default && \
   rc-update add hv_vss_daemon default && \
   rc-update add oom default && \

--- a/alpine/packages/hostsettings/etc/init.d/hostsettings
+++ b/alpine/packages/hostsettings/etc/init.d/hostsettings
@@ -3,7 +3,9 @@
 description="Configuring settings from database."
 
 depend() {
-	before sysctl net
+	# AWS gets settings via network
+	need net
+	before docker
 }
 
 start() {
@@ -11,25 +13,11 @@ start() {
 
 	mobyconfig exists etc/sysctl.conf && mobyconfig get etc/sysctl.conf > /etc/sysctl.conf
 	mobyconfig exists etc/sysfs.conf && mobyconfig get etc/sysfs.conf > /etc/sysfs.conf
-	mobyconfig exists etc/resolv.conf && mobyconfig get etc/resolv.conf > /etc/resolv.conf
-	mobyconfig exists random-seed && mobyconfig get random-seed > /dev/urandom
-	mobyconfig exists etc/hosts && mobyconfig get etc/hosts >> /etc/hosts
 
-        if [ "$(mobyplatform)" = "windows" ]; then
-            # We have two network interfaces. The Hyper-V interface
-            # comes up as eth0. Rename and configure it.
-            ip link set eth0 down
-            ip link set eth0 name hvint0 
-            
-            mobyconfig exists net/config && NETCONFIG=`mobyconfig get net/config`
-            if [ "${NETCONFIG}" = "static" ]; then
-                # assume that the other configsDB entries exist
-                IP=`mobyconfig get net/address`
-                MASK=`mobyconfig get net/netmask`
-                ip addr add ${IP}/${MASK} dev hvint0
-                ip link set hvint0 up
-	    fi
-	fi
+	mobyconfig exists random-seed && mobyconfig get random-seed > /dev/urandom
+
+	mobyconfig exists etc/resolv.conf && mobyconfig get etc/resolv.conf > /etc/resolv.conf
+	mobyconfig exists etc/hosts && mobyconfig get etc/hosts >> /etc/hosts
 
 	mobyconfig exists etc/ssl/certs/ca-certificates.crt && mobyconfig get etc/ssl/certs/ca-certificates.crt >> /etc/ssl/certs/ca-certificates.crt 
 

--- a/alpine/packages/hostsettings/etc/init.d/windowsnet
+++ b/alpine/packages/hostsettings/etc/init.d/windowsnet
@@ -1,0 +1,29 @@
+#!/sbin/openrc-run
+
+description="Configuring Windows network settings from database."
+
+depend() {
+	before sysctl net
+}
+
+start() {
+	[ "$(mobyplatform)" = "windows" ] || exit 0
+
+	ebegin "Configuring Windows network settings from database"
+
+	# We have two network interfaces. The Hyper-V interface
+	# comes up as eth0. Rename and configure it.
+	ip link set eth0 down
+	ip link set eth0 name hvint0 
+            
+	mobyconfig exists net/config && NETCONFIG=`mobyconfig get net/config`
+	if [ "${NETCONFIG}" = "static" ]; then
+		# assume that the other configsDB entries exist
+		IP=`mobyconfig get net/address`
+		MASK=`mobyconfig get net/netmask`
+		ip addr add ${IP}/${MASK} dev hvint0
+		ip link set hvint0 up
+	fi
+
+	eend 0
+}


### PR DESCRIPTION
On cloud editions eg AWS settings may come from the network, so
we need to move this to after network setup, while the Windows
network config changes need to happen before, so split the init script.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>