### PR TITLE
transfused perfstat: fix bug with running multiple perfstats in a row

### DIFF
--- a/alpine/packages/transfused/transfused_perfstat.c
+++ b/alpine/packages/transfused/transfused_perfstat.c
@@ -165,6 +165,7 @@ void *stop_perfstat(parameters_t *params, char *req, size_t len)
 	*((uint64_t *) (reply + 8)) = now(params);
 
 	copy_and_free_perfstats(conn->perfstats, reply + 16);
+	conn->perfstats = NULL;
 
 	unlock("perfstat lock: stop_perfstat", &conn->perfstat_lock);
 


### PR DESCRIPTION
After freeing the head of the perfstat block list, we must set it to NULL to indicate that new blocks must be allocated. Previously, we risked segfaults by trying to use a freed list.
