### PR TITLE
Split kernel files into their own image

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -1,4 +1,4 @@
-all:	initrd.img initrd-test.img mobylinux-efi.iso mobylinux-bios.iso
+all:	initrd.img initrd-test.img mobylinux-efi.iso mobylinux-bios.iso ebpf
 
 ETCFILES=$(shell find etc)
 
@@ -29,13 +29,10 @@ TARTAR2INITRD_IMAGE=mobylinux/tartar2initrd@sha256:e1ad4522ff906d339da5f250b9ef6
 GCE_IMAGE=mobylinux/mkimage-gce@sha256:f9abf2eae20984b7dd3c1afb700b2c9c41e39e6e7c688c78348a51d0780d74cc
 
 moby.img: Dockerfile mkinitrd.sh init $(ETCFILES)
-	$(MAKE) -C kernel
 	$(MAKE) -j -C packages
-	$(MAKE) -C ebpf
 	printf $(TAG)$(DIRTY) > etc/moby-commit
 	BUILD=$$( tar cf - \
 	  Dockerfile etc usr init mkinitrd.sh \
-	  -C kernel usr etc sbin lib -C .. \
 	  -C packages/proxy usr sbin etc -C ../.. \
 	  -C packages/transfused sbin etc -C ../.. \
 	  -C packages/tap-vsockd sbin etc -C ../.. \
@@ -74,11 +71,18 @@ test.img:
 	cat test/container.tar | \
 		docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(TAR2INITRD_IMAGE) > $@
 
-initrd.img: moby.img container.img
+kernel/x86_64/kernel.img:
+	$(MAKE) -C kernel
+
+initrd.img: moby.img kernel/x86_64/kernel.img container.img
 	cat $^ > $@
 
 initrd-test.img: initrd.img test.img
 	cat $^ > $@
+
+.PHONY: epbf
+ebpf: kernel/x86_64/kernel.img
+	$(MAKE) -C ebpf
 
 mobylinux-efi.iso: Dockerfile.efi initrd.img kernel/x86_64/vmlinuz64
 	BUILD=$$( tar cf - $^ | docker build -q -f Dockerfile.efi - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && \

--- a/alpine/kernel/Makefile
+++ b/alpine/kernel/Makefile
@@ -1,6 +1,13 @@
 DEBUG ?= 0
 
+# Tag: d5711601eb5b89de0f052d87365e18388ff3f1b5
+TAR2INITRD_IMAGE=mobylinux/tar2initrd@sha256:58d377e65845f91400e173ce9fca93462f2f237947eef2b0d2c17bb4f2da5ee8
+
 all:	x86_64/vmlinuz64
+
+x86_64/kernel.img:
+	tar cf - etc lib usr sbin | \
+		docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(TAR2INITRD_IMAGE) > $@
 
 ifdef AUFS
 x86_64/vmlinuz64: Dockerfile.aufs kernel_config kernel_config.debug kernel_config.aufs patches-4.9
@@ -13,6 +20,7 @@ x86_64/vmlinuz64: Dockerfile.aufs kernel_config kernel_config.debug kernel_confi
 	mkdir -p etc/kernel-patches
 	cp -a patches-4.9/* etc/kernel-patches
 	tar xf x86_64/kernel-modules.tar
+	$(MAKE) x86_64/kernel.img
 else
 ifdef LTS4.4
 x86_64/vmlinuz64: Dockerfile.4.4 kernel_config kernel_config.debug kernel_config.4.4 patches-4.4
@@ -23,6 +31,7 @@ x86_64/vmlinuz64: Dockerfile.4.4 kernel_config kernel_config.debug kernel_config
 	mv x86_64/bzImage $@
 	cp -a patches-4.4 etc/kernel-patches
 	tar xf x86_64/kernel-modules.tar
+	$(MAKE) x86_64/kernel.img
 else
 x86_64/vmlinuz64: Dockerfile kernel_config kernel_config.debug patches-4.9
 	mkdir -p x86_64 etc lib usr sbin
@@ -32,6 +41,7 @@ x86_64/vmlinuz64: Dockerfile kernel_config kernel_config.debug patches-4.9
 	mv x86_64/bzImage $@
 	cp -a patches-4.9 etc/kernel-patches
 	tar xf x86_64/kernel-modules.tar
+	$(MAKE) x86_64/kernel.img
 endif
 endif
 


### PR DESCRIPTION
This means the base system build and kernel build can be split
without dependencies, and just assembled later.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>