### PR TITLE
Do not include non-efi ISO in media

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ STATUS=$(shell git status -s)
 ifeq ($(DOCKER_EXPERIMENTAL),1)
 MEDIA_PREFIX?=experimental-
 endif
-media: Dockerfile.media alpine/initrd.img alpine/kernel/x86_64/vmlinuz64 alpine/mobylinux-bios.iso alpine/mobylinux-efi.iso
+media: Dockerfile.media alpine/initrd.img alpine/kernel/x86_64/vmlinuz64 alpine/mobylinux-efi.iso
 ifeq ($(STATUS),)
 	tar cf - $^ alpine/mobylinux.efi | docker build -f Dockerfile.media -t mobylinux/media:$(MEDIA_PREFIX)$(TAG) -
 	docker push mobylinux/media:$(MEDIA_PREFIX)$(TAG)


### PR DESCRIPTION
We are not using this for editions.

We should be able to make a dual boot ISO, or you can create from the other
artefacts anyway.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>