### PR TITLE
Fixup kernel patch whitepace

### DIFF
--- a/alpine/kernel/patches/0001-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/alpine/kernel/patches/0001-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,4 +1,4 @@
-From 888876dd84da7cdcb7c2ce7568efb2a2adbc9031 Mon Sep 17 00:00:00 2001
+From c05011868782b0fbad73702161492e953eacbcbf Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
 Subject: [PATCH 1/5] VSOCK: Only allow host network namespace to use AF_VSOCK.
@@ -17,13 +17,14 @@ index 8a398b3..0edc54c 100644
 +++ b/net/vmw_vsock/af_vsock.c
 @@ -1852,6 +1852,9 @@ static const struct proto_ops vsock_stream_ops = {
  static int vsock_create(struct net *net, struct socket *sock,
-			int protocol, int kern)
+ 			int protocol, int kern)
  {
 +	if (!net_eq(net, &init_net))
 +		return -EAFNOSUPPORT;
 +
-	if (!sock)
-		return -EINVAL;
+ 	if (!sock)
+ 		return -EINVAL;
+ 
+-- 
+2.10.2
 
---
-2.10.1

--- a/alpine/kernel/patches/0002-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
+++ b/alpine/kernel/patches/0002-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
@@ -1,4 +1,4 @@
-From 478faef05c2fd212054793b4f5fde3f7ad502e20 Mon Sep 17 00:00:00 2001
+From 457218c0979bb7272eca5e3a6039161890d7dcb5 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 21 May 2016 16:55:50 +0800
 Subject: [PATCH 2/5] Drivers: hv: vmbus: fix the race when querying & updating
@@ -32,12 +32,12 @@ index 56dd261..75343e0 100644
 --- a/drivers/hv/channel.c
 +++ b/drivers/hv/channel.c
 @@ -592,6 +592,7 @@ static int vmbus_close_internal(struct vmbus_channel *channel)
-
+ 
  out:
-	tasklet_enable(tasklet);
+ 	tasklet_enable(tasklet);
 +	tasklet_schedule(tasklet);
-
-	return ret;
+ 
+ 	return ret;
  }
 diff --git a/drivers/hv/channel_mgmt.c b/drivers/hv/channel_mgmt.c
 index b6c1211..8f4e6070 100644
@@ -45,7 +45,7 @@ index b6c1211..8f4e6070 100644
 +++ b/drivers/hv/channel_mgmt.c
 @@ -21,6 +21,7 @@
  #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
-
+ 
  #include <linux/kernel.h>
 +#include <linux/interrupt.h>
  #include <linux/sched.h>
@@ -53,80 +53,81 @@ index b6c1211..8f4e6070 100644
  #include <linux/mm.h>
 @@ -307,12 +308,13 @@ void hv_process_channel_removal(struct vmbus_channel *channel, u32 relid)
  {
-	unsigned long flags;
-	struct vmbus_channel *primary_channel;
+ 	unsigned long flags;
+ 	struct vmbus_channel *primary_channel;
 -
 -	vmbus_release_relid(relid);
 +	struct tasklet_struct *tasklet;
-
-	BUG_ON(!channel->rescind);
-	BUG_ON(!mutex_is_locked(&vmbus_connection.channel_mutex));
-
+ 
+ 	BUG_ON(!channel->rescind);
+ 	BUG_ON(!mutex_is_locked(&vmbus_connection.channel_mutex));
+ 
 +	tasklet = hv_context.event_dpc[channel->target_cpu];
 +	tasklet_disable(tasklet);
-	if (channel->target_cpu != get_cpu()) {
-		put_cpu();
-		smp_call_function_single(channel->target_cpu,
+ 	if (channel->target_cpu != get_cpu()) {
+ 		put_cpu();
+ 		smp_call_function_single(channel->target_cpu,
 @@ -321,6 +323,8 @@ void hv_process_channel_removal(struct vmbus_channel *channel, u32 relid)
-		percpu_channel_deq(channel);
-		put_cpu();
-	}
+ 		percpu_channel_deq(channel);
+ 		put_cpu();
+ 	}
 +	tasklet_enable(tasklet);
 +	tasklet_schedule(tasklet);
-
-	if (channel->primary_channel == NULL) {
-		list_del(&channel->listentry);
+ 
+ 	if (channel->primary_channel == NULL) {
+ 		list_del(&channel->listentry);
 @@ -342,6 +346,8 @@ void hv_process_channel_removal(struct vmbus_channel *channel, u32 relid)
-			  &primary_channel->alloced_cpus_in_node);
-
-	free_channel(channel);
+ 			  &primary_channel->alloced_cpus_in_node);
+ 
+ 	free_channel(channel);
 +
 +	vmbus_release_relid(relid);
  }
-
+ 
  void vmbus_free_channels(void)
 @@ -363,6 +369,7 @@ void vmbus_free_channels(void)
   */
  static void vmbus_process_offer(struct vmbus_channel *newchannel)
  {
 +	struct tasklet_struct *tasklet;
-	struct vmbus_channel *channel;
-	bool fnew = true;
-	unsigned long flags;
+ 	struct vmbus_channel *channel;
+ 	bool fnew = true;
+ 	unsigned long flags;
 @@ -409,6 +416,8 @@ static void vmbus_process_offer(struct vmbus_channel *newchannel)
-
-	init_vp_index(newchannel, dev_type);
-
+ 
+ 	init_vp_index(newchannel, dev_type);
+ 
 +	tasklet = hv_context.event_dpc[newchannel->target_cpu];
 +	tasklet_disable(tasklet);
-	if (newchannel->target_cpu != get_cpu()) {
-		put_cpu();
-		smp_call_function_single(newchannel->target_cpu,
+ 	if (newchannel->target_cpu != get_cpu()) {
+ 		put_cpu();
+ 		smp_call_function_single(newchannel->target_cpu,
 @@ -418,6 +427,8 @@ static void vmbus_process_offer(struct vmbus_channel *newchannel)
-		percpu_channel_enq(newchannel);
-		put_cpu();
-	}
+ 		percpu_channel_enq(newchannel);
+ 		put_cpu();
+ 	}
 +	tasklet_enable(tasklet);
 +	tasklet_schedule(tasklet);
-
-	/*
-	 * This state is used to indicate a successful open
+ 
+ 	/*
+ 	 * This state is used to indicate a successful open
 @@ -469,6 +480,7 @@ err_deq_chan:
-	list_del(&newchannel->listentry);
-	mutex_unlock(&vmbus_connection.channel_mutex);
-
+ 	list_del(&newchannel->listentry);
+ 	mutex_unlock(&vmbus_connection.channel_mutex);
+ 
 +	tasklet_disable(tasklet);
-	if (newchannel->target_cpu != get_cpu()) {
-		put_cpu();
-		smp_call_function_single(newchannel->target_cpu,
+ 	if (newchannel->target_cpu != get_cpu()) {
+ 		put_cpu();
+ 		smp_call_function_single(newchannel->target_cpu,
 @@ -477,6 +489,8 @@ err_deq_chan:
-		percpu_channel_deq(newchannel);
-		put_cpu();
-	}
+ 		percpu_channel_deq(newchannel);
+ 		put_cpu();
+ 	}
 +	tasklet_enable(tasklet);
 +	tasklet_schedule(tasklet);
-
+ 
  err_free_chan:
-	free_channel(newchannel);
---
-2.10.1
+ 	free_channel(newchannel);
+-- 
+2.10.2
+

--- a/alpine/kernel/patches/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/alpine/kernel/patches/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From ccd1d4920969d0dcba862dc98f9b4747a383bfe2 Mon Sep 17 00:00:00 2001
+From f1b841ced482479a9ff9fb5dce29e47d563a1dba Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 3/5] hv_sock: introduce Hyper-V Sockets
@@ -30,12 +30,11 @@ Origin: https://patchwork.kernel.org/patch/9244467/
  include/linux/socket.h      |    4 +-
  include/net/af_hvsock.h     |   78 +++
  include/uapi/linux/hyperv.h |   23 +
- net/Kconfig                 |    1 +
  net/Makefile                |    1 +
  net/hv_sock/Kconfig         |   10 +
  net/hv_sock/Makefile        |    3 +
  net/hv_sock/af_hvsock.c     | 1507 +++++++++++++++++++++++++++++++++++++++++++
- 10 files changed, 1641 insertions(+), 1 deletion(-)
+ 9 files changed, 1640 insertions(+), 1 deletion(-)
  create mode 100644 include/net/af_hvsock.h
  create mode 100644 net/hv_sock/Kconfig
  create mode 100644 net/hv_sock/Makefile
@@ -54,15 +53,15 @@ index babaf82..6126545 100644
 +F:	include/net/af_hvsock.h
  F:	tools/hv/
  F:	Documentation/ABI/stable/sysfs-bus-vmbus
-
+ 
 diff --git a/include/linux/hyperv.h b/include/linux/hyperv.h
 index b10954a..50f8976 100644
 --- a/include/linux/hyperv.h
 +++ b/include/linux/hyperv.h
 @@ -1505,5 +1505,18 @@ static inline void commit_rd_index(struct vmbus_channel *channel)
-		vmbus_set_event(channel);
+ 		vmbus_set_event(channel);
  }
-
+ 
 +struct vmpipe_proto_header {
 +	u32 pkt_type;
 +	u32 data_size;
@@ -73,7 +72,7 @@ index b10954a..50f8976 100644
 +
 +/* See 'prev_indices' in hv_ringbuffer_read(), hv_ringbuffer_write() */
 +#define PREV_INDICES_LEN	(sizeof(u64))
-
+ 
 +#define HVSOCK_PKT_LEN(payload_len)	(HVSOCK_HEADER_LEN + \
 +					ALIGN((payload_len), 8) + \
 +					PREV_INDICES_LEN)
@@ -87,10 +86,10 @@ index b5cc5a6..0b68b58 100644
  #define AF_KCM		41	/* Kernel Connection Multiplexor*/
  #define AF_QIPCRTR	42	/* Qualcomm IPC Router          */
 +#define AF_HYPERV	43	/* Hyper-V Sockets              */
-
+ 
 -#define AF_MAX		43	/* For now.. */
 +#define AF_MAX		44	/* For now.. */
-
+ 
  /* Protocol families, same as address families. */
  #define PF_UNSPEC	AF_UNSPEC
 @@ -251,6 +252,7 @@ struct ucred {
@@ -99,7 +98,7 @@ index b5cc5a6..0b68b58 100644
  #define PF_QIPCRTR	AF_QIPCRTR
 +#define PF_HYPERV	AF_HYPERV
  #define PF_MAX		AF_MAX
-
+ 
  /* Maximum queue length specifiable by listen.  */
 diff --git a/include/net/af_hvsock.h b/include/net/af_hvsock.h
 new file mode 100644
@@ -191,16 +190,16 @@ index e347b24..eb3e44b 100644
 +++ b/include/uapi/linux/hyperv.h
 @@ -26,6 +26,7 @@
  #define _UAPI_HYPERV_H
-
+ 
  #include <linux/uuid.h>
 +#include <linux/socket.h>
-
+ 
  /*
   * Framework version for util services.
 @@ -396,4 +397,26 @@ struct hv_kvp_ip_msg {
-	struct hv_kvp_ipaddr_value      kvp_ip_val;
+ 	struct hv_kvp_ipaddr_value      kvp_ip_val;
  } __attribute__((packed));
-
+ 
 +/* This is the address format of Hyper-V Sockets.
 + * Note: here we just borrow the kernel's built-in type uuid_le. When
 + * an application calls bind() or connect(), the 2 members of struct
@@ -224,18 +223,6 @@ index e347b24..eb3e44b 100644
 +#define SHV_PROTO_RAW		1
 +
  #endif /* _UAPI_HYPERV_H */
-diff --git a/net/Kconfig b/net/Kconfig
-index c2cdbce..921e86f 100644
---- a/net/Kconfig
-+++ b/net/Kconfig
-@@ -231,6 +231,7 @@ source "net/dns_resolver/Kconfig"
- source "net/batman-adv/Kconfig"
- source "net/openvswitch/Kconfig"
- source "net/vmw_vsock/Kconfig"
-+source "net/hv_sock/Kconfig"
- source "net/netlink/Kconfig"
- source "net/mpls/Kconfig"
- source "net/hsr/Kconfig"
 diff --git a/net/Makefile b/net/Makefile
 index 9bd20bb..b4d4e9a 100644
 --- a/net/Makefile
@@ -1786,5 +1773,6 @@ index 0000000..331d375
 +
 +MODULE_DESCRIPTION("Hyper-V Sockets");
 +MODULE_LICENSE("Dual BSD/GPL");
---
-2.10.1
+-- 
+2.10.2
+

--- a/alpine/kernel/patches/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/alpine/kernel/patches/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 59f4c8c2b14753db30aea235624a7d5212a0c715 Mon Sep 17 00:00:00 2001
+From 39ad80464832bca79a5ae1a0a2de87641ca0be13 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 4/5] vmbus: Don't spam the logs with unknown GUIDs
@@ -18,12 +18,13 @@ index 8f4e6070..ef4a512 100644
 --- a/drivers/hv/channel_mgmt.c
 +++ b/drivers/hv/channel_mgmt.c
 @@ -147,7 +147,6 @@ static u16 hv_get_dev_type(const uuid_le *guid)
-		if (!uuid_le_cmp(*guid, vmbus_devs[i].guid))
-			return i;
-	}
+ 		if (!uuid_le_cmp(*guid, vmbus_devs[i].guid))
+ 			return i;
+ 	}
 -	pr_info("Unknown GUID: %pUl\n", guid);
-	return i;
+ 	return i;
  }
+ 
+-- 
+2.10.2
 
---
-2.10.1

--- a/alpine/kernel/patches/0005-gro_cells-mark-napi-struct-as-not-busy-poll-candidat.patch
+++ b/alpine/kernel/patches/0005-gro_cells-mark-napi-struct-as-not-busy-poll-candidat.patch
@@ -1,4 +1,4 @@
-From 56b20d9d99f039745e3b9e9fe8c4243e90d13334 Mon Sep 17 00:00:00 2001
+From 3bcb5d6eddbc61f460aa17d6f2a226e0a0a0ed09 Mon Sep 17 00:00:00 2001
 From: Eric Dumazet <edumazet@google.com>
 Date: Mon, 14 Nov 2016 16:28:42 -0800
 Subject: [PATCH 5/5] gro_cells: mark napi struct as not busy poll candidates
@@ -36,14 +36,15 @@ index d15214d..2a1abbf 100644
 --- a/include/net/gro_cells.h
 +++ b/include/net/gro_cells.h
 @@ -68,6 +68,9 @@ static inline int gro_cells_init(struct gro_cells *gcells, struct net_device *de
-		struct gro_cell *cell = per_cpu_ptr(gcells->cells, i);
-
-		__skb_queue_head_init(&cell->napi_skbs);
+ 		struct gro_cell *cell = per_cpu_ptr(gcells->cells, i);
+ 
+ 		__skb_queue_head_init(&cell->napi_skbs);
 +
 +		set_bit(NAPI_STATE_NO_BUSY_POLL, &cell->napi.state);
 +
-		netif_napi_add(dev, &cell->napi, gro_cell_poll, 64);
-		napi_enable(&cell->napi);
-	}
---
-2.10.1
+ 		netif_napi_add(dev, &cell->napi, gro_cell_poll, 64);
+ 		napi_enable(&cell->napi);
+ 	}
+-- 
+2.10.2
+


### PR DESCRIPTION
Some of git's whitespace fixup option corrupts the patches by (at least)
stripping trailing spaces (which are present for empty lines in context) and
changing leading <space><tab> into just <tab>. `patch(1)` used by the build
here seems to tolerate this, but `git am` and/or `git apply` do not.

Fix this up by running git am and at each failure point (i.e. every patch)
applying the relevant patch using `patch(1)` (which works because `git am` was
unable to even partially apply the patches) before regenerating the whole lot
with `git format-patch`.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>