### PR TITLE
Allow docker engine to be pulled from s3 bucket

### DIFF
--- a/alpine/packages/docker/Makefile
+++ b/alpine/packages/docker/Makefile
@@ -3,6 +3,8 @@ FORCE_CURL?=1
 ARCH?=x86_64
 OS?=Linux
 
+AWS_CLI_IMAGE=mobylinux/aws-cli:9432b650794d38a70cf00be4da971367c52d1d5b@sha256:679f6f45fb8598cab90888733a07ddeeb26a27a7889114f89aaf712eaa3abe06
+
 all: usr/bin/docker
 
 RELEASE_CANDIDATE=$(findstring -rc,$(DOCKER_VERSION))
@@ -37,9 +39,15 @@ cleanusr:
 	mkdir -p usr/bin
 	rm -f usr/bin/* ok
 
+S3_PREFIX=s3://
+
 download: cleanusr
 ifdef DOCKER_BIN_URL
+ifeq ($(filter $(S3_PREFIX)%, $(DOCKER_BIN_URL)),)
 	(curl -fsSL "${DOCKER_BIN_URL}" && touch ok) | tar xzf -
+else
+	(docker run --rm -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID $(AWS_CLI_IMAGE) s3 cp '$(DOCKER_BIN_URL)' -) | tar xzf -
+endif
 else
 	(curl -fsSL https://${DOCKER_HOST}/builds/${OS}/${ARCH}/docker-${DOCKER_VERSION}.tgz && touch ok) | tar xzf -
 endif

--- a/tools/aws-cli/Dockerfile
+++ b/tools/aws-cli/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.5
+
+RUN \
+	mkdir -p /aws && \
+	apk -Uuv add groff less python py-pip && \
+	pip install awscli && \
+	apk --purge -v del py-pip && \
+	rm /var/cache/apk/*
+
+WORKDIR /aws
+ENTRYPOINT ["aws"]

--- a/tools/aws-cli/Makefile
+++ b/tools/aws-cli/Makefile
@@ -1,0 +1,29 @@
+.PHONY: tag push
+
+BASE=alpine:3.5
+IMAGE=aws-cli
+
+default: push
+
+hash: Dockerfile
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c 'cat /Dockerfile /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:


### PR DESCRIPTION
Use aws cli to pull docker engine binaries from s3 bucket.  Conditional and
happens if DOCKER_BIN_URL begins with 's3://'

Example usage:
```
  export AWS_ACCESS_KEY_ID=key
  export AWS_SECRET_ACCESS_KEY=secret
  make DOCKER_BIN_URL=s3://path-to-engine-binaries
```
Signed-off-by: Robb Kistler <robb.kistler@docker.com>