### PR TITLE
Add base image for mksh

### DIFF
--- a/alpine/base/alpine-build-c/Dockerfile
+++ b/alpine/base/alpine-build-c/Dockerfile
@@ -10,6 +10,7 @@ RUN \
   cmake \
   curl \
   gmp-dev \
+  groff \
   installkernel \
   kmod \
   linux-headers \

--- a/alpine/base/mksh/Dockerfile
+++ b/alpine/base/mksh/Dockerfile
@@ -1,0 +1,15 @@
+# Tag: 9e9c6b252d2e4ec03da23c8f48f54fce7ddee8d3
+FROM mobylinux/alpine-build-c@sha256:68737dcc6a1081f07aace1e82aefe90df399a25ae3a025664c4dbdccf76bbd97
+
+ENV VERSION=mksh-R54
+
+RUN curl -O -sSL https://github.com/MirBSD/mksh/archive/$VERSION.tar.gz
+RUN zcat $VERSION.tar.gz | tar xvf -
+
+WORKDIR mksh-$VERSION
+
+ENV LDFLAGS=-static
+
+RUN sh ./Build.sh
+RUN strip mksh
+RUN install -c -s -o root -g bin -m 555 mksh /bin/mksh

--- a/alpine/base/mksh/Makefile
+++ b/alpine/base/mksh/Makefile
@@ -1,0 +1,27 @@
+.PHONY: tag push
+
+IMAGE=mksh
+
+default: push
+
+hash: Dockerfile
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --entrypoint sh $(IMAGE):build -c 'cat /Dockerfile /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:


### PR DESCRIPTION
This is a minimal standalone statically linked shell for use
for now in converting images to containers.

Plan to phase it out and replace with actual programs later.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>