### PR TITLE
Set bootable flag after partition resize

### DIFF
--- a/alpine/packages/automount/etc/init.d/automount
+++ b/alpine/packages/automount/etc/init.d/automount
@@ -40,6 +40,9 @@ do_fsck_extend_mount()
 		sfdisk -q --delete "$DRIVE" 2> /dev/null
 		echo "${START},,83;" | sfdisk -q "$DRIVE"
 
+		# set bootable flag
+		sfdisk -A "$DRIVE" 1
+
 		# update status
 		blockdev --rereadpt $diskdev 2> /dev/null
 		mdev -s


### PR DESCRIPTION
Google Cloud requires this to be set to boot.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>