### PR TITLE
Add a kernel-dev tarball with kernel headers

### DIFF
--- a/Dockerfile.media
+++ b/Dockerfile.media
@@ -6,6 +6,7 @@ ADD \
   alpine/kernel/x86_64/vmlinuz64 \
   alpine/kernel/x86_64/vmlinux \
   alpine/kernel/x86_64/kernel-headers.tar \
+  alpine/kernel/x86_64/kernel-dev.tar \
   alpine/mobylinux-efi.iso \
   alpine/mobylinux.efi \
   / 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ INITRD_IMAGE=mobylinux/mobylinux:$(MEDIA_PREFIX)$(AUFS_PREFIX)$(TAG)
 KERNEL_IMAGE=mobylinux/kernel:$(MEDIA_PREFIX)$(AUFS_PREFIX)$(TAG)
 media: Dockerfile.media alpine/initrd.img alpine/kernel/x86_64/vmlinuz64 alpine/mobylinux-efi.iso
 ifeq ($(STATUS),)
-	tar cf - $^ alpine/mobylinux.efi alpine/kernel/x86_64/vmlinux alpine/kernel/x86_64/kernel-headers.tar | docker build -f Dockerfile.media -t $(MEDIA_IMAGE) -
+	tar cf - $^ alpine/mobylinux.efi alpine/kernel/x86_64/vmlinux alpine/kernel/x86_64/kernel-headers.tar alpine/kernel/x86_64/kernel-dev.tar | docker build -f Dockerfile.media -t $(MEDIA_IMAGE) -
 	docker push $(MEDIA_IMAGE)
 	[ -f $(MOBYLINUX_TAG) ]
 	docker tag $(shell cat $(MOBYLINUX_TAG)) $(INITRD_IMAGE)
@@ -75,6 +75,7 @@ ifeq ($(STATUS),)
 	docker cp $$IMAGE:vmlinuz64 alpine/kernel/x86_64/vmlinuz64 && \
 	docker cp $$IMAGE:vmlinux alpine/kernel/x86_64/vmlinux && \
 	docker cp $$IMAGE:kernel-headers.tar alpine/kernel/x86_64/kernel-headers.tar && \
+	docker cp $$IMAGE:kernel-dev.tar alpine/kernel/x86_64/kernel-dev.tar && \
 	docker cp $$IMAGE:initrd.img alpine/initrd.img && \
 	docker cp $$IMAGE:mobylinux-efi.iso alpine/mobylinux-efi.iso && \
 	docker cp $$IMAGE:mobylinux.efi alpine/mobylinux.efi && \

--- a/alpine/kernel/Dockerfile
+++ b/alpine/kernel/Dockerfile
@@ -32,8 +32,23 @@ RUN make defconfig && \
     make oldconfig && \
     make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie"
 RUN make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install && \
-    make INSTALL_HDR_PATH=/tmp headers_install && \
-    ( cd /tmp && tar cf /kernel-headers.tar include ) && \
-    ( cd /tmp/kernel-modules && tar cf /kernel-modules.tar . )
+    ( DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdepth 1)) && \
+      cd /tmp/kernel-modules/lib/modules/$DVER && \
+      rm build source && \
+      ln -s /usr/src/linux-headers-$DVER build ) && \
+    mkdir -p /tmp/kernel-headers/usr && \
+    make INSTALL_HDR_PATH=/tmp/kernel-headers/usr headers_install && \
+    ( cd /tmp/kernel-headers && tar cf /kernel-headers.tar usr ) && \
+    ( cd /tmp/kernel-modules && tar cf /kernel-modules.tar lib ) && \
+    cp vmlinux arch/x86_64/boot/bzImage /
+
+RUN DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdepth 1)) && \
+    dir=/tmp/usr/src/linux-headers-$DVER && \
+    mkdir -p $dir && \
+    cp /linux/.config $dir && \
+    cd /linux && \
+    cp -a include "$dir" && \
+    mkdir -p "$dir"/arch/x86 && cp -a arch/x86/include "$dir"/arch/x86/ && \
+    ( cd /tmp && tar cf /kernel-dev.tar usr/src )
 
 RUN printf "KERNEL_SOURCE=${KERNEL_SOURCE}\n" > /kernel-source-info

--- a/alpine/kernel/Dockerfile.aufs
+++ b/alpine/kernel/Dockerfile.aufs
@@ -70,9 +70,24 @@ RUN make defconfig && \
     make oldconfig && \
     make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie"
 RUN make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install && \
-    make INSTALL_HDR_PATH=/tmp headers_install && \
-    ( cd /tmp && tar cf /kernel-headers.tar include ) && \
-    ( cd /tmp/kernel-modules && tar cf /kernel-modules.tar . )
+    ( DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdepth 1)) && \
+      cd /tmp/kernel-modules/lib/modules/$DVER && \
+      rm build source && \
+      ln -s /usr/src/linux-headers-$DVER build ) && \
+    mkdir -p /tmp/kernel-headers/usr && \
+    make INSTALL_HDR_PATH=/tmp/kernel-headers/usr headers_install && \
+    ( cd /tmp/kernel-headers && tar cf /kernel-headers.tar usr ) && \
+    ( cd /tmp/kernel-modules && tar cf /kernel-modules.tar lib ) && \
+    cp vmlinux arch/x86_64/boot/bzImage /
+
+RUN DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdepth 1)) && \
+    dir=/tmp/usr/src/linux-headers-$DVER && \
+    mkdir -p $dir && \
+    cp /linux/.config $dir && \
+    cd /linux && \
+    cp -a include "$dir" && \
+    mkdir -p "$dir"/arch/x86 && cp -a arch/x86/include "$dir"/arch/x86/ && \
+    ( cd /tmp && tar cf /kernel-dev.tar usr/src )
 
 # Build aufs tools, do this here as they need kernel headers and to match aufs
 # Fortunately they are built statically linked

--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -6,23 +6,27 @@ ifdef AUFS
 x86_64/vmlinuz64: Dockerfile.aufs kernel_config kernel_config.debug kernel_config.aufs patches-4.9
 	mkdir -p x86_64 etc lib usr sbin
 	BUILD=$$( tar cf - $^ | docker build -f Dockerfile.aufs --build-arg DEBUG=$(DEBUG) -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-modules.tar | tar xf - && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-modules.tar > x86_64/kernel-modules.tar && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /aufs-utils.tar | tar xf - && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-source-info > etc/kernel-source-info && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /linux/vmlinux > x86_64/vmlinux && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /linux/arch/x86_64/boot/bzImage > $@ && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat /vmlinux > x86_64/vmlinux && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-headers.tar > x86_64/kernel-headers.tar && \
-	cp -a patches-4.9 etc/kernel-patches
+	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-dev.tar > x86_64/kernel-dev.tar && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat /bzImage > $@ && \
+	cp -a patches-4.9 etc/kernel-patches && \
+	tar xf x86_64/kernel-modules.tar
 else
 x86_64/vmlinuz64: Dockerfile kernel_config kernel_config.debug patches-4.9
 	mkdir -p x86_64 etc lib usr sbin
 	BUILD=$$( tar cf - $^ | docker build --build-arg DEBUG=$(DEBUG) -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-modules.tar | tar xf - && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-modules.tar > x86_64/kernel-modules.tar && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-source-info > etc/kernel-source-info && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /linux/vmlinux > x86_64/vmlinux && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /linux/arch/x86_64/boot/bzImage > $@ && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat /vmlinux > x86_64/vmlinux && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-headers.tar > x86_64/kernel-headers.tar && \
-	cp -a patches-4.9 etc/kernel-patches
+	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-dev.tar > x86_64/kernel-dev.tar && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat /bzImage > $@ && \
+	cp -a patches-4.9 etc/kernel-patches && \
+	tar xf x86_64/kernel-modules.tar
 endif
 
 clean:


### PR DESCRIPTION
These headers are needed for defining kernel probes etc, tested with
eBPF. Could also be used for perf, building kernel modules etc. Saved
to the media tarball at present, may add to base image or container.

Also rationalise the paths in the headers tarball a little to match.

Will add an eBPF container using these later.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>