### PR TITLE
Do not try to use aufs if kernel has no support

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -94,7 +94,7 @@ start()
 	if ! $(cat /etc/docker/daemon.json | jq -e '."storage-driver"' > /dev/null)
 	then
 		STORAGE_DRIVER="overlay2"
-		[ -d /var/lib/docker/aufs ] && STORAGE_DRIVER="aufs"
+		[ -d /var/lib/docker/aufs ] && grep -q aufs /proc/filesystems && STORAGE_DRIVER="aufs"
 		DOCKER_OPTS="${DOCKER_OPTS} --storage-driver ${STORAGE_DRIVER}"
 	fi
 


### PR DESCRIPTION
This happens with the Moby mainline kernel and in future when we drop aufs.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>