### PR TITLE
kernel: update/fix patches for 4.8.10

### DIFF
--- a/alpine/kernel/patches/0001-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/alpine/kernel/patches/0001-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,4 +1,4 @@
-From c05011868782b0fbad73702161492e953eacbcbf Mon Sep 17 00:00:00 2001
+From afc48615e62910f37b6076f9118c80d2f9613064 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
 Subject: [PATCH 1/5] VSOCK: Only allow host network namespace to use AF_VSOCK.

--- a/alpine/kernel/patches/0002-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
+++ b/alpine/kernel/patches/0002-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
@@ -1,4 +1,4 @@
-From 457218c0979bb7272eca5e3a6039161890d7dcb5 Mon Sep 17 00:00:00 2001
+From 0ee181462b9f52d60ca5188e3013870621068864 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 21 May 2016 16:55:50 +0800
 Subject: [PATCH 2/5] Drivers: hv: vmbus: fix the race when querying & updating

--- a/alpine/kernel/patches/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/alpine/kernel/patches/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From f1b841ced482479a9ff9fb5dce29e47d563a1dba Mon Sep 17 00:00:00 2001
+From e7db86231b7078971c613aa81c9090079571cf24 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 3/5] hv_sock: introduce Hyper-V Sockets
@@ -30,11 +30,12 @@ Origin: https://patchwork.kernel.org/patch/9244467/
  include/linux/socket.h      |    4 +-
  include/net/af_hvsock.h     |   78 +++
  include/uapi/linux/hyperv.h |   23 +
+ net/Kconfig                 |    1 +
  net/Makefile                |    1 +
  net/hv_sock/Kconfig         |   10 +
  net/hv_sock/Makefile        |    3 +
  net/hv_sock/af_hvsock.c     | 1507 +++++++++++++++++++++++++++++++++++++++++++
- 9 files changed, 1640 insertions(+), 1 deletion(-)
+ 10 files changed, 1641 insertions(+), 1 deletion(-)
  create mode 100644 include/net/af_hvsock.h
  create mode 100644 net/hv_sock/Kconfig
  create mode 100644 net/hv_sock/Makefile
@@ -223,6 +224,18 @@ index e347b24..eb3e44b 100644
 +#define SHV_PROTO_RAW		1
 +
  #endif /* _UAPI_HYPERV_H */
+diff --git a/net/Kconfig b/net/Kconfig
+index c2cdbce..921e86f 100644
+--- a/net/Kconfig
++++ b/net/Kconfig
+@@ -231,6 +231,7 @@ source "net/dns_resolver/Kconfig"
+ source "net/batman-adv/Kconfig"
+ source "net/openvswitch/Kconfig"
+ source "net/vmw_vsock/Kconfig"
++source "net/hv_sock/Kconfig"
+ source "net/netlink/Kconfig"
+ source "net/mpls/Kconfig"
+ source "net/hsr/Kconfig"
 diff --git a/net/Makefile b/net/Makefile
 index 9bd20bb..b4d4e9a 100644
 --- a/net/Makefile

--- a/alpine/kernel/patches/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/alpine/kernel/patches/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 39ad80464832bca79a5ae1a0a2de87641ca0be13 Mon Sep 17 00:00:00 2001
+From e8c7a6dee61819c36b77108bc2cddafde26b9876 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 4/5] vmbus: Don't spam the logs with unknown GUIDs

--- a/alpine/kernel/patches/0005-gro_cells-mark-napi-struct-as-not-busy-poll-candidat.patch
+++ b/alpine/kernel/patches/0005-gro_cells-mark-napi-struct-as-not-busy-poll-candidat.patch
@@ -1,4 +1,4 @@
-From 3bcb5d6eddbc61f460aa17d6f2a226e0a0a0ed09 Mon Sep 17 00:00:00 2001
+From f45dc8d3c7bab381eba3c94414bbc04eae208990 Mon Sep 17 00:00:00 2001
 From: Eric Dumazet <edumazet@google.com>
 Date: Mon, 14 Nov 2016 16:28:42 -0800
 Subject: [PATCH 5/5] gro_cells: mark napi struct as not busy poll candidates


### PR DESCRIPTION
In particular 8e0e003b5064638ac90bb316200417c73d196969
seems to have removed the net/Kconfig changes

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>