### PR TITLE
Disable EFI framebuffer

### DIFF
--- a/alpine/kernel/kernel_config
+++ b/alpine/kernel/kernel_config
@@ -1294,8 +1294,7 @@ CONFIG_ALLOW_DEV_COREDUMP=y
 # CONFIG_SYS_HYPERVISOR is not set
 # CONFIG_GENERIC_CPU_DEVICES is not set
 CONFIG_GENERIC_CPU_AUTOPROBE=y
-CONFIG_DMA_SHARED_BUFFER=y
-# CONFIG_FENCE_TRACE is not set
+# CONFIG_DMA_SHARED_BUFFER is not set
 
 #
 # Bus devices
@@ -1924,7 +1923,6 @@ CONFIG_I2C_MUX=y
 # CONFIG_I2C_MUX_PCA9541 is not set
 # CONFIG_I2C_MUX_REG is not set
 CONFIG_I2C_HELPER_AUTO=y
-CONFIG_I2C_ALGOBIT=y
 
 #
 # I2C Hardware Bus support
@@ -2270,45 +2268,9 @@ CONFIG_MFD_VX855=y
 # Graphics support
 #
 # CONFIG_AGP is not set
-CONFIG_VGA_ARB=y
-CONFIG_VGA_ARB_MAX_GPUS=16
+# CONFIG_VGA_ARB is not set
 # CONFIG_VGA_SWITCHEROO is not set
-CONFIG_DRM=y
-CONFIG_DRM_KMS_HELPER=y
-CONFIG_DRM_KMS_FB_HELPER=y
-CONFIG_DRM_FBDEV_EMULATION=y
-# CONFIG_DRM_LOAD_EDID_FIRMWARE is not set
-
-#
-# I2C encoder or helper chips
-#
-# CONFIG_DRM_I2C_ADV7511 is not set
-# CONFIG_DRM_I2C_CH7006 is not set
-# CONFIG_DRM_I2C_SIL164 is not set
-# CONFIG_DRM_I2C_NXP_TDA998X is not set
-# CONFIG_DRM_TDFX is not set
-# CONFIG_DRM_R128 is not set
-# CONFIG_DRM_RADEON is not set
-# CONFIG_DRM_AMDGPU is not set
-# CONFIG_DRM_NOUVEAU is not set
-# CONFIG_DRM_I915 is not set
-# CONFIG_DRM_MGA is not set
-# CONFIG_DRM_VIA is not set
-# CONFIG_DRM_SAVAGE is not set
-# CONFIG_DRM_VGEM is not set
-# CONFIG_DRM_VMWGFX is not set
-# CONFIG_DRM_GMA500 is not set
-# CONFIG_DRM_AST is not set
-# CONFIG_DRM_MGAG200 is not set
-# CONFIG_DRM_CIRRUS_QEMU is not set
-# CONFIG_DRM_QXL is not set
-# CONFIG_DRM_BOCHS is not set
-# CONFIG_DRM_VIRTIO_GPU is not set
-CONFIG_DRM_BRIDGE=y
-
-#
-# Display Interface Bridges
-#
+# CONFIG_DRM is not set
 
 #
 # Frame buffer Devices
@@ -2346,7 +2308,7 @@ CONFIG_FB_DEFERRED_IO=y
 # CONFIG_FB_VGA16 is not set
 # CONFIG_FB_UVESA is not set
 CONFIG_FB_VESA=y
-CONFIG_FB_EFI=y
+# CONFIG_FB_EFI is not set
 # CONFIG_FB_N411 is not set
 # CONFIG_FB_HGA is not set
 # CONFIG_FB_OPENCORES is not set
@@ -2380,11 +2342,10 @@ CONFIG_XEN_FBDEV_FRONTEND=y
 # CONFIG_FB_BROADSHEET is not set
 # CONFIG_FB_AUO_K190X is not set
 CONFIG_FB_HYPERV=y
-CONFIG_FB_SIMPLE=y
+# CONFIG_FB_SIMPLE is not set
 # CONFIG_FB_SM712 is not set
 # CONFIG_BACKLIGHT_LCD_SUPPORT is not set
 # CONFIG_VGASTATE is not set
-CONFIG_HDMI=y
 
 #
 # Console display driver support


### PR DESCRIPTION
Azure only uses the Hyper-V framebuffer, so we should not need this.

Simplify setup for graphics options we are not using.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>