### PR TITLE
Always mount swap not just when created

### DIFF
--- a/alpine/packages/automount/etc/init.d/automount
+++ b/alpine/packages/automount/etc/init.d/automount
@@ -96,8 +96,8 @@ do_swapfile()
 		dd if=/dev/zero of=$SWAP bs=1k count=1048576
 		chmod 600 $SWAP
 		mkswap $SWAP
-		swapon $SWAP
 	fi
+	[ -f "$SWAP" ] && swapon $SWAP
 }
 
 start()


### PR DESCRIPTION
Swap was not being mounted always.

See https://github.com/docker/for-win/issues/403

Signed-off-by: Justin Cormack <justin.cormack@docker.com>