### PR TITLE
Fix alpine/mobylinux-efi.iso target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ kernel/x86_64/vmlinuz64:
 alpine/mobylinux-bios.iso:
 	$(MAKE) -C alpine mobylinux-bios.iso
 
+alpine/mobylinux-efi.iso:
+	$(MAKE) -C alpine mobylinux-efi.iso
+
 alpine/gce.img.tar.gz:
 	$(MAKE) -C alpine gce.img.tar.gz
 


### PR DESCRIPTION
Was trying to compile WireGuard when I found that the `media` target didn't work because of broken links

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>