### PR TITLE
Update kernel to 4.9.9, 4.4.48

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -1,6 +1,6 @@
 FROM mobylinux/alpine-build-c:b77cfc4ad0033d4366df830ed697afc7bab458a2@sha256:53739ea6042cb0ac39cf6e262012c1c4224206b2c9b719569fe7efa3a381348c
 
-ARG KERNEL_VERSION=4.9.8
+ARG KERNEL_VERSION=4.9.9
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 

--- a/kernel/Dockerfile.4.4
+++ b/kernel/Dockerfile.4.4
@@ -1,6 +1,6 @@
 FROM mobylinux/alpine-build-c:b77cfc4ad0033d4366df830ed697afc7bab458a2@sha256:53739ea6042cb0ac39cf6e262012c1c4224206b2c9b719569fe7efa3a381348c
 
-ARG KERNEL_VERSION=4.4.47
+ARG KERNEL_VERSION=4.4.48
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 

--- a/kernel/Dockerfile.aufs
+++ b/kernel/Dockerfile.aufs
@@ -1,6 +1,6 @@
 FROM mobylinux/alpine-build-c:b77cfc4ad0033d4366df830ed697afc7bab458a2@sha256:53739ea6042cb0ac39cf6e262012c1c4224206b2c9b719569fe7efa3a381348c
 
-ARG KERNEL_VERSION=4.9.8
+ARG KERNEL_VERSION=4.9.9
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 


### PR DESCRIPTION
Security update, severity low.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>