### PR TITLE
Simplify base images

### DIFF
--- a/alpine/base/mksh/Dockerfile
+++ b/alpine/base/mksh/Dockerfile
@@ -1,5 +1,13 @@
-# Tag: b77cfc4ad0033d4366df830ed697afc7bab458a2
-FROM mobylinux/alpine-build-c@sha256:53739ea6042cb0ac39cf6e262012c1c4224206b2c9b719569fe7efa3a381348c
+FROM alpine:3.5
+RUN \
+  apk update && apk upgrade && \
+  apk add \
+  curl \
+  gcc \
+  groff \
+  make \
+  musl-dev \
+  && true
 
 COPY . /
 

--- a/alpine/base/mksh/Makefile
+++ b/alpine/base/mksh/Makefile
@@ -1,10 +1,12 @@
 .PHONY: tag push
 
+BASE=alpine:3.5
 IMAGE=mksh
 
 default: push
 
 hash: Dockerfile
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm --entrypoint sh $(IMAGE):build -c 'cat /Dockerfile /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
 

--- a/alpine/base/tini/Dockerfile
+++ b/alpine/base/tini/Dockerfile
@@ -1,5 +1,13 @@
-# Tag: b77cfc4ad0033d4366df830ed697afc7bab458a2
-FROM mobylinux/alpine-build-c@sha256:53739ea6042cb0ac39cf6e262012c1c4224206b2c9b719569fe7efa3a381348c
+FROM alpine:3.5
+RUN \
+  apk update && apk upgrade && \
+  apk add \
+  cmake \
+  gcc \
+  make \
+  musl-dev \
+  vim \
+  && true
 
 COPY . /
 ENV TINI_VERSION=0.13.0

--- a/alpine/base/tini/Makefile
+++ b/alpine/base/tini/Makefile
@@ -1,10 +1,12 @@
 .PHONY: tag push
 
+BASE=alpine:3.5
 IMAGE=tini
 
 default: push
 
 hash: Dockerfile
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm --entrypoint sh $(IMAGE):build -c 'cat /Dockerfile /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
 

--- a/alpine/containers/rng-tools/Makefile
+++ b/alpine/containers/rng-tools/Makefile
@@ -1,5 +1,5 @@
-# Tag c530ee985d21d6c0ee495d03086fc408b8183466
-TINI_IMAGE=mobylinux/tini@sha256:065d5a16baf022324ac5fb997908f3efa5cc21982b455e832aed1151eb636a2a
+# Tag 7cb780fd6b60c089964e81efd6553853c491d59f
+TINI_IMAGE=mobylinux/tini@sha256:7da8c5b371e0d7d3fb1778e96c0bc634e39ace7bf1e7a73bffbf1f8360127fdb
 TINI_BINARY=tini
 
 default: rootfs


### PR DESCRIPTION
Some of the builds do not need to depend on docker-build-c, makes
update a bit simpler.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>