### PR TITLE
Update opam to current alpine 3.5 base

### DIFF
--- a/alpine/packages/iptables/Dockerfile
+++ b/alpine/packages/iptables/Dockerfile
@@ -1,7 +1,7 @@
 # Tag: alpine
-FROM ocaml/opam@sha256:fe4f6783f319fd02829af4f5a154d8e7030c3907ef393a7b7f21552648f89db8
+FROM ocaml/opam@sha256:2d15235a8150d49353533848c8a2c326996558d57872acec59de35f8965dab4d
 RUN sudo apk add m4
-RUN opam install ocamlfind astring syslog -y
+RUN opam install --use-internal-solver ocamlfind astring syslog -y
 WORKDIR /app
 ADD . /app
 RUN sudo chown -R opam /app


### PR DESCRIPTION
Use internal solver as external one is broken at present.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>