### PR TITLE
Create all directories for kernel

### DIFF
--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -4,7 +4,7 @@ all:	x86_64/vmlinuz64
 
 ifdef AUFS
 x86_64/vmlinuz64: Dockerfile.aufs kernel_config kernel_config.debug kernel_config.aufs
-	mkdir -p x86_64 etc
+	mkdir -p x86_64 etc lib usr sbin
 	BUILD=$$( docker build -f Dockerfile.aufs --build-arg DEBUG=$(DEBUG) -q . ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-modules.tar | tar xf - && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /aufs-utils.tar | tar xf - && \
@@ -15,7 +15,7 @@ x86_64/vmlinuz64: Dockerfile.aufs kernel_config kernel_config.debug kernel_confi
 	cp -a patches-aufs etc/kernel-patches
 else
 x86_64/vmlinuz64: Dockerfile kernel_config kernel_config.debug
-	mkdir -p x86_64 etc
+	mkdir -p x86_64 etc lib usr sbin
 	BUILD=$$( docker build --build-arg DEBUG=$(DEBUG) -q . ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-modules.tar | tar xf - && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-source-info > etc/kernel-source-info && \


### PR DESCRIPTION
Non AUFS kernels do not create `sbin/` and `/usr` directories as they
do not provide the AUFS directories. Just create empty directories to
avoid a warning.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>