### PR TITLE
Re-enable bash and openssl for Azure

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-base:547930eb50022274934ee70b0fd9c73c75515216
+FROM mobylinux/alpine-base:5674d2d1268b57fd5d48193cfc47f6835fb5dbf4
 
 ENV ARCH=x86_64
 

--- a/alpine/base/alpine-base/Dockerfile
+++ b/alpine/base/alpine-base/Dockerfile
@@ -5,6 +5,7 @@ COPY repositories /etc/apk/
 RUN \
   apk update && apk upgrade -a && \
   apk add --no-cache \
+  bash \
   busybox-initscripts \
   chrony \
   cifs-utils \
@@ -18,6 +19,7 @@ RUN \
   iptables \
   jq \
   openrc \
+  openssl \
   openssh-client \
   rng-tools@community \
   sfdisk \

--- a/alpine/base/alpine-base/packages
+++ b/alpine/base/alpine-base/packages
@@ -1,6 +1,7 @@
 alpine-baselayout 3.0.4-r0
 alpine-keys 1.3-r0
 apk-tools 2.6.8-r1
+bash 4.3.46-r4
 busybox 1.25.1-r0
 busybox-initscripts 3.0-r8
 ca-certificates 20160104-r8
@@ -24,6 +25,7 @@ libblkid 2.28.2-r0
 libc-utils 0.7-r1
 libcap 2.25-r1
 libcom_err 1.43.3-r0
+libcrypto1.0 1.0.2j-r2
 libcurl 7.51.0-r1
 libfdisk 2.28.2-r0
 libmnl 1.0.4-r0
@@ -32,14 +34,20 @@ libressl2.4-libcrypto 2.4.4-r0
 libressl2.4-libssl 2.4.4-r0
 libsmartcols 2.28.2-r0
 libssh2 1.7.0-r2
+libssl1.0 1.0.2j-r2
 libuuid 2.28.2-r0
 libverto 0.2.5-r0
 musl 1.1.15-r5
 musl-utils 1.1.15-r5
+ncurses-libs 6.0-r7
+ncurses-terminfo 6.0-r7
+ncurses-terminfo-base 6.0-r7
 oniguruma 6.1.2-r0
 openrc 0.21.7-r3
 openssh-client 7.3_p1-r2
+openssl 1.0.2j-r2
 pcre 8.39-r0
+readline 6.3.008-r4
 rng-tools 5-r3
 scanelf 1.1.6-r0
 sfdisk 2.28.2-r0


### PR DESCRIPTION
Cloud editions seem to be using it.

fix #803

Signed-off-by: Justin Cormack <justin.cormack@docker.com>