### PR TITLE
Update kernel config tests

### DIFF
--- a/alpine/test/Makefile
+++ b/alpine/test/Makefile
@@ -2,7 +2,7 @@ default: test.img
 
 RIDDLER=mobylinux/riddler:893c93bf54bc037f6952886330d5ba58746ace37@sha256:3d4a61555110be4b6e8ff6bcdcf5f8aa24d64564eb4162ea4e580d8916d083cc
 
-TEST_IMAGE=mobylinux/test:1a8c5de8ebfa27962f7623846e8538babdf48e76@sha256:7dada68bcb76e897a7a7aa2a28b6b1808b04e8eda7319e1da97bd1cff9952fee
+TEST_IMAGE=mobylinux/test:725422886c3ea8fca2e0f4a8df5c6442cb1e937b@sha256:a077b8f84a51a4f4271b62adaa44985a4feff3d0a82b0d5fa8a46b45378428bc
 
 container.tar:
 	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock $(RIDDLER) \

--- a/base/test/bin/test.sh
+++ b/base/test/bin/test.sh
@@ -11,5 +11,5 @@ docker pull armhf/alpine
 docker run --rm armhf/alpine uname -a
 docker swarm init
 docker run mobylinux/check-config:dc29b05bb5cca871f83421e4c4aaa8f5d3c682f4@sha256:5dcdf0e3386ed506a28a59191eaa1ea48261e15199fcbbe8caf8dc1889405b2d
-docker run mobylinux/check-kernel-config:b7616e925bc58ce9f9cc2b60009a95084ef4ca4a@sha256:0799d81892e65743ea606b4151ae3d13b29b70c0ac6f1636e67d3e8b79541150
+docker run mobylinux/check-kernel-config:3d64e3ddd9315bdc1e82ea652ea27c8b149be5d3@sha256:450c641e045b346e11f3e892d31d0bd9a94874e0129be4715d3741f252439140
 cat /etc/moby

--- a/tools/check-kernel-config/check-kernel-config.sh
+++ b/tools/check-kernel-config/check-kernel-config.sh
@@ -20,7 +20,6 @@ cat unzipped_config | grep CONFIG_DEBUG_RODATA=y
 cat unzipped_config | grep CONFIG_CC_STACKPROTECTOR=y
 cat unzipped_config | grep CONFIG_CC_STACKPROTECTOR_STRONG=y
 cat unzipped_config | grep CONFIG_STRICT_DEVMEM=y
-cat unzipped_config | grep CONFIG_IO_STRICT_DEVMEM=y
 cat unzipped_config | grep CONFIG_SYN_COOKIES=y
 cat unzipped_config | grep CONFIG_DEBUG_CREDENTIALS=y
 cat unzipped_config | grep CONFIG_DEBUG_NOTIFIERS=y
@@ -31,15 +30,9 @@ cat unzipped_config | grep CONFIG_SECURITY=y
 cat unzipped_config | grep CONFIG_SECURITY_YAMA=y
 cat unzipped_config | grep CONFIG_PANIC_ON_OOPS=y
 cat unzipped_config | grep CONFIG_DEBUG_SET_MODULE_RONX=y
-cat unzipped_config | grep CONFIG_HARDENED_USERCOPY=y
 cat unzipped_config | grep CONFIG_SYN_COOKIES=y
-cat unzipped_config | grep CONFIG_PAGE_POISONING=y
-cat unzipped_config | grep CONFIG_PAGE_POISONING_NO_SANITY=y
-cat unzipped_config | grep CONFIG_PAGE_POISONING_ZERO=y
 cat unzipped_config | grep CONFIG_LEGACY_VSYSCALL_NONE=y
-cat unzipped_config | grep CONFIG_BUG_ON_DATA_CORRUPTION=y
 cat unzipped_config | grep CONFIG_RANDOMIZE_BASE=y
-cat unzipped_config | grep CONFIG_RANDOMIZE_MEMORY=y
 
 # Conditional on kernel version
 if [ "$kernelMajor" -ge 4 -a "$kernelMinor" -ge 5 ]; then
@@ -51,6 +44,18 @@ if [ "$kernelMajor" -ge 4 -a "$kernelMinor" -ge 7 ]; then
 fi
 if [ "$kernelMajor" -ge 4 -a "$kernelMinor" -ge 8 ]; then
   cat unzipped_config | grep CONFIG_HARDENED_USERCOPY=y
+  cat unzipped_config | grep CONFIG_RANDOMIZE_MEMORY=y
+fi
+
+# poisoning cannot be enabled in 4.4
+if [ "$kernelMajor" -ge 4 -a "$kernelMinor" -ge 9 ]; then
+  cat unzipped_config | grep CONFIG_PAGE_POISONING=y
+  cat unzipped_config | grep CONFIG_PAGE_POISONING_NO_SANITY=y
+  cat unzipped_config | grep CONFIG_PAGE_POISONING_ZERO=y
+fi
+
+if [ "$kernelMajor" -ge 4 -a "$kernelMinor" -ge 10 ]; then
+  cat unzipped_config | grep CONFIG_BUG_ON_DATA_CORRUPTION=y
 fi
 
 # Negative cases


### PR DESCRIPTION
- `CONFIG_BUG_ON_DATA_CORRUPTION` is a 4.10 kernel only flag, so gate this.
- `CONFIG_IO_STRICT_DEVMEM` was duplicated on gated and normal config

Signed-off-by: Justin Cormack <justin.cormack@docker.com>