### PR TITLE
Support Docker 1.12 on OSX

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -62,7 +62,11 @@ start()
 		NETWORK_MODE="$(mobyconfig get network | tr -d '[[:space:]]')"
 		NATIVE_PORT_FORWARDING="$(mobyconfig get native/port-forwarding | tr -d '[[:space:]]')"
 		if [ "${NETWORK_MODE}" = "slirp" -o "${NATIVE_PORT_FORWARDING}" = "true" ]; then
-			DOCKER_OPTS="${DOCKER_OPTS} --userland-proxy-path /usr/bin/slirp-proxy"
+			if dockerd --help | grep -q -- --userland-proxy-path; then
+				DOCKER_OPTS="${DOCKER_OPTS} --userland-proxy-path /usr/bin/slirp-proxy"
+			else
+				cp /usr/bin/slirp-proxy /usr/bin/docker-proxy
+			fi
 		fi
 	fi
 


### PR DESCRIPTION
I had occasion to use a Moby build of 1.12 on Docker for Mac today
and I had to patch this in. Given that we re-added support for 1.12
for cloud, for CS, may as well support on OSX too as we are still
doing releases.

The fix is a bit messy (hence the flag), as it writes to the file
system but we will remove it later, or work around the write if
we need to continue to support 1.12 outside the 1.12.x branch.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>