### PR TITLE
[1.13] Update kernel to 4.9.7 and 4.4.46

### DIFF
--- a/alpine/kernel/Dockerfile
+++ b/alpine/kernel/Dockerfile
@@ -1,7 +1,7 @@
 # Tag: 3da0b0ea0da2724232603094e67c75b41adab551
 FROM mobylinux/alpine-build-c@sha256:0236d6599f6c8f7aa42829285e04202fbe99984df2818af0f5a453a59de8b090
 
-ARG KERNEL_VERSION=4.9.6
+ARG KERNEL_VERSION=4.9.7
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 

--- a/alpine/kernel/Dockerfile.4.4
+++ b/alpine/kernel/Dockerfile.4.4
@@ -1,7 +1,7 @@
 # Tag: b77cfc4ad0033d4366df830ed697afc7bab458a2
 FROM mobylinux/alpine-build-c@sha256:53739ea6042cb0ac39cf6e262012c1c4224206b2c9b719569fe7efa3a381348c
 
-ARG KERNEL_VERSION=4.4.45
+ARG KERNEL_VERSION=4.4.46
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 

--- a/alpine/kernel/Dockerfile.aufs
+++ b/alpine/kernel/Dockerfile.aufs
@@ -1,7 +1,7 @@
 # Tag: 3da0b0ea0da2724232603094e67c75b41adab551
 FROM mobylinux/alpine-build-c@sha256:0236d6599f6c8f7aa42829285e04202fbe99984df2818af0f5a453a59de8b090
 
-ARG KERNEL_VERSION=4.9.6
+ARG KERNEL_VERSION=4.9.7
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 


### PR DESCRIPTION
- security update, severity low

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>