### PR TITLE
[1.13] Revert "sched/cpuacct: Show all possible CPUs in cpuacct output" in 4.9 kernel

### DIFF
--- a/alpine/kernel/patches-4.9/0001-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/alpine/kernel/patches-4.9/0001-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,7 +1,7 @@
 From 3d6fce5663241a06b78e10c2b5ae298abd7a72ba Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
-Subject: [PATCH 1/8] VSOCK: Only allow host network namespace to use AF_VSOCK.
+Subject: [PATCH 1/9] VSOCK: Only allow host network namespace to use AF_VSOCK.
 
 The VSOCK addressing schema does not really lend itself to simply creating an
 alternative end point address within a namespace.

--- a/alpine/kernel/patches-4.9/0002-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/alpine/kernel/patches-4.9/0002-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,7 +1,7 @@
 From c76fa3c421e8d424cab8a048f186fe61e0415f82 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
-Subject: [PATCH 2/8] hv_sock: introduce Hyper-V Sockets
+Subject: [PATCH 2/9] hv_sock: introduce Hyper-V Sockets
 
 Hyper-V Sockets (hv_sock) supplies a byte-stream based communication
 mechanism between the host and the guest. It's somewhat like TCP over

--- a/alpine/kernel/patches-4.9/0003-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/alpine/kernel/patches-4.9/0003-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,7 +1,7 @@
 From 7ffe2cc44e33996ad39c2cdbf37f958691489e81 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
-Subject: [PATCH 3/8] vmbus: Don't spam the logs with unknown GUIDs
+Subject: [PATCH 3/9] vmbus: Don't spam the logs with unknown GUIDs
 
 With Hyper-V sockets device types are introduced on the fly. The pr_info()
 then prints a message on every connection, which is way too verbose.  Since

--- a/alpine/kernel/patches-4.9/0004-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/alpine/kernel/patches-4.9/0004-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,7 +1,7 @@
 From 3bc5a0bf749b3d7758c2dec93f5044480b506e5a Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
-Subject: [PATCH 4/8] Drivers: hv: utils: Fix the mapping between host version
+Subject: [PATCH 4/9] Drivers: hv: utils: Fix the mapping between host version
  and protocol to use
 
 We should intentionally declare the protocols to use for every known host

--- a/alpine/kernel/patches-4.9/0005-Drivers-hv-vss-Improve-log-messages.patch
+++ b/alpine/kernel/patches-4.9/0005-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,7 +1,7 @@
 From e351f71f036780c5764b81874b417da5b361473b Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
-Subject: [PATCH 5/8] Drivers: hv: vss: Improve log messages.
+Subject: [PATCH 5/9] Drivers: hv: vss: Improve log messages.
 
 Adding log messages to help troubleshoot error cases and transaction
 handling.

--- a/alpine/kernel/patches-4.9/0006-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/alpine/kernel/patches-4.9/0006-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,7 +1,7 @@
 From adb4437c3ee5973a5f84864cdfb06c00b3b3c651 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
-Subject: [PATCH 6/8] Drivers: hv: vss: Operation timeouts should match host
+Subject: [PATCH 6/9] Drivers: hv: vss: Operation timeouts should match host
  expectation
 
 Increase the timeout of backup operations. When system is under I/O load,

--- a/alpine/kernel/patches-4.9/0007-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/alpine/kernel/patches-4.9/0007-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,7 +1,7 @@
 From 3ffbfea0d7cf206fec3fbd2a090778d882ddcf83 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
-Subject: [PATCH 7/8] Drivers: hv: vmbus: Use all supported IC versions to
+Subject: [PATCH 7/9] Drivers: hv: vmbus: Use all supported IC versions to
  negotiate
 
 Previously, we were assuming that each IC protocol version was tied to a

--- a/alpine/kernel/patches-4.9/0008-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/alpine/kernel/patches-4.9/0008-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,7 +1,7 @@
 From 2b6c873e6f7bde90f4d60dac6b4d933c4ed2610d Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
-Subject: [PATCH 8/8] Drivers: hv: Log the negotiated IC versions.
+Subject: [PATCH 8/9] Drivers: hv: Log the negotiated IC versions.
 
 Log the negotiated IC versions.
 

--- a/kernel/patches-4.9/0009-Revert-sched-cpuacct-Show-all-possible-CPUs-in-cpuac.patch
+++ b/kernel/patches-4.9/0009-Revert-sched-cpuacct-Show-all-possible-CPUs-in-cpuac.patch
@@ -1,0 +1,65 @@
+From e7db8e1ad4a35b5048b803511c1425940cb7002b Mon Sep 17 00:00:00 2001
+From: Ian Campbell <ian.campbell@docker.com>
+Date: Fri, 17 Feb 2017 11:45:31 +0000
+Subject: [PATCH 9/9] Revert "sched/cpuacct: Show all possible CPUs in cpuacct
+ output"
+
+This reverts commit 5ca3726af7f66a8cc71ce4414cfeb86deb784491.
+
+Signed-off-by: Ian Campbell <ian.campbell@docker.com>
+---
+ kernel/sched/cpuacct.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/sched/cpuacct.c b/kernel/sched/cpuacct.c
+index bc0b309c3f19..64d2115f3564 100644
+--- a/kernel/sched/cpuacct.c
++++ b/kernel/sched/cpuacct.c
+@@ -169,7 +169,7 @@ static u64 __cpuusage_read(struct cgroup_subsys_state *css,
+ 	u64 totalcpuusage = 0;
+ 	int i;
+ 
+-	for_each_possible_cpu(i)
++	for_each_present_cpu(i)
+ 		totalcpuusage += cpuacct_cpuusage_read(ca, i, index);
+ 
+ 	return totalcpuusage;
+@@ -204,7 +204,7 @@ static int cpuusage_write(struct cgroup_subsys_state *css, struct cftype *cft,
+ 	if (val)
+ 		return -EINVAL;
+ 
+-	for_each_possible_cpu(cpu)
++	for_each_present_cpu(cpu)
+ 		cpuacct_cpuusage_write(ca, cpu, 0);
+ 
+ 	return 0;
+@@ -217,7 +217,7 @@ static int __cpuacct_percpu_seq_show(struct seq_file *m,
+ 	u64 percpu;
+ 	int i;
+ 
+-	for_each_possible_cpu(i) {
++	for_each_present_cpu(i) {
+ 		percpu = cpuacct_cpuusage_read(ca, i, index);
+ 		seq_printf(m, "%llu ", (unsigned long long) percpu);
+ 	}
+@@ -251,7 +251,7 @@ static int cpuacct_all_seq_show(struct seq_file *m, void *V)
+ 		seq_printf(m, " %s", cpuacct_stat_desc[index]);
+ 	seq_puts(m, "\n");
+ 
+-	for_each_possible_cpu(cpu) {
++	for_each_online_cpu(cpu) {
+ 		struct cpuacct_usage *cpuusage = per_cpu_ptr(ca->cpuusage, cpu);
+ 
+ 		seq_printf(m, "%d", cpu);
+@@ -284,7 +284,7 @@ static int cpuacct_stats_show(struct seq_file *sf, void *v)
+ 	int stat;
+ 
+ 	memset(val, 0, sizeof(val));
+-	for_each_possible_cpu(cpu) {
++	for_each_online_cpu(cpu) {
+ 		u64 *cpustat = per_cpu_ptr(ca->cpustat, cpu)->cpustat;
+ 
+ 		val[CPUACCT_STAT_USER]   += cpustat[CPUTIME_USER];
+-- 
+2.11.0
+


### PR DESCRIPTION
This change (5ca3726 added in v4.7-rc1) exposed issues described in
https://github.com/docker/docker/issues/28941, since we don't support CPU
hotplug anyway revert the change while we decide on a proper fix.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>