### PR TITLE
Only default to experimental if dockerd supports it

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -76,8 +76,11 @@ start()
 	# Set Docker to debug debug if not specified in daemon.json
 	cat /etc/docker/daemon.json | jq -e 'has("debug")' > /dev/null || DOCKER_OPTS="${DOCKER_OPTS} --debug"
 
-	# Set experimental=true if not specified in daemon.json
-	cat /etc/docker/daemon.json | jq -e 'has("experimental")' > /dev/null || DOCKER_OPTS="${DOCKER_OPTS} --experimental"
+	# Set experimental=true if not specified in daemon.json and on 1.13+
+	if dockerd --help | grep -q -- --experimental
+	then
+		cat /etc/docker/daemon.json | jq -e 'has("experimental")' > /dev/null || DOCKER_OPTS="${DOCKER_OPTS} --experimental"
+	fi
 
 	# choose storage driver
 	if ! $(cat /etc/docker/daemon.json | jq -e '."storage-driver"' > /dev/null)


### PR DESCRIPTION
This allows 1.12 engine to still be supported on master.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>