### PR TITLE
kernel: Rebase kernel patches proper

### DIFF
--- a/kernel/patches-4.4/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
+++ b/kernel/patches-4.4/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
@@ -1,4 +1,4 @@
-From 190d2525e7d454f9fb5a20bb6a49277877143e6b Mon Sep 17 00:00:00 2001
+From 323b71b276638b2c526132c6d3cd3d153cdad74d Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 17 Dec 2015 16:53:43 +0800
 Subject: [PATCH 01/44] virtio: make find_vqs() checkpatch.pl-friendly

--- a/kernel/patches-4.4/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
+++ b/kernel/patches-4.4/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
@@ -1,4 +1,4 @@
-From 2b608e3d358b8eac9c32840aaaf4ab212d532493 Mon Sep 17 00:00:00 2001
+From a4e4e50474fe9699ae86bda2f6158a9b17b55ce6 Mon Sep 17 00:00:00 2001
 From: Julia Lawall <julia.lawall@lip6.fr>
 Date: Sat, 21 Nov 2015 18:39:17 +0100
 Subject: [PATCH 02/44] VSOCK: constify vmci_transport_notify_ops structures

--- a/kernel/patches-4.4/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
+++ b/kernel/patches-4.4/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
@@ -1,4 +1,4 @@
-From 4644873be14865b14b9dd11a78fb20881a116ea0 Mon Sep 17 00:00:00 2001
+From f9c52b586dba5efb7d0d370971ba1cb2313734bf Mon Sep 17 00:00:00 2001
 From: Claudio Imbrenda <imbrenda@linux.vnet.ibm.com>
 Date: Tue, 22 Mar 2016 17:05:52 +0100
 Subject: [PATCH 03/44] AF_VSOCK: Shrink the area influenced by prepare_to_wait

--- a/kernel/patches-4.4/0004-vsock-make-listener-child-lock-ordering-explicit.patch
+++ b/kernel/patches-4.4/0004-vsock-make-listener-child-lock-ordering-explicit.patch
@@ -1,4 +1,4 @@
-From 58af9ca05d4337a956f9b8303a2d7b0b968788bb Mon Sep 17 00:00:00 2001
+From 97a83a1eb15e1f03b5f8d9f02d144f7de7ec24e5 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 23 Jun 2016 16:28:58 +0100
 Subject: [PATCH 04/44] vsock: make listener child lock ordering explicit

--- a/kernel/patches-4.4/0005-VSOCK-transport-specific-vsock_transport-functions.patch
+++ b/kernel/patches-4.4/0005-VSOCK-transport-specific-vsock_transport-functions.patch
@@ -1,4 +1,4 @@
-From c122f28889868dc16add4712af3603a467bb7fd3 Mon Sep 17 00:00:00 2001
+From cedd7f21072bc632d7422011c4834c1a14d124ff Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:30 +0100
 Subject: [PATCH 05/44] VSOCK: transport-specific vsock_transport functions

--- a/kernel/patches-4.4/0006-VSOCK-defer-sock-removal-to-transports.patch
+++ b/kernel/patches-4.4/0006-VSOCK-defer-sock-removal-to-transports.patch
@@ -1,4 +1,4 @@
-From c388401f49ad3f0ec37aab115f883e180427aae0 Mon Sep 17 00:00:00 2001
+From 4796e1fe473b506ba6f9268cae7e8da03e7af1d8 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:31 +0100
 Subject: [PATCH 06/44] VSOCK: defer sock removal to transports

--- a/kernel/patches-4.4/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
+++ b/kernel/patches-4.4/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
@@ -1,4 +1,4 @@
-From 7d8134e14e6199a3843d3297be701051691e0443 Mon Sep 17 00:00:00 2001
+From d738c110fe475ea13b752e582172a94125df9372 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:32 +0100
 Subject: [PATCH 07/44] VSOCK: Introduce virtio_vsock_common.ko

--- a/kernel/patches-4.4/0008-VSOCK-Introduce-virtio_transport.ko.patch
+++ b/kernel/patches-4.4/0008-VSOCK-Introduce-virtio_transport.ko.patch
@@ -1,4 +1,4 @@
-From fb158aa4227b765ec8605ef39d23846389a7ffb2 Mon Sep 17 00:00:00 2001
+From 739dee8ceb16a6124824e0a6a2de8d00fa94faf9 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:33 +0100
 Subject: [PATCH 08/44] VSOCK: Introduce virtio_transport.ko

--- a/kernel/patches-4.4/0009-VSOCK-Introduce-vhost_vsock.ko.patch
+++ b/kernel/patches-4.4/0009-VSOCK-Introduce-vhost_vsock.ko.patch
@@ -1,4 +1,4 @@
-From 429b9374590476305988dcf27c291f3b25d4fabe Mon Sep 17 00:00:00 2001
+From eace43fb2842f04c484f38ff336b52c8e9b40145 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:34 +0100
 Subject: [PATCH 09/44] VSOCK: Introduce vhost_vsock.ko

--- a/kernel/patches-4.4/0010-VSOCK-Add-Makefile-and-Kconfig.patch
+++ b/kernel/patches-4.4/0010-VSOCK-Add-Makefile-and-Kconfig.patch
@@ -1,4 +1,4 @@
-From 17b7a6b41700d4a075c228526761d8c1d2d555d2 Mon Sep 17 00:00:00 2001
+From 6eecb6ff272b4931e019198880478b519b11a90e Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:35 +0100
 Subject: [PATCH 10/44] VSOCK: Add Makefile and Kconfig

--- a/kernel/patches-4.4/0011-VSOCK-Use-kvfree.patch
+++ b/kernel/patches-4.4/0011-VSOCK-Use-kvfree.patch
@@ -1,4 +1,4 @@
-From 2eb16145fb76667bcc47b02bf3708ff2fc6389fb Mon Sep 17 00:00:00 2001
+From f80edd87e498837f85f84c58bd1dde008d8dcee3 Mon Sep 17 00:00:00 2001
 From: Wei Yongjun <weiyj.lk@gmail.com>
 Date: Tue, 2 Aug 2016 13:50:42 +0000
 Subject: [PATCH 11/44] VSOCK: Use kvfree()

--- a/kernel/patches-4.4/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
+++ b/kernel/patches-4.4/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
@@ -1,4 +1,4 @@
-From de224dfc853e82a22203479455d8fd3192e9b535 Mon Sep 17 00:00:00 2001
+From a10152c47497e9f95325fb4d677164ec68300686 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 4 Aug 2016 14:52:53 +0100
 Subject: [PATCH 12/44] vhost/vsock: fix vhost virtio_vsock_pkt use-after-free

--- a/kernel/patches-4.4/0013-virtio-vsock-fix-include-guard-typo.patch
+++ b/kernel/patches-4.4/0013-virtio-vsock-fix-include-guard-typo.patch
@@ -1,4 +1,4 @@
-From cad999979a54a6b0a301544645ca2ea99a2cb695 Mon Sep 17 00:00:00 2001
+From 587871efbc0371792e3b3d841bbc84167a394e19 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Fri, 5 Aug 2016 13:52:09 +0100
 Subject: [PATCH 13/44] virtio-vsock: fix include guard typo

--- a/kernel/patches-4.4/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
+++ b/kernel/patches-4.4/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
@@ -1,4 +1,4 @@
-From 20fcf536994ef51a2786d1c41c143d0278fc4afc Mon Sep 17 00:00:00 2001
+From 8782c72ec60881b5e5a66fbb7c0078cbebd9052e Mon Sep 17 00:00:00 2001
 From: Gerard Garcia <ggarcia@deic.uab.cat>
 Date: Wed, 10 Aug 2016 17:24:34 +0200
 Subject: [PATCH 14/44] vhost/vsock: drop space available check for TX vq

--- a/kernel/patches-4.4/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/kernel/patches-4.4/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,4 +1,4 @@
-From e2d417429738c3a8da5086a4f9bd815fca3ba0a6 Mon Sep 17 00:00:00 2001
+From 5b92d2939789b508e45f236c6da1bac792bd1439 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
 Subject: [PATCH 15/44] VSOCK: Only allow host network namespace to use

--- a/kernel/patches-4.4/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
+++ b/kernel/patches-4.4/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
@@ -1,4 +1,4 @@
-From 4331f8b43f608d81e14b5caee4b0c24cd896eb4d Mon Sep 17 00:00:00 2001
+From b3b9368065a3d8d28b84ec205b3ec6fdd295dd49 Mon Sep 17 00:00:00 2001
 From: Jake Oshins <jakeo@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:41 -0800
 Subject: [PATCH 16/44] drivers:hv: Define the channel type for Hyper-V PCI

--- a/kernel/patches-4.4/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
+++ b/kernel/patches-4.4/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
@@ -1,4 +1,4 @@
-From ac16740f1c65a5b960e288a96965053171f654d5 Mon Sep 17 00:00:00 2001
+From 2040901bd94f69e4deda11bd834f99b0bda1b143 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:43 -0800
 Subject: [PATCH 17/44] Drivers: hv: vmbus: Use uuid_le type consistently

--- a/kernel/patches-4.4/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
+++ b/kernel/patches-4.4/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
@@ -1,4 +1,4 @@
-From bd9affada850f2723a678ec65910d5547184843e Mon Sep 17 00:00:00 2001
+From ee1d1bdcb41f3925aed5e93a361bd8d1bd2929a4 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:44 -0800
 Subject: [PATCH 18/44] Drivers: hv: vmbus: Use uuid_le_cmp() for comparing

--- a/kernel/patches-4.4/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
+++ b/kernel/patches-4.4/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
@@ -1,4 +1,4 @@
-From ed712a86d76146f4e5279ac473ce346f6acaaae1 Mon Sep 17 00:00:00 2001
+From 67ed51a12d61aeb16148d1e524fc6a530edb057b Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:48 -0800
 Subject: [PATCH 19/44] Drivers: hv: vmbus: do sanity check of channel state in

--- a/kernel/patches-4.4/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
+++ b/kernel/patches-4.4/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
@@ -1,4 +1,4 @@
-From d6f12dc4d3efb1005519e87382c2800843dd3e0d Mon Sep 17 00:00:00 2001
+From e2628e8b649e64015b2cfee8c93481a0d9eec19b Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:50 -0800
 Subject: [PATCH 20/44] Drivers: hv: vmbus: release relid on error in

--- a/kernel/patches-4.4/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
+++ b/kernel/patches-4.4/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
@@ -1,4 +1,4 @@
-From 0d14411db1498d805f8b4b060295ca77e0c872cd Mon Sep 17 00:00:00 2001
+From 01ddf13654bcea824dc2d1d3f16d1fad0a93e9c0 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:51 -0800
 Subject: [PATCH 21/44] Drivers: hv: vmbus: channge

--- a/kernel/patches-4.4/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
+++ b/kernel/patches-4.4/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
@@ -1,4 +1,4 @@
-From 76f7fdc166bb0b747b666c1e6de0184cd00835b8 Mon Sep 17 00:00:00 2001
+From ea36e149bb07676f2752cd718cea6d435074eb74 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Mon, 14 Dec 2015 19:02:00 -0800
 Subject: [PATCH 22/44] Drivers: hv: remove code duplication between

--- a/kernel/patches-4.4/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
+++ b/kernel/patches-4.4/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
@@ -1,4 +1,4 @@
-From acdf851a460410451073ae3eea087e48c9244770 Mon Sep 17 00:00:00 2001
+From 1391ff6973074b30f917970e0c38ef9207cd66d8 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Dec 2015 12:21:22 -0800
 Subject: [PATCH 23/44] Drivers: hv: vmbus: fix the building warning with

--- a/kernel/patches-4.4/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
+++ b/kernel/patches-4.4/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
@@ -1,4 +1,4 @@
-From c952417ede883823ddf02ca6747c19f03728559a Mon Sep 17 00:00:00 2001
+From d1750564e8aad31593d1dc8621edd79f7ab50031 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Tue, 15 Dec 2015 16:27:27 -0800
 Subject: [PATCH 24/44] Drivers: hv: vmbus: Treat Fibre Channel devices as

--- a/kernel/patches-4.4/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
+++ b/kernel/patches-4.4/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
@@ -1,4 +1,4 @@
-From b8f2da0e5160cd380ee25b81a1e5f8c922a713fe Mon Sep 17 00:00:00 2001
+From d45737ba390bbd5d98c73b0856a6d077d13b3013 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Fri, 25 Dec 2015 20:00:30 -0800
 Subject: [PATCH 25/44] Drivers: hv: vmbus: Add vendor and device atttributes

--- a/kernel/patches-4.4/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
+++ b/kernel/patches-4.4/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
@@ -1,4 +1,4 @@
-From 26e5ac0096b7b4f80dbda30ab21101077ce75286 Mon Sep 17 00:00:00 2001
+From 1186196a10b5dcc990f16f053e67d0e5a42e6670 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:37 -0800
 Subject: [PATCH 26/44] Drivers: hv: vmbus: add a helper function to set a

--- a/kernel/patches-4.4/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
+++ b/kernel/patches-4.4/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
@@ -1,4 +1,4 @@
-From 47c82abe6f2ddc2de58719c0dc3fb8588b2d6765 Mon Sep 17 00:00:00 2001
+From 51fa4c75a130d806e3aad041e5be96a0a91965ee Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:38 -0800
 Subject: [PATCH 27/44] Drivers: hv: vmbus: define the new offer type for

--- a/kernel/patches-4.4/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
+++ b/kernel/patches-4.4/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
@@ -1,4 +1,4 @@
-From 3f42252209bb88705c6c00609b258f902871bc2a Mon Sep 17 00:00:00 2001
+From bd872a1a2f116392b7fed159305012a837ac780d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:39 -0800
 Subject: [PATCH 28/44] Drivers: hv: vmbus: vmbus_sendpacket_ctl: hvsock: avoid

--- a/kernel/patches-4.4/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
+++ b/kernel/patches-4.4/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
@@ -1,4 +1,4 @@
-From 0dccd1ae4a259fed2c1301d5cc1476eba75919bb Mon Sep 17 00:00:00 2001
+From b6cfb4c6ee1271f99ddec40476f8ac005ac46a72 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:40 -0800
 Subject: [PATCH 29/44] Drivers: hv: vmbus: define a new VMBus message type for

--- a/kernel/patches-4.4/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
+++ b/kernel/patches-4.4/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
@@ -1,4 +1,4 @@
-From 373b96e951d271e553d9854267ce65baab0241da Mon Sep 17 00:00:00 2001
+From 8657ab2c666f81c7a8d7b305fd59f132dc3183fe Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:41 -0800
 Subject: [PATCH 30/44] Drivers: hv: vmbus: add a hvsock flag in struct

--- a/kernel/patches-4.4/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
+++ b/kernel/patches-4.4/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
@@ -1,4 +1,4 @@
-From af38922b309452853cb5cf1e67a07aab4f0da8dd Mon Sep 17 00:00:00 2001
+From b000aea3b2148f409df6cf1a358daaac48b3282a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:42 -0800
 Subject: [PATCH 31/44] Drivers: hv: vmbus: add a per-channel rescind callback

--- a/kernel/patches-4.4/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
+++ b/kernel/patches-4.4/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
@@ -1,4 +1,4 @@
-From 9b2cf4ec84e167a677b1deda17e8cef862d795b6 Mon Sep 17 00:00:00 2001
+From 456dd839340e8a3b8b0fdeac24e985165ef6ab2e Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:43 -0800
 Subject: [PATCH 32/44] Drivers: hv: vmbus: add an API

--- a/kernel/patches-4.4/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
+++ b/kernel/patches-4.4/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
@@ -1,4 +1,4 @@
-From a62a66fbd2a18f72dfae5f6e3a50e1abb0cf8322 Mon Sep 17 00:00:00 2001
+From 076310fa41bd8b58563b47ab54592096e2ced9ff Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:45 -0800
 Subject: [PATCH 33/44] Drivers: hv: vmbus: Give control over how the ring

--- a/kernel/patches-4.4/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
+++ b/kernel/patches-4.4/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
@@ -1,4 +1,4 @@
-From a71950ae5474cdb6dabb2aac9ef05bf51a6331d6 Mon Sep 17 00:00:00 2001
+From 2965b1319cfccfb1d3045f95159b745414786c4e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:16 -0800
 Subject: [PATCH 34/44] Drivers: hv: vmbus: avoid wait_for_completion() on

--- a/kernel/patches-4.4/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
+++ b/kernel/patches-4.4/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
@@ -1,4 +1,4 @@
-From b0bf62f85f29a28c998b288aa164f98b449776a9 Mon Sep 17 00:00:00 2001
+From 6ca33a0ffb676c1f97a52865fea6f48ad4d4d720 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:18 -0800
 Subject: [PATCH 35/44] Drivers: hv: vmbus: avoid unneeded compiler

--- a/kernel/patches-4.4/0036-kcm-Kernel-Connection-Multiplexor-module.patch
+++ b/kernel/patches-4.4/0036-kcm-Kernel-Connection-Multiplexor-module.patch
@@ -1,4 +1,4 @@
-From b925b9f249062386d3fb47119e0f0aeab94824d5 Mon Sep 17 00:00:00 2001
+From 1a2b165efc132d750c2e0de8c3fa1a07ec08b28d Mon Sep 17 00:00:00 2001
 From: Tom Herbert <tom@herbertland.com>
 Date: Mon, 7 Mar 2016 14:11:06 -0800
 Subject: [PATCH 36/44] kcm: Kernel Connection Multiplexor module

--- a/kernel/patches-4.4/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From b6ca7ee0ff47bd5858de7dd01a1e4144f60b02fd Mon Sep 17 00:00:00 2001
+From db99c3e4c5996421990fb988b1969351cfc9a9a3 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:51:09 -0700
 Subject: [PATCH 37/44] net: add the AF_KCM entries to family name tables

--- a/kernel/patches-4.4/0038-net-Add-Qualcomm-IPC-router.patch
+++ b/kernel/patches-4.4/0038-net-Add-Qualcomm-IPC-router.patch
@@ -1,4 +1,4 @@
-From 3687c27135029a89719a0e6f1d4c1478ca8a5047 Mon Sep 17 00:00:00 2001
+From 5565201c88f9c6a25b8ce9d064266c91adccdc5d Mon Sep 17 00:00:00 2001
 From: Courtney Cavin <courtney.cavin@sonymobile.com>
 Date: Wed, 27 Apr 2016 12:13:03 -0700
 Subject: [PATCH 38/44] net: Add Qualcomm IPC router

--- a/kernel/patches-4.4/0039-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.4/0039-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From ddba6d4b693a1f67f32ea40ddaf6c240f6615b01 Mon Sep 17 00:00:00 2001
+From 461b872f847f462f28fe3c6e590f562dff0422b5 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 15 May 2016 09:53:11 -0700
 Subject: [PATCH 39/44] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.4/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From 9f77b052096cbdc1fe56c00b19a95855a8c3849e Mon Sep 17 00:00:00 2001
+From 4a409111d98dd8fd1431fe862f64c56dd1bf36f7 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:53:08 -0700
 Subject: [PATCH 40/44] net: add the AF_HYPERV entries to family name tables

--- a/kernel/patches-4.4/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
+++ b/kernel/patches-4.4/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
@@ -1,4 +1,4 @@
-From 23b4d08adcd276a1fcd8949b09f75f722f5ecaa2 Mon Sep 17 00:00:00 2001
+From 4ece12b8c2c09887e1eb2fa62ef47d6da029e116 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 21 May 2016 16:55:50 +0800
 Subject: [PATCH 41/44] Drivers: hv: vmbus: fix the race when querying &

--- a/kernel/patches-4.4/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.4/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From ffb0e64e9dbe037beb69dda9daf6567582adcac1 Mon Sep 17 00:00:00 2001
+From a351270cb79f7ce1cce20ce8111cdc9ccdbd17bb Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 42/44] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.4/0043-fs-add-filp_clone_open-API.patch
+++ b/kernel/patches-4.4/0043-fs-add-filp_clone_open-API.patch
@@ -1,4 +1,4 @@
-From 784c13b38b4413144b146699bb3ab090c291e6c2 Mon Sep 17 00:00:00 2001
+From c72a2508d4ca6deb4704616fd3bc26efd764dc30 Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:49:38 -0800
 Subject: [PATCH 43/44] fs: add filp_clone_open API

--- a/kernel/patches-4.4/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
+++ b/kernel/patches-4.4/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
@@ -1,4 +1,4 @@
-From 20127ca4e2ea3b4adfdf2161a915439454005579 Mon Sep 17 00:00:00 2001
+From 69e7ae2e8f10e25f9a7c62e2657b5fc81a626d30 Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:51:16 -0800
 Subject: [PATCH 44/44] binfmt_misc: add persistent opened binary handler for

--- a/kernel/patches-4.9/0001-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/kernel/patches-4.9/0001-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,4 +1,4 @@
-From fb4ee21f744b2639a1a7d495a732198a3e9c96ec Mon Sep 17 00:00:00 2001
+From 0d7f0d07b0161db56894ddd9da3c90074d9d5995 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
 Subject: [PATCH 01/12] VSOCK: Only allow host network namespace to use

--- a/kernel/patches-4.9/0002-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9/0002-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 6d42aeb54b6231920d58ea324e67d94ffc01a11a Mon Sep 17 00:00:00 2001
+From ed8ec8533647a523bd510b41b128888adec2d2a7 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 02/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9/0003-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9/0003-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 087c906e5cd36f32e8d0edcbea8a4cfb5bb98947 Mon Sep 17 00:00:00 2001
+From 3572be36490b411085bf2c28c2a6f06a698bd80d Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 03/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9/0004-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9/0004-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 59043b28040811e2af89841dbb4d3b9445ae67e1 Mon Sep 17 00:00:00 2001
+From 550e05bf72b6be4bc525b0274c02fc00c2d20e52 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 04/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9/0005-Drivers-hv-vmbus-Base-host-signaling-strictly-on-the.patch
+++ b/kernel/patches-4.9/0005-Drivers-hv-vmbus-Base-host-signaling-strictly-on-the.patch
@@ -1,7 +1,7 @@
-From dedfc354773877960dcf6c8a926faa4a94803ec5 Mon Sep 17 00:00:00 2001
+From 085b322dfe10994050e8b6c0310d9b89cd6d0437 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:16 -0800
-Subject: [PATCH 06/12] Drivers: hv: vmbus: Base host signaling strictly on the
+Subject: [PATCH 05/12] Drivers: hv: vmbus: Base host signaling strictly on the
  ring state
 
 One of the factors that can result in the host concluding that a given

--- a/kernel/patches-4.9/0006-Drivers-hv-vmbus-On-write-cleanup-the-logic-to-inter.patch
+++ b/kernel/patches-4.9/0006-Drivers-hv-vmbus-On-write-cleanup-the-logic-to-inter.patch
@@ -1,7 +1,7 @@
-From 59b43ccde9636cdb874156a6f6e570414eb3d67b Mon Sep 17 00:00:00 2001
+From 78777547745d7f0bf25e55cbf323ce5191e4b89a Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:17 -0800
-Subject: [PATCH 07/12] Drivers: hv: vmbus: On write cleanup the logic to
+Subject: [PATCH 06/12] Drivers: hv: vmbus: On write cleanup the logic to
  interrupt the host
 
 Signal the host when we determine the host is to be signaled.

--- a/kernel/patches-4.9/0007-Drivers-hv-vmbus-On-the-read-path-cleanup-the-logic-.patch
+++ b/kernel/patches-4.9/0007-Drivers-hv-vmbus-On-the-read-path-cleanup-the-logic-.patch
@@ -1,7 +1,7 @@
-From d77258d2dded3a5601ccd54edb6f99e035dc7b20 Mon Sep 17 00:00:00 2001
+From 983afbbd6d063c25e8bb8b4e0cbaa840e7ddb0b6 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:18 -0800
-Subject: [PATCH 08/12] Drivers: hv: vmbus: On the read path cleanup the logic
+Subject: [PATCH 07/12] Drivers: hv: vmbus: On the read path cleanup the logic
  to interrupt the host
 
 Signal the host when we determine the host is to be signaled -

--- a/kernel/patches-4.9/0008-Drivers-hv-vmbus-finally-fix-hv_need_to_signal_on_re.patch
+++ b/kernel/patches-4.9/0008-Drivers-hv-vmbus-finally-fix-hv_need_to_signal_on_re.patch
@@ -1,7 +1,7 @@
-From 21d5ad16c820d2e949ca80881986db3d228d8a33 Mon Sep 17 00:00:00 2001
+From 4e662fc5eed67dbc95569ee89fc628d27a1646d3 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Tue, 24 Jan 2017 06:54:46 +0000
-Subject: [PATCH 09/12] Drivers: hv: vmbus: finally fix
+Subject: [PATCH 08/12] Drivers: hv: vmbus: finally fix
  hv_need_to_signal_on_read()
 
 Commit a389fcfd2cb5 ("Drivers: hv: vmbus: Fix signaling logic in hv_need_to_signal_on_read()")

--- a/kernel/patches-4.9/0009-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9/0009-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,7 +1,7 @@
-From e87bfb9b2b1f3e79252b25261a033e51a976fb49 Mon Sep 17 00:00:00 2001
+From fcb33d2dd7fa294c410f37f40a3ffb579ca04811 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
-Subject: [PATCH 10/12] Drivers: hv: vss: Improve log messages.
+Subject: [PATCH 09/12] Drivers: hv: vss: Improve log messages.
 
 Adding log messages to help troubleshoot error cases and transaction
 handling.

--- a/kernel/patches-4.9/0010-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9/0010-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,7 +1,7 @@
-From b422d8d6fe1a29c9cc856c5e6e6bb081e30a11e9 Mon Sep 17 00:00:00 2001
+From 603fe73ad632d1acd4c1351c8b902d103c4aed44 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
-Subject: [PATCH 11/12] Drivers: hv: vss: Operation timeouts should match host
+Subject: [PATCH 10/12] Drivers: hv: vss: Operation timeouts should match host
  expectation
 
 Increase the timeout of backup operations. When system is under I/O load,

--- a/kernel/patches-4.9/0011-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9/0011-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,7 +1,7 @@
-From 3cbf33b27c52d640801d8482fa2b7b8376addff5 Mon Sep 17 00:00:00 2001
+From 364e61023027502953bb24666508073d73f39d4b Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
-Date: Wed, 18 Jan 2017 12:02:44 -0800
-Subject: [PATCH 12/12] Drivers: hv: vmbus: Use all supported IC versions to
+Date: Sat, 28 Jan 2017 12:37:17 -0700
+Subject: [PATCH 11/12] Drivers: hv: vmbus: Use all supported IC versions to
  negotiate
 
 Previously, we were assuming that each IC protocol version was tied to a
@@ -20,18 +20,20 @@ version and protocol to use")
 
 Reported-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
 Signed-off-by: Alex Ng <alexng@messages.microsoft.com>
-Origin: Email from Alex Ng
+Signed-off-by: K. Y. Srinivasan <kys@microsoft.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit a1656454131880980bc3a5313c8bf66ef5990c91)
 ---
- drivers/hv/channel_mgmt.c | 78 ++++++++++++++++++++++++++-------------
+ drivers/hv/channel_mgmt.c | 80 +++++++++++++++++++++++++++-------------
  drivers/hv/hv_fcopy.c     | 20 +++++++---
  drivers/hv/hv_kvp.c       | 41 +++++++++------------
  drivers/hv/hv_snapshot.c  | 18 +++++++--
  drivers/hv/hv_util.c      | 94 +++++++++++++++++++++++++----------------------
  include/linux/hyperv.h    |  7 ++--
- 6 files changed, 152 insertions(+), 106 deletions(-)
+ 6 files changed, 154 insertions(+), 106 deletions(-)
 
 diff --git a/drivers/hv/channel_mgmt.c b/drivers/hv/channel_mgmt.c
-index 8f3d9f787288..253e17c78c58 100644
+index 8f3d9f787288..672a8859a3e9 100644
 --- a/drivers/hv/channel_mgmt.c
 +++ b/drivers/hv/channel_mgmt.c
 @@ -179,33 +179,34 @@ static u16 hv_get_dev_type(const struct vmbus_channel *channel)
@@ -111,7 +113,7 @@ index 8f3d9f787288..253e17c78c58 100644
  	}
  
  	if (!found_match)
-@@ -235,14 +245,24 @@ bool vmbus_prep_negotiate_resp(struct icmsg_hdr *icmsghdrp,
+@@ -235,14 +245,26 @@ bool vmbus_prep_negotiate_resp(struct icmsg_hdr *icmsghdrp,
  
  	found_match = false;
  
@@ -129,8 +131,10 @@ index 8f3d9f787288..253e17c78c58 100644
 +		for (j = negop->icframe_vercnt;
 +			(j < negop->icframe_vercnt + negop->icmsg_vercnt);
 +			j++) {
++
 +			if ((negop->icversion_data[j].major == srv_major) &&
-+			    (negop->icversion_data[j].minor == srv_minor)) {
++				(negop->icversion_data[j].minor == srv_minor)) {
++
 +				icmsg_major = negop->icversion_data[j].major;
 +				icmsg_minor = negop->icversion_data[j].minor;
 +				found_match = true;
@@ -143,7 +147,7 @@ index 8f3d9f787288..253e17c78c58 100644
  	}
  
  	/*
-@@ -259,6 +279,12 @@ bool vmbus_prep_negotiate_resp(struct icmsg_hdr *icmsghdrp,
+@@ -259,6 +281,12 @@ bool vmbus_prep_negotiate_resp(struct icmsg_hdr *icmsghdrp,
  		negop->icmsg_vercnt = 1;
  	}
  
@@ -465,7 +469,7 @@ index e7707747f56d..f3797c07be10 100644
  			srv->util_cb, dev->channel);
  	if (ret)
 diff --git a/include/linux/hyperv.h b/include/linux/hyperv.h
-index e34da6846348..032322e4a73e 100644
+index e34da6846348..6c3ed0c001ff 100644
 --- a/include/linux/hyperv.h
 +++ b/include/linux/hyperv.h
 @@ -1452,9 +1452,10 @@ struct hyperv_service_callback {
@@ -475,10 +479,10 @@ index e34da6846348..032322e4a73e 100644
 -extern bool vmbus_prep_negotiate_resp(struct icmsg_hdr *,
 -					struct icmsg_negotiate *, u8 *, int,
 -					int);
-+extern bool vmbus_prep_negotiate_resp(struct icmsg_hdr *, u8 *,
-+					const int *, int,
-+					const int *, int,
-+					int *, int *);
++extern bool vmbus_prep_negotiate_resp(struct icmsg_hdr *icmsghdrp, u8 *buf,
++				const int *fw_version, int fw_vercnt,
++				const int *srv_version, int srv_vercnt,
++				int *nego_fw_version, int *nego_srv_version);
  
  void hv_event_tasklet_disable(struct vmbus_channel *channel);
  void hv_event_tasklet_enable(struct vmbus_channel *channel);

--- a/kernel/patches-4.9/0012-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9/0012-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,0 +1,117 @@
+From 0c2c1129f54f01a7889f4e114cace61ec2c833e7 Mon Sep 17 00:00:00 2001
+From: Alex Ng <alexng@messages.microsoft.com>
+Date: Sat, 28 Jan 2017 12:37:18 -0700
+Subject: [PATCH 12/12] Drivers: hv: Log the negotiated IC versions.
+
+Log the negotiated IC versions.
+
+Signed-off-by: Alex Ng <alexng@messages.microsoft.com>
+Signed-off-by: K. Y. Srinivasan <kys@microsoft.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+(cherry picked from commit 1274a690f6b2bd2b37447c47e3062afa8aa43f93)
+---
+ drivers/hv/hv_fcopy.c    |  9 +++++++--
+ drivers/hv/hv_kvp.c      |  8 ++++++--
+ drivers/hv/hv_snapshot.c | 11 ++++++++---
+ drivers/hv/hv_util.c     |  4 ++--
+ 4 files changed, 23 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/hv/hv_fcopy.c b/drivers/hv/hv_fcopy.c
+index 3e3a633cab58..a5596a642ed0 100644
+--- a/drivers/hv/hv_fcopy.c
++++ b/drivers/hv/hv_fcopy.c
+@@ -250,10 +250,15 @@ void hv_fcopy_onchannelcallback(void *context)
+ 	icmsghdr = (struct icmsg_hdr *)&recv_buffer[
+ 			sizeof(struct vmbuspipe_hdr)];
+ 	if (icmsghdr->icmsgtype == ICMSGTYPE_NEGOTIATE) {
+-		vmbus_prep_negotiate_resp(icmsghdr, recv_buffer,
++		if (vmbus_prep_negotiate_resp(icmsghdr, recv_buffer,
+ 				fw_versions, FW_VER_COUNT,
+ 				fcopy_versions, FCOPY_VER_COUNT,
+-				NULL, &fcopy_srv_version);
++				NULL, &fcopy_srv_version)) {
++
++			pr_info("FCopy IC version %d.%d\n",
++				fcopy_srv_version >> 16,
++				fcopy_srv_version & 0xFFFF);
++		}
+ 	} else {
+ 		fcopy_msg = (struct hv_fcopy_hdr *)&recv_buffer[
+ 				sizeof(struct vmbuspipe_hdr) +
+diff --git a/drivers/hv/hv_kvp.c b/drivers/hv/hv_kvp.c
+index 70c28b8806de..a1adfe2cfb34 100644
+--- a/drivers/hv/hv_kvp.c
++++ b/drivers/hv/hv_kvp.c
+@@ -650,10 +650,14 @@ void hv_kvp_onchannelcallback(void *context)
+ 			sizeof(struct vmbuspipe_hdr)];
+ 
+ 		if (icmsghdrp->icmsgtype == ICMSGTYPE_NEGOTIATE) {
+-			vmbus_prep_negotiate_resp(icmsghdrp,
++			if (vmbus_prep_negotiate_resp(icmsghdrp,
+ 				 recv_buffer, fw_versions, FW_VER_COUNT,
+ 				 kvp_versions, KVP_VER_COUNT,
+-				 NULL, &kvp_srv_version);
++				 NULL, &kvp_srv_version)) {
++				pr_info("KVP IC version %d.%d\n",
++					kvp_srv_version >> 16,
++					kvp_srv_version & 0xFFFF);
++			}
+ 		} else {
+ 			kvp_msg = (struct hv_kvp_msg *)&recv_buffer[
+ 				sizeof(struct vmbuspipe_hdr) +
+diff --git a/drivers/hv/hv_snapshot.c b/drivers/hv/hv_snapshot.c
+index 8e62bf7f6265..e659d1b94a57 100644
+--- a/drivers/hv/hv_snapshot.c
++++ b/drivers/hv/hv_snapshot.c
+@@ -303,7 +303,7 @@ void hv_vss_onchannelcallback(void *context)
+ 	u32 recvlen;
+ 	u64 requestid;
+ 	struct hv_vss_msg *vss_msg;
+-
++	int vss_srv_version;
+ 
+ 	struct icmsg_hdr *icmsghdrp;
+ 
+@@ -318,10 +318,15 @@ void hv_vss_onchannelcallback(void *context)
+ 			sizeof(struct vmbuspipe_hdr)];
+ 
+ 		if (icmsghdrp->icmsgtype == ICMSGTYPE_NEGOTIATE) {
+-			vmbus_prep_negotiate_resp(icmsghdrp,
++			if (vmbus_prep_negotiate_resp(icmsghdrp,
+ 				 recv_buffer, fw_versions, FW_VER_COUNT,
+ 				 vss_versions, VSS_VER_COUNT,
+-				 NULL, NULL);
++				 NULL, &vss_srv_version)) {
++
++				pr_info("VSS IC version %d.%d\n",
++					vss_srv_version >> 16,
++					vss_srv_version & 0xFFFF);
++			}
+ 		} else {
+ 			vss_msg = (struct hv_vss_msg *)&recv_buffer[
+ 				sizeof(struct vmbuspipe_hdr) +
+diff --git a/drivers/hv/hv_util.c b/drivers/hv/hv_util.c
+index f3797c07be10..89440c2eb346 100644
+--- a/drivers/hv/hv_util.c
++++ b/drivers/hv/hv_util.c
+@@ -294,7 +294,7 @@ static void timesync_onchannelcallback(void *context)
+ 						fw_versions, FW_VER_COUNT,
+ 						ts_versions, TS_VER_COUNT,
+ 						NULL, &ts_srv_version)) {
+-				pr_info("TimeSync version %d.%d\n",
++				pr_info("TimeSync IC version %d.%d\n",
+ 					ts_srv_version >> 16,
+ 					ts_srv_version & 0xFFFF);
+ 			}
+@@ -360,7 +360,7 @@ static void heartbeat_onchannelcallback(void *context)
+ 					hb_versions, HB_VER_COUNT,
+ 					NULL, &hb_srv_version)) {
+ 
+-				pr_info("Heartbeat version %d.%d\n",
++				pr_info("Heartbeat IC version %d.%d\n",
+ 					hb_srv_version >> 16,
+ 					hb_srv_version & 0xFFFF);
+ 			}
+-- 
+2.11.0
+


### PR DESCRIPTION
Regenerate the kernel patches from
https://github.com/rneugeba/linux-stable/

Note, the last two 4.9 patches are no properly
cherry-picked from linux-next. We previously had
0011-Drivers-hv-vmbus-Use-all... from an email.
0012-Drivers-hv-Log-the... is new, but may further aid
debugging version mismatch issues.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>