### PR TITLE
Bump Azure digest and version for 1.13.1

### DIFF
--- a/alpine/packages/azure/etc/init.d/azure
+++ b/alpine/packages/azure/etc/init.d/azure
@@ -34,8 +34,8 @@ start()
 
 	einfo "Running Windows Azure Linux Agent container"
 
-	export DOCKER_FOR_IAAS_VERSION="azure-v1.13.0-rc5-beta15"
-	export DOCKER_FOR_IAAS_VERSION_DIGEST="85c28edf90026ae6713c435fa40c36a1710e963a6478a7cdeac3da944f6c13ad"
+	export DOCKER_FOR_IAAS_VERSION="azure-v1.13.1-ga-2"
+	export DOCKER_FOR_IAAS_VERSION_DIGEST="badffbf8fff6fb1bdf05ec485b52ae15d80f6e23c6b3ba0e89abd80fb932bd84"
 
 	# "Fake" /etc/hostname setup for persistence across reboots
 	#


### PR DESCRIPTION
I guess I'll cherry-pick this to `1.13.x` after? Making these changes in two places every time is going to get old fast...

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>