### PR TITLE
[1.12] Update to Linux 4.4.38

### DIFF
--- a/alpine/kernel/Dockerfile
+++ b/alpine/kernel/Dockerfile
@@ -1,6 +1,6 @@
 FROM mobylinux/alpine-build-c:7303e33e9dcd5276b8bb5269644a9bf3354008c8
 
-ARG KERNEL_VERSION=4.4.37
+ARG KERNEL_VERSION=4.4.38
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 


### PR DESCRIPTION
Includes fix for CVE-2016-8655 Linux af_packet.c race condition.

This gives a container escape with default container capabilities.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>