### PR TITLE
grep test for kernel config

### DIFF
--- a/alpine/base/check-kernel-config/Dockerfile
+++ b/alpine/base/check-kernel-config/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.5
+ADD check-kernel-config.sh /usr/bin/check-kernel-config.sh
+ENTRYPOINT ["/bin/sh", "/usr/bin/check-kernel-config.sh"]

--- a/alpine/base/check-kernel-config/Makefile
+++ b/alpine/base/check-kernel-config/Makefile
@@ -1,0 +1,31 @@
+.PHONY: tag push
+
+BASE=alpine:3.5
+IMAGE=check-kernel-config
+
+default: push
+
+hash: Dockerfile check-kernel-config.sh
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c 'cat /usr/bin/check-kernel-config.sh /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker tag $(IMAGE):build mobylinux/$(IMAGE):latest && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):latest)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/alpine/base/check-kernel-config/check-kernel-config.sh
+++ b/alpine/base/check-kernel-config/check-kernel-config.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -ex
+
+echo "starting kernel config sanity test with /proc/config.gz"
+
+# decompress /proc/config.gz from the Moby host
+zcat /proc/config.gz > unzipped_config
+
+# Most tests against https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project
+# Positive cases
+cat unzipped_config | grep CONFIG_BUG=y
+cat unzipped_config | grep CONFIG_DEBUG_KERNEL=y
+cat unzipped_config | grep CONFIG_DEBUG_RODATA=y
+cat unzipped_config | grep CONFIG_CC_STACKPROTECTOR=y
+cat unzipped_config | grep CONFIG_CC_STACKPROTECTOR_STRONG=y
+cat unzipped_config | grep CONFIG_STRICT_DEVMEM=y
+cat unzipped_config | grep CONFIG_IO_STRICT_DEVMEM=y
+cat unzipped_config | grep CONFIG_SYN_COOKIES=y
+cat unzipped_config | grep CONFIG_DEBUG_CREDENTIALS=y
+cat unzipped_config | grep CONFIG_DEBUG_NOTIFIERS=y
+cat unzipped_config | grep CONFIG_DEBUG_LIST=y
+cat unzipped_config | grep CONFIG_SECCOMP=y
+cat unzipped_config | grep CONFIG_SECCOMP_FILTER=y
+cat unzipped_config | grep CONFIG_SECURITY=y
+cat unzipped_config | grep CONFIG_SECURITY_YAMA=y
+cat unzipped_config | grep CONFIG_HARDENED_USERCOPY=y
+cat unzipped_config | grep CONFIG_SLAB_FREELIST_RANDOM=y
+cat unzipped_config | grep CONFIG_PANIC_ON_OOPS=y
+cat unzipped_config | grep CONFIG_DEBUG_SET_MODULE_RONX=y
+
+# Negative cases
+cat unzipped_config | grep 'CONFIG_ACPI_CUSTOM_METHOD is not set'
+cat unzipped_config | grep 'CONFIG_COMPAT_BRK is not set'
+cat unzipped_config | grep 'CONFIG_DEVKMEM is not set'
+cat unzipped_config | grep 'CONFIG_COMPAT_VDSO is not set'
+cat unzipped_config | grep 'CONFIG_KEXEC is not set'
+cat unzipped_config | grep 'CONFIG_HIBERNATION is not set'
+cat unzipped_config | grep 'CONFIG_LEGACY_PTYS is not set'

--- a/alpine/test/test.sh
+++ b/alpine/test/test.sh
@@ -11,3 +11,4 @@ docker pull armhf/alpine
 docker run --rm armhf/alpine uname -a
 docker swarm init
 docker run mobylinux/check-config@sha256:4282f589d5a72004c3991c0412e45ba0ab6bb8c0c7d97dc40dabc828700e99ab
+docker run mobylinux/check-kernel-config@sha256:8e89a61496317db6599e8b666319c699fe611cc855f2e468474455583265e5fd


### PR DESCRIPTION
Adds a container to `make test` to do a quick grep test against the kernel config in `/proc/config.gz`.  Non-exhaustive for now, but focusing on https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project recommendations.

Part of testing for #926

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>