### PR TITLE
Update to golang:1.7-alpine3.5 images

### DIFF
--- a/alpine/base/alpine-build-go/Dockerfile
+++ b/alpine/base/alpine-build-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7-alpine
+FROM golang:1.7-alpine3.5
 RUN apk update && apk add --no-cache build-base git
 
 # Get linting tools

--- a/alpine/base/alpine-build-go/Makefile
+++ b/alpine/base/alpine-build-go/Makefile
@@ -1,6 +1,6 @@
 .PHONY: tag push
 
-BASE=golang:1.7-alpine
+BASE=golang:1.7-alpine3.5
 IMAGE=alpine-build-go
 
 default: push

--- a/alpine/base/go-compile/Dockerfile
+++ b/alpine/base/go-compile/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7-alpine
+FROM golang:1.7-alpine3.5
 RUN apk update && apk add --no-cache build-base git
 
 RUN go get -u github.com/golang/lint/golint

--- a/alpine/base/go-compile/Makefile
+++ b/alpine/base/go-compile/Makefile
@@ -1,6 +1,6 @@
 .PHONY: tag push
 
-BASE=golang:1.7-alpine
+BASE=golang:1.7-alpine3.5
 IMAGE=go-compile
 
 default: push

--- a/alpine/packages/diagnostics/Makefile
+++ b/alpine/packages/diagnostics/Makefile
@@ -1,5 +1,5 @@
-# Tag: 470f68ec32e016484fb8e0bcc2f06cd3f201ea68
-GO_COMPILE=mobylinux/go-compile@sha256:b723c0e95a6293300392e57d6ab52574f9217e2410b390a24cbfc4f9070edb6b
+# Tag: 9c777a22fd84f08e1ea342c0b4ebabfb09fca086
+GO_COMPILE=mobylinux/go-compile@sha256:5e7f1909b0316261653d84f73aeb9188ef20d06b1ecf92eaa4402b32221adfba
 
 default: usr/bin/diagnostics-server
 

--- a/alpine/packages/proxy/Makefile
+++ b/alpine/packages/proxy/Makefile
@@ -1,5 +1,5 @@
-# Tag: 470f68ec32e016484fb8e0bcc2f06cd3f201ea68
-GO_COMPILE=mobylinux/go-compile@sha256:b723c0e95a6293300392e57d6ab52574f9217e2410b390a24cbfc4f9070edb6b
+# Tag: 9c777a22fd84f08e1ea342c0b4ebabfb09fca086
+GO_COMPILE=mobylinux/go-compile@sha256:5e7f1909b0316261653d84f73aeb9188ef20d06b1ecf92eaa4402b32221adfba
 
 all: usr/bin/slirp-proxy sbin/proxy-vsockd
 

--- a/alpine/packages/vsudd/Makefile
+++ b/alpine/packages/vsudd/Makefile
@@ -1,5 +1,5 @@
-# Tag: 470f68ec32e016484fb8e0bcc2f06cd3f201ea68
-GO_COMPILE=mobylinux/go-compile@sha256:b723c0e95a6293300392e57d6ab52574f9217e2410b390a24cbfc4f9070edb6b
+# Tag: 9c777a22fd84f08e1ea342c0b4ebabfb09fca086
+GO_COMPILE=mobylinux/go-compile@sha256:5e7f1909b0316261653d84f73aeb9188ef20d06b1ecf92eaa4402b32221adfba
 
 default: sbin/vsudd
 


### PR DESCRIPTION
Now there is an Alpine 3.5 variant of the Go 1.7 images, use this.

fix #972

Note updated the containers/binfmt image as this will be converted
to go-compile shortly, at which point alpine-build-go can be removed.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>