### PR TITLE
[1.12] Bump kernel to 4.4.39

### DIFF
--- a/alpine/kernel/Dockerfile
+++ b/alpine/kernel/Dockerfile
@@ -1,6 +1,6 @@
 FROM mobylinux/alpine-build-c:7303e33e9dcd5276b8bb5269644a9bf3354008c8
 
-ARG KERNEL_VERSION=4.4.38
+ARG KERNEL_VERSION=4.4.39
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 


### PR DESCRIPTION
Part of same kernel bump as https://github.com/docker/moby/pull/892

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>