### PR TITLE
Explicit Dockerfile copy

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -8,7 +8,7 @@ RUN \
   passwd -d root && \
   adduser -D -H -s /sbin/nologin dockremap
 
-COPY . .
+COPY . /
 RUN rm Dockerfile
 
 RUN \


### PR DESCRIPTION
Getting some weird errors when trying to build this in jenkins on Docker 1.12
```
19:40:54 Step 4 : COPY . .
19:40:54 lchown /var/lib/docker/aufs/mnt/20ef7b3944b72e4070f175c0e942fb1e81e81d2938fc42de1a3ab3034787c850/Dockerfile: no such file or directory
19:40:54 Makefile:6: recipe for target 'initrd.img' failed
19:40:54 make[1]: *** [initrd.img] Error 1
```
https://ci.qa.aws.dckr.io/job/docker/job/editions/job/run-alone/26/execution/node/129/log/

This makes the copy explicit and hopefully fixes the above issue.

cc @nathanleclaire @justincormack 

