### PR TITLE
Fix up direct database accesses after move to /Database

### DIFF
--- a/alpine/base/pinata-iptables/main.ml
+++ b/alpine/base/pinata-iptables/main.ml
@@ -76,7 +76,7 @@ let _ =
   ( try Unix.mkdir _pid_dir 0o0755 with Unix.Unix_error(Unix.EEXIST, _, _) -> () );
   let port_forwarding =
     try
-      let ic = open_in "/Database/branch/master/ro/com.docker.driver.amd64-linux/native/port-forwarding" in
+      let ic = open_in "/Database/native/port-forwarding" in
       bool_of_string (String.trim (input_line ic))
     with _ -> false in
   logf "port_forwarding=%b intercepted arguments [%s]" port_forwarding (String.concat "; " (Array.to_list Sys.argv));

--- a/alpine/packages/diagnostics/capture.go
+++ b/alpine/packages/diagnostics/capture.go
@@ -174,7 +174,7 @@ func NewDatabaseCapturer() DatabaseCapturer {
 // Capture writes output from a DatabaseCapturer to a tar archive
 func (dc DatabaseCapturer) Capture(parentCtx context.Context, w *tar.Writer) {
 	// Dump the database
-	dbBase := "/Database/branch/master/ro"
+	dbBase := "/Database"
 	filepath.Walk(dbBase, func(path string, f os.FileInfo, err error) error {
 		if f.Mode().IsRegular() {
 			dc.CommandCapturer.args = []string{path}

--- a/alpine/packages/iptables/Makefile
+++ b/alpine/packages/iptables/Makefile
@@ -1,5 +1,5 @@
 # This image is currently just tagged latest as non reproducible
-IPTABLES_IMAGE=mobylinux/pinata-iptables@sha256:4dc27c9515c99dc80c8ec431de2c7db7d382425e5c1de13a560e6ec4c6a52b89
+IPTABLES_IMAGE=mobylinux/pinata-iptables@sha256:c94aa6902e858712058d0550320564ecb03d1f8f6370f91cdbc3f18b87662411
 
 all: usr/local/sbin/iptables
 


### PR DESCRIPTION
In #1057 removed the 9p paths from the database mount
but that broke some users accessing them directly. Fix these.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>