### PR TITLE
Disable kexec load in sysctl config

### DIFF
--- a/alpine/etc/sysctl.d/01-moby.conf
+++ b/alpine/etc/sysctl.d/01-moby.conf
@@ -8,3 +8,4 @@ fs.aio-max-nr = 1048576
 fs.inotify.max_user_watches = 524288
 fs.file-max = 524288
 kernel.random.write_wakeup_threshold = 3072
+kernel.kexec_load_disabled = 1


### PR DESCRIPTION
Disables `kexec` by disabling the `kexec_load` syscall with the moby [sysctl](https://www.kernel.org/doc/Documentation/sysctl/kernel.txt) config 

Closes #838 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>