### PR TITLE
Use Alpine 3.5

### DIFF
--- a/licensing/Dockerfile
+++ b/licensing/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.5
 
 RUN apk update && apk add lua git bash
 


### PR DESCRIPTION
Since Alpine 3.5 is out, update the license to use. 
Hub image isn't available yet, so I couldn't do qa. :(