### PR TITLE
Push a copy of the Moby base image to mobylinux/mobylinux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,14 @@ test: Dockerfile.test alpine/initrd.img alpine/kernel/x86_64/vmlinuz64
 
 TAG=$(shell git rev-parse HEAD)
 STATUS=$(shell git status -s)
+MOBYLINUX_TAG=alpine/mobylinux.tag
 media: Dockerfile.media alpine/initrd.img alpine/kernel/x86_64/vmlinuz64 alpine/mobylinux-efi.iso
 ifeq ($(STATUS),)
 	tar cf - $^ alpine/mobylinux.efi alpine/kernel/x86_64/vmlinux | docker build -f Dockerfile.media -t mobylinux/media:$(MEDIA_PREFIX)$(TAG) -
 	docker push mobylinux/media:$(MEDIA_PREFIX)$(TAG)
+	[ -f $(MOBYLINUX_TAG) ]
+	docker tag $(shell cat $(MOBYLINUX_TAG)) mobylinux/mobylinux:$(MEDIA_PREFIX)$(TAG)
+	docker push mobylinux/mobylinux:$(MEDIA_PREFIX)$(TAG)
 else
 	$(error "git not clean")
 endif

--- a/alpine/.gitignore
+++ b/alpine/.gitignore
@@ -1,4 +1,5 @@
 *.img
+*.tag
 /mobylinux.img
 /mobylinux.vhd
 /mobylinux-bios.iso

--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -43,6 +43,7 @@ moby-initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	  -C packages/azure etc -C ../.. \
 	  | \
 	  docker build -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
+	echo $$BUILD > mobylinux.tag && \
 	docker run --read-only --net=none --log-driver=none --rm --tmpfs /tmp --tmpfs /initrd $$BUILD > $@
 
 container-initrd.img:
@@ -174,7 +175,7 @@ vhdartifact:
 	docker volume create --name vhdartifact || true
 
 clean:
-	rm -f *.img *.vhd *.iso mobylinux.efi zeropad etc/moby-commit
+	rm -f *.img *.vhd *.iso *.tag mobylinux.efi zeropad etc/moby-commit
 	docker images -q moby-azure:build | xargs docker rmi -f || true
 	docker images -q moby-azure:raw2vhd | xargs docker rmi -f || true
 	docker volume rm vhdartifact || true


### PR DESCRIPTION
This will be used for ongoing security scanning.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

Images pushed to https://hub.docker.com/r/mobylinux/mobylinux/tags/ which is private and should be security scanned.