### PR TITLE
Use a 1G AMI

### DIFF
--- a/alpine/cloud/aws/bake-ami.sh
+++ b/alpine/cloud/aws/bake-ami.sh
@@ -25,7 +25,7 @@ bake_image()
 	# initrd via syslinux in MBR.  That formatted drive can then be snapshotted
 	# and turned into an AMI.
 	VOLUME_ID=$(aws ec2 create-volume \
-		--size 20 \
+		--size 1 \
 		--availability-zone $(current_instance_az) | jq -r .VolumeId)
 
 	tag ${VOLUME_ID} ${DAY} ${CHANNEL}


### PR DESCRIPTION
Now we do dynamic resize, choose the smallest AMI size, 1G rather
than the old 20G AMI.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>