### PR TITLE
Make sure we do not create a swap file if /var not mounted

### DIFF
--- a/alpine/packages/automount/etc/init.d/automount
+++ b/alpine/packages/automount/etc/init.d/automount
@@ -83,8 +83,11 @@ do_swapfile()
 	DRIVE=$1
 	SIZE=$(sfdisk -J "$DRIVE" | jq -e -r '.partitiontable.partitions | map(select(.type=="83")) | .[0].size')
 	SWAP=/var/spool/swap
+	MOUNT=$(mount | grep 'on /var type')
 	# Create swap on desktop platforms if disk size larger than 16GB
-	if [ "$(mobyplatform)" = "mac" -o "$(mobyplatform)" = "windows" ] && [ ! -f $SWAP ] && [ "$SIZE" -gt 33554432 ]
+	if [ "$(mobyplatform)" = "mac" -o "$(mobyplatform)" = "windows" ] && \
+		[ ! -f $SWAP ] && [ "$SIZE" -gt 33554432 ] && \
+		[ -n "$MOUNT" ]
 	then
 		mkdir -p "$(dirname $SWAP)"
 		dd if=/dev/zero of=$SWAP bs=1k count=1048576


### PR DESCRIPTION
See #875

This will only happen if there has been some sort of error
before, but lets not make it worse.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>