### PR TITLE
Fix the cgroup memory hierarchy warning

### DIFF
--- a/alpine/etc/sysfs.d/01-moby.conf
+++ b/alpine/etc/sysfs.d/01-moby.conf
@@ -1,2 +1,3 @@
+fs/cgroup/memory/memory.use_hierarchy = 1
 kernel/mm/transparent_hugepage/enabled = madvise
 kernel/mm/transparent_hugepage/defrag = madvise


### PR DESCRIPTION
Needed to make the memory cgroup work properly

fix #373

Signed-off-by: Justin Cormack <justin.cormack@docker.com>