### PR TITLE
Default to experimental if not specified in daemon.json

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -84,6 +84,12 @@ start()
 	# Set Docker to debug debug if not specified in daemon.json
 	cat /etc/docker/daemon.json | jq -e 'has("debug")' > /dev/null || DOCKER_OPTS="${DOCKER_OPTS} --debug"
 
+	# Set experimental=true if not specified in daemon.json if dockerd supports it
+	if dockerd --help | grep -q experimental
+	then
+		cat /etc/docker/daemon.json | jq -e 'has("experimental")' > /dev/null || DOCKER_OPTS="${DOCKER_OPTS} --experimental"
+	fi
+
 	# choose storage driver
 	if ! $(cat /etc/docker/daemon.json | jq -e '."storage-driver"' > /dev/null)
 	then


### PR DESCRIPTION
Most editions were shipping with experimental; now it is a daemon
flag this seems the best behaviour.

Only do this on recent dockerd as we are still supporting 1.12 for
a while longer.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

fix #750 

cc @nathanleclaire 