### PR TITLE
Do not set WORKDIR in kernel builds

### DIFF
--- a/alpine/kernel/Dockerfile
+++ b/alpine/kernel/Dockerfile
@@ -27,11 +27,12 @@ RUN cd /linux && \
         patch -p1 < "$patch"; \
     done
 
-WORKDIR /linux
-RUN make defconfig && \
+RUN cd /linux && \
+    make defconfig && \
     make oldconfig && \
     make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie"
-RUN make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install && \
+RUN cd /linux && \
+    make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install && \
     ( DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdepth 1)) && \
       cd /tmp/kernel-modules/lib/modules/$DVER && \
       rm build source && \

--- a/alpine/kernel/Dockerfile.aufs
+++ b/alpine/kernel/Dockerfile.aufs
@@ -65,11 +65,12 @@ RUN cd /linux && \
         patch -p1 < "$patch"; \
     done
 
-WORKDIR /linux
-RUN make defconfig && \
+RUN cd /linux && \
+    make defconfig && \
     make oldconfig && \
     make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie"
-RUN make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install && \
+RUN cd /linux && \
+    make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install && \
     ( DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdepth 1)) && \
       cd /tmp/kernel-modules/lib/modules/$DVER && \
       rm build source && \


### PR DESCRIPTION
This is a temporary workaround for https://github.com/docker/docker/issues/29950
which has broken caching and therefore is very annoying for development, but we
don't really need to set it, so it can stay...

Signed-off-by: Justin Cormack <justin.cormack@docker.com>