### PR TITLE
Update Linux 4.4 to 4.4.49

### DIFF
--- a/kernel/Dockerfile.4.4
+++ b/kernel/Dockerfile.4.4
@@ -1,6 +1,6 @@
 FROM mobylinux/alpine-build-kernel:0e893fbf6fa7638d2f23354de03ea11017bb8065@sha256:3ef3f9d11f0802b759dbd9c43a7706cf0ec37263c99ae90e2b10c29ea85739fa
 
-ARG KERNEL_VERSION=4.4.48
+ARG KERNEL_VERSION=4.4.49
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 


### PR DESCRIPTION
Security update, low importance.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>