### PR TITLE
OS X CI test without docker installed

### DIFF
--- a/Dockerfile.media
+++ b/Dockerfile.media
@@ -2,6 +2,7 @@ FROM mobylinux/toybox-media:0a26fe5f574e444849983f9c4148ef74b3804d55@sha256:5ac3
 
 ADD \
   alpine/initrd.img \
+  alpine/initrd-test.img \
   alpine/kernel/x86_64/vmlinuz64 \
   alpine/kernel/x86_64/vmlinux \
   alpine/kernel/x86_64/kernel-headers.tar \


### PR DESCRIPTION
OS X CI test without docker installed

OS X CI endpoints won't need to do a build, the artifacts can be pulled
from mobylinux/media.  This requires docker, which may not be available.

- 'get-regextract' make target pulls media without Docker using the
  regextract utility, which it will fetch from CI if needed.
- Add initrd-test.img to mobylinux/media image

Addresses #1046

Signed-off-by: Robb Kistler <robb.kistler@docker.com>
