### PR TITLE
Added docker image for VHD utils

### DIFF
--- a/alpine/cloud/Dockerfile.azure
+++ b/alpine/cloud/Dockerfile.azure
@@ -1,15 +1,4 @@
-FROM golang:alpine
-
-RUN apk add --update \
-    curl \
-    e2fsprogs \
-    syslinux \
-    multipath-tools \
-    git \
-    tar \
-    util-linux
-
-RUN go get -u github.com/Microsoft/azure-vhd-utils
+FROM docker4x/azure-vhd-utils@sha256:2fd21df46e65d2f4007133e664a0a81611d8d23f7badedce56ca8d2f9ca39f94
 
 RUN mkdir /build
 RUN mkdir /scripts

--- a/alpine/cloud/Dockerfile.azure-vhd-utils
+++ b/alpine/cloud/Dockerfile.azure-vhd-utils
@@ -1,0 +1,12 @@
+FROM golang:alpine
+
+RUN apk add --update \
+    curl \
+    e2fsprogs \
+    syslinux \
+    multipath-tools \
+    git \
+    tar \
+    util-linux
+
+RUN go get -u github.com/Microsoft/azure-vhd-utils


### PR DESCRIPTION
This probably not a perfect fix, but will at least allow us to always use the same version of the `azure-vhd-utils`.
We only get the util to then upload the VHD - we don't actually use it as a binary. I didn't see any released binary within their github, which would be better:
https://github.com/Microsoft/azure-vhd-utils/releases

Fixes #812

cc @justincormack @nathanleclaire 