### PR TITLE
Disable legacy registries unless specified in daemon.json

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -80,6 +80,9 @@ start()
 	# Set Docker to debug debug if not specified in daemon.json
 	cat /etc/docker/daemon.json | jq -e 'has("debug")' > /dev/null || DOCKER_OPTS="${DOCKER_OPTS} --debug"
 
+	# Disable legacy registries if not specified in daemon.json, deprecated in 1.14
+	cat /etc/docker/daemon.json | jq -e 'has("disable-legacy-registry")' > /dev/null || DOCKER_OPTS="${DOCKER_OPTS} --disable-legacy-registry"
+
 	# Set experimental=true if not specified in daemon.json and on 1.13+
 	if dockerd --help | grep -q -- --experimental
 	then


### PR DESCRIPTION
This will be disabled by default in 1.14: https://docs.docker.com/engine/deprecated/#/interacting-with-v1-registries

Also improves our docker bench report

@nathanleclaire does our fancy mixpanel ping have any stats on this or other daemon configs?

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>