### PR TITLE
Explicitly use slirp-proxy in iptables

### DIFF
--- a/alpine/packages/iptables/main.ml
+++ b/alpine/packages/iptables/main.ml
@@ -6,7 +6,7 @@
 *)
 
 let _iptables = "/sbin/iptables"
-let _proxy = "/usr/bin/docker-proxy"
+let _proxy = "/usr/bin/slirp-proxy"
 let _pid_dir = "/var/run/service-port-opener"
 
 type port = {


### PR DESCRIPTION
So as to allow a read only root filesystem, we use the proxy
path config option to override the Docker proxy for 1.13.

This means that the iptables override needs to call this binary
not the original docker-proxy binary to allow port forwarding.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>