### PR TITLE
Use digests for external images and scripts where possible

### DIFF
--- a/Dockerfile.media
+++ b/Dockerfile.media
@@ -1,4 +1,5 @@
-FROM mobylinux/toybox-media:e22a41942621b5655bd952b7715d695eaed32647
+# Tag: e22a41942621b5655bd952b7715d695eaed32647
+FROM mobylinux/toybox-media@sha256:b13ff14a256a77f8c993a6a08517596a8b0b8759391d77f28481fd6b440245ea
 
 ADD \
   alpine/initrd.img \

--- a/Dockerfile.qemu
+++ b/Dockerfile.qemu
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-qemu:804b2c40d078287c40aeb9166e475e843544e597 
+# Tag: 804b2c40d078287c40aeb9166e475e843544e597
+FROM mobylinux/alpine-qemu@sha256:aaecc961a62b14ee0ecd3a4fe792af5232637f0a49f7d0f90b87acaeb6f3fa4a
 
 COPY alpine/initrd.img .
 COPY alpine/kernel/x86_64/vmlinuz64 .

--- a/Dockerfile.qemuiso
+++ b/Dockerfile.qemuiso
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-qemu:804b2c40d078287c40aeb9166e475e843544e597 
+# Tag: 804b2c40d078287c40aeb9166e475e843544e597
+FROM mobylinux/alpine-qemu@sha256:aaecc961a62b14ee0ecd3a4fe792af5232637f0a49f7d0f90b87acaeb6f3fa4a
 
 COPY alpine/mobylinux-bios.iso .
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-qemu:804b2c40d078287c40aeb9166e475e843544e597 
+# Tag: 804b2c40d078287c40aeb9166e475e843544e597
+FROM mobylinux/alpine-qemu@sha256:aaecc961a62b14ee0ecd3a4fe792af5232637f0a49f7d0f90b87acaeb6f3fa4a
 
 COPY alpine/initrd.img .
 COPY alpine/kernel/x86_64/vmlinuz64 .

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-base:547930eb50022274934ee70b0fd9c73c75515216
+# Tag: 547930eb50022274934ee70b0fd9c73c75515216
+FROM mobylinux/alpine-base@sha256:e1ec2779ecbea58c78130aeb29500ad17ada4d34f5822c9436fc7a388ae95c06
 
 ENV ARCH=x86_64
 

--- a/alpine/Dockerfile.efi
+++ b/alpine/Dockerfile.efi
@@ -1,5 +1,6 @@
 # Create a EFI Bootable ISO
-FROM mobylinux/alpine-efi:41ce281ca20186b8f5cae3b0fd05260189d6a3d2
+# Tag: 41ce281ca20186b8f5cae3b0fd05260189d6a3d2
+FROM mobylinux/alpine-efi@sha256:15f82d91a6eb7ddd26bf6fe861787dd04073b4b5d3453a00d1052b0e4b972722
 
 WORKDIR /tmp/efi
 

--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -10,6 +10,9 @@ else
 DIRTY=-dirty
 endif
 
+# Tag: e6cb3f313db7098a1cd21051e678b01931a037a0
+ALPINE_BIOS_DIGEST=b06567c9d00fd4d1193e58fa8242a85121482eb2fb20ac4442388b7eb9cdceb3
+
 initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	$(MAKE) -C kernel
 	$(MAKE) -j -C packages
@@ -50,7 +53,7 @@ mobylinux-efi.iso: Dockerfile.efi initrd.img kernel/x86_64/vmlinuz64
 
 mobylinux-bios.iso: initrd.img kernel/x86_64/vmlinuz64
 	tar cf - initrd.img -C kernel/x86_64 vmlinuz64 | \
-	  docker run --net=none --log-driver=none --rm -i mobylinux/alpine-bios:e6cb3f313db7098a1cd21051e678b01931a037a0 >$@
+	  docker run --net=none --log-driver=none --rm -i mobylinux/alpine-bios@sha256:$(ALPINE_BIOS_DIGEST) >$@
 
 common: initrd.img
 	$(MAKE) -C kernel

--- a/alpine/containers/binfmt/Dockerfile
+++ b/alpine/containers/binfmt/Dockerfile
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-build-go:78d9a136c632c66f0767e11ce3c661989d706f21
+# Tag: 78d9a136c632c66f0767e11ce3c661989d706f21
+FROM mobylinux/alpine-build-go@sha256:d82b855d16994ae94f10fa45d0c31e99663aa3e8e4254ef5f31129b899de8ce0
 
 COPY *.go /go/src/binfmt/
 

--- a/alpine/containers/binfmt/Makefile
+++ b/alpine/containers/binfmt/Makefile
@@ -1,4 +1,5 @@
-QEMU_IMAGE=mobylinux/qemu-user-static:7a07de557d7f6ae3d72873c32bfb4c51c7687d03
+# Tag 7a07de557d7f6ae3d72873c32bfb4c51c7687d03
+QEMU_IMAGE=mobylinux/qemu-user-static@sha256:cbeba25809c7c3feebc9e20522145e33d8abe5956674afa52814fc57c6644497
 QEMU_BINARIES=qemu-arm-static qemu-aarch64-static qemu-ppc64le-static
 
 default: rootfs

--- a/alpine/kernel/Dockerfile
+++ b/alpine/kernel/Dockerfile
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-build-c:36aecb5cf4738737634140eec9abebe1f6559a39
+# Tag: 36aecb5cf4738737634140eec9abebe1f6559a39
+FROM mobylinux/alpine-build-c@sha256:d66b9625abc831f28f8c584991a9cb6975e85d3bb3d3768474b592f1cf32a3a6
 
 ARG KERNEL_VERSION=4.8.11
 

--- a/alpine/packages/9pmount-vsock/Dockerfile
+++ b/alpine/packages/9pmount-vsock/Dockerfile
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-build-c:36aecb5cf4738737634140eec9abebe1f6559a39
+# Tag: 36aecb5cf4738737634140eec9abebe1f6559a39
+FROM mobylinux/alpine-build-c@sha256:d66b9625abc831f28f8c584991a9cb6975e85d3bb3d3768474b592f1cf32a3a6
 
 COPY . /9pmount-vsock
 

--- a/alpine/packages/azure/etc/init.d/azure
+++ b/alpine/packages/azure/etc/init.d/azure
@@ -34,7 +34,8 @@ start()
 
 	einfo "Running Windows Azure Linux Agent container"
 
-	export DOCKER_FOR_IAAS_VERSION="azure-v1.13.0-rc2-beta12"
+	# Tag: azure-v1.13.0-rc2-beta12
+	export DOCKER_FOR_IAAS_VERSION_DIGEST="89801638f220c6ce485ce827a23f23be524db62fc2969c7e4cdd7d5d6de16d2e"
 
 	docker run -d \
 		--privileged \
@@ -54,7 +55,7 @@ start()
 		-v /lib/modules:/lib/modules \
 		-v /lib/firmware:/lib/firmware \
 		-v /var/lib/waagent:/var/lib/waagent \
-		"docker4x/agent-azure:$DOCKER_FOR_IAAS_VERSION"
+		"docker4x/agent-azure@sha256:$DOCKER_FOR_IAAS_VERSION_DIGEST
 
 	# Wait for docker user to be added by agent.
 	while [ ! -d /home/docker ]

--- a/alpine/packages/diagnostics/Dockerfile
+++ b/alpine/packages/diagnostics/Dockerfile
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-build-go:78d9a136c632c66f0767e11ce3c661989d706f21
+# Tag: 78d9a136c632c66f0767e11ce3c661989d706f21
+FROM mobylinux/alpine-build-go@sha256:d82b855d16994ae94f10fa45d0c31e99663aa3e8e4254ef5f31129b899de8ce0
 
 COPY ./ /go/src/diagnostics-server/
 

--- a/alpine/packages/iptables/Dockerfile
+++ b/alpine/packages/iptables/Dockerfile
@@ -1,4 +1,5 @@
-FROM ocaml/opam:alpine
+# Tag: alpine
+FROM ocaml/opam@sha256:fe4f6783f319fd02829af4f5a154d8e7030c3907ef393a7b7f21552648f89db8
 RUN sudo apk add m4
 RUN opam install ocamlfind astring syslog -y
 WORKDIR /app

--- a/alpine/packages/nc-vsock/Dockerfile
+++ b/alpine/packages/nc-vsock/Dockerfile
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-build-c:36aecb5cf4738737634140eec9abebe1f6559a39
+# Tag: 36aecb5cf4738737634140eec9abebe1f6559a39
+FROM mobylinux/alpine-build-c@sha256:d66b9625abc831f28f8c584991a9cb6975e85d3bb3d3768474b592f1cf32a3a6
 
 COPY . /nc-vsock
 

--- a/alpine/packages/proxy/Dockerfile
+++ b/alpine/packages/proxy/Dockerfile
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-build-go:78d9a136c632c66f0767e11ce3c661989d706f21
+# Tag: 78d9a136c632c66f0767e11ce3c661989d706f21
+FROM mobylinux/alpine-build-go@sha256:d82b855d16994ae94f10fa45d0c31e99663aa3e8e4254ef5f31129b899de8ce0
 
 COPY ./ /go/src/proxy/
 

--- a/alpine/packages/tap-vsockd/Dockerfile
+++ b/alpine/packages/tap-vsockd/Dockerfile
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-build-c:36aecb5cf4738737634140eec9abebe1f6559a39
+# Tag: 36aecb5cf4738737634140eec9abebe1f6559a39
+FROM mobylinux/alpine-build-c@sha256:d66b9625abc831f28f8c584991a9cb6975e85d3bb3d3768474b592f1cf32a3a6
 
 COPY . /tap-vsockd
 

--- a/alpine/packages/transfused/Dockerfile
+++ b/alpine/packages/transfused/Dockerfile
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-build-c:36aecb5cf4738737634140eec9abebe1f6559a39
+# Tag: 36aecb5cf4738737634140eec9abebe1f6559a39
+FROM mobylinux/alpine-build-c@sha256:d66b9625abc831f28f8c584991a9cb6975e85d3bb3d3768474b592f1cf32a3a6
 
 COPY . /transfused
 

--- a/alpine/packages/vsudd/Dockerfile
+++ b/alpine/packages/vsudd/Dockerfile
@@ -1,4 +1,5 @@
-FROM mobylinux/alpine-build-go:78d9a136c632c66f0767e11ce3c661989d706f21
+# Tag: 78d9a136c632c66f0767e11ce3c661989d706f21
+FROM mobylinux/alpine-build-go@sha256:d82b855d16994ae94f10fa45d0c31e99663aa3e8e4254ef5f31129b899de8ce0
 
 COPY ./ /go/src/vsudd/
 


### PR DESCRIPTION
Addresses https://github.com/docker/moby/issues/818 for images built outside of moby.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>