### PR TITLE
Simplify file system format code

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-base:e869e63cb94d904351f0895f423a1ba715564eb1
+FROM mobylinux/alpine-base:3f34b5c66b78f81fe7aa976ec784c2e650f6f4ca
 
 ENV ARCH=x86_64
 

--- a/alpine/base/alpine-base/Dockerfile
+++ b/alpine/base/alpine-base/Dockerfile
@@ -5,7 +5,6 @@ COPY repositories /etc/apk/
 RUN \
   apk update && apk upgrade && \
   apk add --no-cache \
-  alpine-conf \
   busybox-initscripts \
   chrony \
   cifs-utils \

--- a/alpine/base/alpine-base/packages
+++ b/alpine/base/alpine-base/packages
@@ -1,5 +1,4 @@
 alpine-baselayout 3.0.3-r0
-alpine-conf 3.4.1-r5
 alpine-keys 1.1-r0
 apk-tools 2.6.7-r0
 busybox 1.24.2-r12

--- a/alpine/packages/automount/etc/init.d/automount
+++ b/alpine/packages/automount/etc/init.d/automount
@@ -18,6 +18,41 @@ do_fsck()
 	return "${EXIT_CODE}"
 }
 
+do_mkfs()
+{
+	diskdev="$1"
+
+	# new disks does not have an DOS signature in sector 0
+	# this makes sfdisk complain. We can workaround this by letting
+	# fdisk create that DOS signature, by just do a "w", a write.
+	# http://bugs.alpinelinux.org/issues/show/145
+	echo "w" | fdisk $diskdev >/dev/null
+
+	# format one large partition, offset 1M
+	printf "1M,,83\n" | sfdisk --quiet $diskdev
+
+	# update status
+	blockdev --rereadpt $diskdev 2> /dev/null
+	mdev -s
+
+	mkfs.ext4 ${diskdev}1
+
+	mount ${diskdev}1 /var
+}
+
+do_swapfile()
+{
+	SWAP=/var/spool/swap
+	if [ "$(mobyplatform)" = "mac" ] || [ "$(mobyplatform)" = "windows" ] && [ ! -f $SWAP ]
+	then
+		mkdir -p "$(basnename $SWAP)"
+		dd if=/dev/zero of=$SWAP bs=1k count=4090876
+		chmod 600 $SWAP
+		mkswap $SWAP
+		swapon $SWAP
+	fi
+}
+
 start()
 {
 	ebegin "Configuring host block device"
@@ -47,22 +82,23 @@ start()
 
 	if fdisk -l "${DRIVE}" | grep -q "doesn't contain a valid partition table"
 	then
-		ERASE_DISKS="${DRIVE}" setup-disk -m data "${DRIVE}"
-		blockdev --rereadpt "${DRIVE}" 2> /dev/null
+		do_mkfs "${DRIVE}"
 	else
-		SWAP=$(fdisk -l "${DRIVE}" | grep 'Linux swap' | head -1 | awk '{print $1}')
 		DATA=$(fdisk -l "${DRIVE}" | grep 'Linux$' | head -1 | awk '{print $1}')
 		if [ -z "$DATA" ]
 		then
-			ERASE_DISKS="${DRIVE}" setup-disk -m data ${DRIVE}
-			blockdev --rereadpt "${DRIVE}" 2> /dev/null
+			do_mkfs "${DRIVE}"
 		else
-			( do_fsck "${DATA}" && mount "${DATA}" /var && ([ -z "${SWAP}" ] || swapon "${SWAP}") ) || \
-			  ( ERASE_DISKS="${DRIVE}" setup-disk -m data ${DRIVE}; blockdev --rereadpt ${DRIVE} 2> /dev/null )
+			( do_fsck "${DATA}" && mount "${DATA}" /var ) || do_mkfs "${DRIVE}"
 		fi
-		# boot2docker compat, has /var and /tmp on partition
-		[ -d /var/var/lib/boot2docker/ ] && mount --bind /var/var /var
 	fi
+
+	SWAP=$(fdisk -l "${DRIVE}" | grep 'Linux swap' | head -1 | awk '{print $1}')
+	[ -z "${SWAP}" ] && do_swapfile || swapon "${SWAP}"
+
+	# boot2docker compat, has /var and /tmp on partition
+	[ -d /var/var/lib/boot2docker/ ] && mount --bind /var/var /var
+
 
 	# can remove when we run before bootmisc
 	[ -L /var/run ] || ln -s /run /var/run


### PR DESCRIPTION
- use our own code rather than Alpine setup-disk
- remove alpine setup code as not needed
- do not create swap partitions
- create swap file on desktop editions for now (may remove)

Fix #619

Signed-off-by: Justin Cormack <justin.cormack@docker.com>