### PR TITLE
Remove bind-tools

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-base:6268305aa272bedd756426c5dd3f60beb634f5f8
+FROM mobylinux/alpine-base:779567ef160aeda5ea7942b68303884fa69a21fa
 
 ENV ARCH=x86_64
 

--- a/alpine/base/alpine-base/Dockerfile
+++ b/alpine/base/alpine-base/Dockerfile
@@ -6,7 +6,6 @@ RUN \
   apk update && apk upgrade && \
   apk add --no-cache \
   alpine-conf \
-  bind-tools \
   busybox-initscripts \
   chrony \
   cifs-utils \

--- a/alpine/base/alpine-base/packages
+++ b/alpine/base/alpine-base/packages
@@ -2,8 +2,6 @@ alpine-baselayout 3.0.3-r0
 alpine-conf 3.4.1-r5
 alpine-keys 1.1-r0
 apk-tools 2.6.7-r0
-bind-libs 9.10.4_p3-r0
-bind-tools 9.10.4_p3-r0
 busybox 1.24.2-r12
 busybox-initscripts 3.0-r3
 ca-certificates 20160104-r4
@@ -32,7 +30,6 @@ libcom_err 1.43-r0
 libcrypto1.0 1.0.2j-r0
 libcurl 7.50.3-r0
 libfdisk 2.28-r3
-libgcc 5.3.0-r0
 libmnl 1.0.3-r1
 libnftnl-libs 1.0.5-r0
 libnl 1.1.4-r0


### PR DESCRIPTION
We do not seem to need this. Busybox provides versions of some commands.

As far as I can tell it was introduced for debugging. Flagged as a security
issue on the scans due to `bind` issues, not a real issue but flags we do
not use it.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>