### PR TITLE
Add new Makefile targets for the CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,24 @@ else
 	$(error "git not clean")
 endif
 
+ci:
+	$(MAKE) clean
+	$(MAKE) all
+	$(MAKE) test
+	$(MAKE) media
+	$(MAKE) clean
+	$(MAKE) AUFS=1 all
+	$(MAKE) AUFS=1 test
+	$(MAKE) AUFS=1 media
+
+ci-pr:
+	$(MAKE) clean
+	$(MAKE) all
+	$(MAKE) test
+	$(MAKE) clean
+	$(MAKE) AUFS=1 all
+	$(MAKE) AUFS=1 test
+
 .PHONY: clean
 
 clean:


### PR DESCRIPTION
This builds both the standard and AUFS versions of Moby,
and does `make clean` carefully.

- `make ci` for branches (pushes artifacts)
- `make pr` for PRs

Signed-off-by: Justin Cormack <justin.cormack@docker.com>