### PR TITLE
Align compressed initrd to 4 bytes

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -44,7 +44,7 @@ initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	  containers/*/rootfs containers/*/config.json \
 	  | \
 	  docker build -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
-	docker run --net=none --log-driver=none --rm $$BUILD > $@
+	docker run --read-only --net=none --log-driver=none --rm --tmpfs /tmp --tmpfs /initrd $$BUILD > $@
 
 mobylinux-efi.iso: Dockerfile.efi initrd.img kernel/x86_64/vmlinuz64
 	BUILD=$$( tar cf - $^ | docker build -q -f Dockerfile.efi - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \

--- a/alpine/mkinitrd.sh
+++ b/alpine/mkinitrd.sh
@@ -32,7 +32,31 @@ EOF
 
 printf 'moby' > /tmp/etc/hostname
 
-rm /tmp/mkinitrd.sh
-
 cd /tmp
-find . | cpio -H newc -o | gzip -9
+
+rm mkinitrd.sh
+
+find . | cpio -H newc -o | gzip -9 > /initrd/initrd.img
+
+cd /initrd
+
+SIZE=$(stat -c "%s" initrd.img)
+SIZE4=$(( $SIZE / 4 \* 4 ))
+DIFF=$(( $SIZE - $SIZE4 ))
+[ $DIFF -ne 0 ] && DIFF=$(( 4 - $DIFF ))
+
+dd if=/dev/zero bs=1 count=$DIFF of=zeropad
+
+cat zeropad >> initrd.img
+
+SIZE=$(stat -c "%s" initrd.img)
+SIZE4=$(( $SIZE / 4 \* 4 )) 
+DIFF=$(( $SIZE - $SIZE4 ))
+
+if [ $DIFF -ne 0 ]
+then
+	echo "Bad aligment" >2
+	exit 1
+fi
+
+cat initrd.img


### PR DESCRIPTION
Fix #618

Allows appending another initrd.

Also build initrd on tmpfs as should be a bit faster now we have to do another copy.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>