### PR TITLE
Create and chown persistent homedir

### DIFF
--- a/alpine/packages/azure/etc/init.d/azure
+++ b/alpine/packages/azure/etc/init.d/azure
@@ -44,6 +44,11 @@ start()
 	then
 		mkdir -p /var/etc
 	fi
+	if [ ! -d /var/home/ ]
+	then
+		mkdir -p /var/home/
+		chown docker:docker /var/home/
+	fi
 	if [ ! -f /var/etc/hostname ]
 	then
 		echo "moby" >/var/etc/hostname


### PR DESCRIPTION
FYI @FrenchBen @justincormack 

PTAL

We need the `/var/home` directory to be writeable by `docker` user in case user drops some files there, etc.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>