### PR TITLE
Fixed Azure go utils

### DIFF
--- a/alpine/cloud/Dockerfile.azure
+++ b/alpine/cloud/Dockerfile.azure
@@ -9,7 +9,7 @@ RUN apk add --update \
     tar \
     util-linux
 
-RUN go get -u github.com/Microsoft/azure-vhd-utils-for-go
+RUN go get -u github.com/Microsoft/azure-vhd-utils
 
 RUN mkdir /build
 RUN mkdir /scripts

--- a/alpine/cloud/azure/bake-azure.sh
+++ b/alpine/cloud/azure/bake-azure.sh
@@ -77,7 +77,7 @@ case "$1" in
 
 		arrowecho "Uploading VHD to ${BLOBURL}..."
 
-		azure-vhd-utils-for-go upload \
+		azure-vhd-utils upload \
 			--localvhdpath "/tmp/mobylinux.vhd" \
 			--stgaccountname "${AZURE_STG_ACCOUNT_NAME}" \
 			--stgaccountkey "${AZURE_STG_ACCOUNT_KEY}" \


### PR DESCRIPTION
As pointed by @ddebroy and observed last night, I couldn't build the Azure VHD due to some recent changes to the Azure VHD utils, namely:
https://github.com/Microsoft/azure-vhd-utils/commit/c3020d9468493cb181b9778338c8699d546e9db5

This PR updates the Azure VHD build to use the properly named tools. 

cc @justincormack @nathanleclaire 