### PR TITLE
Always start vsudd before syslog

### DIFF
--- a/alpine/etc/init.d/sysklogd
+++ b/alpine/etc/init.d/sysklogd
@@ -1,0 +1,76 @@
+#!/sbin/openrc-run
+# Copyright 1999-2011 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License, v2 or later
+# $Header: /var/cvsroot/gentoo-x86/app-admin/sysklogd/files/sysklogd.rc7,v 1.1 2011/09/14 22:22:57 polynomial-c Exp $
+
+extra_started_commands="reload"
+
+depend() {
+	need clock hostname localmount vsudd
+	before net
+	provide logger
+}
+
+start_daemon() {
+	local retval=0
+	local daemon="$1"
+	local options="$2"
+
+	[ -z "${daemon}" ] && return 1
+
+	ebegin "sysklogd -> start: ${daemon}"
+	start-stop-daemon --start --exec /usr/sbin/"${daemon}" \
+		--pidfile /var/run/"${daemon}".pid -- ${options}
+	retval=$?
+	eend ${retval} "Failed to start ${daemon}"
+
+	return ${retval}
+}
+
+stop_daemon() {
+	local retval=0
+	local daemon="$1"
+
+	[ -z "${daemon}" ] && return 1
+
+	ebegin "sysklogd -> stop: ${daemon}"
+	# syslogd can be stubborn some times (--retry 15)...
+	start-stop-daemon --stop --retry 15 --quiet --pidfile /var/run/"${daemon}".pid
+	retval=$?
+	eend ${retval} "Failed to stop ${daemon}"
+
+	return ${retval}
+}
+
+start() {
+	start_daemon "syslogd" "${SYSLOGD}" || return 1
+
+	# klogd do not always start proper if started too early
+	sleep 1
+
+	if ! start_daemon "klogd" "${KLOGD}" ; then
+		stop_daemon "syslogd"
+		return 1
+	fi
+
+	return 0
+}
+
+stop() {
+	stop_daemon "klogd" || return 1
+	stop_daemon "syslogd" || return 1
+	return 0
+}
+
+reload() {
+	local ret=0
+
+	ebegin "Reloading configuration"
+
+	start-stop-daemon --signal HUP --pidfile /var/run/syslogd.pid
+	ret=$((${ret} + $?))
+	start-stop-daemon --signal USR1 --pidfile /var/run/klogd.pid
+	ret=$((${ret} + $?))
+
+	eend ${ret}
+}

--- a/alpine/packages/vsudd/etc/init.d/vsudd
+++ b/alpine/packages/vsudd/etc/init.d/vsudd
@@ -2,11 +2,6 @@
 
 description="vsock socket proxy client"
 
-depend()
-{
-	before logger docker
-}
-
 start()
 {
 	[ "$(mobyplatform)" != "mac" ] && [ "$(mobyplatform)" != "windows" ] && exit 0
@@ -31,10 +26,11 @@ start()
 	start-stop-daemon --start --quiet \
 		--background \
 		--exec /sbin/vsudd \
-		--make-pidfile --pidfile ${PIDFILE} \
 		-- -inport "${DOCKER_PORT}:unix:/var/run/docker.sock" \
 		   ${SYSLOG_OPT} \
-		   -detach
+		   -pidfile ${PIDFILE}
+
+	[ -n "${SYSLOG_OPT}" ] && ewaitfile 10 /var/run/syslog.vsock
 
 	eend $? "Failed to start vsudd"
 }


### PR DESCRIPTION
If we are using vsudd to forward syslog to the host, as on osx,
we need to start it before syslog starts, and make sure it has
created its socket.

Add a pidfile to vsudd to make startup more reliable.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>