### PR TITLE
Remove sysctl and sysfs database overrides

### DIFF
--- a/alpine/packages/hostsettings/etc/init.d/hostsettings
+++ b/alpine/packages/hostsettings/etc/init.d/hostsettings
@@ -11,9 +11,6 @@ depend() {
 start() {
 	ebegin "Configuring host settings from database"
 
-	mobyconfig exists etc/sysctl.conf && mobyconfig get etc/sysctl.conf > /etc/sysctl.conf
-	mobyconfig exists etc/sysfs.conf && mobyconfig get etc/sysfs.conf > /etc/sysfs.conf
-
 	mobyconfig exists random-seed && mobyconfig get random-seed > /dev/urandom
 
 	mobyconfig exists etc/resolv.conf && mobyconfig get etc/resolv.conf > /etc/resolv.conf


### PR DESCRIPTION
These never got an interface on any platform, and I don't think they
ever will, we can increase global limits or you can set something
with a privileged container. Can add back later if required.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>