### PR TITLE
Use bin dir and clean up hyperkit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 test.log
+/bin
 *.swp
-/hyperkit.bin
 *.img
 *.tag
 *.iso

--- a/hyperkit.sh
+++ b/hyperkit.sh
@@ -17,7 +17,7 @@ PCI_DEV="-s 0:0,hostbridge -s 31,lpc"
 RND="-s 5,virtio-rnd"
 LPC_DEV="-l com1,stdio"
 
-hyperkit.bin/com.docker.slirp --ethernet $SLIRP_SOCK &>/dev/null &
+bin/com.docker.slirp --ethernet $SLIRP_SOCK &>/dev/null &
 trap "kill $!; rm $SLIRP_SOCK" EXIT
 
-hyperkit.bin/com.docker.hyperkit -A $MEM $SMP $PCI_DEV $LPC_DEV $NET $IMG_HDD $RND -u -f kexec,$KERNEL,$INITRD,"$CMDLINE"
+bin/com.docker.hyperkit -A $MEM $SMP $PCI_DEV $LPC_DEV $NET $IMG_HDD $RND -u -f kexec,$KERNEL,$INITRD,"$CMDLINE"


### PR DESCRIPTION
- make a `bin/` directory
- make hyperkit-test pass, as it writes to pty so redirect was not working

Signed-off-by: Justin Cormack <justin.cormack@docker.com>