### PR TITLE
kernel: update kernel patches

### DIFF
--- a/alpine/kernel/patches-4.9/0001-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/alpine/kernel/patches-4.9/0001-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,7 +1,7 @@
-From 516c17c1faf4a12abf158648d55bd5939efd4f18 Mon Sep 17 00:00:00 2001
+From 5bf1a42b6b504c80c307dbfa010e562e6474a176 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
-Subject: [PATCH 1/3] VSOCK: Only allow host network namespace to use AF_VSOCK.
+Subject: [PATCH 1/5] VSOCK: Only allow host network namespace to use AF_VSOCK.
 
 The VSOCK addressing schema does not really lend itself to simply creating an
 alternative end point address within a namespace.

--- a/alpine/kernel/patches-4.9/0002-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/alpine/kernel/patches-4.9/0002-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,7 +1,7 @@
-From ed236f71c930c65452adeefd9c85ed9be6fe7318 Mon Sep 17 00:00:00 2001
+From 29327f7a13083a659126751ea4d0a6f1a0d70310 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
-Subject: [PATCH 2/3] hv_sock: introduce Hyper-V Sockets
+Subject: [PATCH 2/5] hv_sock: introduce Hyper-V Sockets
 
 Hyper-V Sockets (hv_sock) supplies a byte-stream based communication
 mechanism between the host and the guest. It's somewhat like TCP over

--- a/alpine/kernel/patches-4.9/0003-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/alpine/kernel/patches-4.9/0003-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,7 +1,7 @@
-From b94d3c2ef91598613e1f6b88ecff896c6bf353e5 Mon Sep 17 00:00:00 2001
+From e075282679db3435104a6b7a2cf73486bb894ea0 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
-Subject: [PATCH 3/3] vmbus: Don't spam the logs with unknown GUIDs
+Subject: [PATCH 3/5] vmbus: Don't spam the logs with unknown GUIDs
 
 With Hyper-V sockets device types are introduced on the fly. The pr_info()
 then prints a message on every connection, which is way too verbose.  Since
@@ -14,7 +14,7 @@ Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/hv/channel_mgmt.c b/drivers/hv/channel_mgmt.c
-index 96a85cd39580..d2c3af841552 100644
+index 1bc1d4795243..db5bccf4fa7e 100644
 --- a/drivers/hv/channel_mgmt.c
 +++ b/drivers/hv/channel_mgmt.c
 @@ -169,7 +169,6 @@ static u16 hv_get_dev_type(const struct vmbus_channel *channel)

--- a/alpine/kernel/patches-4.9/0004-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/alpine/kernel/patches-4.9/0004-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,0 +1,47 @@
+From ce622362a9535c8a7d0a40c3f580a348ad7219eb Mon Sep 17 00:00:00 2001
+From: Alex Ng <alexng@messages.microsoft.com>
+Date: Sun, 6 Nov 2016 13:14:07 -0800
+Subject: [PATCH 4/5] Drivers: hv: utils: Fix the mapping between host version
+ and protocol to use
+
+We should intentionally declare the protocols to use for every known host
+and default to using the latest protocol if the host is unknown or new.
+
+Signed-off-by: Alex Ng <alexng@microsoft.com>
+Signed-off-by: K. Y. Srinivasan <kys@microsoft.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 3da0401b4d0e17aea7526db0235d98fa535d903e)
+---
+ drivers/hv/hv_util.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/hv/hv_util.c b/drivers/hv/hv_util.c
+index bcd06306f3e8..e7707747f56d 100644
+--- a/drivers/hv/hv_util.c
++++ b/drivers/hv/hv_util.c
+@@ -389,16 +389,19 @@ static int util_probe(struct hv_device *dev,
+ 		ts_srv_version = TS_VERSION_1;
+ 		hb_srv_version = HB_VERSION_1;
+ 		break;
+-	case(VERSION_WIN10):
++	case VERSION_WIN7:
++	case VERSION_WIN8:
++	case VERSION_WIN8_1:
+ 		util_fw_version = UTIL_FW_VERSION;
+ 		sd_srv_version = SD_VERSION;
+-		ts_srv_version = TS_VERSION;
++		ts_srv_version = TS_VERSION_3;
+ 		hb_srv_version = HB_VERSION;
+ 		break;
++	case VERSION_WIN10:
+ 	default:
+ 		util_fw_version = UTIL_FW_VERSION;
+ 		sd_srv_version = SD_VERSION;
+-		ts_srv_version = TS_VERSION_3;
++		ts_srv_version = TS_VERSION;
+ 		hb_srv_version = HB_VERSION;
+ 	}
+ 
+-- 
+2.11.0
+

--- a/alpine/kernel/patches-4.9/0005-Drivers-hv-utils-Force-TimeSync-version-3.0-on-Windo.patch
+++ b/alpine/kernel/patches-4.9/0005-Drivers-hv-utils-Force-TimeSync-version-3.0-on-Windo.patch
@@ -1,0 +1,36 @@
+From 9bf0f68e0b1f318544fed1c1832996962e6b8862 Mon Sep 17 00:00:00 2001
+From: Rolf Neugebauer <rolf.neugebauer@docker.com>
+Date: Wed, 11 Jan 2017 22:40:38 +0000
+Subject: [PATCH 5/5] Drivers: hv: utils: Force TimeSync version 3.0 on Windows
+ 10
+
+Some older Windows 10 builds, including 10586 do not seem to
+support TimeSync protocol 4.0 causing loss of time synchronisation
+and a lot of log spam.
+
+Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
+---
+ drivers/hv/hv_util.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/hv/hv_util.c b/drivers/hv/hv_util.c
+index e7707747f56d..5961f1a49deb 100644
+--- a/drivers/hv/hv_util.c
++++ b/drivers/hv/hv_util.c
+@@ -401,7 +401,12 @@ static int util_probe(struct hv_device *dev,
+ 	default:
+ 		util_fw_version = UTIL_FW_VERSION;
+ 		sd_srv_version = SD_VERSION;
+-		ts_srv_version = TS_VERSION;
++		/*
++		 * XXX rneugeba: force TimeSync Version to 3.0 on
++		 * Windows 10 as well as older Windows 10 builds,
++		 * including 10586 to not support version 4.0
++		 */
++		ts_srv_version = TS_VERSION_3;
+ 		hb_srv_version = HB_VERSION;
+ 	}
+ 
+-- 
+2.11.0
+


### PR DESCRIPTION
On older Windows builds (e.g. 10586) the 4.9.x TimeSync integration
service spams the logs with multiple messages a second of the form:
hv_utils: Using TimeSync version 4.0

It seems that a new protocol version was introduced with newer
Windows 10 builds but the kernel patches don't negotiate the
protocol version based on what the host supports, but instead
simply use the Windows version of the host.

Added two new patches:
- the first one is a cherry-pick from upstream which fixes some
  of the TimeSync protocol negotiation, but does not fix the issue.
- the second one forces the TimeSync protocol to version 3.0 even on
  Windows 10 hosts.

Patches based on: https://github.com/rneugeba/linux-stable/tree/v4.9.2-moby

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

fixes #992