### PR TITLE
Use apk audit to check system binaries

### DIFF
--- a/alpine/packages/diagnostics/capture.go
+++ b/alpine/packages/diagnostics/capture.go
@@ -29,6 +29,7 @@ var (
 		{"/bin/uname", []string{"-a"}, defaultCommandTimeout},
 		{"/bin/ps", []string{"uax"}, defaultCommandTimeout},
 		{"/bin/netstat", []string{"-tulpn"}, defaultCommandTimeout},
+		{"/sbin/apk", []string{"audit", "--system"}, defaultCommandTimeout}, // check if system binaries were modified
 		{"/sbin/iptables-save", nil, defaultCommandTimeout},
 		{"/sbin/ifconfig", nil, defaultCommandTimeout},
 		{"/sbin/route", nil, defaultCommandTimeout},


### PR DESCRIPTION
Adds `apk audit --system` to our diagnostic captures

cc @rneugeba for diagkit porting

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>