### PR TITLE
Kernel scanning now fixed, only needs vmlinuz64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifeq ($(STATUS),)
 	[ -f $(MOBYLINUX_TAG) ]
 	docker tag $(shell cat $(MOBYLINUX_TAG)) mobylinux/mobylinux:$(MEDIA_PREFIX)$(TAG)
 	docker push mobylinux/mobylinux:$(MEDIA_PREFIX)$(TAG)
-	tar cf - Dockerfile.kernel alpine/kernel/x86_64/boot.tar | docker build -f Dockerfile.kernel -t mobylinux/kernel:$(MEDIA_PREFIX)$(TAG) -
+	tar cf - Dockerfile.kernel alpine/kernel/x86_64/vmlinuz64 | docker build -f Dockerfile.kernel -t mobylinux/kernel:$(MEDIA_PREFIX)$(TAG) -
 	docker push mobylinux/kernel:$(MEDIA_PREFIX)$(TAG)
 else
 	$(error "git not clean")

--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -10,7 +10,6 @@ x86_64/vmlinuz64: Dockerfile kernel_config
 	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-source-info > etc/kernel-source-info && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /linux/vmlinux > x86_64/vmlinux && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /linux/arch/x86_64/boot/bzImage > $@ && \
-	docker run --rm --net=none --log-driver=none $$BUILD tar cf - /linux/arch/x86/boot > x86_64/boot.tar && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-headers.tar > x86_64/kernel-headers.tar && \
 	cp -a patches etc/kernel-patches
 


### PR DESCRIPTION
- The scanning process was not ignoring the kernel extraversion before,
so was only sometimes picking up issues.

Now this is fixed upstream, just `vmlinuz64` is sufficient for scanning.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>