### PR TITLE
Only disable sysrq for cloud editions

### DIFF
--- a/alpine/etc/sysctl.d/02-lynis.conf
+++ b/alpine/etc/sysctl.d/02-lynis.conf
@@ -1,5 +1,4 @@
 kernel.kptr_restrict = 2
-kernel.sysrq = 0
 net.ipv4.conf.all.send_redirects = 0
 net.ipv4.conf.default.accept_redirects = 0
 net.ipv4.conf.default.accept_source_route = 0

--- a/alpine/etc/sysctl.d/cloud/security.conf
+++ b/alpine/etc/sysctl.d/cloud/security.conf
@@ -1,1 +1,2 @@
 kernel.modules_disabled=1
+kernel.sysrq = 0


### PR DESCRIPTION
Addresses https://github.com/docker/moby/pull/819#issuecomment-267647240 - only disable `kernel.sysrq` for cloud editions because we use it for desktop

cc @justincormack 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>