### PR TITLE
Fix /run symlink issues

### DIFF
--- a/alpine/etc/init.d/sysklogd
+++ b/alpine/etc/init.d/sysklogd
@@ -6,7 +6,7 @@
 extra_started_commands="reload"
 
 depend() {
-	need clock hostname localmount vsudd
+	need clock hostname localmount vsudd bootmisc
 	before net
 	provide logger
 }

--- a/alpine/packages/automount/etc/init.d/automount
+++ b/alpine/packages/automount/etc/init.d/automount
@@ -52,6 +52,10 @@ start()
 		[ -d /var/var/lib/boot2docker/ ] && mount --bind /var/var /var
 	fi
 
+	# can remove when we run before bootmisc
+	[ -L /var/run ] || ln -s /run /var/run
+	[ -L /var/run ] || ln -s /run/lock /var/lock
+
 	mount | grep -q "${DEV}. on /var type"
 
 	eend $? "Failed to mount block device"


### PR DESCRIPTION
- run bootmisc before sysklogd so symlinks from /var/run to
  /run are created
- recreate symlinks that bootmisc created when we remount /var
  until this gets moved earlier

Signed-off-by: Justin Cormack <justin.cormack@docker.com>