### PR TITLE
Bump digest and re-add DOCKER_FOR_IAAS_VERSION for Azure

### DIFF
--- a/alpine/packages/azure/etc/init.d/azure
+++ b/alpine/packages/azure/etc/init.d/azure
@@ -34,8 +34,8 @@ start()
 
 	einfo "Running Windows Azure Linux Agent container"
 
-	# Tag: azure-v1.13.0-rc2-beta12
-	export DOCKER_FOR_IAAS_VERSION_DIGEST="90c58b579e7034b27f7b14e3790d9f3deb72899e1c873ae6cb7ce8492897d923"
+	export DOCKER_FOR_IAAS_VERSION="azure-v1.13.0-rc2-beta12"
+	export DOCKER_FOR_IAAS_VERSION_DIGEST="66c8d6dd8451c12c761aea5ef1403489aff4cb014ec507deb1d41f408778e605"
 
 	docker run -d \
 		--privileged \
@@ -45,6 +45,7 @@ start()
 		--net host \
 		--uts host \
 		--restart unless-stopped \
+		-e DOCKER_FOR_IAAS_VERSION \
 		-v /usr/bin/docker:/usr/local/bin/docker:ro \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v /var/log:/var/log \


### PR DESCRIPTION
FYI @justincormack @riyazdf 

as summed up by @ddebroy in chat:

> we spoke about the versioning scheme in the standup and the plan now for upcoming public beta is: (1) keep using content-addressable hashes for waagent and (2) export a textual tag for the rest of the containers [this keeps things consistent for Azure and AWS]. Later during GA, we will move to using content-addressable hash for versioning and pulling all service containers across Azure and AWS

Over time we would like to move to digests for those as well.  It slows down development a lot though so I think we will need to roll it out carefully.

BTW, we're rolling out first version of Azure without :2375 exposed this release :) (I'm just carrying patch locally)   Not sure about AWS we should check in before yanking it completely.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>