### PR TITLE
[1.13] Update kernel to 4.9.9

### DIFF
--- a/alpine/kernel/Dockerfile
+++ b/alpine/kernel/Dockerfile
@@ -1,7 +1,7 @@
 # Tag: 3da0b0ea0da2724232603094e67c75b41adab551
 FROM mobylinux/alpine-build-c@sha256:0236d6599f6c8f7aa42829285e04202fbe99984df2818af0f5a453a59de8b090
 
-ARG KERNEL_VERSION=4.9.8
+ARG KERNEL_VERSION=4.9.9
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 

--- a/alpine/kernel/Dockerfile.aufs
+++ b/alpine/kernel/Dockerfile.aufs
@@ -1,7 +1,7 @@
 # Tag: 3da0b0ea0da2724232603094e67c75b41adab551
 FROM mobylinux/alpine-build-c@sha256:0236d6599f6c8f7aa42829285e04202fbe99984df2818af0f5a453a59de8b090
 
-ARG KERNEL_VERSION=4.9.8
+ARG KERNEL_VERSION=4.9.9
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 


### PR DESCRIPTION
Security fix, severity low.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>