### PR TITLE
Curl security update

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-base:6268305aa272bedd756426c5dd3f60beb634f5f8
+FROM mobylinux/alpine-base:2d4cde2e18d032f5e85c4f4239ab6d906864401c
 
 ENV ARCH=x86_64
 

--- a/alpine/base/alpine-base/packages
+++ b/alpine/base/alpine-base/packages
@@ -9,7 +9,7 @@ busybox-initscripts 3.0-r3
 ca-certificates 20160104-r4
 chrony 2.3-r1
 cifs-utils 6.5-r0
-curl 7.50.3-r0
+curl 7.51.0-r0
 device-mapper 2.02.154-r0
 dhcpcd 6.10.3-r1
 e2fsprogs 1.43-r0
@@ -30,7 +30,7 @@ libc-utils 0.7-r0
 libcap 2.25-r0
 libcom_err 1.43-r0
 libcrypto1.0 1.0.2j-r0
-libcurl 7.50.3-r0
+libcurl 7.51.0-r0
 libfdisk 2.28-r3
 libgcc 5.3.0-r0
 libmnl 1.0.3-r1


### PR DESCRIPTION
Upgrade to 7.51, fix the following CVEs

  CVE-2016-7141, CVE-2016-7167, CVE-2016-8615, CVE-2016-8616,
  CVE-2016-8617, CVE-2016-8618, CVE-2016-8619, CVE-2016-8620,
  CVE-2016-8621, CVE-2016-8622, CVE-2016-8623, CVE-2016-8624

Signed-off-by: Justin Cormack <justin.cormack@docker.com>