### PR TITLE
Split config database setup by platform

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -48,6 +48,10 @@ RUN \
   rc-update add transfused default && \
   rc-update add automount sysinit && \
   rc-update add diagnostics default && \
+  rc-update add database-mac boot && \
+  rc-update add database-windows boot && \
+  rc-update add database-aws default && \
+  rc-update add database-gcp default && \
   rc-update add hostsettings default && \
   rc-update add windowsnet boot && \
   rc-update add hv_kvp_daemon default && \

--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -45,7 +45,7 @@ moby.img: Dockerfile mkinitrd.sh init $(ETCFILES)
 	  -C packages/userns etc -C ../.. \
 	  -C packages/nc-vsock usr -C ../.. \
 	  -C packages/vsudd sbin etc -C ../.. \
-	  -C packages/mobyconfig usr -C ../.. \
+	  -C packages/mobyconfig etc usr -C ../.. \
 	  -C packages/mobyplatform usr -C ../.. \
 	  -C packages/oom etc -C ../.. \
 	  -C packages/9pmount-vsock sbin -C ../.. \

--- a/alpine/packages/mobyconfig/etc/init.d/database-aws
+++ b/alpine/packages/mobyconfig/etc/init.d/database-aws
@@ -1,0 +1,29 @@
+#!/sbin/openrc-run
+
+description="Set up database (AWS)."
+
+depend() {
+	before docker hostsettings windowsnet
+}
+
+start() {
+	[ "$(mobyplatform)" = "aws" ] || exit 0
+
+	ebegin "Setting up database (AWS)"
+
+	mkdir -p /Database
+	mount -t tmpfs tmpfs /Database
+
+	ENDPOINT="http://169.254.169.254/latest/meta-data"
+	curl "${ENDPOINT}/local-hostname" 2> /dev/null | mobyconfig set etc/hostname
+	# as this is a bit late let us set it anyway
+	mobyconfig get etc/hostname > /etc/hostname
+	hostname -F /etc/hostname
+	# TODO should collect all keys
+	curl -f -I "${ENDPOINT}/public-keys/0/openssh-key" 2> /dev/null > /dev/null && \
+		curl "${ENDPOINT}/public-keys/0/openssh-key" 2> /dev/null | mobyconfig set etc/ssh/authorized_keys
+	USERDATA="http://169.254.169.254/latest/user-data/"
+	curl "${USERDATA}" 2> /dev/null | mobyconfig set userdata
+
+	eend 0
+}

--- a/alpine/packages/mobyconfig/etc/init.d/database-gcp
+++ b/alpine/packages/mobyconfig/etc/init.d/database-gcp
@@ -1,0 +1,27 @@
+#!/sbin/openrc-run
+
+description="Set up database (GCP)."
+
+depend() {
+	before docker hostsettings windowsnet
+}
+
+start() {
+	[ "$(mobyplatform)" = "gcp" ] || exit 0
+
+	ebegin "Setting up database (GCP)"
+
+	mkdir -p /Database
+	mount -t tmpfs tmpfs /Database
+
+	PROJECT=http://metadata.google.internal/computeMetadata/v1/project
+	INSTANCE=http://metadata.google.internal/computeMetadata/v1/instance
+	curl "${INSTANCE}/hostname" 2> /dev/null | mobyconfig set etc/hostname
+	# as this is a bit late let us set it anyway
+	mobyconfig get etc/hostname > /etc/hostname
+	hostname -F /etc/hostname
+	curl -f -I "${PROJECT}/attributes/sshKeys" 2> /dev/null > /dev/null && \
+		curl "${PROJECT}/attributes/sshKeys" 2> /dev/null | mobyconfig set etc/ssh/authorized_keys
+
+	eend 0
+}

--- a/alpine/packages/mobyconfig/etc/init.d/database-mac
+++ b/alpine/packages/mobyconfig/etc/init.d/database-mac
@@ -1,0 +1,22 @@
+#!/sbin/openrc-run
+
+description="Set up database (OSX)."
+
+depend() {
+	before docker hostsettings windowsnet
+}
+
+start() {
+	[ "$(mobyplatform)" = "mac" ] || exit 0
+
+	ebegin "Setting up database (OSX)"
+
+	mkdir -p /Database
+	mount -t tmpfs tmpfs /Database
+	mkdir -p /tmp/db
+	mount -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 db /tmp/db
+	[ $? -ne 0 ] && rm -rf /Database && printf "Could not mount configuration database\n" 1>&2 && eend 1
+	cp -a /tmp/db/branch/master/ro/com.docker.driver.amd64-linux/* /Database
+
+	eend 0
+}

--- a/alpine/packages/mobyconfig/etc/init.d/database-windows
+++ b/alpine/packages/mobyconfig/etc/init.d/database-windows
@@ -1,0 +1,22 @@
+#!/sbin/openrc-run
+
+description="Set up database (Windows)."
+
+depend() {
+	before docker hostsettings windowsnet
+}
+
+start() {
+	[ "$(mobyplatform)" = "windows" ] || exit 0
+
+	ebegin "Setting up database (Windows)"
+
+	mkdir -p /Database
+	mount -t tmpfs tmpfs /Database
+	mkdir -p /tmp/db
+	/sbin/9pmount-vsock listen db /tmp/db
+	[ $? -ne 0 ] && rm -rf /Database && printf "Could not mount configuration database\n" 1>&2 && eend 1
+	cp -a /tmp/db/branch/master/ro/com.docker.driver.amd64-linux/* /Database
+
+	eend 0
+}

--- a/alpine/packages/mobyconfig/usr/bin/mobyconfig
+++ b/alpine/packages/mobyconfig/usr/bin/mobyconfig
@@ -2,33 +2,8 @@
 
 if [ $# -ne 2 ]
 then
-  printf "usage: $0 [get|exists|path|dir|find] key\n"
+  printf "usage: $0 [get|set|wait|exists|path|dir|find] key\n"
   exit 0
-fi
-
-if [ $1 == "set" ]
-then
-  printf "Configuration is immutable\n" 1>&2
-  exit 1
-fi
-
-if [ ! -d /Database ]
-then
-  mkdir -p /Database
-  case "$(mobyplatform)" in
-    windows)
-      mkdir -p /tmp/db
-      /sbin/9pmount-vsock listen db /tmp/db
-      [ $? -ne 0 ] && rm -rf /Database && printf "Could not mount configuration database\n" 1>&2 && exit 1
-      mount --bind /tmp/db/branch/master/ro/com.docker.driver.amd64-linux /Database
-    ;;
-    mac)
-      mkdir -p /tmp/db
-      mount -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 db /tmp/db
-      [ $? -ne 0 ] && rm -rf /Database && printf "Could not mount configuration database\n" 1>&2 && exit 1
-      mount --bind /tmp/db/branch/master/ro/com.docker.driver.amd64-linux /Database
-    ;;
-  esac
 fi
 
 BASE=/Database
@@ -61,6 +36,22 @@ then
   fi
 fi
 
+if [ $1 == "set" ]
+then
+  mkdir -p $(dirname "${BASE}/${KEY}")
+  cat - > ${BASE}/${KEY}
+  exit 0
+fi
+
+if [ $1 == "wait" ]
+then
+  while [ ! -s ${BASE}/${KEY} ]
+  do
+    sleep 1
+  done
+  exit 0
+fi
+
 if [ $1 == "path" ]
 then
   if [ -e ${BASE}/${KEY} ]
@@ -85,5 +76,5 @@ then
   fi
 fi
 
-printf "usage: $0 [get|exists|path|dir|find] key\n"
+printf "usage: $0 [get|set|wait|exists|path|dir|find] key\n"
 exit 1

--- a/alpine/packages/tap-vsockd/etc/init.d/tap-vsockd
+++ b/alpine/packages/tap-vsockd/etc/init.d/tap-vsockd
@@ -4,6 +4,7 @@ description="VPN proxy"
 
 depend()
 {
+	need database-windows
 	before net
 }
 

--- a/alpine/packages/windowsnet/etc/init.d/windowsnet
+++ b/alpine/packages/windowsnet/etc/init.d/windowsnet
@@ -3,6 +3,7 @@
 description="Configuring Windows network settings from database."
 
 depend() {
+	need database-windows
 	before sysctl net
 }
 


### PR DESCRIPTION
Add basic database setup for AWS, GCP although these are not yet used
by the setup code but will be useful later.

Currently each is gated by `mobyplatform` but this can be removed once we
construct Moby per platform, and once these are containerised so they
are not run from `openrc`.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>