### PR TITLE
Update kernel to 4.9.13 and 4.4.52

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -1,6 +1,6 @@
 FROM mobylinux/alpine-build-kernel:0e893fbf6fa7638d2f23354de03ea11017bb8065@sha256:3ef3f9d11f0802b759dbd9c43a7706cf0ec37263c99ae90e2b10c29ea85739fa
 
-ARG KERNEL_VERSION=4.9.12
+ARG KERNEL_VERSION=4.9.13
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 

--- a/kernel/Dockerfile.4.4
+++ b/kernel/Dockerfile.4.4
@@ -1,6 +1,6 @@
 FROM mobylinux/alpine-build-kernel:0e893fbf6fa7638d2f23354de03ea11017bb8065@sha256:3ef3f9d11f0802b759dbd9c43a7706cf0ec37263c99ae90e2b10c29ea85739fa
 
-ARG KERNEL_VERSION=4.4.51
+ARG KERNEL_VERSION=4.4.52
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 

--- a/kernel/Dockerfile.aufs
+++ b/kernel/Dockerfile.aufs
@@ -1,6 +1,6 @@
 FROM mobylinux/alpine-build-kernel:0e893fbf6fa7638d2f23354de03ea11017bb8065@sha256:3ef3f9d11f0802b759dbd9c43a7706cf0ec37263c99ae90e2b10c29ea85739fa
 
-ARG KERNEL_VERSION=4.9.12
+ARG KERNEL_VERSION=4.9.13
 
 ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz
 


### PR DESCRIPTION
- security update, severity low

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
