### PR TITLE
diagnostics: Collect "docker info"

### DIFF
--- a/alpine/packages/diagnostics/capture.go
+++ b/alpine/packages/diagnostics/capture.go
@@ -34,6 +34,7 @@ var (
 		{"/usr/sbin/brctl", []string{"show"}, defaultCommandTimeout},
 		{"/bin/dmesg", nil, defaultCommandTimeout},
 		{"/usr/bin/docker", []string{"ps"}, defaultCommandTimeout},
+		{"/usr/bin/docker", []string{"version"}, defaultCommandTimeout},
 		{"/usr/bin/docker", []string{"info"}, defaultCommandTimeout},
 		{"/usr/bin/tail", []string{"-20000", "/var/log/docker.log"}, defaultCommandTimeout},
 		{"/usr/bin/tail", []string{"-20000", "/var/log/messages"}, defaultCommandTimeout},


### PR DESCRIPTION
Signed-off-by: Ian Campbell <ian.campbell@docker.com>

Build but not runtime tested. @justincormack is there anything else we ought to gather? We already get `docker ps` and I've just remembered `docker version` which I'll push to this PR in a moment.