### PR TITLE
Change kernel upload for new tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ ifeq ($(STATUS),)
 	[ -f $(MOBYLINUX_TAG) ]
 	docker tag $(shell cat $(MOBYLINUX_TAG)) $(INITRD_IMAGE)
 	docker push $(INITRD_IMAGE)
-	tar cf - Dockerfile.media -C kernel/x86_64 vmlinuz64 | docker build -f Dockerfile.media -t $(KERNEL_IMAGE) -
+	tar cf - Dockerfile.media -C kernel/x86_64 bzImage kernel.tar | docker build -f Dockerfile.media -t $(KERNEL_IMAGE) -
 	docker push $(KERNEL_IMAGE)
 else
 	$(error "git not clean")

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -2,11 +2,13 @@ DEBUG ?= 0
 
 TAR2INITRD_IMAGE=mobylinux/tar2initrd:d5711601eb5b89de0f052d87365e18388ff3f1b5@sha256:58d377e65845f91400e173ce9fca93462f2f237947eef2b0d2c17bb4f2da5ee8
 
-all:	x86_64/vmlinuz64
+all:	x86_64/vmlinuz64 x86_64/kernel.img
 
-x86_64/kernel.img:
-	tar cf - etc lib usr sbin | \
-		docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(TAR2INITRD_IMAGE) > $@
+x86_64/kernel.tar: x86_64/bzImage
+	tar cf - etc lib usr sbin > $@
+
+x86_64/kernel.img: x86_64/kernel.tar x86_64/vmlinuz64
+	cat $< | docker run --rm --read-only --net=none --log-driver=none --tmpfs /tmp -i $(TAR2INITRD_IMAGE) > $@
 
 ifdef AUFS
 kernel.tag: Dockerfile.aufs kernel_config kernel_config.debug kernel_config.aufs patches-4.9
@@ -19,15 +21,16 @@ endif
 endif
 	BUILD=$$( tar cf - $^ | docker build -f $< --build-arg DEBUG=$(DEBUG) -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && echo "$$BUILD" > $@
 
-x86_64/vmlinuz64: kernel.tag
+x86_64/vmlinuz64: x86_64/bzImage
+	cp -a $< $@
+
+x86_64/bzImage: kernel.tag
 	rm -rf etc/kernel-patches
 	mkdir -p x86_64 etc lib usr sbin etc/kernel-patches
 	docker run --rm --net=none --log-driver=none $(shell cat kernel.tag) cat kernel-source-info > etc/kernel-source-info
 	docker run --rm --net=none --log-driver=none $(shell cat kernel.tag) tar cf - bzImage kernel-dev.tar kernel-headers.tar vmlinux kernel-modules.tar | tar xf - -C x86_64
 	docker run --rm --net=none --log-driver=none $(shell cat kernel.tag) tar cf - -C patches . | tar xf - -C etc/kernel-patches
-	mv x86_64/bzImage $@
 	tar xf x86_64/kernel-modules.tar
-	$(MAKE) x86_64/kernel.img
 
 clean:
 	rm -rf x86_64 lib etc usr sbin kernel.tag


### PR DESCRIPTION
The mobylinux/kernel image now has the bzImage (no longer named vmlinuz64)
and a tarball of the files needed for the initrd, ie modules etc.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

Currently this is our image for scanning, but making it the image for the new tool for now too.