### PR TITLE
Using alpine edge to build licensing

### DIFF
--- a/licensing/Dockerfile
+++ b/licensing/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:edge
 
 RUN apk update && apk add lua git bash
 


### PR DESCRIPTION
No `alpine:3.5` is available at the moment, which means that `alpine:edge` is needed to pull out the licensing bit from moby. 