### PR TITLE
Improve matching of mounted drive in diagnostics

### DIFF
--- a/alpine/packages/diagnostics/usr/bin/diagnostics
+++ b/alpine/packages/diagnostics/usr/bin/diagnostics
@@ -3,7 +3,7 @@
 printf '\n'
 DEV="$(find /dev -maxdepth 1 -type b ! -name 'loop*' | grep -v '[0-9]$' | sed 's@.*/dev/@@' | head -1 )"
 [ $? -eq 0 ] && printf "✓ Drive found: $DEV\n" || printf "✗ No drive found\n"
-DEV=$(mount | grep '/dev/.*da. on /var type')
+DEV=$(mount | grep '/dev/.* on /var type')
 [ $? -eq 0 ] && printf "✓ Drive mounted: $DEV\n" || printf "✗ No drive mounted\n"
 INET=$(ifconfig eth0 2> /dev/null | grep 'inet addr')
 [ $? -eq 0 ] && printf "✓ Network connected: $INET\n" || printf "✗ No network connection\n"


### PR DESCRIPTION
Was failing on AWS as drive did not match patter that was too precise.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>