### PR TITLE
Format filesystems earlier, before syslog

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -35,14 +35,13 @@ RUN \
   rc-update add sysfs && \
   rc-update add sysfsconf && \
   rc-update add fsck && \
-  rc-update add root && \
   rc-update add crond && \
   rc-update add local && \
   rc-update add localmount && \
   rc-update add docker default && \
   rc-update add proxy default && \
   rc-update add transfused default && \
-  rc-update add automount boot && \
+  rc-update add automount sysinit && \
   rc-update add diagnostics default && \
   rc-update add binfmt_misc default && \
   rc-update add hostsettings default && \

--- a/alpine/etc/init.d/fsck
+++ b/alpine/etc/init.d/fsck
@@ -1,0 +1,12 @@
+#!/sbin/openrc-run
+# do nothing as we do this in automount script
+
+start()
+{
+	return 0
+}
+
+stop()
+{
+	return 0
+}

--- a/alpine/packages/automount/etc/init.d/automount
+++ b/alpine/packages/automount/etc/init.d/automount
@@ -2,8 +2,7 @@
 
 depend()
 {
-	after dev
-	before docker
+	need dev
 }
 
 start()


### PR DESCRIPTION
So that we can write to /var early, move filesystem formatting as early as possible.

Adds a dummy fsck service, as we already do fsck in format script, and it complains.

Replaces #535

Signed-off-by: Justin Cormack <justin.cormack@docker.com>