### PR TITLE
Stop Docker listening on port 2375

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -37,11 +37,6 @@ start()
 
 	# Only start with networking on cloud editions
 	DOCKER_OPTS="${DOCKER_OPTS} -H unix:///var/run/docker.sock"
-	if [ "$(mobyplatform)" = "aws" ] || [ "$(mobyplatform)" = "azure" ]
-	then
-		# TODO: Don't do this
-		DOCKER_OPTS="${DOCKER_OPTS} -H 0.0.0.0:2375"
-	fi
 
 	# On desktop editions, force swarm advertise address to be on eth0
 	# Currently we do not support multi node swarm on these editions


### PR DESCRIPTION
This is a huge security hole, remove from Moby.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>