### PR TITLE
Add some basic shell commands in media image for debug

### DIFF
--- a/Dockerfile.media
+++ b/Dockerfile.media
@@ -1,4 +1,4 @@
-FROM scratch
+FROM mobylinux/toybox-media:d476c196534464ca0dd93f8c765002c13d880a1a
 
 ADD \
   alpine/initrd.img \

--- a/alpine/base/alpine-build-toybox/Dockerfile
+++ b/alpine/base/alpine-build-toybox/Dockerfile
@@ -1,0 +1,9 @@
+FROM mobylinux/alpine-build-c:36aecb5cf4738737634140eec9abebe1f6559a39
+COPY . .
+# 0.7.2
+ENV LDFLAGS=--static
+RUN git clone https://github.com/landley/toybox.git && \
+  cd toybox && git checkout b27d5d9ad0c56014d8661d91f69ee498bbbe4cf9 && \
+  make defconfig
+WORKDIR /toybox
+ENTRYPOINT ["/build.sh"]

--- a/alpine/base/alpine-build-toybox/Makefile
+++ b/alpine/base/alpine-build-toybox/Makefile
@@ -1,0 +1,27 @@
+.PHONY: tag push
+
+IMAGE=alpine-build-toybox
+
+default: push
+
+hash: Dockerfile build.sh
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --entrypoint sh $(IMAGE):build -c 'cat /Dockerfile /build.sh /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/alpine/base/alpine-build-toybox/build.sh
+++ b/alpine/base/alpine-build-toybox/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+FILES=$@
+make $FILES > /dev/null
+[ $# -eq 1 ] && FILES=toybox
+# TODO symlinks if just use toybox
+mkdir -p /out/bin
+mv $FILES /out/bin
+printf "FROM scratch\nCOPY bin/ bin/\n" > /out/Dockerfile
+cd /out
+tar cf - .

--- a/alpine/base/toybox-media/Makefile
+++ b/alpine/base/toybox-media/Makefile
@@ -1,0 +1,29 @@
+.PHONY: tag push
+
+IMAGE=toybox-media
+
+default: push
+
+hash: 
+	docker run mobylinux/alpine-build-toybox:9d6a5b75d2c5ba1686f23c333b59cbb56bfc4ccf \
+		ls tar sh find sha1sum | \
+		docker build -q -t $(IMAGE):build -
+	docker run $(IMAGE):build tar cf - bin | docker run -i $(IMAGE):build sha1sum -b - > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:


### PR DESCRIPTION
Add toybox statically linked ls, sh, find etc so that it is
possible to examine the archive eaily.

Fix #749

Signed-off-by: Justin Cormack <justin.cormack@docker.com>