### PR TITLE
Add a build flag to build from master

### DIFF
--- a/alpine/packages/docker/Makefile
+++ b/alpine/packages/docker/Makefile
@@ -14,6 +14,17 @@ endif
 
 DOCKER_IMAGE?=docker:$(DOCKER_VERSION)
 
+ifeq ($(DOCKER_VERSION),master)
+ifeq ($(OS),Linux)
+OS=linux
+endif
+ifeq ($(ARCH),x86_64)
+ARCH=amd64
+endif
+MASTER_VERSION:=$(shell curl -fsSL https://master.dockerproject.org/version)
+DOCKER_BIN_URL=https://master.dockerproject.org/$(OS)/$(ARCH)/docker-$(MASTER_VERSION).tgz
+endif
+
 .PHONY: download hub cleanusr
 
 ifeq ($(DOCKER_BIN_URL)$(FORCE_CURL)$(RELEASE_CANDIDATE),)


### PR DESCRIPTION
This donwloads from master.dockerproject.org and fixes up the
different URL structure.

Use `make DOCKER_VERSION=master`

Signed-off-by: Justin Cormack <justin.cormack@docker.com>