### PR TITLE
Remove vsudd output from the console.

### DIFF
--- a/alpine/packages/vsudd/etc/init.d/vsudd
+++ b/alpine/packages/vsudd/etc/init.d/vsudd
@@ -32,8 +32,6 @@ start()
 	start-stop-daemon --start --quiet \
 		--background \
 		--exec /sbin/vsudd \
-		--stdout /dev/console \
-		--stderr /dev/console \
 		-- -inport "${DOCKER_PORT}:unix:/var/run/docker.sock" \
 		   ${SYSLOG_OPT} \
 		   -pidfile ${PIDFILE}


### PR DESCRIPTION
vsudd is quite verbose, and we are confident enough about its stability.
This will clean Pinata logs as well indirectly

Signed-off-by: Simon Ferquel <simon.ferquel@docker.com>