### PR TITLE
Docker 1.13 needs more disk space

### DIFF
--- a/Dockerfile.qemu
+++ b/Dockerfile.qemu
@@ -3,6 +3,6 @@ FROM mobylinux/alpine-qemu:804b2c40d078287c40aeb9166e475e843544e597
 COPY alpine/initrd.img .
 COPY alpine/kernel/x86_64/vmlinuz64 .
 
-RUN qemu-img create -f raw disk.img 100M
+RUN qemu-img create -f raw disk.img 256M
 
 ENTRYPOINT [ "qemu-system-x86_64", "-drive", "file=disk.img,format=raw", "-device", "virtio-rng-pci", "-serial", "stdio", "-kernel", "vmlinuz64", "-initrd", "initrd.img", "-m", "2048", "-append", "earlyprintk=serial console=ttyS0 noapic", "-vnc", "none" ]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -3,6 +3,6 @@ FROM mobylinux/alpine-qemu:804b2c40d078287c40aeb9166e475e843544e597
 COPY alpine/initrd.img .
 COPY alpine/kernel/x86_64/vmlinuz64 .
 
-RUN qemu-img create -f raw disk.img 100M
+RUN qemu-img create -f raw disk.img 256M
 
 ENTRYPOINT [ "qemu-system-x86_64", "-drive", "file=disk.img,format=raw", "-device", "virtio-rng-pci", "-serial", "stdio", "-kernel", "vmlinuz64", "-initrd", "initrd.img", "-m", "1024", "-append", "earlyprintk=serial console=ttyS0 noapic mobyplatform=test", "-vnc", "none" ]

--- a/hyperkit.sh
+++ b/hyperkit.sh
@@ -6,7 +6,7 @@ KERNEL="alpine/kernel/x86_64/vmlinuz64"
 INITRD="alpine/initrd.img"
 CMDLINE="earlyprintk=serial console=ttyS0"
 
-[ -f disk.img ] || dd if=/dev/zero of=disk.img bs=1m count=100
+[ -f disk.img ] || dd if=/dev/zero of=disk.img bs=1m count=256
 
 MEM="-m 1G"
 SMP="-c 1"


### PR DESCRIPTION
Swarm mode now `fallocate`s a whole lot of space, so give it more so
test passes.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>