### PR TITLE
If no hostname is set, use mac address to generate one.

### DIFF
--- a/base/init/etc/init.d/rcS
+++ b/base/init/etc/init.d/rcS
@@ -83,7 +83,16 @@ done
 mdev -s
 
 # set hostname
-[ -s /etc/hostname ] && hostname -F /etc/hostname
+if [ -s /etc/hostname ]
+then
+	hostname -F /etc/hostname
+fi
+
+if [ $(hostname) = "moby" -a -f /sys/class/net/eth0/address ]
+then
+	mac=$(cat /sys/class/net/eth0/address)
+	hostname moby-$(echo $mac | sed 's/://g')
+fi
 
 # set system clock from hwclock
 hwclock --hctosys --utc

--- a/moby/moby.yaml
+++ b/moby/moby.yaml
@@ -1,5 +1,5 @@
 kernel: "mobylinux/kernel:7fa748810d7866797fd807a5682d5cb3c9c98111"
-init: "mobylinux/init:1f283250ba0f8e2f7ac0a9d7543719dd1a3b761b"
+init: "mobylinux/init:ecc2f4a116aca240081754ca063151c52d3e697c"
 system:
   - name: binfmt
     image: "mobylinux/binfmt:a94e0587b702edaa95cc6f303464959d0eb2311c@sha256:432732b90cbe0498f5ca148d75b90bb1eabd8fbfe8c872df8b23906c225091b1"


### PR DESCRIPTION
Currently not working very well in hyperkit due to https://github.com/docker/vpnkit/issues/190

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

fix #342 