### PR TITLE
Force Debian installs to never prompt the user

### DIFF
--- a/alpine/base/ca-certificates/Dockerfile
+++ b/alpine/base/ca-certificates/Dockerfile
@@ -1,3 +1,4 @@
 FROM debian:stable
 
-RUN apt-get update && apt-get -y upgrade && apt-get install -y ca-certificates
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -yq upgrade && apt-get install -yq ca-certificates

--- a/alpine/base/qemu-user-static/Dockerfile
+++ b/alpine/base/qemu-user-static/Dockerfile
@@ -1,3 +1,4 @@
 FROM debian:testing
 
-RUN apt-get update && apt-get -y upgrade && apt-get install -y qemu-user-static
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -yq upgrade && apt-get install -yq qemu-user-static


### PR DESCRIPTION
Sometimes Debian just wants to ask you questions on an install,
this is really not a useful behaviour when there is no one
attached to the process.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>