### PR TITLE
Use shell to execute userdata

### DIFF
--- a/alpine/packages/aws/etc/init.d/aws
+++ b/alpine/packages/aws/etc/init.d/aws
@@ -60,8 +60,7 @@ start()
 	# TODO(nathanleclaire/kencochrane): Migrate this to mobyconfig, or similar.
 	if [ $? -eq 0 ]
 	then
-		chmod 755 /tmp/user-data
-		/tmp/user-data
+		sh /tmp/user-data
 	fi
 
 	eend 0


### PR DESCRIPTION
/tmp is mounted `noexec`, just use the shell to execute the userdata.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>