### PR TITLE
Install kernel headers in kernel image and upload kernel for scans

### DIFF
--- a/Dockerfile.kernel
+++ b/Dockerfile.kernel
@@ -1,0 +1,2 @@
+FROM scratch
+ADD . /

--- a/Dockerfile.media
+++ b/Dockerfile.media
@@ -5,6 +5,7 @@ ADD \
   alpine/initrd.img \
   alpine/kernel/x86_64/vmlinuz64 \
   alpine/kernel/x86_64/vmlinux \
+  alpine/kernel/x86_64/kernel-headers.tar \
   alpine/mobylinux-efi.iso \
   alpine/mobylinux.efi \
   / 

--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,13 @@ STATUS=$(shell git status -s)
 MOBYLINUX_TAG=alpine/mobylinux.tag
 media: Dockerfile.media alpine/initrd.img alpine/kernel/x86_64/vmlinuz64 alpine/mobylinux-efi.iso
 ifeq ($(STATUS),)
-	tar cf - $^ alpine/mobylinux.efi alpine/kernel/x86_64/vmlinux | docker build -f Dockerfile.media -t mobylinux/media:$(MEDIA_PREFIX)$(TAG) -
+	tar cf - $^ alpine/mobylinux.efi alpine/kernel/x86_64/vmlinux alpine/kernel/x86_64/kernel-headers.tar | docker build -f Dockerfile.media -t mobylinux/media:$(MEDIA_PREFIX)$(TAG) -
 	docker push mobylinux/media:$(MEDIA_PREFIX)$(TAG)
 	[ -f $(MOBYLINUX_TAG) ]
 	docker tag $(shell cat $(MOBYLINUX_TAG)) mobylinux/mobylinux:$(MEDIA_PREFIX)$(TAG)
 	docker push mobylinux/mobylinux:$(MEDIA_PREFIX)$(TAG)
+	tar cf - Dockerfile.kernel alpine/kernel/x86_64/boot.tar | docker build -f Dockerfile.kernel -t mobylinux/kernel:$(MEDIA_PREFIX)$(TAG) -
+	docker push mobylinux/kernel:$(MEDIA_PREFIX)$(TAG)
 else
 	$(error "git not clean")
 endif
@@ -56,6 +58,7 @@ ifeq ($(STATUS),)
 	mkdir -p alpine/kernel/x86_64 && \
 	docker cp $$IMAGE:vmlinuz64 alpine/kernel/x86_64/vmlinuz64 && \
 	docker cp $$IMAGE:vmlinux alpine/kernel/x86_64/vmlinux && \
+	docker cp $$IMAGE:kernel-headers.tar alpine/kernel/x86_64/kernel-headers.tar && \
 	docker cp $$IMAGE:initrd.img alpine/initrd.img && \
 	docker cp $$IMAGE:mobylinux-efi.iso alpine/mobylinux-efi.iso && \
 	docker cp $$IMAGE:mobylinux.efi alpine/mobylinux.efi && \

--- a/alpine/kernel/Dockerfile
+++ b/alpine/kernel/Dockerfile
@@ -63,18 +63,19 @@ RUN cd /linux && \
         patch -p1 < "$patch"; \
     done
 
-RUN cd /linux && \
-    make defconfig && \
+WORKDIR /linux
+RUN make defconfig && \
     make oldconfig && \
-    make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
-    make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install && \
-    ( cd /tmp/kernel-modules && tar cf /kernel-modules.tar . ) && \
-    make INSTALL_HDR_PATH=/tmp/kernel-headers headers_install
+    make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie"
+RUN make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install && \
+    make INSTALL_HDR_PATH=/tmp headers_install && \
+    ( cd /tmp && tar cf /kernel-headers.tar include ) && \
+    ( cd /tmp/kernel-modules && tar cf /kernel-modules.tar . )
 
 # Build aufs tools, do this here as they need kernel headers and to match aufs
 # Fortunately they are built statically linked
 RUN cd /aufs-util && \
-    CPPFLAGS="-I/tmp/kernel-headers/include" CFLAGS=$CPPFLAGS LDFLAGS=$CPPFLAGS make && \
+    CPPFLAGS="-I/tmp/include" CFLAGS=$CPPFLAGS LDFLAGS=$CPPFLAGS make && \
     DESTDIR=/tmp/aufs-utils make install && \
     rm -rf /tmp/aufs-utils/usr/lib /tmp/aufs-utils/usr/share && \
     cd /tmp/aufs-utils && rm libau* && tar cf /aufs-utils.tar .

--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -10,6 +10,8 @@ x86_64/vmlinuz64: Dockerfile kernel_config
 	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-source-info > etc/kernel-source-info && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /linux/vmlinux > x86_64/vmlinux && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /linux/arch/x86_64/boot/bzImage > $@ && \
+	docker run --rm --net=none --log-driver=none $$BUILD tar cf - /linux/arch/x86/boot > x86_64/boot.tar && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-headers.tar > x86_64/kernel-headers.tar && \
 	cp -a patches etc/kernel-patches
 
 clean:


### PR DESCRIPTION
Also upload kernel to a private repo at mobylinux/kernel on Hub so that
we can use this to scan.

Keep kernel headers in media image.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>