### PR TITLE
Run rngd inside a system container

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
-# Tag: 547930eb50022274934ee70b0fd9c73c75515216
-FROM mobylinux/alpine-base@sha256:e1ec2779ecbea58c78130aeb29500ad17ada4d34f5822c9436fc7a388ae95c06
+# Tag: be663b9af6f6ca464dbfec5aeea7ac94274fba34
+FROM mobylinux/alpine-base@sha256:3cd5f66d3ae6970905bea2a562358dd53b45483c47caba67acb7c0d049a0fb8a
 
 ENV ARCH=x86_64
 
@@ -36,7 +36,6 @@ RUN \
   rc-update add dmesg sysinit && \
   rc-update add devfs sysinit && \
   rc-update add hwdrivers sysinit && \
-  rc-update add rngd && \
   rc-update add sysfs && \
   rc-update add procfs && \
   rc-update add sysfsconf && \

--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -41,7 +41,7 @@ initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	  -C packages/containerd etc -C ../.. \
 	  -C packages/aws etc -C ../.. \
 	  -C packages/azure etc -C ../.. \
-	  containers/binfmt/rootfs containers/binfmt/config.json \
+	  containers/*/rootfs containers/*/config.json \
 	  | \
 	  docker build -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
 	docker run --net=none --log-driver=none --rm $$BUILD > $@

--- a/alpine/base/alpine-base/Dockerfile
+++ b/alpine/base/alpine-base/Dockerfile
@@ -19,7 +19,6 @@ RUN \
   jq \
   openrc \
   openssh-client \
-  rng-tools@community \
   sfdisk \
   strace \
   sysklogd \

--- a/alpine/base/alpine-base/packages
+++ b/alpine/base/alpine-base/packages
@@ -13,7 +13,7 @@ e2fsprogs-extra 1.43.3-r0
 e2fsprogs-libs 1.43.3-r0
 expat 2.2.0-r0
 fuse 2.9.7-r0
-git 2.10.2-r0
+git 2.11.0-r0
 hvtools 4.4.15-r0
 iptables 1.6.0-r0
 jq 1.5-r3
@@ -40,7 +40,6 @@ oniguruma 6.1.2-r0
 openrc 0.21.7-r3
 openssh-client 7.3_p1-r2
 pcre 8.39-r0
-rng-tools 5-r3
 scanelf 1.1.6-r0
 sfdisk 2.28.2-r0
 strace 4.14-r0

--- a/alpine/base/alpine-base/repositories
+++ b/alpine/base/alpine-base/repositories
@@ -1,2 +1,1 @@
 http://dl-cdn.alpinelinux.org/alpine/v3.5/main
-@community http://dl-cdn.alpinelinux.org/alpine/v3.5/community

--- a/alpine/base/alpine-build-c/Dockerfile
+++ b/alpine/base/alpine-build-c/Dockerfile
@@ -3,9 +3,11 @@ RUN \
   apk update && apk upgrade && \
   apk add \
   alpine-sdk \
+  argp-standalone \
   automake \
   bash \
   bc \
+  cmake \
   curl \
   gmp-dev \
   installkernel \

--- a/alpine/base/tini/Dockerfile
+++ b/alpine/base/tini/Dockerfile
@@ -1,0 +1,9 @@
+# Tag: 7b94dce736818ca5c9d5367be360b79714687ca5
+FROM mobylinux/alpine-build-c@sha256:9157aa25a781b5c47c563c0b9a5d564d41b32ceac9bf26d1e1249e8849d62c8b
+
+ENV TINI_VERSION=0.13.0
+ADD https://github.com/krallin/tini/archive/v${TINI_VERSION}.tar.gz tini-${TINI_VERSION}.tar.gz
+RUN zcat tini-${TINI_VERSION}.tar.gz | tar xvf -
+WORKDIR tini-${TINI_VERSION}
+RUN cmake . && make
+RUN cp -a tini-static /bin/tini

--- a/alpine/base/tini/Makefile
+++ b/alpine/base/tini/Makefile
@@ -1,0 +1,27 @@
+.PHONY: tag push
+
+IMAGE=tini
+
+default: push
+
+hash: Dockerfile
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --entrypoint sh $(IMAGE):build -c 'cat /Dockerfile /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/alpine/containers/rng-tools/.gitignore
+++ b/alpine/containers/rng-tools/.gitignore
@@ -1,0 +1,2 @@
+rootfs
+tini

--- a/alpine/containers/rng-tools/Dockerfile
+++ b/alpine/containers/rng-tools/Dockerfile
@@ -1,0 +1,33 @@
+FROM mobylinux/alpine-build-c:701eedf80c332bafcb8dd085b758702ed37dab0e
+
+ENV pkgname=rng-tools pkgver=5
+
+COPY . .
+
+RUN curl -O -sSL http://downloads.sourceforge.net/project/gkernel/$pkgname/$pkgver/$pkgname-$pkgver.tar.gz
+RUN sha256sum -c sha256sums
+RUN zcat $pkgname-$pkgver.tar.gz | tar xf -
+
+WORKDIR $pkgname-$pkgver
+RUN for p in ../*.patch; do cat $p | patch -p1; done
+
+RUN export LIBS="-largp" && \
+  LDFLAGS=-static ./configure \
+    --prefix=/usr \
+    --libexecdir=/usr/lib/rng-tools \
+    --sysconfdir=/etc \
+    --disable-silent-rules && \
+  make && \
+  make DESTDIR=/ install && \
+  strip /usr/sbin/rngd
+
+WORKDIR /rootfs
+
+RUN mkdir -p dev proc sys usr/sbin bin
+
+RUN cp -a /usr/sbin/rngd usr/sbin/
+RUN cp -a /tini bin/
+
+RUN printf 'FROM scratch\nCOPY . ./\nCMD ["/bin/tini", "/usr/sbin/rngd", "-f"]\n' > Dockerfile
+
+CMD ["tar", "cf", "-", "."]

--- a/alpine/containers/rng-tools/Makefile
+++ b/alpine/containers/rng-tools/Makefile
@@ -1,0 +1,26 @@
+# Tag 7b94dce736818ca5c9d5367be360b79714687ca5
+TINI_IMAGE=mobylinux/tini@sha256:5f697e501ce12af1c72fbdf5dd74299bcc8c4f58e6215a7c48627dc6e11d9a29
+TINI_BINARY=tini
+
+default: rootfs
+
+$(TINI_BINARY): Dockerfile
+	docker run --rm --net=none $(TINI_IMAGE) tar cf - -C /bin $@ | tar xf -
+
+rootfs: Dockerfile fix-textrels-on-PIC-x86.patch sha256sums $(TINI_BINARY)
+	mkdir -p $@
+	BUILD=$$( tar cf - $^ | docker build -q - ) && \
+	[ -n "$$BUILD" ] && \
+	echo "Built $$BUILD" && \
+	IMAGE=$$( docker run --rm --net=none $$BUILD | docker build -q - ) && \
+	[ -n "$$IMAGE" ] && \
+	echo "Built $$IMAGE" && \
+	CONTAINER=$$( docker create $$IMAGE /dev/null ) && \
+	docker export $$CONTAINER | tar -xf - -C $@ && \
+	docker rm $$CONTAINER && \
+	( cd $@ && rm -rf .dockerenv Dockerfile dev/* etc/hostname etc/hosts etc/mtab etc/resolv.conf )
+
+clean:
+	rm -rf rootfs $(TINI_BINARY)
+
+.DELETE_ON_ERROR:

--- a/alpine/containers/rng-tools/config.json
+++ b/alpine/containers/rng-tools/config.json
@@ -1,0 +1,158 @@
+{
+    "ociVersion": "1.0.0-rc2-dev",
+    "platform": {
+        "os": "linux",
+        "arch": "amd64"
+    },
+    "process": {
+        "terminal": false,
+        "user": {
+            "uid": 0,
+            "gid": 0
+        },
+        "args": [
+	    "/bin/tini",
+	    "/usr/sbin/rngd",
+	    "-f"
+        ],
+        "env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "cwd": "/",
+	"capabilities": [
+		"CAP_SYS_ADMIN"
+	],
+        "rlimits": [
+            {
+                "type": "RLIMIT_NOFILE",
+                "hard": 1024,
+                "soft": 1024
+            }
+        ],
+        "noNewPrivileges": true
+    },
+    "root": {
+        "path": "rootfs",
+        "readonly": true
+    },
+    "hostname": "gloomy_saha",
+    "mounts": [
+        {
+            "destination": "/proc",
+            "type": "proc",
+            "source": "proc"
+        },
+        {
+            "destination": "/dev",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/pts",
+            "type": "devpts",
+            "source": "devpts",
+            "options": [
+                "nosuid",
+                "noexec",
+                "newinstance",
+                "ptmxmode=0666",
+                "mode=0620",
+                "gid=5"
+            ]
+        },
+        {
+            "destination": "/dev/shm",
+            "type": "tmpfs",
+            "source": "shm",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "mode=1777",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/mqueue",
+            "type": "mqueue",
+            "source": "mqueue",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/sys",
+            "type": "sysfs",
+            "source": "sysfs",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/sys/fs/cgroup",
+            "type": "cgroup",
+            "source": "cgroup",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "relatime",
+                "ro"
+            ]
+        }
+    ],
+    "hooks": {},
+        "linux": {
+                "resources": {
+                        "devices": [
+                                {
+                                        "allow": false,
+                                        "access": "rwm"
+                                }
+                        ]
+                },
+                "namespaces": [
+                        {
+                                "type": "pid"
+                        },
+                        {
+                                "type": "network"
+                        },
+                        {
+                                "type": "ipc"
+                        },
+                        {
+                                "type": "uts"
+                        },
+                        {
+                                "type": "mount"
+                        }
+                ],
+                "maskedPaths": [
+                        "/proc/kcore",
+                        "/proc/latency_stats",
+                        "/proc/timer_list",
+                        "/proc/timer_stats",
+                        "/proc/sched_debug",
+                        "/sys/firmware"
+                ],
+                "readonlyPaths": [
+                        "/proc/asound",
+                        "/proc/bus",
+                        "/proc/fs",
+                        "/proc/irq",
+                        "/proc/sys",
+                        "/proc/sysrq-trigger"
+                ]
+        }
+}

--- a/alpine/containers/rng-tools/fix-textrels-on-PIC-x86.patch
+++ b/alpine/containers/rng-tools/fix-textrels-on-PIC-x86.patch
@@ -1,0 +1,50 @@
+--- rng-tools/rdrand_asm.S
++++ rng-tools/rdrand_asm.S
+@@ -49,6 +49,7 @@
+ 	ret
+ ENDPROC(x86_rdrand_nlong)
+ 
++#define INIT_PIC()
+ #define SETPTR(var,ptr)	leaq var(%rip),ptr
+ #define PTR0	%rdi
+ #define PTR1	%rsi
+@@ -84,7 +85,16 @@
+ 	ret
+ ENDPROC(x86_rdrand_nlong)
+ 
++#if defined(__PIC__)
++#undef __i686 /* gcc builtin define gets in our way */
++#define INIT_PIC() \
++	call __i686.get_pc_thunk.bx ; \
++	addl $_GLOBAL_OFFSET_TABLE_, %ebx
++#define SETPTR(var,ptr)	leal (var)@GOTOFF(%ebx),ptr
++#else
++#define INIT_PIC()
+ #define SETPTR(var,ptr)	movl $(var),ptr
++#endif
+ #define PTR0	%eax
+ #define PTR1	%edx
+ #define PTR2	%ecx
+@@ -101,6 +111,7 @@
+ 	movl	8(%ebp), %eax
+ 	movl	12(%ebp), %edx
+ #endif
++	INIT_PIC()
+ 
+ 	SETPTR(aes_round_keys, PTR2)
+ 
+@@ -166,6 +177,17 @@
+ #endif
+ 	ret
+ ENDPROC(x86_aes_mangle)
++
++#if defined(__i386__) && defined(__PIC__)
++	.section .gnu.linkonce.t.__i686.get_pc_thunk.bx,"ax",@progbits
++.globl __i686.get_pc_thunk.bx
++	.hidden  __i686.get_pc_thunk.bx
++	.type    __i686.get_pc_thunk.bx,@function
++__i686.get_pc_thunk.bx:
++	movl (%esp), %ebx
++	ret
++#endif
++

--- a/alpine/containers/rng-tools/sha256sums
+++ b/alpine/containers/rng-tools/sha256sums
@@ -1,0 +1,1 @@
+60a102b6603bbcce2da341470cad42eeaa9564a16b4490e7867026ca11a3078e  rng-tools-5.tar.gz

--- a/alpine/etc/conf.d/rngd
+++ b/alpine/etc/conf.d/rngd
@@ -1,1 +1,0 @@
-RNGD_OPTS=""

--- a/alpine/etc/sysctl.d/01-moby.conf
+++ b/alpine/etc/sysctl.d/01-moby.conf
@@ -7,3 +7,4 @@ net.ipv4.neigh.default.gc_thresh3 = 32768
 fs.aio-max-nr = 1048576
 fs.inotify.max_user_watches = 524288
 fs.file-max = 524288
+kernel.random.write_wakeup_threshold = 3072

--- a/alpine/packages/containerd/etc/init.d/containerd
+++ b/alpine/packages/containerd/etc/init.d/containerd
@@ -21,11 +21,16 @@ start()
 
 	ebegin "Running system containers"
 
+	LOG=/var/log/system-containers.log
+	touch $LOG
+
 	for f in /containers/*
 	do
-		# note we attach, so will be synchronous for now
-		containerd-ctr containers start --no-pivot --attach "$(basename $f)" "$f"
+		containerd-ctr containers start --no-pivot --attach "$(basename $f)" "$f" 2>$LOG >$LOG &
+		printf " $(basename $f)"
 	done
+
+	printf "\n"
 
 	eend $? "Failed to start system containers"
 }


### PR DESCRIPTION
- this needs an init as it does not respond to stop signals, so include tini
- needs CAP_SYS_ADMIN to write to kernel entropy estimate
- set kernel.random.write_wakeup_threshold so that rngd does not need sysctl write access
- build patches from Alpine, but statically linked
- remove rngd from base image, means we no longer need community repository

Signed-off-by: Justin Cormack <justin.cormack@docker.com>