### PR TITLE
[1.13] Remove aufs 4.4 support

### DIFF
--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -1,26 +1,8 @@
 DEBUG ?= 0
 
-ifdef AUFS4.4
-AUFS=1
-endif
-
 all:	x86_64/vmlinuz64
 
 ifdef AUFS
-ifdef AUFS4.4
-x86_64/vmlinuz64: Dockerfile.aufs4.4 kernel_config kernel_config.debug kernel_config.aufs kernel_config.4.4 patches-4.4
-	mkdir -p x86_64 etc lib usr sbin
-	BUILD=$$( tar cf - $^ | docker build -f Dockerfile.aufs4.4 --build-arg DEBUG=$(DEBUG) -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-modules.tar > x86_64/kernel-modules.tar && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /aufs-utils.tar | tar xf - && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-source-info > etc/kernel-source-info && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /vmlinux > x86_64/vmlinux && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-headers.tar > x86_64/kernel-headers.tar && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-dev.tar > x86_64/kernel-dev.tar && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /bzImage > $@ && \
-	cp -a patches-4.4 etc/kernel-patches && \
-	tar xf x86_64/kernel-modules.tar
-else
 x86_64/vmlinuz64: Dockerfile.aufs kernel_config kernel_config.debug kernel_config.aufs patches-4.9
 	mkdir -p x86_64 etc lib usr sbin
 	BUILD=$$( tar cf - $^ | docker build -f Dockerfile.aufs --build-arg DEBUG=$(DEBUG) -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
@@ -33,7 +15,6 @@ x86_64/vmlinuz64: Dockerfile.aufs kernel_config kernel_config.debug kernel_confi
 	docker run --rm --net=none --log-driver=none $$BUILD cat /bzImage > $@ && \
 	cp -a patches-4.9 etc/kernel-patches && \
 	tar xf x86_64/kernel-modules.tar
-endif
 else
 ifdef LTS4.4
 x86_64/vmlinuz64: Dockerfile.4.4 kernel_config kernel_config.debug kernel_config.4.4 patches-4.4


### PR DESCRIPTION
This only shipped for one rc and we are not going to ship it any more,
and CI is disabled.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>