### PR TITLE
Start diagnostics server earlier, before Docker

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -43,6 +43,7 @@ RUN \
   rc-update add transfused default && \
   rc-update add automount sysinit && \
   rc-update add diagnostics default && \
+  rc-update add diagnostics-server boot && \
   rc-update add database-mac boot && \
   rc-update add database-windows boot && \
   rc-update add database-aws default && \

--- a/alpine/packages/diagnostics/etc/init.d/diagnostics
+++ b/alpine/packages/diagnostics/etc/init.d/diagnostics
@@ -7,28 +7,5 @@ depend()
 
 start()
 {
-	ebegin "Checking system state"
-
-	DIAGNOSTICS_SERVER_FLAGS=""
-
-	case "$(mobyplatform)" in
-		"aws")
-			DIAGNOSTICS_SERVER_FLAGS="-http"
-		;;
-		"azure")
-			DIAGNOSTICS_SERVER_FLAGS="-http"
-		;;
-		"gcp")
-			DIAGNOSTICS_SERVER_FLAGS="-http"
-		;;
-		"windows")
-			DIAGNOSTICS_SERVER_FLAGS="-hvsock"
-		;;
-		"mac")
-			DIAGNOSTICS_SERVER_FLAGS="-vsock"
-		;;
-	esac
-
-	/usr/bin/diagnostics-server ${DIAGNOSTICS_SERVER_FLAGS} &
 	/usr/bin/diagnostics
 }

--- a/alpine/packages/diagnostics/etc/init.d/diagnostics-server
+++ b/alpine/packages/diagnostics/etc/init.d/diagnostics-server
@@ -1,0 +1,30 @@
+#!/sbin/openrc-run
+
+start()
+{
+	ebegin "Starting diagnostics server"
+
+	DIAGNOSTICS_SERVER_FLAGS=""
+
+	case "$(mobyplatform)" in
+		"aws")
+			DIAGNOSTICS_SERVER_FLAGS="-http"
+		;;
+		"azure")
+			DIAGNOSTICS_SERVER_FLAGS="-http"
+		;;
+		"gcp")
+			DIAGNOSTICS_SERVER_FLAGS="-http"
+		;;
+		"windows")
+			DIAGNOSTICS_SERVER_FLAGS="-hvsock"
+		;;
+		"mac")
+			DIAGNOSTICS_SERVER_FLAGS="-vsock"
+		;;
+	esac
+
+	/usr/bin/diagnostics-server ${DIAGNOSTICS_SERVER_FLAGS} &
+
+	eend 0
+}

--- a/alpine/packages/diagnostics/usr/bin/diagnostics
+++ b/alpine/packages/diagnostics/usr/bin/diagnostics
@@ -13,7 +13,6 @@ ok()
 	printf "✓ $1"
 }
 
-printf '\n'
 DEV="$(find /dev -maxdepth 1 -type b ! -name 'loop*' | grep -v '[0-9]$' | sed 's@.*/dev/@@' | head -1 )"
 [ $? -eq 0 ] && ok "Drive found: $DEV\n" || fail "No drive found\n"
 DEV=$(mount | grep '/dev/.* on /var type')


### PR DESCRIPTION
Allows it to be used to see what the boot state is.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>