### PR TITLE
Add the MTU script for dhcpcd

### DIFF
--- a/alpine/usr/lib/dhcpcd/dhcpcd-hooks/10-mtu
+++ b/alpine/usr/lib/dhcpcd/dhcpcd-hooks/10-mtu
@@ -1,0 +1,38 @@
+# Configure the MTU for the interface
+
+mtu_dir="$state_dir/mtu"
+
+set_mtu()
+{
+	local mtu=$1
+
+	if [ -w /sys/class/net/$interface/mtu ]; then
+		echo "$mtu" >/sys/class/net/$interface/mtu
+	else
+		ifconfig "$interface" mtu "$mtu"
+	fi
+}
+
+if [ "$reason" = PREINIT -a -e "$mtu_dir/$interface" ]; then
+	rm "$mtu_dir/$interface"
+elif [ -n "$new_interface_mtu" ] && $if_up; then
+	# The smalled MTU dhcpcd can work with is 576
+	if [ "$new_interface_mtu" -ge 576 ]; then
+		if set_mtu "$new_interface_mtu"; then
+			syslog info "$interface: MTU set to $new_interface_mtu"
+			# Save the MTU so we can restore it later
+			if [ ! -e "$mtu_dir/$interface" ]; then
+				mkdir -p "$mtu_dir"
+				echo "$ifmtu" > "$mtu_dir/$interface"
+			fi
+		fi
+	fi
+elif [ -e "$mtu_dir/$interface" ]; then
+	if $if_up || $if_down; then
+		# No MTU in this state, so restore the prior MTU
+		mtu=$(cat "$mtu_dir/$interface")
+		syslog info "$interface: MTU restored to $mtu"
+		set_mtu "$mtu"
+		rm "$mtu_dir/$interface"
+	fi
+fi


### PR DESCRIPTION
This might fix the issue that GCE is not setting the MTU from
the DHCP response. The documentation says this is shipped but
it is not in Alpine, this one is from a NetBSD install.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>