### PR TITLE
Run TRIM on Windows every 15m

### DIFF
--- a/alpine/etc/periodic/15m/trim
+++ b/alpine/etc/periodic/15m/trim
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Windows always has TRIM support, clean out unused frequently
+[ "$(mobyplatform)" = "windows" ] && /sbin/fstrim /var


### PR DESCRIPTION
As the Windows virtual device supports TRIM we can run this to free
up disk space frequently. Not recommended to run on physical devices
this often.

See https://github.com/docker/pinata/issues/5298

Signed-off-by: Justin Cormack <justin.cormack@docker.com>