### PR TITLE
Restore containerd and runc images

### DIFF
--- a/base/containerd/Dockerfile
+++ b/base/containerd/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.7-alpine3.5
+RUN \
+  apk update && apk upgrade -a && \
+  apk add --no-cache \
+  gcc \
+  git \
+  libc-dev \
+  make \
+  && true
+ENV CONTAINERD_COMMIT=3b79682548339895fcf9976f60ddea8abc5fc97e
+RUN mkdir -p $GOPATH/src/github.com/docker && \
+  cd $GOPATH/src/github.com/docker && \
+  git clone https://github.com/docker/containerd.git
+WORKDIR $GOPATH/src/github.com/docker/containerd
+RUN git checkout $CONTAINERD_COMMIT
+RUN make binaries GO_GCFLAGS="-buildmode pie --ldflags '-extldflags \"-fno-PIC -static\"'"
+RUN cp bin/containerd bin/ctr bin/containerd-shim /usr/bin/
+WORKDIR /
+COPY . .

--- a/base/containerd/Makefile
+++ b/base/containerd/Makefile
@@ -1,0 +1,29 @@
+.PHONY: tag push
+
+BASE=golang:1.7-alpine3.5
+IMAGE=containerd
+
+default: push
+
+hash: Dockerfile
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm $(IMAGE):build sh -c 'cat Dockerfile /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > $@
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/base/runc/Dockerfile
+++ b/base/runc/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.7-alpine3.5
+RUN \
+  apk update && apk upgrade -a && \
+  apk add --no-cache \
+  bash \
+  gcc \
+  git \
+  libc-dev \
+  libseccomp-dev \
+  linux-headers \
+  make \
+  && true
+ENV RUNC_COMMIT=51371867a01c467f08af739783b8beafc154c4d7
+RUN mkdir -p $GOPATH/src/github.com/opencontainers && \
+  cd $GOPATH/src/github.com/opencontainers && \
+  git clone https://github.com/opencontainers/runc.git
+WORKDIR $GOPATH/src/github.com/opencontainers/runc
+RUN git checkout $RUNC_COMMIT
+# TODO static pie, currently no easy way to change build options
+RUN make static BUILDTAGS="seccomp"
+RUN cp runc /usr/bin/
+WORKDIR /
+COPY . .

--- a/base/runc/Makefile
+++ b/base/runc/Makefile
@@ -1,0 +1,29 @@
+.PHONY: tag push
+
+BASE=golang:1.7-alpine3.5
+IMAGE=runc
+
+default: push
+
+hash: Dockerfile
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm $(IMAGE):build sh -c 'cat Dockerfile /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > $@
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:


### PR DESCRIPTION
These were removed in #1145

Need these for a new build; keeping the current build in the
`alpine/` directory unchanged for editions for now so the issues
here do not affect them.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>