### PR TITLE
Clean up build to not use alpine-build-c where not needed

### DIFF
--- a/Dockerfile.media
+++ b/Dockerfile.media
@@ -1,5 +1,5 @@
-# Tag: 0e76bc8d0bd0f0cd505d0353b3a550266c52133c
-FROM mobylinux/toybox-media@sha256:69f9ae2e9192746f4f588d15ed15b9d8e005bbca394cfff1cfbbef023c4a7eed
+# Tag: 0a26fe5f574e444849983f9c4148ef74b3804d55
+FROM mobylinux/toybox-media@sha256:5ac38f77b66deb194c9016591b9b096e81fcdc9f7c3e6d01566294a6b4b4ebd2
 
 ADD \
   alpine/initrd.img \

--- a/alpine/base/alpine-build-toybox/Dockerfile
+++ b/alpine/base/alpine-build-toybox/Dockerfile
@@ -1,5 +1,12 @@
-# Tag: b77cfc4ad0033d4366df830ed697afc7bab458a2
-FROM mobylinux/alpine-build-c@sha256:53739ea6042cb0ac39cf6e262012c1c4224206b2c9b719569fe7efa3a381348c
+FROM alpine:3.5
+RUN \
+  apk update && apk upgrade && \
+  apk add \
+  automake \
+  bash \
+  build-base \
+  git \
+  && true
 COPY . .
 # 0.7.2
 ENV LDFLAGS=--static

--- a/alpine/base/alpine-build-toybox/Makefile
+++ b/alpine/base/alpine-build-toybox/Makefile
@@ -1,10 +1,12 @@
 .PHONY: tag push
 
+BASE=alpine:3.5
 IMAGE=alpine-build-toybox
 
 default: push
 
 hash: Dockerfile build.sh
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm --entrypoint sh $(IMAGE):build -c 'cat /Dockerfile /build.sh /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
 

--- a/alpine/base/perf/Dockerfile
+++ b/alpine/base/perf/Dockerfile
@@ -1,7 +1,25 @@
-# Tag: 3da0b0ea0da2724232603094e67c75b41adab551
-FROM mobylinux/alpine-build-c@sha256:0236d6599f6c8f7aa42829285e04202fbe99984df2818af0f5a453a59de8b090
+FROM alpine:3.4
 
-ARG KERNEL_VERSION=4.8.14
+RUN \
+  apk update && apk upgrade && \
+  apk add \
+  argp-standalone \
+  automake \
+  bc \
+  binutils-dev \
+  bison \
+  build-base \
+  curl \
+  flex \
+  libelf-dev \
+  linux-headers \
+  sed \
+  tar \
+  util-linux-dev \
+  xz \
+  && true
+
+ARG KERNEL_VERSION=4.9.3
 
 # get kernel source and extract it under /linux
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz

--- a/alpine/base/perf/Makefile
+++ b/alpine/base/perf/Makefile
@@ -1,7 +1,10 @@
+BASE=alpine:3.4
+
 DEPS=Dockerfile
 
 bin/perf: $(DEPS)
-	mkdir -p bin
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	mkdir -p $(dir $@)
 	BUILD=$$( docker build -q . ) && \
 	docker run --rm --net=none $$BUILD | tar xf - -C bin
 

--- a/alpine/base/toybox-media/Makefile
+++ b/alpine/base/toybox-media/Makefile
@@ -1,7 +1,6 @@
 .PHONY: tag push
-
-# Tag: c544d1d4e0a5dd6af3e867c0fa19a628dc128e0c
-BASE=mobylinux/alpine-build-toybox@sha256:3ef02ab3d9edebd9676b0178d729503d32f92230ef53132c26221d25911431d1
+# Tag: bec336327b738df1e225bd845f416762a6b12dfc
+BASE=mobylinux/alpine-build-toybox@sha256:54c813bcdd13c1108bb69ffdc9f3c0135db94625f1e57a885277717703bbf22b
 IMAGE=toybox-media
 
 default: push


### PR DESCRIPTION
Makes updates simpler.

Makes it explicit that `perf` currently requires Alpine 3.4, and update kernel version.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>