### PR TITLE
Remove ssh server packages

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-base:50f80b04bfad0d23e44c6d4227bb045f39b42fae
+FROM mobylinux/alpine-base:127878341b96b4e504957559fae24f7c38d8aa0b
 
 ENV ARCH=x86_64
 

--- a/alpine/base/alpine-base/Dockerfile
+++ b/alpine/base/alpine-base/Dockerfile
@@ -18,7 +18,6 @@ RUN \
   iptables \
   jq \
   openrc \
-  openssh \
   openssh-client \
   rng-tools@community \
   sfdisk \

--- a/alpine/base/alpine-base/packages
+++ b/alpine/base/alpine-base/packages
@@ -39,9 +39,7 @@ musl 1.1.15-r5
 musl-utils 1.1.15-r5
 oniguruma 6.1.2-r0
 openrc 0.21.7-r2
-openssh 7.3_p1-r2
 openssh-client 7.3_p1-r2
-openssh-sftp-server 7.3_p1-r2
 pcre 8.39-r0
 rng-tools 5-r3
 scanelf 1.1.6-r0


### PR DESCRIPTION
These will be containerised, and were disabled anyway.

Need client, as git needs it, and docker needs git.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>