### PR TITLE
Move test directory to top level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: test hyperkit-test qemu qemu-iso qemu-gce media ebpf ci ci-pr
+
 all:
 	$(MAKE) -C alpine
 
@@ -127,4 +129,5 @@ ci-pr:
 clean:
 	$(MAKE) -C alpine clean
 	$(MAKE) -C containers clean
+	$(MAKE) -C test clean
 	rm -rf bin disk.img test.log

--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -58,10 +58,8 @@ moby.img: Dockerfile etc usr init
 ../containers/container.img:
 	$(MAKE) -C ../containers
 
-test.img:
-	$(MAKE) -j -C test
-	cat test/container.tar | \
-		docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(TAR2INITRD_IMAGE) > $@
+../test/test.img:
+	$(MAKE) -C ../test
 
 kernel/x86_64/kernel.img:
 	$(MAKE) -C kernel
@@ -69,7 +67,7 @@ kernel/x86_64/kernel.img:
 initrd.img: moby.img kernel/x86_64/kernel.img ../containers/container.img
 	cat $^ > $@
 
-initrd-test.img: initrd.img test.img
+initrd-test.img: initrd.img ../test/test.img
 	cat $^ > $@
 
 # outputs tarball of mobylinux-efi.iso mobylinux.efi
@@ -202,7 +200,6 @@ clean:
 	docker images -q moby-azure:raw2vhd | xargs docker rmi -f || true
 	docker volume rm vhdartifact || true
 	$(MAKE) -C packages clean
-	$(MAKE) -C test clean
 	$(MAKE) -C kernel clean
 
 .DELETE_ON_ERROR:

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,8 +1,8 @@
+default: test.img
+
 RIDDLER=mobylinux/riddler:893c93bf54bc037f6952886330d5ba58746ace37@sha256:3d4a61555110be4b6e8ff6bcdcf5f8aa24d64564eb4162ea4e580d8916d083cc
 
 TEST_IMAGE=mobylinux/test:fc8e36cbd58b5e9078ae6aa57a348ca2fbec76dc@sha256:7155b16109270dc2d950f63279e5a682b2793b83bb26ff70c4783e6d723db5ba
-
-default: container.tar
 
 container.tar:
 	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock $(RIDDLER) \
@@ -12,7 +12,12 @@ container.tar:
 	  -v /etc/resolv.conf:/etc/resolv.conf:ro \
 	  --net host --read-only $(TEST_IMAGE) /bin/sh /bin/test.sh >$@
 
+TAR2INITRD_IMAGE=mobylinux/tar2initrd:d5711601eb5b89de0f052d87365e18388ff3f1b5@sha256:58d377e65845f91400e173ce9fca93462f2f237947eef2b0d2c17bb4f2da5ee8
+
+test.img: container.tar
+	cat $^ | docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(TAR2INITRD_IMAGE) > $@
+
 clean:
-	rm -f container.tar
+	rm -f container.tar test.img
 
 .DELETE_ON_ERROR:


### PR DESCRIPTION
This is temporary, it should be under `containers/` just as soon
as we have a manifest setup.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>