### PR TITLE
Set vsyscall=emulate for D4GCP

### DIFF
--- a/alpine/base/mkimage-gce/syslinux.cfg
+++ b/alpine/base/mkimage-gce/syslinux.cfg
@@ -2,4 +2,4 @@ DEFAULT linux
 LABEL linux
     KERNEL /vmlinuz64
     INITRD /initrd.img
-    APPEND earlyprintk=ttyS0,115200 console=ttyS0,115200 mobyplatform=gcp
+    APPEND earlyprintk=ttyS0,115200 console=ttyS0,115200 mobyplatform=gcp vsyscall=emulate


### PR DESCRIPTION
Following the other cloud editions since `CONFIG_LEGACY_VSYSCALL_NONE=y` in the kernel config 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>