### PR TITLE
Less verbose kernel config test

### DIFF
--- a/alpine/base/check-kernel-config/check-kernel-config.sh
+++ b/alpine/base/check-kernel-config/check-kernel-config.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -ex
+set -e
 
 echo "starting kernel config sanity test with /proc/config.gz"
 

--- a/alpine/test/test.sh
+++ b/alpine/test/test.sh
@@ -11,5 +11,5 @@ docker pull armhf/alpine
 docker run --rm armhf/alpine uname -a
 docker swarm init
 docker run mobylinux/check-config@sha256:4282f589d5a72004c3991c0412e45ba0ab6bb8c0c7d97dc40dabc828700e99ab
-docker run mobylinux/check-kernel-config@sha256:8c48a0f8456e1e5027eb2540974e6304d8cf58263c7553b61838cb627c4e790c
+docker run mobylinux/check-kernel-config@sha256:6821a7bce30bd013a6cc190d171228f9b02359e9c792858005f401ab15357575
 cat /etc/moby


### PR DESCRIPTION
As `grep` echoes the output, no need to have `set -x` on this script,
make output smaller and cleaner.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>