### PR TITLE
Allow exec on /tmp

### DIFF
--- a/alpine/etc/fstab
+++ b/alpine/etc/fstab
@@ -1,2 +1,2 @@
 tmpfs	/run	tmpfs	defaults,nodev,nosuid,noexec,relatime,size=10%,mode=755 0 0
-tmpfs	/tmp	tmpfs	defaults,nodev,nosuid,noexec,relatime,size=10%,mode=1777	0 0
+tmpfs	/tmp	tmpfs	defaults,nodev,nosuid,relatime,size=10%,mode=1777	0 0


### PR DESCRIPTION
Over zealously copied /run, but AWS/Azure editions are using /tmp for exec
of userdata at present.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>