### PR TITLE
Update ca-certificates to 20161130

### DIFF
--- a/alpine/base/ca-certificates/Dockerfile
+++ b/alpine/base/ca-certificates/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:testing
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -yq upgrade && apt-get install -yq ca-certificates

--- a/alpine/base/ca-certificates/Makefile
+++ b/alpine/base/ca-certificates/Makefile
@@ -1,6 +1,6 @@
 .PHONY: tag push
 
-BASE=debian:stable
+BASE=debian:testing
 IMAGE=ca-certificates
 
 default: push
@@ -8,7 +8,7 @@ default: push
 hash: Dockerfile
 	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
-	docker run --rm $(IMAGE):build sh -c 'apt list --installed 2>/dev/null | sha1sum' | sed 's/ .*//' > hash
+	docker run --rm $(IMAGE):build sh -c 'cat /etc/ssl/certs/ca-certificates.crt | sha1sum' | sed 's/ .*//' > hash
 
 push: hash
 	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \

--- a/alpine/base/test/Makefile
+++ b/alpine/base/test/Makefile
@@ -3,8 +3,8 @@ MKSH_IMAGE=mobylinux/mksh@sha256:b3ca9febef294d002894b91e0ce0f794235db73a3024be3
 MKSH_BINARY=bin/mksh
 SH_BINARY=bin/sh
 
-# Tag: 41e4b91c9a619e46f76ce2d024067c09b62f07b4
-CACERT_IMAGE=mobylinux/ca-certificates@sha256:6ca2dca9cfb8534a55f3a17f8797943527db5bbac08c98a5c9a4836250f4c548
+# Tag: e091a05fbf7c5e16f18b23602febd45dd690ba2f
+CACERT_IMAGE=mobylinux/ca-certificates@sha256:a4e217ab2036bc128dc57a639a25fd285dbd68c47f9a46a91f1a9afab2bab3d3
 CACERT_FILE=etc/ssl/certs/ca-certificates.crt
 
 TEST_SCRIPT=bin/test.sh

--- a/alpine/test/Makefile
+++ b/alpine/test/Makefile
@@ -1,5 +1,5 @@
-# Tag: 6479aea36e0c3d177297cc936db5cbf93ece467c
-TEST_IMAGE=mobylinux/test@sha256:5425a613bfbb9563d122c21a4a5377cc4cf836a5b201accfecf596a13c8dc607
+# Tag: a61cdb69d8b5c95c2766b2b856e4f331bd2a6d2d
+TEST_IMAGE=mobylinux/test@sha256:1a2cb7acab25059532c5287c2cdde1a5cfc0fbb944593e02b85b5bb334a4187d
 
 default: config.json
 


### PR DESCRIPTION
In most places we use the Alpine one, which is already here, but
make sure this is updated, as we may use it more (yes, we should be
consistent).

Change the hash to just use the ca-cert hash, not the apt hash.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>