### PR TITLE
Fix filesystem resize by calling `e2fsck -f` first

### DIFF
--- a/alpine/packages/automount/etc/init.d/automount
+++ b/alpine/packages/automount/etc/init.d/automount
@@ -7,7 +7,7 @@ depend()
 
 do_fsck()
 {
-	/sbin/e2fsck -p "$1"
+	/sbin/e2fsck -p $*
 	EXIT_CODE=$?
 	# exit code 1 is errors corrected
 	[ "${EXIT_CODE}" -eq 1 ] && EXIT_CODE=0
@@ -44,6 +44,8 @@ do_fsck_extend_mount()
 		blockdev --rereadpt $diskdev 2> /dev/null
 		mdev -s
 
+		# resize2fs fails unless we use -f here
+		do_fsck -f "$DATA" || return 1
 		resize2fs "$DATA"
 
 		do_fsck "$DATA" || return 1


### PR DESCRIPTION
Previously when the block device was resized the partition table was also resized but the filesystem was not. For an increase from 64GiB to 128GiB the console showed:

     * Configuring host block device .../dev/vda1: clean, 62/4194304 files, 604445/16776960 blocks
    Resizing disk partition: Unpartitioned space /dev/vda: 64 GiB, 68719476736 bytes, 134217728 sectors
    resize2fs 1.43.3 (04-Sep-2016)
    Please run 'e2fsck -f /dev/vda1' first.

    /dev/vda1: clean, 62/4194304 files, 604445/16776960 blocks

This patch makes `resize2fs` happy by running `e2fsck -f` beforehand as requested.

Signed-off-by: David Scott <dave.scott@docker.com>