### PR TITLE
[1.13] Upgrade to 4.9.5 and 4.4.44 kernels

### DIFF
--- a/alpine/kernel/Dockerfile
+++ b/alpine/kernel/Dockerfile
@@ -1,7 +1,7 @@
 # Tag: 3da0b0ea0da2724232603094e67c75b41adab551
 FROM mobylinux/alpine-build-c@sha256:0236d6599f6c8f7aa42829285e04202fbe99984df2818af0f5a453a59de8b090
 
-ARG KERNEL_VERSION=4.9.4
+ARG KERNEL_VERSION=4.9.5
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 

--- a/alpine/kernel/Dockerfile.4.4
+++ b/alpine/kernel/Dockerfile.4.4
@@ -1,7 +1,7 @@
 # Tag: b77cfc4ad0033d4366df830ed697afc7bab458a2
 FROM mobylinux/alpine-build-c@sha256:53739ea6042cb0ac39cf6e262012c1c4224206b2c9b719569fe7efa3a381348c
 
-ARG KERNEL_VERSION=4.4.43
+ARG KERNEL_VERSION=4.4.44
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 

--- a/alpine/kernel/Dockerfile.aufs
+++ b/alpine/kernel/Dockerfile.aufs
@@ -1,7 +1,7 @@
 # Tag: 3da0b0ea0da2724232603094e67c75b41adab551
 FROM mobylinux/alpine-build-c@sha256:0236d6599f6c8f7aa42829285e04202fbe99984df2818af0f5a453a59de8b090
 
-ARG KERNEL_VERSION=4.9.4
+ARG KERNEL_VERSION=4.9.5
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 


### PR DESCRIPTION
- security release, severity low
4.9.5 release notes: https://lkml.org/lkml/2017/1/20/161
4.4.44 release notes: https://lkml.org/lkml/2017/1/20/170

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>