### PR TITLE
Add gitignore for generated binfmt rootfs and config.json

### DIFF
--- a/alpine/containers/binfmt/.gitignore
+++ b/alpine/containers/binfmt/.gitignore
@@ -1,0 +1,2 @@
+rootfs
+config.json


### PR DESCRIPTION
Small nit - noticed we can add a gitignore for this dir to ignore `rootfs` and `config.json` that get generated on make

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>