### PR TITLE
Containerize test suite

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,9 +1,9 @@
 # Tag: 804b2c40d078287c40aeb9166e475e843544e597
 FROM mobylinux/alpine-qemu@sha256:aaecc961a62b14ee0ecd3a4fe792af5232637f0a49f7d0f90b87acaeb6f3fa4a
 
-COPY alpine/initrd.img .
+COPY alpine/initrd-test.img initrd.img
 COPY alpine/kernel/x86_64/vmlinuz64 .
 
 RUN qemu-img create -f raw disk.img 256M
 
-ENTRYPOINT [ "qemu-system-x86_64", "-drive", "file=disk.img,format=raw", "-device", "virtio-rng-pci", "-serial", "stdio", "-kernel", "vmlinuz64", "-initrd", "initrd.img", "-m", "1024", "-append", "earlyprintk=serial console=ttyS0 noapic mobyplatform=test", "-vnc", "none" ]
+ENTRYPOINT [ "qemu-system-x86_64", "-drive", "file=disk.img,format=raw", "-device", "virtio-rng-pci", "-serial", "stdio", "-kernel", "vmlinuz64", "-initrd", "initrd.img", "-m", "1024", "-append", "earlyprintk=serial console=ttyS0 noapic", "-vnc", "none" ]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ all:
 alpine/initrd.img:
 	$(MAKE) -C alpine initrd.img
 
+alpine/initrd-test.img:
+	$(MAKE) -C alpine
+
 alpine/kernel/x86_64/vmlinuz64:
 	$(MAKE) -C alpine/kernel x86_64/vmlinuz64
 
@@ -27,7 +30,7 @@ hyperkit.git/build/com.docker.hyperkit: hyperkit.git
 hyperkit: hyperkit.sh hyperkit.git/build/com.docker.hyperkit alpine/initrd.img alpine/kernel/x86_64/vmlinuz64
 	sudo ./hyperkit.sh
 
-test: Dockerfile.test alpine/initrd.img alpine/kernel/x86_64/vmlinuz64
+test: Dockerfile.test alpine/initrd-test.img alpine/kernel/x86_64/vmlinuz64
 	$(MAKE) -C alpine
 	BUILD=$$( tar cf - $^ | docker build -f Dockerfile.test -q - ) && \
 	[ -n "$$BUILD" ] && \

--- a/alpine/.gitignore
+++ b/alpine/.gitignore
@@ -1,9 +1,7 @@
 *.img
 *.tag
-/mobylinux.img
-/mobylinux.vhd
-/mobylinux-bios.iso
-/mobylinux-efi.iso
+*.iso
+*.vhd
 /mobylinux-boot.vhdx
 /mobylinux.efi
 etc/moby-commit

--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -1,4 +1,4 @@
-all:	initrd.img mobylinux-efi.iso mobylinux-bios.iso
+all:	initrd.img initrd-test.img mobylinux-efi.iso mobylinux-bios.iso
 
 ETCFILES=$(shell find etc)
 
@@ -13,10 +13,9 @@ endif
 # Tag: e6cb3f313db7098a1cd21051e678b01931a037a0
 ALPINE_BIOS_DIGEST=b06567c9d00fd4d1193e58fa8242a85121482eb2fb20ac4442388b7eb9cdceb3
 
-moby-initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
+moby.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	$(MAKE) -C kernel
 	$(MAKE) -j -C packages
-	$(MAKE) -j -C containers
 	printf $(TAG)$(DIRTY) > etc/moby-commit
 	BUILD=$$( tar cf - \
 	  Dockerfile etc usr init mkinitrd.sh \
@@ -36,7 +35,7 @@ moby-initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	  -C packages/mobyplatform usr -C ../.. \
 	  -C packages/oom etc -C ../.. \
 	  -C packages/9pmount-vsock sbin -C ../.. \
-	  -C packages/test etc usr -C ../.. \
+	  -C packages/test etc -C ../.. \
 	  -C packages/iptables usr -C ../.. \
 	  -C packages/containerd etc -C ../.. \
 	  -C packages/aws etc -C ../.. \
@@ -46,7 +45,8 @@ moby-initrd.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	echo $$BUILD > mobylinux.tag && \
 	docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp --tmpfs /initrd $$BUILD > $@
 
-container-initrd.img:
+container.img:
+	$(MAKE) -j -C containers
 	(find containers -type d -maxdepth 1 && \
 	 find containers/*/rootfs containers/*/config.json) | \
 		cpio -H newc -o | gzip -9 > $@
@@ -58,7 +58,23 @@ container-initrd.img:
 	cat zeropad >> $@
 	rm zeropad
 
-initrd.img: moby-initrd.img container-initrd.img
+test.img:
+	$(MAKE) -j -C test
+	(find test -maxdepth 0 && \
+	 find test/rootfs test/config.json) | \
+		cpio -H newc -o | gzip -9 > $@
+	SIZE=$$(cat $@ | wc -c); \
+	SIZE4=$$(( $$SIZE / 4 * 4 )); \
+	DIFF=$$(( $$SIZE - $$SIZE4 )); \
+	[ $$DIFF -ne 0 ] && DIFF=$$(( 4 - $$DIFF )); \
+	dd if=/dev/zero bs=1 count=$$DIFF of=zeropad
+	cat zeropad >> $@
+	rm zeropad
+
+initrd.img: moby.img container.img
+	cat $^ > $@
+
+initrd-test.img: initrd.img test.img
 	cat $^ > $@
 
 mobylinux-efi.iso: Dockerfile.efi initrd.img kernel/x86_64/vmlinuz64
@@ -181,6 +197,7 @@ clean:
 	docker volume rm vhdartifact || true
 	$(MAKE) -C packages clean
 	$(MAKE) -C containers clean
+	$(MAKE) -C test clean
 	$(MAKE) -C kernel clean
 
 .DELETE_ON_ERROR:

--- a/alpine/base/ca-certificates/Dockerfile
+++ b/alpine/base/ca-certificates/Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:stable
+
+RUN apt-get update && apt-get -y upgrade && apt-get install -y ca-certificates

--- a/alpine/base/ca-certificates/Makefile
+++ b/alpine/base/ca-certificates/Makefile
@@ -1,0 +1,29 @@
+.PHONY: tag push
+
+BASE=debian:stable
+IMAGE=ca-certificates
+
+default: push
+
+hash: Dockerfile
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm $(IMAGE):build sh -c 'apt list --installed 2>/dev/null | sha1sum' | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/alpine/packages/containerd/etc/init.d/containerd
+++ b/alpine/packages/containerd/etc/init.d/containerd
@@ -30,7 +30,5 @@ start()
 		printf " $(basename $f)"
 	done
 
-	printf "\n"
-
 	eend $? "Failed to start system containers"
 }

--- a/alpine/packages/test/etc/init.d/test
+++ b/alpine/packages/test/etc/init.d/test
@@ -2,16 +2,16 @@
 
 depend()
 {
-	need docker
+	need docker containerd
 }
 
 start()
 {
-	[ "$(mobyplatform)" != "test" ] && exit 0
+	[ -d /test ] || exit 0
 
 	ebegin "Running tests"
 
-	if mobytest
+	if containerd-ctr containers start --no-pivot --attach test /test
 	then
 		printf "Moby test suite PASSED\n"
 	else

--- a/alpine/test/.gitignore
+++ b/alpine/test/.gitignore
@@ -1,0 +1,3 @@
+ca-certificates.crt
+mksh
+rootfs

--- a/alpine/test/Dockerfile
+++ b/alpine/test/Dockerfile
@@ -1,0 +1,14 @@
+# Will do a Go build in future
+# Tag: 1ae7bf8ec49a6537a93fba0c90720c65fa1c6ece
+FROM mobylinux/alpine-build-go@sha256:5e9aed92363c25349c2845b9be4a5285e0f56376b8b3ce92c7361bb59e6eeb2d
+
+COPY test.sh mksh /tmp/bin/
+COPY ca-certificates.crt /tmp/etc/ssl/certs/ca-certificates.crt
+
+WORKDIR /tmp
+
+RUN printf 'FROM scratch\nCOPY . ./\nENTRYPOINT ["/bin/sh", "-c"]\nCMD ["/bin/test.sh"]' > Dockerfile
+
+RUN mv bin/mksh bin/sh
+
+CMD ["tar", "cf", "-", "."]

--- a/alpine/test/Makefile
+++ b/alpine/test/Makefile
@@ -1,0 +1,35 @@
+# Tag dd4754bf8bc8b4af00210e688f233c869ddaa909
+MKSH_IMAGE=mobylinux/mksh@sha256:dd73f387248377af1f900b33eb3422eef093e57f31cdaabad3017fcfb42ef65b
+MKSH_FILE=mksh
+MKSH_PATH=/bin
+
+# Tag: 41e4b91c9a619e46f76ce2d024067c09b62f07b4
+CACERT_IMAGE=mobylinux/ca-certificates@sha256:6ca2dca9cfb8534a55f3a17f8797943527db5bbac08c98a5c9a4836250f4c548
+CACERT_FILE=ca-certificates.crt
+CACERT_PATH=/etc/ssl/certs
+
+default: rootfs
+
+$(MKSH_FILE):
+	docker run --rm --net=none $(MKSH_IMAGE) tar cf - -C $(MKSH_PATH) $(MKSH_FILE) | tar xf -
+
+$(CACERT_FILE):
+	docker run --rm --net=none $(CACERT_IMAGE) tar cf - -C $(CACERT_PATH) $(CACERT_FILE) | tar xf -
+
+rootfs: Dockerfile test.sh $(MKSH_FILE) $(CACERT_FILE)
+	mkdir -p $@
+	BUILD=$$( tar cf - $^ | docker build -q - ) && \
+	[ -n "$$BUILD" ] && \
+	echo "Built $$BUILD" && \
+	IMAGE=$$( docker run --rm --net=none $$BUILD | docker build -q - ) && \
+	[ -n "$$IMAGE" ] && \
+	echo "Built $$IMAGE" && \
+	CONTAINER=$$( docker create $$IMAGE /dev/null ) && \
+	docker export $$CONTAINER | tar -xf - -C $@ && \
+	docker rm $$CONTAINER && \
+	( cd $@ && rm -rf .dockerenv Dockerfile dev/* etc/hostname etc/hosts etc/mtab etc/resolv.conf )
+
+clean:
+	rm -rf rootfs $(MKSH_FILE) $(CACERT_FILE)
+
+.DELETE_ON_ERROR:

--- a/alpine/test/config.json
+++ b/alpine/test/config.json
@@ -1,0 +1,197 @@
+{
+    "ociVersion": "1.0.0-rc2-dev",
+    "platform": {
+        "os": "linux",
+        "arch": "amd64"
+    },
+    "process": {
+        "terminal": false,
+        "user": {
+            "uid": 0,
+            "gid": 0
+        },
+        "args": [
+            "/bin/sh",
+            "-c",
+            "/bin/test.sh"
+        ],
+        "env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "HOME=/tmp"
+        ],
+        "cwd": "/",
+	"capabilities": [],
+        "rlimits": [
+            {
+                "type": "RLIMIT_NOFILE",
+                "hard": 1024,
+                "soft": 1024
+            }
+        ],
+        "noNewPrivileges": true
+    },
+    "root": {
+        "path": "rootfs",
+        "readonly": true
+    },
+    "hostname": "elegant_albattani",
+    "mounts": [
+        {
+            "destination": "/usr/bin/docker",
+            "type": "bind",
+            "source": "/usr/bin/docker",
+            "options": [
+                "ro",
+                "rbind",
+                "rprivate"
+            ]
+        },
+        {
+            "destination": "/tmp",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "strictatime",
+                "mode=1755",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/var/run/docker.sock",
+            "type": "bind",
+            "source": "/var/run/docker.sock",
+            "options": [
+                "ro",
+                "rbind",
+                "rprivate"
+            ]
+        },
+        {
+            "destination": "/etc/resolv.conf",
+            "type": "bind",
+            "source": "/etc/resolv.conf",
+            "options": [
+                "ro",
+                "rbind",
+                "rprivate"
+            ]
+        },
+        {
+            "destination": "/proc",
+            "type": "proc",
+            "source": "proc"
+        },
+        {
+            "destination": "/dev",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/pts",
+            "type": "devpts",
+            "source": "devpts",
+            "options": [
+                "nosuid",
+                "noexec",
+                "newinstance",
+                "ptmxmode=0666",
+                "mode=0620",
+                "gid=5"
+            ]
+        },
+        {
+            "destination": "/dev/shm",
+            "type": "tmpfs",
+            "source": "shm",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "mode=1777",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/mqueue",
+            "type": "mqueue",
+            "source": "mqueue",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/sys",
+            "type": "sysfs",
+            "source": "sysfs",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/sys/fs/cgroup",
+            "type": "cgroup",
+            "source": "cgroup",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "relatime",
+                "ro"
+            ]
+        }
+    ],
+    "hooks": {},
+        "linux": {
+                "resources": {
+                        "devices": [
+                                {
+                                        "allow": false,
+                                        "access": "rwm"
+                                }
+                        ]
+                },
+                "namespaces": [
+                        {
+                                "type": "pid"
+                        },
+                        {
+                                "type": "ipc"
+                        },
+                        {
+                                "type": "uts"
+                        },
+                        {
+                                "type": "mount"
+                        }
+                ],
+                "maskedPaths": [
+                        "/proc/kcore",
+                        "/proc/latency_stats",
+                        "/proc/timer_list",
+                        "/proc/timer_stats",
+                        "/proc/sched_debug",
+                        "/sys/firmware"
+                ],
+                "readonlyPaths": [
+                        "/proc/asound",
+                        "/proc/bus",
+                        "/proc/fs",
+                        "/proc/irq",
+                        "/proc/sys",
+                        "/proc/sysrq-trigger"
+                ]
+        }
+}

--- a/alpine/test/test.sh
+++ b/alpine/test/test.sh
@@ -2,18 +2,12 @@
 
 set -ex
 
-ifconfig
-diagnostics
 docker version
 docker info
 docker ps
 DOCKER_CONTENT_TRUST=1 docker pull alpine
-docker run alpine true
+docker run --rm alpine true
 docker pull armhf/alpine
-docker run armhf/alpine uname -a
-docker run --name webserver -d -p 80:80 alpine httpd -f -h /etc
-wget -O - -q localhost/hostname
-docker kill webserver
-docker rm webserver
+docker run --rm armhf/alpine uname -a
 docker swarm init
 docker run mobylinux/check-config:bc2b57a0770129c75a6676ae0c944ece1d50cc3f


### PR DESCRIPTION
- run test suite under containerd
- in future this should be converted to Go not shell see #860
- test suite is now in its own initrd, can be run on any platform not just qemu

Signed-off-by: Justin Cormack <justin.cormack@docker.com>