### PR TITLE
Add a CI tag Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,12 @@ test: alpine/initrd-test.img kernel/x86_64/vmlinuz64
 	tar cf - $^ | docker run --rm -i $(QEMU_IMAGE) 2>&1 | tee test.log
 	$(call check_test_log, test.log)
 
+ifeq ($(CI_TAG),)
 TAG=$(shell git rev-parse HEAD)
+else
+TAG=$(CI_TAG)
+endif
+
 STATUS=$(shell git status -s)
 MOBYLINUX_TAG=alpine/mobylinux.tag
 ifdef AUFS
@@ -85,6 +90,7 @@ endif
 ifdef LTS4.4
 AUFS_PREFIX=lts4.4-
 endif
+
 MEDIA_IMAGE=mobylinux/media:$(MEDIA_PREFIX)$(AUFS_PREFIX)$(TAG)
 INITRD_IMAGE=mobylinux/mobylinux:$(MEDIA_PREFIX)$(AUFS_PREFIX)$(TAG)
 KERNEL_IMAGE=mobylinux/kernel:$(MEDIA_PREFIX)$(AUFS_PREFIX)$(TAG)
@@ -149,6 +155,12 @@ else
 endif
 
 ci:
+	$(MAKE) clean
+	$(MAKE) all
+	$(MAKE) test
+	$(MAKE) media
+
+ci-tag:
 	$(MAKE) clean
 	$(MAKE) all
 	$(MAKE) test


### PR DESCRIPTION
The CI will set `CI_TAG` to the tag name, which will be used for the
uploaded images instead of the git commit ID.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>