### PR TITLE
Update Go build packages to Alpine 3.5

### DIFF
--- a/alpine/containers/binfmt/Dockerfile
+++ b/alpine/containers/binfmt/Dockerfile
@@ -1,5 +1,5 @@
-# Tag: d3f266a146a79f35d3bebf252cce62eee25fcfa9
-FROM mobylinux/alpine-build-go@sha256:1eca9f912cfa4f59ad817acad76744516b999395c080bc01a50b3a2b3a9a3f5c
+# Tag: 2c9434f1c4ff70b102f34a97d2df1a8363a11a65
+FROM mobylinux/alpine-build-go@sha256:d528bbf7102e4209bd59ef030d41de9003ab8e42c303956f62b2df47f3e17849
 
 COPY *.go /go/src/binfmt/
 

--- a/alpine/packages/diagnostics/Dockerfile
+++ b/alpine/packages/diagnostics/Dockerfile
@@ -1,5 +1,5 @@
-# Tag: d3f266a146a79f35d3bebf252cce62eee25fcfa9
-FROM mobylinux/alpine-build-go@sha256:1eca9f912cfa4f59ad817acad76744516b999395c080bc01a50b3a2b3a9a3f5c
+# Tag: 2c9434f1c4ff70b102f34a97d2df1a8363a11a65
+FROM mobylinux/alpine-build-go@sha256:d528bbf7102e4209bd59ef030d41de9003ab8e42c303956f62b2df47f3e17849
 
 COPY ./ /go/src/diagnostics-server/
 

--- a/alpine/packages/proxy/Dockerfile
+++ b/alpine/packages/proxy/Dockerfile
@@ -1,5 +1,5 @@
-# Tag: d3f266a146a79f35d3bebf252cce62eee25fcfa9
-FROM mobylinux/alpine-build-go@sha256:1eca9f912cfa4f59ad817acad76744516b999395c080bc01a50b3a2b3a9a3f5c
+# Tag: 2c9434f1c4ff70b102f34a97d2df1a8363a11a65
+FROM mobylinux/alpine-build-go@sha256:d528bbf7102e4209bd59ef030d41de9003ab8e42c303956f62b2df47f3e17849
 
 COPY ./ /go/src/proxy/
 

--- a/alpine/packages/vsudd/Dockerfile
+++ b/alpine/packages/vsudd/Dockerfile
@@ -1,5 +1,5 @@
-# Tag: d3f266a146a79f35d3bebf252cce62eee25fcfa9
-FROM mobylinux/alpine-build-go@sha256:1eca9f912cfa4f59ad817acad76744516b999395c080bc01a50b3a2b3a9a3f5c
+# Tag: 2c9434f1c4ff70b102f34a97d2df1a8363a11a65
+FROM mobylinux/alpine-build-go@sha256:d528bbf7102e4209bd59ef030d41de9003ab8e42c303956f62b2df47f3e17849
 
 COPY ./ /go/src/vsudd/
 

--- a/alpine/test/Dockerfile
+++ b/alpine/test/Dockerfile
@@ -1,6 +1,6 @@
 # Will do a Go build in future
-# Tag: d3f266a146a79f35d3bebf252cce62eee25fcfa9
-FROM mobylinux/alpine-build-go@sha256:1eca9f912cfa4f59ad817acad76744516b999395c080bc01a50b3a2b3a9a3f5c
+# Tag: 2c9434f1c4ff70b102f34a97d2df1a8363a11a65
+FROM mobylinux/alpine-build-go@sha256:d528bbf7102e4209bd59ef030d41de9003ab8e42c303956f62b2df47f3e17849
 
 COPY test.sh mksh /tmp/bin/
 COPY ca-certificates.crt /tmp/etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Signed-off-by: Justin Cormack <justin.cormack@docker.com>

This is the last of the Alpine 3.5 updates.