### PR TITLE
Update alpine-base

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
-# Tag: be663b9af6f6ca464dbfec5aeea7ac94274fba34
-FROM mobylinux/alpine-base@sha256:3cd5f66d3ae6970905bea2a562358dd53b45483c47caba67acb7c0d049a0fb8a
+# Tag: 1cd8331da83bae733a49f1e1ddea0614a5ec1756
+FROM mobylinux/alpine-base@sha256:04b1cf888e0011432194c783ab1190807570ac07438a81c6d8a171d3822ac4a1
 
 ENV ARCH=x86_64
 

--- a/alpine/base/alpine-base/packages
+++ b/alpine/base/alpine-base/packages
@@ -3,7 +3,7 @@ alpine-keys 1.3-r0
 apk-tools 2.6.8-r1
 busybox 1.25.1-r0
 busybox-initscripts 3.0-r8
-ca-certificates 20160104-r8
+ca-certificates 20161130-r0
 chrony 2.4-r0
 cifs-utils 6.6-r0
 curl 7.51.0-r1


### PR DESCRIPTION
Updates ca-certificates to 20161130

Includes the 20161102 updates see http://metadata.ftp-master.debian.org/changelogs/main/c/ca-certificates/ca-certificates_20161130_changelog

Signed-off-by: Justin Cormack <justin.cormack@docker.com>