### PR TITLE
Run cpio in a container

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -16,6 +16,9 @@ BIOS_IMAGE=mobylinux/mkimage-iso-bios@sha256:7e28f7745fd62284142dce59a137c3331f7
 # Tag: 95d4fef1a9555b640b4f94a4a3968533714059fe
 PAD4_IMAGE=mobylinux/pad4@sha256:a26e02f16bdafa241a55e05fa09b9bb260e69a3a8c90418bb40b4ae936437d17
 
+# Tag: 74b6ce93033430a58826d90b0b88513e0dcfcb5a
+TAR2INITRD_IMAGE=mobylinux/tar2initrd@sha256:42e242f5bf8dc7971c1f0e6e7b156008d930d5b3129136e72c4b867f2ff15e98
+
 # Tag: df1b8ef666d66694e84f23772937ff45c46fa6c1
 GCE_IMAGE=mobylinux/mkimage-gce@sha256:b19ba24184ed5602df5b666ed475d5d7211fa67bee51d3e6380cf0380c63f65b
 
@@ -54,17 +57,13 @@ moby.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 
 container.img:
 	$(MAKE) -j -C containers
-	(find containers -type d -maxdepth 1 && \
-	 find containers/*/rootfs containers/*/config.json) | \
-		cpio -H newc -o | gzip -9 | \
-		docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(PAD4_IMAGE) > $@
+	tar cf - containers/*/rootfs containers/*/config.json | \
+		docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(TAR2INITRD_IMAGE) > $@
 
 test.img:
 	$(MAKE) -j -C test
-	(find test -maxdepth 0 && \
-	 find test/rootfs test/config.json) | \
-		cpio -H newc -o | gzip -9 | \
-		docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(PAD4_IMAGE) > $@
+	tar cf - test/rootfs test/config.json | \
+		docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(TAR2INITRD_IMAGE) > $@
 
 initrd.img: moby.img container.img
 	cat $^ > $@

--- a/alpine/base/tar2initrd/Dockerfile
+++ b/alpine/base/tar2initrd/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.4
+
+COPY . /
+
+ENTRYPOINT ["/bin/sh", "-c"]
+CMD ["/tar2initrd.sh"]

--- a/alpine/base/tar2initrd/Makefile
+++ b/alpine/base/tar2initrd/Makefile
@@ -1,0 +1,31 @@
+.PHONY: tag push
+
+BASE=alpine:3.4
+IMAGE=tar2initrd
+
+default: push
+
+hash: Dockerfile tar2initrd.sh
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c 'cat Dockerfile pad4.sh /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker tag $(IMAGE):build mobylinux/$(IMAGE):latest && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):latest)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/alpine/base/tar2initrd/tar2initrd.sh
+++ b/alpine/base/tar2initrd/tar2initrd.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+mkdir -p /tmp/input
+
+cd /tmp/input
+
+tar xf -
+
+find . | cpio -H newc -o | gzip -9 > ../initrd.img
+
+cd /tmp
+
+SIZE=$(stat -c "%s" initrd.img)
+SIZE4=$(( $SIZE / 4 \* 4 ))
+DIFF=$(( $SIZE - $SIZE4 ))
+[ $DIFF -ne 0 ] && DIFF=$(( 4 - $DIFF ))
+
+dd if=/dev/zero bs=1 count=$DIFF of=zeropad
+
+cat zeropad >> initrd.img
+
+SIZE=$(stat -c "%s" initrd.img)
+SIZE4=$(( $SIZE / 4 \* 4 )) 
+DIFF=$(( $SIZE - $SIZE4 ))
+
+if [ $DIFF -ne 0 ]
+then
+	echo "Bad alignment" >2
+	exit 1
+fi
+
+cat initrd.img


### PR DESCRIPTION
This way it runs as root so files always owned by root.

Fix #887

This is the simplest fix for 1.13, we can also use this for
creating the main system initrd, but that needs more changes
so leaving for 1.14.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>