### PR TITLE
containerd: Don't use standard NATS port

### DIFF
--- a/alpine/packages/containerd/etc/init.d/containerd
+++ b/alpine/packages/containerd/etc/init.d/containerd
@@ -13,7 +13,7 @@ start()
 	ulimit -n 1048576
 	ulimit -p unlimited
 
-	/usr/bin/containerd 1>&2 2>/var/log/containerd.log &
+	/usr/bin/containerd -e nats://localhost:61725 1>&2 2>/var/log/containerd.log &
 
 	ewaitfile 5 /var/run/containerd/containerd.sock
 


### PR DESCRIPTION
Newer versions of containerd provide a pub/sub based service
to things like engine. By default this uses the standrd NATS
port 4222 which interferes with users wanting to run NATS in
a container.

This commit moves the NATS port used by containerd to a different
port. No other changes should be required as we run containerd
in standalone mode.

wip: #1138 

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>