### PR TITLE
Build a GCE image

### DIFF
--- a/Dockerfile.qemugce
+++ b/Dockerfile.qemugce
@@ -1,0 +1,7 @@
+# Tag: 804b2c40d078287c40aeb9166e475e843544e597
+FROM mobylinux/alpine-qemu@sha256:aaecc961a62b14ee0ecd3a4fe792af5232637f0a49f7d0f90b87acaeb6f3fa4a
+
+COPY alpine/gce.img.tar.gz .
+RUN zcat gce.img.tar.gz | tar xf -
+
+ENTRYPOINT [ "qemu-system-x86_64", "-serial", "stdio", "-drive", "file=disk.raw,format=raw", "-m", "2048", "-vnc", "none" ]

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ qemu-iso: Dockerfile.qemuiso alpine/mobylinux-bios.iso
 	tar cf - $^ | docker build -f Dockerfile.qemuiso -t mobyqemuiso:build -
 	docker run -it --rm mobyqemuiso:build
 
+qemu-gce: Dockerfile.qemugce alpine/gce.img.tar.gz
+	tar cf - $^ | docker build -f Dockerfile.qemugce -t mobyqemugce:build -
+	docker run -it --rm mobyqemugce:build
+
 hyperkit.git:
 	git clone https://github.com/docker/hyperkit.git hyperkit.git
 

--- a/alpine/.gitignore
+++ b/alpine/.gitignore
@@ -2,6 +2,7 @@
 *.tag
 *.iso
 *.vhd
+*.tar.gz
 /mobylinux-boot.vhdx
 /mobylinux.efi
 etc/moby-commit

--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -16,6 +16,9 @@ BIOS_IMAGE=mobylinux/mkimage-iso-bios@sha256:7e28f7745fd62284142dce59a137c3331f7
 # Tag: 95d4fef1a9555b640b4f94a4a3968533714059fe
 PAD4_IMAGE=mobylinux/pad4@sha256:a26e02f16bdafa241a55e05fa09b9bb260e69a3a8c90418bb40b4ae936437d17
 
+# Tag: df1b8ef666d66694e84f23772937ff45c46fa6c1
+GCE_IMAGE=mobylinux/mkimage-gce@sha256:b19ba24184ed5602df5b666ed475d5d7211fa67bee51d3e6380cf0380c63f65b
+
 moby.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	$(MAKE) -C kernel
 	$(MAKE) -j -C packages
@@ -76,7 +79,13 @@ mobylinux-efi.iso: Dockerfile.efi initrd.img kernel/x86_64/vmlinuz64
 
 mobylinux-bios.iso: initrd.img kernel/x86_64/vmlinuz64
 	tar cf - initrd.img -C kernel/x86_64 vmlinuz64 | \
-	  docker run --rm --net=none --log-driver=none -i $(BIOS_IMAGE) >$@
+		docker run --rm --net=none --log-driver=none -i $(BIOS_IMAGE) >$@
+
+gce: gce.img.tar.gz
+
+gce.img.tar.gz: common
+	tar cf - initrd.img -C kernel/x86_64 vmlinuz64 | \
+		docker run --rm --net=none --log-driver=none -i $(GCE_IMAGE) >$@
 
 common: initrd.img
 	$(MAKE) -C kernel

--- a/alpine/base/guestfs/Dockerfile
+++ b/alpine/base/guestfs/Dockerfile
@@ -1,0 +1,4 @@
+FROM debian:jessie
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -yq upgrade && apt-get install -yq libguestfs-tools syslinux linux-image-amd64 vim

--- a/alpine/base/guestfs/Makefile
+++ b/alpine/base/guestfs/Makefile
@@ -1,0 +1,29 @@
+.PHONY: tag push
+
+BASE=debian:jessie
+IMAGE=guestfs
+
+default: push
+
+hash: Dockerfile
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm $(IMAGE):build sh -c 'apt list --installed 2>/dev/null | sha1sum' | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/alpine/base/mkimage-gce/Dockerfile
+++ b/alpine/base/mkimage-gce/Dockerfile
@@ -1,0 +1,10 @@
+# Tag: 8719f0f33b3cf9d59a62be64a42220978ac96486
+FROM mobylinux/guestfs@sha256:c7229f01c1a54270d2bc3597c30121628c18db211ed32fb7202823b6eaa4f853
+
+WORKDIR /tmp/image
+
+COPY . .
+
+COPY make-gce /usr/bin
+
+CMD [ "/usr/bin/make-gce" ]

--- a/alpine/base/mkimage-gce/Makefile
+++ b/alpine/base/mkimage-gce/Makefile
@@ -1,0 +1,27 @@
+.PHONY: tag push
+
+IMAGE=mkimage-gce
+
+default: push
+
+hash: Dockerfile make-gce syslinux.cfg
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm $(IMAGE):build sh -c "(cat $^; apt list --installed 2>/dev/null) | sha1sum" | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/alpine/base/mkimage-gce/make-gce
+++ b/alpine/base/mkimage-gce/make-gce
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+# input is a tarball of vmlinuz64 and initrd.img on stdin
+# output is a compressed tarball of a raw disk image on stdout
+
+mkdir -p files
+tar xf - -C files
+
+cp syslinux.cfg files
+
+tar cf files.tar -C files .
+
+virt-make-fs --size=1G --type=ext4 --partition files.tar disk.raw
+
+guestfish -a disk.raw -m /dev/sda1 <<EOF
+  upload /usr/lib/SYSLINUX/mbr.bin /mbr.bin
+  copy-file-to-device /mbr.bin /dev/sda size:440
+  rm /mbr.bin
+  extlinux /
+  part-set-bootable /dev/sda 1 true
+EOF
+
+tar cf - disk.raw | gzip -9

--- a/alpine/base/mkimage-gce/syslinux.cfg
+++ b/alpine/base/mkimage-gce/syslinux.cfg
@@ -1,0 +1,5 @@
+DEFAULT linux
+LABEL linux
+    KERNEL /vmlinuz64
+    INITRD /initrd.img
+    APPEND earlyprintk=ttyS0,115200 console=ttyS0,115200


### PR DESCRIPTION
- this is a raw 1GB filesystem image with syslinux for booting
- built with libguestfs so does not need any privileges
- need not be built on GCE
- there is a target that runs the image in qemu for local tests
- filesystem resize working

Does not yet have a script to upload the image to cloud storage or create image from it.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

boot log:
```
SeaBIOS (version 1.8.2-20160912_142521-google)
Total RAM Size = 0x00000000f0000000 = 3840 MiB
CPUs found: 1     Max CPUs supported: 1
found virtio-scsi at 0:3
virtio-scsi vendor='Google' product='PersistentDisk' rev='1' type=0 removable=0
virtio-scsi blksize=512 sectors=41943040 = 20480 MiB
drive 0x000f4760: PCHS=0/0/0 translation=lba LCHS=1024/255/63 s=41943040
Booting from Hard Disk 0...
early console in extract_kernel
input_data: 0x0000000001ecd3b4
input_len: 0x00000000005ff09c
output: 0x0000000001000000
output_len: 0x00000000014ba910
kernel_total_size: 0x0000000001172000

Decompressing Linux... Parsing ELF... done.
Booting the kernel.
Linux version 4.8.14-moby (root@1d811a9194c4) (gcc version 5.3.0 (Alpine 5.3.0) ) #1 SMP Sat Dec 10 18:51:29 UTC 2016
Command line: BOOT_IMAGE=/vmlinuz64 earlyprintk=ttyS0,115200 console=ttyS0,115200 initrd=/initrd.img
x86/fpu: Supporting XSAVE feature 0x001: 'x87 floating point registers'
x86/fpu: Supporting XSAVE feature 0x002: 'SSE registers'
x86/fpu: Supporting XSAVE feature 0x004: 'AVX registers'
x86/fpu: xstate_offset[2]:  576, xstate_sizes[2]:  256
x86/fpu: Enabled xstate features 0x7, context size is 832 bytes, using 'standard' format.
x86/fpu: Using 'eager' FPU context switches.
e820: BIOS-provided physical RAM map:
BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
BIOS-e820: [mem 0x0000000000100000-0x00000000bfffcfff] usable
BIOS-e820: [mem 0x00000000bfffd000-0x00000000bfffffff] reserved
BIOS-e820: [mem 0x00000000fffbc000-0x00000000ffffffff] reserved
BIOS-e820: [mem 0x0000000100000000-0x000000012fffffff] usable
bootconsole [earlyser0] enabled
NX (Execute Disable) protection: active
SMBIOS 2.4 present.
Hypervisor detected: KVM
e820: last_pfn = 0x130000 max_arch_pfn = 0x400000000
x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WC  UC- WT  
e820: last_pfn = 0xbfffd max_arch_pfn = 0x400000000
found SMP MP-table at [mem 0x000f4980-0x000f498f] mapped at [ffff8800000f4980]
Using GB pages for direct mapping
RAMDISK: [mem 0x7cb68000-0x7fffffff]
ACPI: Early table checksum verification disabled
ACPI: RSDP 0x00000000000F47A0 000014 (v00 Google)
ACPI: RSDT 0x00000000BFFFDF60 000034 (v01 Google GOOGRSDT 00000001 GOOG 00000001)
ACPI: FACP 0x00000000BFFFFF00 0000F4 (v02 Google GOOGFACP 00000001 GOOG 00000001)
ACPI: DSDT 0x00000000BFFFDFA0 0015A3 (v01 Google GOOGDSDT 00000001 GOOG 00000001)
ACPI: FACS 0x00000000BFFFFEC0 000040
ACPI: FACS 0x00000000BFFFFEC0 000040
ACPI: SSDT 0x00000000BFFFF670 000843 (v01 Google GOOGSSDT 00000001 GOOG 00000001)
ACPI: APIC 0x00000000BFFFF580 00006E (v01 Google GOOGAPIC 00000001 GOOG 00000001)
ACPI: WAET 0x00000000BFFFF550 000028 (v01 Google GOOGWAET 00000001 GOOG 00000001)
kvm-clock: Using msrs 4b564d01 and 4b564d00
kvm-clock: cpu 0, msr 1:2fffc001, primary cpu clock
clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
Zone ranges:
  DMA      [mem 0x0000000000001000-0x0000000000ffffff]
  DMA32    [mem 0x0000000001000000-0x00000000ffffffff]
  Normal   [mem 0x0000000100000000-0x000000012fffffff]
Movable zone start for each node
Early memory node ranges
  node   0: [mem 0x0000000000001000-0x000000000009efff]
  node   0: [mem 0x0000000000100000-0x00000000bfffcfff]
  node   0: [mem 0x0000000100000000-0x000000012fffffff]
Initmem setup node 0 [mem 0x0000000000001000-0x000000012fffffff]
ACPI: PM-Timer IO Port: 0xb008
ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
Using ACPI (MADT) for SMP configuration information
smpboot: Allowing 1 CPUs, 0 hotplug CPUs
e820: [mem 0xc0000000-0xfffbbfff] available for PCI devices
Booting paravirtualized kernel on KVM
clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
setup_percpu: NR_CPUS:128 nr_cpumask_bits:128 nr_cpu_ids:1 nr_node_ids:1
percpu: Embedded 35 pages/cpu @ffff88012fc00000 s105048 r8192 d30120 u2097152
Built 1 zonelists in Zone order, mobility grouping on.  Total pages: 967558
Kernel command line: BOOT_IMAGE=/vmlinuz64 earlyprintk=ttyS0,115200 console=ttyS0,115200 initrd=/initrd.img
PID hash table entries: 4096 (order: 3, 32768 bytes)
Dentry cache hash table entries: 524288 (order: 10, 4194304 bytes)
Inode-cache hash table entries: 262144 (order: 9, 2097152 bytes)
Memory: 3726044K/3931756K available (8420K kernel code, 1392K rwdata, 2820K rodata, 1368K init, 580K bss, 205712K reserved, 0K cma-reserved)
Hierarchical RCU implementation.
	Build-time adjustment of leaf fanout to 64.
	RCU restricting CPUs from NR_CPUS=128 to nr_cpu_ids=1.
RCU: Adjusting geometry for rcu_fanout_leaf=64, nr_cpu_ids=1
NR_IRQS:8448 nr_irqs:256 16
Console: colour *CGA 80x25
console [ttyS0] enabled
console [ttyS0] enabled
bootconsole [earlyser0] disabled
bootconsole [earlyser0] disabled
tsc: Detected 2200.000 MHz processor
Calibrating delay loop (skipped) preset value.. 4400.00 BogoMIPS (lpj=22000000)
pid_max: default: 32768 minimum: 301
ACPI: Core revision 20160422
ACPI: 2 ACPI AML tables successfully acquired and loaded

Security Framework initialized
Mount-cache hash table entries: 8192 (order: 4, 65536 bytes)
Mountpoint-cache hash table entries: 8192 (order: 4, 65536 bytes)
CPU: Physical Processor ID: 0
CPU: Processor Core ID: 0
Last level iTLB entries: 4KB 64, 2MB 8, 4MB 8
Last level dTLB entries: 4KB 64, 2MB 0, 4MB 0, 1GB 4
Freeing SMP alternatives memory: 24K (ffffffff820b4000 - ffffffff820ba000)
ftrace: allocating 37119 entries in 145 pages
smpboot: APIC(0) Converting physical 0 to logical package 0
smpboot: Max logical packages: 1
..TIMER: vector=0x30 apic1=0 pin1=0 apic2=-1 pin2=-1
smpboot: CPU0: Intel(R) Xeon(R) CPU @ 2.20GHz (family: 0x6, model: 0x4f, stepping: 0x0)
Performance Events: unsupported p6 CPU model 79 no PMU driver, software events only.
x86: Booted up 1 node, 1 CPUs
smpboot: Total of 1 processors activated (4400.00 BogoMIPS)
devtmpfs: initialized
x86/mm: Memory block size: 128MB
clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
NET: Registered protocol family 16
cpuidle: using governor ladder
cpuidle: using governor menu
ACPI: bus type PCI registered
PCI: Using configuration type 1 for base access
HugeTLB registered 1 GB page size, pre-allocated 0 pages
HugeTLB registered 2 MB page size, pre-allocated 0 pages
ACPI: Added _OSI(Module Device)
ACPI: Added _OSI(Processor Device)
ACPI: Added _OSI(3.0 _SCP Extensions)
ACPI: Added _OSI(Processor Aggregator Device)
ACPI: Executed 2 blocks of module-level executable AML code
ACPI: Interpreter enabled
ACPI: (supports S0 S5)
ACPI: Using IOAPIC for interrupt routing
PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
acpi PNP0A03:00: _OSC: OS supports [ASPM ClockPM Segments MSI]
acpi PNP0A03:00: _OSC failed (AE_NOT_FOUND); disabling ASPM
acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
PCI host bridge to bus 0000:00
pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
pci_bus 0000:00: root bus resource [mem 0xc0000000-0xfebfffff window]
pci_bus 0000:00: root bus resource [bus 00-ff]
pci 0000:00:01.3: quirk: [io  0xb000-0xb03f] claimed by PIIX4 ACPI
ACPI: PCI Interrupt Link [LNKA] (IRQs 5 *10 11)
ACPI: PCI Interrupt Link [LNKB] (IRQs 5 *10 11)
ACPI: PCI Interrupt Link [LNKC] (IRQs 5 10 *11)
ACPI: PCI Interrupt Link [LNKD] (IRQs 5 10 *11)
ACPI: PCI Interrupt Link [LNKS] (IRQs *9)
ACPI: Enabled 16 GPEs in block 00 to 0F
SCSI subsystem initialized
pps_core: LinuxPPS API ver. 1 registered
pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
PTP clock support registered
wmi: Mapper loaded
PCI: Using ACPI for IRQ routing
NetLabel: Initializing
NetLabel:  domain hash size = 128
NetLabel:  protocols = UNLABELED CIPSOv4
NetLabel:  unlabeled traffic allowed by default
clocksource: Switched to clocksource kvm-clock
FS-Cache: Loaded
CacheFiles: Loaded
pnp: PnP ACPI init
pnp: PnP ACPI: found 7 devices
clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
NET: Registered protocol family 2
TCP established hash table entries: 32768 (order: 6, 262144 bytes)
TCP bind hash table entries: 32768 (order: 7, 524288 bytes)
TCP: Hash tables configured (established 32768 bind 32768)
UDP hash table entries: 2048 (order: 4, 65536 bytes)
UDP-Lite hash table entries: 2048 (order: 4, 65536 bytes)
NET: Registered protocol family 1
RPC: Registered named UNIX socket transport module.
RPC: Registered udp transport module.
RPC: Registered tcp transport module.
RPC: Registered tcp NFSv4.1 backchannel transport module.
pci 0000:00:00.0: Limiting direct PCI/PCI transfers
Unpacking initramfs...
Freeing initrd memory: 53856K (ffff88007cb68000 - ffff880080000000)
PCI-DMA: Using software bounce buffering for IO (SWIOTLB)
software IO TLB [mem 0xbbffd000-0xbfffd000] (64MB) mapped at [ffff8800bbffd000-ffff8800bfffcfff]
RAPL PMU: API unit is 2^-32 Joules, 4 fixed counters, 10737418240 ms ovfl timer
RAPL PMU: hw unit of domain pp0-core 2^-0 Joules
RAPL PMU: hw unit of domain package 2^-0 Joules
RAPL PMU: hw unit of domain dram 2^-0 Joules
RAPL PMU: hw unit of domain pp1-gpu 2^-0 Joules
futex hash table entries: 256 (order: 2, 16384 bytes)
audit: initializing netlink subsys (disabled)
audit: type=2000 audit(1481598977.669:1): initialized
workingset: timestamp_bits=46 max_order=20 bucket_order=0
FS-Cache: Netfs 'nfs' registered for caching
NFS: Registering the id_resolver key type
Key type id_resolver registered
Key type id_legacy registered
nfs4filelayout_init: NFSv4 File Layout Driver Registering...
Installing knfsd (copyright (C) 1996 okir@monad.swb.de).
FS-Cache: Netfs 'cifs' registered for caching
ntfs: driver 2.1.32 [Flags: R/O].
fuse init (API version 7.25)
9p: Installing v9fs 9p2000 file system support
FS-Cache: Netfs '9p' registered for caching
aufs 4.8-20161010
NET: Registered protocol family 38
Key type asymmetric registered
Asymmetric key parser 'x509' registered
Block layer SCSI generic (bsg) driver version 0.4 loaded (major 251)
io scheduler noop registered
io scheduler deadline registered (default)
io scheduler cfq registered
pci_hotplug: PCI Hot Plug PCI Core version: 0.5
pciehp: PCI Express Hot Plug Controller Driver version: 0.4
shpchp: Standard Hot Plug PCI Controller Driver version: 0.4
hv_vmbus: registering driver hyperv_fb
input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input0
ACPI: Power Button [PWRF]
input: Sleep Button as /devices/LNXSYSTM:00/LNXSLPBN:00/input/input1
ACPI: Sleep Button [SLPF]
GHES: HEST is not enabled!
ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11
virtio-pci 0000:00:03.0: virtio_pci: leaving for legacy driver
ACPI: PCI Interrupt Link [LNKD] enabled at IRQ 10
virtio-pci 0000:00:04.0: virtio_pci: leaving for legacy driver
Serial: 8250/16550 driver, 4 ports, IRQ sharing disabled
00:03: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
00:04: ttyS1 at I/O 0x2f8 (irq = 3, base_baud = 115200) is a 16550A
00:05: ttyS2 at I/O 0x3e8 (irq = 6, base_baud = 115200) is a 16550A
00:06: ttyS3 at I/O 0x2e8 (irq = 7, base_baud = 115200) is a 16550A
Initializing Nozomi driver 2.1d
Non-volatile memory driver v1.3
Hangcheck: starting hangcheck timer 0.9.1 (tick is 180 seconds, margin is 60 seconds).
loop: module loaded
nbd: registered device at major 43
scsi host0: Virtio SCSI HBA
scsi 0:0:1:0: Direct-Access     Google   PersistentDisk   1    PQ: 0 ANSI: 6
random: fast init done
VMware PVSCSI driver - version 1.0.6.0-k
hv_vmbus: registering driver hv_storvsc
sd 0:0:1:0: [sda] 41943040 512-byte logical blocks: (21.5 GB/20.0 GiB)
sd 0:0:1:0: [sda] 4096-byte physical blocks
sd 0:0:1:0: Attached scsi generic sg0 type 0
Ethernet Channel Bonding Driver: v3.7.1 (April 27, 2011)
sd 0:0:1:0: [sda] Write Protect is off
tun: Universal TUN/TAP device driver, 1.6
tun: (C) 1999-2004 Max Krasnyansky <maxk@qualcomm.com>
sd 0:0:1:0: [sda] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
e1000: Intel(R) PRO/1000 Network Driver - version 7.3.21-k8-NAPI
e1000: Copyright (c) 1999-2006 Intel Corporation.
e1000e: Intel(R) PRO/1000 Network Driver - 3.2.6-k
e1000e: Copyright(c) 1999 - 2015 Intel Corporation.
ixgbevf: Intel(R) 10 Gigabit PCI Express Virtual Function Network Driver - version 3.2.2-k
ixgbevf: Copyright (c) 2009 - 2015 Intel Corporation.
PPP generic driver version 2.4.2
PPP BSD Compression module registered
PPP Deflate Compression module registered
PPP MPPE Compression module registered
NET: Registered protocol family 24
 sda: sda1
PPTP driver version 0.8.5
VMware vmxnet3 virtual NIC driver - version 1.4.a.0-k-NAPI
hv_vmbus: registering driver hv_netvsc
Fusion MPT base driver 3.04.20
Copyright (c) 1999-2008 LSI Corporation
sd 0:0:1:0: [sda] Attached SCSI disk
Fusion MPT SPI Host driver 3.04.20
aoe: AoE v85 initialised.
i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
i8042: Warning: Keylock active
serio: i8042 KBD port at 0x60,0x64 irq 1
serio: i8042 AUX port at 0x60,0x64 irq 12
hv_vmbus: registering driver hyperv_keyboard
mousedev: PS/2 mouse device common for all mice
input: PC Speaker as /devices/platform/pcspkr/input/input3
rtc_cmos 00:00: RTC can wake from S4
rtc_cmos 00:00: rtc core: registered rtc_cmos as rtc0
rtc_cmos 00:00: alarms up to one day, 114 bytes nvram
i2c /dev entries driver
hv_utils: Registering HyperV Utility Driver
hv_vmbus: registering driver hv_util
oprofile: using timer interrupt.
GACT probability on
Mirror/redirect action on
Simple TC action Loaded
netem: version 1.3
u32 classifier
    Performance counters on
    input device check on
    Actions configured
Netfilter messages via NETLINK v0.30.
nfnl_acct: registering with nfnetlink.
nf_conntrack version 0.5.0 (16384 buckets, 65536 max)
ctnetlink v0.93: registering with nfnetlink.
nf_tables: (c) 2007-2009 Patrick McHardy <kaber@trash.net>
nf_tables_compat: (c) 2012 Pablo Neira Ayuso <pablo@netfilter.org>
xt_time: kernel timezone is -0000
ip_set: protocol 6
IPVS: Registered protocols (TCP, UDP, SCTP, AH, ESP)
IPVS: Connection hash table configured (size=4096, memory=64Kbytes)
IPVS: Creating netns size=2104 id=0
IPVS: ipvs loaded.
IPVS: [rr] scheduler registered.
IPVS: [wrr] scheduler registered.
IPVS: [lc] scheduler registered.
IPVS: [wlc] scheduler registered.
IPVS: [fo] scheduler registered.
IPVS: [ovf] scheduler registered.
IPVS: [lblc] scheduler registered.
IPVS: [lblcr] scheduler registered.
IPVS: [dh] scheduler registered.
IPVS: [sh] scheduler registered.
IPVS: [sed] scheduler registered.
IPVS: [nq] scheduler registered.
IPVS: ftp: loaded support on port[0] = 21
ipip: IPv4 and MPLS over IPv4 tunneling driver
gre: GRE over IPv4 demultiplexor driver
ip_gre: GRE over IPv4 tunneling driver
IPv4 over IPsec tunneling driver
ip_tables: (C) 2000-2006 Netfilter Core Team
ipt_CLUSTERIP: ClusterIP Version 0.8 loaded successfully
arp_tables: arp_tables: (C) 2002 David S. Miller
Initializing XFRM netlink socket
NET: Registered protocol family 10
mip6: Mobile IPv6
ip6_tables: (C) 2000-2006 Netfilter Core Team
sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
ip6_gre: GRE over IPv6 tunneling driver
NET: Registered protocol family 17
NET: Registered protocol family 15
bridge: automatic filtering via arp/ip/ip6tables has been deprecated. Update your scripts to load br_netfilter if you need this.
Bridge firewalling registered
Ebtables v2.0 registered
l2tp_core: L2TP core driver, V2.0
l2tp_ppp: PPPoL2TP kernel driver, V2.0
8021q: 802.1Q VLAN Support v1.8
9pnet: Installing 9P2000 support
Key type dns_resolver registered
openvswitch: Open vSwitch switching datapath
mpls_gso: MPLS GSO support
microcode: sig=0x406f0, pf=0x1, revision=0x1
microcode: Microcode Update Driver: v2.01 <tigran@aivazian.fsnet.co.uk>, Peter Oruba
AVX2 version of gcm_enc/dec engaged.
AES CTR mode by8 optimization enabled
registered taskstats version 1
Key type big_key registered
Key type encrypted registered
rtc_cmos 00:00: setting system clock to 2016-12-13 03:16:18 UTC (1481598978)
Freeing unused kernel memory: 1368K (ffffffff81f5e000 - ffffffff820b4000)
Write protecting the kernel read-only data: 14336k
Freeing unused kernel memory: 1804K (ffff88000183d000 - ffff880001a00000)
Freeing unused kernel memory: 1276K (ffff880001cc1000 - ffff880001e00000)
input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input2

   OpenRC 0.21.7.e3f10ac is starting up Linux 4.8.14-moby (x86_64)

 * Mounting /proc ... [ ok ]
 * Mounting /run ... * /run/openrc: creating directory
 * /run/lock: creating directory
 * /run/lock: correcting owner
 * Caching service dependencies ... [ ok ]
 * Mounting /sys ... [ ok ]
 * Mounting security filesystem ... [ ok ]
 * Mounting debug filesystem ... [ ok ]
 * Mounting fuse control filesystem ... [ ok ]
 * Mounting persistent storage (pstore) filesystem ... [ ok ]
 * Mounting cgroup filesystem ... [ ok ]
 * Mounting devtmpfs on /dev ... [ ok ]
 * Mounting /dev/mqueue ... [ ok ]
 * Mounting /dev/pts ... [ ok ]
 * Mounting /dev/shm ... [ ok ]
 * Starting busybox mdev ... [ ok ]
 * Configuring host block device .../dev/sda1: clean, 16/65536 files, 23597/262112 blocks
Resizing disk partition: Unpartitioned space /dev/sda: 19 GiB, 20401094656 bytes, 39845888 sectors
/dev/sda1: 16/65536 files (0.0% non-contiguous), 23597/262112 blocks
resize2fs 1.43.3 (04-Sep-2016)
Resizing the filesystem on /dev/sda1 to 5242864 (4k) blocks.
The filesystem on /dev/sda1 is now 5242864 (4k) blocks long.

/dev/sda1: clean, 16/1310720 files, 102115/5242864 blocks
 [ ok ]
 * Loading hardware drivers ...modprobe: module fbcon not found in modules.dep
 [ ok ]
 * Remounting filesystems ... [ ok ]
 * Mounting local filesystems ... [ ok ]
 * Setting system clock using the hardware clock [UTC] ... [ ok ]
 * Setting hostname ... [ ok ]
 * Creating user login records ... [ ok ]
 * sysklogd -> start: syslogd ... [ ok ]
 * sysklogd -> start: klogd ... [ ok ]
 * Starting busybox crond ... [ ok ]
 * Mounting misc binary format filesystem ... [ ok ]
 * Setting sysfs variables ... [ ok ]
 * Starting local ... [ ok ]
 * Configuring kernel parameters ... [ ok ]
 * Starting DHCP Client Daemon ... [ ok ]
 * Starting networking ... *   lo ... [ ok ]
 * Starting busybox acpid ... [ ok ]
 * Running system containerd ... [ ok ]
 * Running system containers ... binfmt rng-tools [ ok ]
 * Configuring host settings from database ... [ ok ]
 * Starting Docker ... [ ok ]
 * Starting chronyd ... [ ok ]
 * Checking system state ...
✓ Drive found: sda
✓ Drive mounted: /dev/sda1 on /var type ext4 (rw,relatime,data=ordered)
✓ Network connected:           inet addr:10.138.0.2  Bcast:10.138.0.2  Mask:255.255.255.255
✓ Process dockerd running: dockerd --pidfile=/run/docker.pid -H unix:///var/run/docker.sock --debug --experimental --storage-driver overlay2
✓ Process containerd running: docker-containerd -l unix:///var/run/docker/libcontainerd/docker-containerd.sock --metrics-interval=0 --start-timeout 2m --state-dir /var/run/docker/libcontainerd/containerd --shim docker-containerd-shim --runtime docker-runc --debug
✓ Docker daemon working: 1.13.0-rc3
✓ Diagnostics server running: /usr/bin/diagnostics-server
✓ System containerd server running: /usr/bin/containerd
✓ System containerd working
 * Starting Hyper-V daemon: hv_kvp_daemon ... [ ok ]
 * Starting Hyper-V daemon: hv_vss_daemon ... [ ok ]
 * Adjusting oom killer settings ... [ ok ]

Welcome to Moby

/ # [6n
```
