### PR TITLE
linux: patch fuse to fix a dcache timeout bug

### DIFF
--- a/alpine/kernel/patches-4.9/0001-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/alpine/kernel/patches-4.9/0001-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,7 +1,7 @@
 From 5bf1a42b6b504c80c307dbfa010e562e6474a176 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
-Subject: [PATCH 1/5] VSOCK: Only allow host network namespace to use AF_VSOCK.
+Subject: [PATCH 1/6] VSOCK: Only allow host network namespace to use AF_VSOCK.
 
 The VSOCK addressing schema does not really lend itself to simply creating an
 alternative end point address within a namespace.
@@ -12,7 +12,7 @@ Signed-off-by: Ian Campbell <ian.campbell@docker.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/net/vmw_vsock/af_vsock.c b/net/vmw_vsock/af_vsock.c
-index 8a398b3fb532..0edc54c5e6ed 100644
+index 8a398b3..0edc54c 100644
 --- a/net/vmw_vsock/af_vsock.c
 +++ b/net/vmw_vsock/af_vsock.c
 @@ -1852,6 +1852,9 @@ static const struct proto_ops vsock_stream_ops = {
@@ -26,5 +26,5 @@ index 8a398b3fb532..0edc54c5e6ed 100644
  		return -EINVAL;
  
 -- 
-2.11.0
+2.7.1
 

--- a/alpine/kernel/patches-4.9/0002-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/alpine/kernel/patches-4.9/0002-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,7 +1,7 @@
 From 29327f7a13083a659126751ea4d0a6f1a0d70310 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
-Subject: [PATCH 2/5] hv_sock: introduce Hyper-V Sockets
+Subject: [PATCH 2/6] hv_sock: introduce Hyper-V Sockets
 
 Hyper-V Sockets (hv_sock) supplies a byte-stream based communication
 mechanism between the host and the guest. It's somewhat like TCP over
@@ -42,7 +42,7 @@ Origin: https://patchwork.kernel.org/patch/9244467/
  create mode 100644 net/hv_sock/af_hvsock.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 63cefa62324c..e64920219d88 100644
+index 63cefa6..e649202 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -5853,7 +5853,9 @@ F:	drivers/pci/host/pci-hyperv.c
@@ -56,7 +56,7 @@ index 63cefa62324c..e64920219d88 100644
  F:	Documentation/ABI/stable/sysfs-bus-vmbus
  
 diff --git a/include/linux/hyperv.h b/include/linux/hyperv.h
-index cd184bdca58f..468e15e29f5f 100644
+index cd184bd..468e15e 100644
 --- a/include/linux/hyperv.h
 +++ b/include/linux/hyperv.h
 @@ -1593,5 +1593,18 @@ static inline void commit_rd_index(struct vmbus_channel *channel)
@@ -79,7 +79,7 @@ index cd184bdca58f..468e15e29f5f 100644
 +					PREV_INDICES_LEN)
  #endif /* _HYPERV_H */
 diff --git a/include/linux/socket.h b/include/linux/socket.h
-index b5cc5a6d7011..0b68b587d6ee 100644
+index b5cc5a6..0b68b58 100644
 --- a/include/linux/socket.h
 +++ b/include/linux/socket.h
 @@ -202,8 +202,9 @@ struct ucred {
@@ -103,7 +103,7 @@ index b5cc5a6d7011..0b68b587d6ee 100644
  /* Maximum queue length specifiable by listen.  */
 diff --git a/include/net/af_hvsock.h b/include/net/af_hvsock.h
 new file mode 100644
-index 000000000000..e7a8a3ae08e8
+index 0000000..e7a8a3a
 --- /dev/null
 +++ b/include/net/af_hvsock.h
 @@ -0,0 +1,78 @@
@@ -186,7 +186,7 @@ index 000000000000..e7a8a3ae08e8
 +
 +#endif /* __AF_HVSOCK_H__ */
 diff --git a/include/uapi/linux/hyperv.h b/include/uapi/linux/hyperv.h
-index e347b24ef9fb..eb3e44b69a5d 100644
+index e347b24..eb3e44b 100644
 --- a/include/uapi/linux/hyperv.h
 +++ b/include/uapi/linux/hyperv.h
 @@ -26,6 +26,7 @@
@@ -225,7 +225,7 @@ index e347b24ef9fb..eb3e44b69a5d 100644
 +
  #endif /* _UAPI_HYPERV_H */
 diff --git a/net/Kconfig b/net/Kconfig
-index 7b6cd340b72b..a9be6907a620 100644
+index 7b6cd34..a9be690 100644
 --- a/net/Kconfig
 +++ b/net/Kconfig
 @@ -231,6 +231,7 @@ source "net/dns_resolver/Kconfig"
@@ -237,7 +237,7 @@ index 7b6cd340b72b..a9be6907a620 100644
  source "net/mpls/Kconfig"
  source "net/hsr/Kconfig"
 diff --git a/net/Makefile b/net/Makefile
-index 4cafaa2b4667..2b357eb81865 100644
+index 4cafaa2..2b357eb 100644
 --- a/net/Makefile
 +++ b/net/Makefile
 @@ -71,6 +71,7 @@ obj-$(CONFIG_BATMAN_ADV)	+= batman-adv/
@@ -250,7 +250,7 @@ index 4cafaa2b4667..2b357eb81865 100644
  ifneq ($(CONFIG_NET_SWITCHDEV),)
 diff --git a/net/hv_sock/Kconfig b/net/hv_sock/Kconfig
 new file mode 100644
-index 000000000000..ff84875564d1
+index 0000000..ff84875
 --- /dev/null
 +++ b/net/hv_sock/Kconfig
 @@ -0,0 +1,10 @@
@@ -266,7 +266,7 @@ index 000000000000..ff84875564d1
 +	  will be called hv_sock.
 diff --git a/net/hv_sock/Makefile b/net/hv_sock/Makefile
 new file mode 100644
-index 000000000000..716c01230129
+index 0000000..716c012
 --- /dev/null
 +++ b/net/hv_sock/Makefile
 @@ -0,0 +1,3 @@
@@ -275,7 +275,7 @@ index 000000000000..716c01230129
 +hv_sock-y += af_hvsock.o
 diff --git a/net/hv_sock/af_hvsock.c b/net/hv_sock/af_hvsock.c
 new file mode 100644
-index 000000000000..331d3759f5cb
+index 0000000..331d375
 --- /dev/null
 +++ b/net/hv_sock/af_hvsock.c
 @@ -0,0 +1,1507 @@
@@ -1787,5 +1787,5 @@ index 000000000000..331d3759f5cb
 +MODULE_DESCRIPTION("Hyper-V Sockets");
 +MODULE_LICENSE("Dual BSD/GPL");
 -- 
-2.11.0
+2.7.1
 

--- a/alpine/kernel/patches-4.9/0003-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/alpine/kernel/patches-4.9/0003-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,7 +1,7 @@
 From e075282679db3435104a6b7a2cf73486bb894ea0 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
-Subject: [PATCH 3/5] vmbus: Don't spam the logs with unknown GUIDs
+Subject: [PATCH 3/6] vmbus: Don't spam the logs with unknown GUIDs
 
 With Hyper-V sockets device types are introduced on the fly. The pr_info()
 then prints a message on every connection, which is way too verbose.  Since
@@ -14,7 +14,7 @@ Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/hv/channel_mgmt.c b/drivers/hv/channel_mgmt.c
-index 1bc1d4795243..db5bccf4fa7e 100644
+index 1bc1d479..db5bccf 100644
 --- a/drivers/hv/channel_mgmt.c
 +++ b/drivers/hv/channel_mgmt.c
 @@ -169,7 +169,6 @@ static u16 hv_get_dev_type(const struct vmbus_channel *channel)
@@ -26,5 +26,5 @@ index 1bc1d4795243..db5bccf4fa7e 100644
  }
  
 -- 
-2.11.0
+2.7.1
 

--- a/alpine/kernel/patches-4.9/0004-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/alpine/kernel/patches-4.9/0004-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,7 +1,7 @@
 From ce622362a9535c8a7d0a40c3f580a348ad7219eb Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
-Subject: [PATCH 4/5] Drivers: hv: utils: Fix the mapping between host version
+Subject: [PATCH 4/6] Drivers: hv: utils: Fix the mapping between host version
  and protocol to use
 
 We should intentionally declare the protocols to use for every known host
@@ -16,7 +16,7 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
  1 file changed, 6 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/hv/hv_util.c b/drivers/hv/hv_util.c
-index bcd06306f3e8..e7707747f56d 100644
+index bcd0630..e770774 100644
 --- a/drivers/hv/hv_util.c
 +++ b/drivers/hv/hv_util.c
 @@ -389,16 +389,19 @@ static int util_probe(struct hv_device *dev,
@@ -43,5 +43,5 @@ index bcd06306f3e8..e7707747f56d 100644
  	}
  
 -- 
-2.11.0
+2.7.1
 

--- a/alpine/kernel/patches-4.9/0005-Drivers-hv-utils-Force-TimeSync-version-3.0-on-Windo.patch
+++ b/alpine/kernel/patches-4.9/0005-Drivers-hv-utils-Force-TimeSync-version-3.0-on-Windo.patch
@@ -1,7 +1,7 @@
 From 9bf0f68e0b1f318544fed1c1832996962e6b8862 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@docker.com>
 Date: Wed, 11 Jan 2017 22:40:38 +0000
-Subject: [PATCH 5/5] Drivers: hv: utils: Force TimeSync version 3.0 on Windows
+Subject: [PATCH 5/6] Drivers: hv: utils: Force TimeSync version 3.0 on Windows
  10
 
 Some older Windows 10 builds, including 10586 do not seem to
@@ -14,7 +14,7 @@ Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/hv/hv_util.c b/drivers/hv/hv_util.c
-index e7707747f56d..5961f1a49deb 100644
+index e770774..5961f1a 100644
 --- a/drivers/hv/hv_util.c
 +++ b/drivers/hv/hv_util.c
 @@ -401,7 +401,12 @@ static int util_probe(struct hv_device *dev,
@@ -32,5 +32,5 @@ index e7707747f56d..5961f1a49deb 100644
  	}
  
 -- 
-2.11.0
+2.7.1
 

--- a/alpine/kernel/patches-4.9/0006-fuse-fix-time_to_jiffies-nsec-sanity-check.patch
+++ b/alpine/kernel/patches-4.9/0006-fuse-fix-time_to_jiffies-nsec-sanity-check.patch
@@ -1,0 +1,35 @@
+From cf88604f5275ea9f72059cf5ee8ea033aa9817d3 Mon Sep 17 00:00:00 2001
+From: David Sheets <david.sheets@docker.com>
+Date: Fri, 13 Jan 2017 15:58:30 +0000
+Subject: [PATCH 6/6] fuse: fix time_to_jiffies nsec sanity check
+
+Commit bcb6f6d2b9c2 ("fuse: use timespec64") introduced clamped nsec values
+in time_to_jiffies but used the max of nsec and NSEC_PER_SEC - 1 instead of
+the min. Because of this, dentries would stay in the cache longer than
+requested and go stale in scenarios that relied on their timely eviction.
+
+Fixes: bcb6f6d2b9c2 ("fuse: use timespec64")
+Signed-off-by: David Sheets <dsheets@docker.com>
+Signed-off-by: Miklos Szeredi <mszeredi@redhat.com>
+Cc: <stable@vger.kernel.org> # 4.9
+(cherry picked from commit 210675270caa33253e4c33f3c5e657e7d6060812)
+---
+ fs/fuse/dir.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/fs/fuse/dir.c b/fs/fuse/dir.c
+index 096f799..642c57b 100644
+--- a/fs/fuse/dir.c
++++ b/fs/fuse/dir.c
+@@ -68,7 +68,7 @@ static u64 time_to_jiffies(u64 sec, u32 nsec)
+ 	if (sec || nsec) {
+ 		struct timespec64 ts = {
+ 			sec,
+-			max_t(u32, nsec, NSEC_PER_SEC - 1)
++			min_t(u32, nsec, NSEC_PER_SEC - 1)
+ 		};
+ 
+ 		return get_jiffies_64() + timespec64_to_jiffies(&ts);
+-- 
+2.7.1
+


### PR DESCRIPTION
Introduced in torvalds/linux@bcb6f6d2b9c299db32b20f4357c36a101e7f0293 to check that nsec values are sane, a max was used where a min should have been.

Fixes #923.

Signed-off-by: David Sheets <dsheets@docker.com>