### PR TITLE
Clean up go-compile

### DIFF
--- a/alpine/base/go-compile/compile.sh
+++ b/alpine/base/go-compile/compile.sh
@@ -8,7 +8,7 @@
 set -e
 
 usage() {
-	echo "Usage: -o file [--docker]"
+	echo "Usage: -o file"
 	exit 1
 }
 
@@ -30,8 +30,6 @@ do
 	shift
 done
 
-[ $# -gt 0 ] && [ $1 = "--docker" ] && DOCKER=1 && shift
-
 [ $# -gt 0 ] && usage
 [ -z "$out" ] && usage
 
@@ -46,14 +44,9 @@ tar xf - -C $dir
 
 /usr/bin/lint.sh $dir
 
+>&2 echo "go build..."
+
 go build -o $out --ldflags '-extldflags "-fno-PIC -static"' "$package"
 
-if [ -z "$DOCKER" ]
-then
-	tar cf - $out
-	exit 0
-fi
-
-printf "FROM scratch\nCOPY $out $out\nENTRYPOINT [\"$out\"]\n" > Dockerfile
-
-tar cf - Dockerfile $out
+tar cf - $out
+exit 0

--- a/alpine/base/go-compile/lint.sh
+++ b/alpine/base/go-compile/lint.sh
@@ -12,5 +12,3 @@ test -z $(go tool vet -printf=false . 2>&1 | grep -v */vendor/ | tee /dev/stderr
 
 >&2 echo "golint..."
 test -z $(find . -type f -name "*.go" -not -path "*/vendor/*" -not -name "*.pb.*" -exec golint {} \; | tee /dev/stderr)
-
->&2 echo "Successful lint check!"

--- a/alpine/packages/diagnostics/Makefile
+++ b/alpine/packages/diagnostics/Makefile
@@ -1,5 +1,5 @@
-# Tag: 9c777a22fd84f08e1ea342c0b4ebabfb09fca086
-GO_COMPILE=mobylinux/go-compile@sha256:5e7f1909b0316261653d84f73aeb9188ef20d06b1ecf92eaa4402b32221adfba
+# Tag: 6075d4b9c5fe30e19581f1b7ef1813f3041cca32
+GO_COMPILE=mobylinux/go-compile@sha256:badfd8a1730ab6e640682d0f95a8f9c51f3cd4b2e8db261fe1a1fd8c6f60bd6e
 
 default: usr/bin/diagnostics-server
 

--- a/alpine/packages/proxy/Makefile
+++ b/alpine/packages/proxy/Makefile
@@ -1,5 +1,5 @@
-# Tag: 9c777a22fd84f08e1ea342c0b4ebabfb09fca086
-GO_COMPILE=mobylinux/go-compile@sha256:5e7f1909b0316261653d84f73aeb9188ef20d06b1ecf92eaa4402b32221adfba
+# Tag: 6075d4b9c5fe30e19581f1b7ef1813f3041cca32
+GO_COMPILE=mobylinux/go-compile@sha256:badfd8a1730ab6e640682d0f95a8f9c51f3cd4b2e8db261fe1a1fd8c6f60bd6e
 
 all: usr/bin/slirp-proxy sbin/proxy-vsockd
 

--- a/alpine/packages/vsudd/Makefile
+++ b/alpine/packages/vsudd/Makefile
@@ -1,5 +1,5 @@
-# Tag: 9c777a22fd84f08e1ea342c0b4ebabfb09fca086
-GO_COMPILE=mobylinux/go-compile@sha256:5e7f1909b0316261653d84f73aeb9188ef20d06b1ecf92eaa4402b32221adfba
+# Tag: 6075d4b9c5fe30e19581f1b7ef1813f3041cca32
+GO_COMPILE=mobylinux/go-compile@sha256:badfd8a1730ab6e640682d0f95a8f9c51f3cd4b2e8db261fe1a1fd8c6f60bd6e
 
 default: sbin/vsudd
 


### PR DESCRIPTION
- remove unused `--docker` option
- neater output for stages of check, build

Signed-off-by: Justin Cormack <justin.cormack@docker.com>