### PR TITLE
Use an image to pad initrd files to 4 bytes

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -13,6 +13,9 @@ endif
 # Tag: e6cb3f313db7098a1cd21051e678b01931a037a0
 ALPINE_BIOS_DIGEST=b06567c9d00fd4d1193e58fa8242a85121482eb2fb20ac4442388b7eb9cdceb3
 
+# Tag: 95d4fef1a9555b640b4f94a4a3968533714059fe
+PAD4_IMAGE=mobylinux/pad4@sha256:a26e02f16bdafa241a55e05fa09b9bb260e69a3a8c90418bb40b4ae936437d17
+
 moby.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	$(MAKE) -C kernel
 	$(MAKE) -j -C packages
@@ -43,33 +46,22 @@ moby.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	  | \
 	  docker build -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
 	echo $$BUILD > mobylinux.tag && \
-	docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp --tmpfs /initrd $$BUILD > $@
+	docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp --tmpfs /initrd $$BUILD | \
+		docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(PAD4_IMAGE) > $@
 
 container.img:
 	$(MAKE) -j -C containers
 	(find containers -type d -maxdepth 1 && \
 	 find containers/*/rootfs containers/*/config.json) | \
-		cpio -H newc -o | gzip -9 > $@
-	SIZE=$$(cat $@ | wc -c); \
-	SIZE4=$$(( $$SIZE / 4 * 4 )); \
-	DIFF=$$(( $$SIZE - $$SIZE4 )); \
-	[ $$DIFF -ne 0 ] && DIFF=$$(( 4 - $$DIFF )); \
-	dd if=/dev/zero bs=1 count=$$DIFF of=zeropad
-	cat zeropad >> $@
-	rm zeropad
+		cpio -H newc -o | gzip -9 | \
+		docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(PAD4_IMAGE) > $@
 
 test.img:
 	$(MAKE) -j -C test
 	(find test -maxdepth 0 && \
 	 find test/rootfs test/config.json) | \
-		cpio -H newc -o | gzip -9 > $@
-	SIZE=$$(cat $@ | wc -c); \
-	SIZE4=$$(( $$SIZE / 4 * 4 )); \
-	DIFF=$$(( $$SIZE - $$SIZE4 )); \
-	[ $$DIFF -ne 0 ] && DIFF=$$(( 4 - $$DIFF )); \
-	dd if=/dev/zero bs=1 count=$$DIFF of=zeropad
-	cat zeropad >> $@
-	rm zeropad
+		cpio -H newc -o | gzip -9 | \
+		docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(PAD4_IMAGE) > $@
 
 initrd.img: moby.img container.img
 	cat $^ > $@
@@ -191,7 +183,7 @@ vhdartifact:
 	docker volume create --name vhdartifact || true
 
 clean:
-	rm -f *.img *.vhd *.iso *.tag mobylinux.efi zeropad etc/moby-commit
+	rm -f *.img *.vhd *.iso *.tag mobylinux.efi etc/moby-commit
 	docker images -q moby-azure:build | xargs docker rmi -f || true
 	docker images -q moby-azure:raw2vhd | xargs docker rmi -f || true
 	docker volume rm vhdartifact || true

--- a/alpine/base/pad4/Dockerfile
+++ b/alpine/base/pad4/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.4
+
+COPY . /
+
+ENTRYPOINT ["/bin/sh", "-c"]
+CMD ["/pad4.sh"]

--- a/alpine/base/pad4/Makefile
+++ b/alpine/base/pad4/Makefile
@@ -1,0 +1,31 @@
+.PHONY: tag push
+
+BASE=alpine:3.4
+IMAGE=pad4
+
+default: push
+
+hash: Dockerfile pad4.sh
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c 'cat Dockerfile pad4.sh /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker tag $(IMAGE):build mobylinux/$(IMAGE):latest && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):latest)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/alpine/base/pad4/pad4.sh
+++ b/alpine/base/pad4/pad4.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+cd /tmp
+
+cat > initrd.img
+
+SIZE=$(stat -c "%s" initrd.img)
+SIZE4=$(( $SIZE / 4 \* 4 ))
+DIFF=$(( $SIZE - $SIZE4 ))
+[ $DIFF -ne 0 ] && DIFF=$(( 4 - $DIFF ))
+
+dd if=/dev/zero bs=1 count=$DIFF of=zeropad
+
+cat zeropad >> initrd.img
+
+SIZE=$(stat -c "%s" initrd.img)
+SIZE4=$(( $SIZE / 4 \* 4 )) 
+DIFF=$(( $SIZE - $SIZE4 ))
+
+if [ $DIFF -ne 0 ]
+then
+	echo "Bad alignment" >2
+	exit 1
+fi
+
+cat initrd.img

--- a/alpine/mkinitrd.sh
+++ b/alpine/mkinitrd.sh
@@ -36,27 +36,4 @@ cd /tmp
 
 rm mkinitrd.sh
 
-find . | cpio -H newc -o | gzip -9 > /initrd/initrd.img
-
-cd /initrd
-
-SIZE=$(stat -c "%s" initrd.img)
-SIZE4=$(( $SIZE / 4 \* 4 ))
-DIFF=$(( $SIZE - $SIZE4 ))
-[ $DIFF -ne 0 ] && DIFF=$(( 4 - $DIFF ))
-
-dd if=/dev/zero bs=1 count=$DIFF of=zeropad
-
-cat zeropad >> initrd.img
-
-SIZE=$(stat -c "%s" initrd.img)
-SIZE4=$(( $SIZE / 4 \* 4 )) 
-DIFF=$(( $SIZE - $SIZE4 ))
-
-if [ $DIFF -ne 0 ]
-then
-	echo "Bad aligment" >2
-	exit 1
-fi
-
-cat initrd.img
+find . | cpio -H newc -o | gzip -9


### PR DESCRIPTION
This saves a lot of duplicated nasty Makefile code, and generally
cleans things up.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>