### PR TITLE
Use TRIM on Mac as well as Windows

### DIFF
--- a/alpine/etc/periodic/15m/trim
+++ b/alpine/etc/periodic/15m/trim
@@ -1,4 +1,8 @@
 #!/bin/sh
 
-# Windows always has TRIM support, clean out unused frequently
-[ "$(mobyplatform)" = "windows" ] && /sbin/fstrim /var
+# Windows and Mac have TRIM support, clean out unused frequently
+case "$(mobyplatform)" in
+  "windows"|"mac")
+     /sbin/fstrim /var
+     ;;
+esac


### PR DESCRIPTION
Previously we only ran `fstrim` on Windows. Docker for Mac now supports TRIM so we should run `fstrim` there too.

Note it's possible to turn off TRIM on the Mac at the virtual hardware level via the database, but this should be harmless -- the `fstrim` fails immediately with an obvious error if the device doesn't support it: `fstrim: ioctl 0xc0185879 failed: Not supported`.

Signed-off-by: David Scott <dave.scott@docker.com>