### PR TITLE
[1.13] Simplify extracting from kernel build

### DIFF
--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -6,39 +6,30 @@ ifdef AUFS
 x86_64/vmlinuz64: Dockerfile.aufs kernel_config kernel_config.debug kernel_config.aufs patches-4.9
 	mkdir -p x86_64 etc lib usr sbin
 	BUILD=$$( tar cf - $^ | docker build -f Dockerfile.aufs --build-arg DEBUG=$(DEBUG) -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-modules.tar > x86_64/kernel-modules.tar && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /aufs-utils.tar | tar xf - && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-source-info > etc/kernel-source-info && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /vmlinux > x86_64/vmlinux && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-headers.tar > x86_64/kernel-headers.tar && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-dev.tar > x86_64/kernel-dev.tar && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /bzImage > $@ && \
-	cp -a patches-4.9 etc/kernel-patches && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat aufs-utils.tar | tar xf - && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat kernel-source-info > etc/kernel-source-info && \
+	docker run --rm --net=none --log-driver=none $$BUILD tar cf - bzImage kernel-dev.tar kernel-headers.tar vmlinux kernel-modules.tar | tar xf - -C x86_64
+	mv x86_64/bzImage $@
+	cp -a patches-4.9 etc/kernel-patches
 	tar xf x86_64/kernel-modules.tar
 else
 ifdef LTS4.4
 x86_64/vmlinuz64: Dockerfile.4.4 kernel_config kernel_config.debug kernel_config.4.4 patches-4.4
 	mkdir -p x86_64 etc lib usr sbin
 	BUILD=$$( tar cf - $^ | docker build -f Dockerfile.4.4 --build-arg DEBUG=$(DEBUG) -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-modules.tar > x86_64/kernel-modules.tar && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-source-info > etc/kernel-source-info && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /vmlinux > x86_64/vmlinux && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-headers.tar > x86_64/kernel-headers.tar && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-dev.tar > x86_64/kernel-dev.tar && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /bzImage > $@ && \
-	cp -a patches-4.4 etc/kernel-patches && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat kernel-source-info > etc/kernel-source-info && \
+	docker run --rm --net=none --log-driver=none $$BUILD tar cf - bzImage kernel-dev.tar kernel-headers.tar vmlinux kernel-modules.tar | tar xf - -C x86_64
+	mv x86_64/bzImage $@
+	cp -a patches-4.4 etc/kernel-patches
 	tar xf x86_64/kernel-modules.tar
 else
 x86_64/vmlinuz64: Dockerfile kernel_config kernel_config.debug patches-4.9
 	mkdir -p x86_64 etc lib usr sbin
 	BUILD=$$( tar cf - $^ | docker build --build-arg DEBUG=$(DEBUG) -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-modules.tar > x86_64/kernel-modules.tar && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-source-info > etc/kernel-source-info && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /vmlinux > x86_64/vmlinux && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-headers.tar > x86_64/kernel-headers.tar && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /kernel-dev.tar > x86_64/kernel-dev.tar && \
-	docker run --rm --net=none --log-driver=none $$BUILD cat /bzImage > $@ && \
-	cp -a patches-4.9 etc/kernel-patches && \
+	docker run --rm --net=none --log-driver=none $$BUILD cat kernel-source-info > etc/kernel-source-info && \
+	docker run --rm --net=none --log-driver=none $$BUILD tar cf - bzImage kernel-dev.tar kernel-headers.tar vmlinux kernel-modules.tar | tar xf - -C x86_64
+	mv x86_64/bzImage $@
+	cp -a patches-4.9 etc/kernel-patches
 	tar xf x86_64/kernel-modules.tar
 endif
 endif


### PR DESCRIPTION
Makes build faster

Improve #691

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

Keep kernel directories in line for easy of cherry pickage