### PR TITLE
slirp binary renamed to vpnkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ bin:
 	mkdir -p $@
 
 DOCKER_HYPERKIT=/Applications/Docker.app/Contents/MacOS/com.docker.hyperkit
-DOCKER_SLIRP=/Applications/Docker.app/Contents/MacOS/com.docker.slirp
+DOCKER_VPNKIT=/Applications/Docker.app/Contents/MacOS/vpnkit
 
 bin/com.docker.hyperkit: | bin
 ifneq ("$(wildcard $(DOCKER_HYPERKIT))","")
@@ -56,12 +56,12 @@ else
 	chmod a+x $@
 endif
 
-bin/com.docker.slirp: | bin
-ifneq ("$(wildcard $(DOCKER_SLIRP))","")
-	ln -s $(DOCKER_SLIRP) $@
+bin/vpnkit: | bin
+ifneq ("$(wildcard $(DOCKER_VPNKIT))","")
+	ln -s $(DOCKER_VPNKIT) $@
 else
-	curl -fsSL https://circleci.com/api/v1/project/docker/vpnkit/latest/artifacts/0//Users/distiller/vpnkit/com.docker.slirp.tgz \
-		| tar xz --strip=2 -C $(dir $@) Contents/MacOS/com.docker.slirp
+	curl -fsSL https://circleci.com/api/v1/project/docker/vpnkit/latest/artifacts/0//Users/distiller/vpnkit/vpnkit.tgz \
+		| tar xz --strip=2 -C $(dir $@) Contents/MacOS/vpnkit
 	touch $@
 endif
 

--- a/scripts/hyperkit.sh
+++ b/scripts/hyperkit.sh
@@ -17,7 +17,7 @@ PCI_DEV="-s 0:0,hostbridge -s 31,lpc"
 RND="-s 5,virtio-rnd"
 LPC_DEV="-l com1,stdio"
 
-bin/com.docker.slirp --ethernet $SLIRP_SOCK &>/dev/null &
+bin/vpnkit --ethernet $SLIRP_SOCK &>/dev/null &
 trap "kill $!; rm $SLIRP_SOCK" EXIT
 
 bin/com.docker.hyperkit -A $MEM $SMP $PCI_DEV $LPC_DEV $NET $IMG_HDD $RND -u -f kexec,$KERNEL,$INITRD,"$CMDLINE"


### PR DESCRIPTION
Recently com.docker.slirp was renamed.

Please update Docker for Mac before using this script...

Signed-off-by: Justin Cormack <justin.cormack@docker.com>