### PR TITLE
Use docker run to run tests and interactive containers

### DIFF
--- a/Dockerfile.qemu
+++ b/Dockerfile.qemu
@@ -1,9 +1,0 @@
-# Tag: 97cc67f5569c437175f2e54b3c3b9a96a8615a16
-FROM mobylinux/alpine-qemu@sha256:80e17a465b332d774fd91b53c0bcb18ed0ea8a77c17bf8d8451c57a8ab8b4e66
-
-COPY alpine/initrd.img .
-COPY alpine/kernel/x86_64/vmlinuz64 .
-
-RUN qemu-img create -f raw disk.img 256M
-
-ENTRYPOINT [ "qemu-system-x86_64", "-drive", "file=disk.img,format=raw", "-device", "virtio-rng-pci", "-serial", "stdio", "-kernel", "vmlinuz64", "-initrd", "initrd.img", "-m", "2048", "-append", "earlyprintk=serial console=ttyS0 noapic", "-vnc", "none" ]

--- a/Dockerfile.qemugce
+++ b/Dockerfile.qemugce
@@ -1,7 +1,0 @@
-# Tag: 97cc67f5569c437175f2e54b3c3b9a96a8615a16
-FROM mobylinux/alpine-qemu@sha256:80e17a465b332d774fd91b53c0bcb18ed0ea8a77c17bf8d8451c57a8ab8b4e66
-
-COPY alpine/gce.img.tar.gz .
-RUN zcat gce.img.tar.gz | tar xf -
-
-ENTRYPOINT [ "qemu-system-x86_64", "-serial", "stdio", "-drive", "file=disk.raw,format=raw", "-m", "2048", "-vnc", "none" ]

--- a/Dockerfile.qemuiso
+++ b/Dockerfile.qemuiso
@@ -1,6 +1,0 @@
-# Tag: 97cc67f5569c437175f2e54b3c3b9a96a8615a16
-FROM mobylinux/alpine-qemu@sha256:80e17a465b332d774fd91b53c0bcb18ed0ea8a77c17bf8d8451c57a8ab8b4e66
-
-COPY alpine/mobylinux-bios.iso .
-
-ENTRYPOINT [ "qemu-system-x86_64", "-serial", "stdio", "-cdrom", "./mobylinux-bios.iso", "-m", "2048", "-vnc", "none" ]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,9 +1,0 @@
-# Tag: 97cc67f5569c437175f2e54b3c3b9a96a8615a16
-FROM mobylinux/alpine-qemu@sha256:80e17a465b332d774fd91b53c0bcb18ed0ea8a77c17bf8d8451c57a8ab8b4e66
-
-COPY alpine/initrd-test.img initrd.img
-COPY alpine/kernel/x86_64/vmlinuz64 .
-
-RUN qemu-img create -f raw disk.img 256M
-
-ENTRYPOINT [ "qemu-system-x86_64", "-drive", "file=disk.img,format=raw", "-device", "virtio-rng-pci", "-serial", "stdio", "-kernel", "vmlinuz64", "-initrd", "initrd.img", "-m", "1024", "-append", "earlyprintk=serial console=ttyS0 noapic", "-vnc", "none" ]

--- a/base/qemu/Dockerfile
+++ b/base/qemu/Dockerfile
@@ -3,7 +3,11 @@ FROM alpine:3.5
 RUN \
   apk update && apk upgrade && \
   apk add --no-cache \
+  libarchive-tools \
   qemu-img \
   qemu-system-arm \
   qemu-system-x86_64 \
   && true
+
+COPY . .
+ENTRYPOINT ["/qemu.sh"]

--- a/base/qemu/Makefile
+++ b/base/qemu/Makefile
@@ -1,14 +1,14 @@
 .PHONY: tag push
 
 BASE=alpine:3.5
-IMAGE=alpine-qemu
+IMAGE=qemu
 
 default: push
 
-hash: Dockerfile
+hash: Dockerfile qemu.sh
 	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
-	docker run --rm $(IMAGE):build sha1sum /lib/apk/db/installed | sed 's/ .*//' > hash
+	docker run --rm --entrypoint /bin/sh $(IMAGE):build -c 'cat Dockerfile qemu.sh /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > $@
 
 push: hash
 	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \

--- a/base/qemu/qemu.sh
+++ b/base/qemu/qemu.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -e
+
+cd /tmp
+
+# extract. BSD tar auto recognises compression, unlike GNU tar
+# only if stdin is a tty, if so need files volume mounted...
+[ -t 0 ] || bsdtar xzf -
+
+TGZ="$(find . -name '*.tgz' -or -name '*.tar.gz')"
+[ -n "$TGZ" ] && bsdtar xzf "$TGZ"
+
+ISO="$(find . -name '*.iso')"
+RAW="$(find . -name '*.raw')"
+INITRD="$(find . -name '*.img')"
+KERNEL="$(find . -name vmlinuz64 -or -name bzImage)"
+
+if [ -n "$ISO" ]
+then
+	ARGS="-cdrom $ISO -drive file=systemdisk.img,format=raw"
+elif [ -n "$RAW" ]
+then
+	# should test with more drives
+	ARGS="-drive file=$RAW,format=raw"
+elif [ -n "KERNEL" ]
+then
+	ARGS="-kernel $KERNEL"
+	if [ -n "$INITRD" ]
+	then
+		ARGS="$ARGS -initrd $INITRD"
+	fi
+	ARGS="$ARGS -append console=ttyS0 -drive file=systemdisk.img,format=raw"
+else
+	echo "no recognised boot media" >2
+	exit 1
+fi
+
+echo "$ARGS" | grep -q systemdisk && qemu-img create -f raw systemdisk.img 256M
+
+qemu-system-x86_64 -device virtio-rng-pci -serial stdio -vnc none -m 1024 $ARGS $*


### PR DESCRIPTION
Using docker build is slower and needs lots of Dockerfiles,
while a single image with a careful script can accept any type
of image, either with `-v` to share into `/tmp` for interactive
use (where you need the input and a tty, or by adding a tarball
for cases where there is no login such as running tests, so you
can still use a remote daemon in these cases.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>