### PR TITLE
remove bios media from Dockerfile and add vmlinux

### DIFF
--- a/Dockerfile.media
+++ b/Dockerfile.media
@@ -3,7 +3,7 @@ FROM scratch
 ADD \
   alpine/initrd.img \
   alpine/kernel/x86_64/vmlinuz64 \
-  alpine/mobylinux-bios.iso \
+  alpine/kernel/x86_64/vmlinux \
   alpine/mobylinux-efi.iso \
   alpine/mobylinux.efi \
   / 


### PR DESCRIPTION
Fixes `make media`

Signed-off-by: Justin Cormack <justin.cormack@docker.com>