### PR TITLE
Use DOCKER_CONTENT_TRUST=1 when pulling library images

### DIFF
--- a/alpine/base/alpine-aws/Makefile
+++ b/alpine/base/alpine-aws/Makefile
@@ -6,7 +6,7 @@ IMAGE=alpine-aws
 default: push
 
 hash: Dockerfile
-	docker pull $(BASE)
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm $(IMAGE):build sh -c '(pip list && cat /lib/apk/db/installed) | sha1sum' | sed 's/ .*//' > hash
 

--- a/alpine/base/alpine-base/Makefile
+++ b/alpine/base/alpine-base/Makefile
@@ -6,7 +6,7 @@ IMAGE=alpine-base
 default: push
 
 hash: Dockerfile repositories
-	docker pull $(BASE)
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm $(IMAGE):build sha1sum /lib/apk/db/installed | sed 's/ .*//' > hash
 

--- a/alpine/base/alpine-bios/Makefile
+++ b/alpine/base/alpine-bios/Makefile
@@ -6,7 +6,7 @@ IMAGE=alpine-bios
 default: push
 
 hash:
-	docker pull $(BASE)
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - Dockerfile make-iso isolinux.cfg | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm $(IMAGE):build sha1sum /lib/apk/db/installed | sed 's/ .*//' > hash
 

--- a/alpine/base/alpine-build-c/Makefile
+++ b/alpine/base/alpine-build-c/Makefile
@@ -6,7 +6,7 @@ IMAGE=alpine-build-c
 default: push
 
 hash:
-	docker pull $(BASE)
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - Dockerfile | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm $(IMAGE):build sha1sum /lib/apk/db/installed | sed 's/ .*//' > hash
 

--- a/alpine/base/alpine-build-go/Makefile
+++ b/alpine/base/alpine-build-go/Makefile
@@ -6,7 +6,7 @@ IMAGE=alpine-build-go
 default: push
 
 hash:
-	docker pull $(BASE)
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - Dockerfile | docker build --no-cache -t $(IMAGE):build -
 	docker run $(IMAGE):build sh -c 'cat /usr/local/go/bin/go /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
 

--- a/alpine/base/alpine-efi/Makefile
+++ b/alpine/base/alpine-efi/Makefile
@@ -6,7 +6,7 @@ IMAGE=alpine-efi
 default: push
 
 hash:
-	docker pull $(BASE)
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - Dockerfile | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm $(IMAGE):build sha1sum /lib/apk/db/installed | sed 's/ .*//' > hash
 

--- a/alpine/base/alpine-qemu/Makefile
+++ b/alpine/base/alpine-qemu/Makefile
@@ -6,7 +6,7 @@ IMAGE=alpine-qemu
 default: push
 
 hash: Dockerfile repositories
-	docker pull $(BASE)
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm $(IMAGE):build sha1sum /lib/apk/db/installed | sed 's/ .*//' > hash
 

--- a/alpine/base/check-config/Makefile
+++ b/alpine/base/check-config/Makefile
@@ -6,7 +6,7 @@ IMAGE=check-config
 default: push
 
 hash:
-	docker pull $(BASE)
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - Dockerfile | docker build --no-cache -t $(IMAGE):build -
 	docker run --entrypoint=/bin/sh $(IMAGE):build -c 'cat /usr/bin/check-config.sh /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
 

--- a/alpine/base/qemu-user-static/Makefile
+++ b/alpine/base/qemu-user-static/Makefile
@@ -6,7 +6,7 @@ IMAGE=qemu-user-static
 default: push
 
 hash: Dockerfile
-	docker pull $(BASE)
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm $(IMAGE):build sh -c 'apt list --installed 2>/dev/null | sha1sum' | sed 's/ .*//' > hash
 

--- a/alpine/packages/test/usr/bin/mobytest
+++ b/alpine/packages/test/usr/bin/mobytest
@@ -7,7 +7,7 @@ diagnostics
 docker version
 docker info
 docker ps
-docker pull alpine
+DOCKER_CONTENT_TRUST=-1 docker pull alpine
 docker run alpine true
 docker pull armhf/alpine
 docker run armhf/alpine uname -a


### PR DESCRIPTION
When building the base images always test signatures. 

This will be the default at some point.

Also test it works in a test, in case it somehow broke.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>