### PR TITLE
alpine-build-c is only used for kernel builds so rename

### DIFF
--- a/base/alpine-build-kernel/Dockerfile
+++ b/base/alpine-build-kernel/Dockerfile
@@ -2,33 +2,23 @@ FROM alpine:3.5
 RUN \
   apk update && apk upgrade && \
   apk add \
-  alpine-sdk \
+  build-base \
   argp-standalone \
   automake \
   bash \
   bc \
   binutils-dev \
-  bison \
-  cmake \
   curl \
-  flex \
+  git \
   gmp-dev \
-  gtk+2.0-dev \
-  gtk+-dev \
-  groff \
   installkernel \
   kmod \
   libelf-dev \
   linux-headers \
   ncurses-dev \
-  perl-dev \
-  python-dev \
   sed \
-  slang-dev \
   squashfs-tools \
   syslinux \
-  unzip \
-  util-linux-dev \
-  vim \
+  tar \
   xz \
   && true

--- a/base/alpine-build-kernel/Makefile
+++ b/base/alpine-build-kernel/Makefile
@@ -1,7 +1,7 @@
 .PHONY: tag push
 
 BASE=alpine:3.5
-IMAGE=alpine-build-c
+IMAGE=alpine-build-kernel
 
 default: push
 

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-build-c:b77cfc4ad0033d4366df830ed697afc7bab458a2@sha256:53739ea6042cb0ac39cf6e262012c1c4224206b2c9b719569fe7efa3a381348c
+FROM mobylinux/alpine-build-kernel:0e893fbf6fa7638d2f23354de03ea11017bb8065@sha256:3ef3f9d11f0802b759dbd9c43a7706cf0ec37263c99ae90e2b10c29ea85739fa
 
 ARG KERNEL_VERSION=4.9.9
 

--- a/kernel/Dockerfile.4.4
+++ b/kernel/Dockerfile.4.4
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-build-c:b77cfc4ad0033d4366df830ed697afc7bab458a2@sha256:53739ea6042cb0ac39cf6e262012c1c4224206b2c9b719569fe7efa3a381348c
+FROM mobylinux/alpine-build-kernel:0e893fbf6fa7638d2f23354de03ea11017bb8065@sha256:3ef3f9d11f0802b759dbd9c43a7706cf0ec37263c99ae90e2b10c29ea85739fa
 
 ARG KERNEL_VERSION=4.4.48
 

--- a/kernel/Dockerfile.aufs
+++ b/kernel/Dockerfile.aufs
@@ -1,4 +1,4 @@
-FROM mobylinux/alpine-build-c:b77cfc4ad0033d4366df830ed697afc7bab458a2@sha256:53739ea6042cb0ac39cf6e262012c1c4224206b2c9b719569fe7efa3a381348c
+FROM mobylinux/alpine-build-kernel:0e893fbf6fa7638d2f23354de03ea11017bb8065@sha256:3ef3f9d11f0802b759dbd9c43a7706cf0ec37263c99ae90e2b10c29ea85739fa
 
 ARG KERNEL_VERSION=4.9.9
 


### PR DESCRIPTION
Also remove some unecessary packages.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>