### PR TITLE
[1.12] Use opam internal solver on 1.12 branch

### DIFF
--- a/alpine/packages/iptables/Dockerfile
+++ b/alpine/packages/iptables/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:alpine
 RUN sudo apk add m4
-RUN opam install ocamlfind astring syslog -y
+RUN opam install --use-internal-solver ocamlfind astring syslog -y
 WORKDIR /app
 ADD . /app
 RUN sudo chown -R opam /app


### PR DESCRIPTION
See #968

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

Cannot currently build 1.12.x because of this...