### PR TITLE
Add aufs patch for 4.9 to fix issue with extended attribute removal

### DIFF
--- a/alpine/kernel/Dockerfile.aufs
+++ b/alpine/kernel/Dockerfile.aufs
@@ -58,7 +58,7 @@ RUN if [ $DEBUG -ne "0" ]; then \
     fi
 
 # Apply local patches
-COPY patches-4.9 /patches
+COPY patches-4.9/* patches-4.9-aufs/* /patches/
 RUN cd /linux && \
     set -e && for patch in /patches/*.patch; do \
         echo "Applying $patch"; \

--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -3,14 +3,15 @@ DEBUG ?= 0
 all:	x86_64/vmlinuz64
 
 ifdef AUFS
-x86_64/vmlinuz64: Dockerfile.aufs kernel_config kernel_config.debug kernel_config.aufs patches-4.9
+x86_64/vmlinuz64: Dockerfile.aufs kernel_config kernel_config.debug kernel_config.aufs patches-4.9 patches-4.9-aufs
 	mkdir -p x86_64 etc lib usr sbin
 	BUILD=$$( tar cf - $^ | docker build -f Dockerfile.aufs --build-arg DEBUG=$(DEBUG) -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat aufs-utils.tar | tar xf - && \
 	docker run --rm --net=none --log-driver=none $$BUILD cat kernel-source-info > etc/kernel-source-info && \
 	docker run --rm --net=none --log-driver=none $$BUILD tar cf - bzImage kernel-dev.tar kernel-headers.tar vmlinux kernel-modules.tar | tar xf - -C x86_64
 	mv x86_64/bzImage $@
-	cp -a patches-4.9 etc/kernel-patches
+	mkdir -p etc/kernel-patches
+	cp -a patches-4.9/* patches-4.9-aufs/* etc/kernel-patches
 	tar xf x86_64/kernel-modules.tar
 else
 ifdef LTS4.4

--- a/alpine/kernel/patches-4.9-aufs/0001-aufs-posix-acl.patch
+++ b/alpine/kernel/patches-4.9-aufs/0001-aufs-posix-acl.patch
@@ -1,0 +1,40 @@
+commit 750946c8bfce458490e7e4aba34f22893c16a297
+Author: J. R. Okajima <hooanon05g@gmail.com>
+Date:   Mon Jan 23 03:36:33 2017 +0900
+
+    aufs: for v4.9, support posix acl
+    
+    The commit
+    	3801e27 2016-12-08 aufs: for v4.9-rc1, support new xattr scheme
+    was not enough, and supporting posix acl was missing.
+    
+    Reported-by: Justin Cormack <justin.cormack@docker.com>
+    See-also: https://github.com/docker/docker/issues/30245#issuecomment-274152452
+    Signed-off-by: J. R. Okajima <hooanon05g@gmail.com>
+
+diff --git a/fs/aufs/xattr.c b/fs/aufs/xattr.c
+index d0834e4..35fcc50 100644
+--- a/fs/aufs/xattr.c
++++ b/fs/aufs/xattr.c
+@@ -19,6 +19,8 @@
+  * handling xattr functions
+  */
+ 
++#include <linux/fs.h>
++#include <linux/posix_acl_xattr.h>
+ #include <linux/xattr.h>
+ #include "aufs.h"
+ 
+@@ -322,7 +324,11 @@ static const struct xattr_handler au_xattr_handler = {
+ };
+ 
+ static const struct xattr_handler *au_xattr_handlers[] = {
+-	&au_xattr_handler,
++#ifdef CONFIG_FS_POSIX_ACL
++	&posix_acl_access_xattr_handler,
++	&posix_acl_default_xattr_handler,
++#endif
++	&au_xattr_handler, /* must be last */
+ 	NULL
+ };
+ 


### PR DESCRIPTION
See https://github.com/docker/docker/issues/30245

Pinata issue https://github.com/docker/pinata/issues/6419

This should hit aufs upstream patch set shortly.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>