### PR TITLE
Refactoring of Moby tool

### DIFF
--- a/moby/config.go
+++ b/moby/config.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Moby struct {
+	Kernel   string
+	Init     string
+	System   []MobyImage
+	Database []struct {
+		File  string
+		Value string
+	}
+}
+
+type MobyImage struct {
+	Name         string
+	Image        string
+	Capabilities []string
+	Binds        []string
+	OomScoreAdj  int64 `yaml:"oom_score_adj"`
+	Command      []string
+	NetworkMode  string `yaml:"network_mode"`
+}
+
+const riddler = "mobylinux/riddler:7d4545d8b8ac2700971a83f12a3446a76db28c14@sha256:11b7310df6482fc38aa52b419c2ef1065d7b9207c633d47554e13aa99f6c0b72"
+
+func NewConfig(config []byte) (*Moby, error) {
+	m := Moby{}
+
+	err := yaml.Unmarshal(config, &m)
+	if err != nil {
+		return &m, err
+	}
+
+	return &m, nil
+}
+
+func ConfigToRun(image *MobyImage) []string {
+	// riddler arguments
+	args := []string{"run", "--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", riddler, image.Image, "/containers/" + image.Name}
+	// docker arguments
+	args = append(args, "--cap-drop", "all")
+	for _, cap := range image.Capabilities {
+		if strings.ToUpper(cap)[0:4] == "CAP_" {
+			cap = cap[4:]
+		}
+		args = append(args, "--cap-add", cap)
+	}
+	if image.OomScoreAdj != 0 {
+		args = append(args, "--oom-score-adj", strconv.FormatInt(image.OomScoreAdj, 10))
+	}
+	if image.NetworkMode != "" {
+		args = append(args, "--net", image.NetworkMode)
+	}
+	for _, bind := range image.Binds {
+		args = append(args, "-v", bind)
+	}
+	// image
+	args = append(args, image.Image)
+	// command
+	args = append(args, image.Command...)
+
+	return args
+}

--- a/moby/moby.yaml
+++ b/moby/moby.yaml
@@ -3,18 +3,23 @@ init: "mobylinux/init:1f283250ba0f8e2f7ac0a9d7543719dd1a3b761b"
 system:
   - name: binfmt
     image: "mobylinux/binfmt:a94e0587b702edaa95cc6f303464959d0eb2311c@sha256:432732b90cbe0498f5ca148d75b90bb1eabd8fbfe8c872df8b23906c225091b1"
-    cap_drop:
-     - all
-    bind: /proc/sys/fs/binfmt_misc:/binfmt_misc
+    binds:
+     - /proc/sys/fs/binfmt_misc:/binfmt_misc
     command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
   - name: rngd
     image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"
-    cap_drop:
-     - all
-    cap_add:
-     - SYS_ADMIN
+    capabilities:
+     - CAP_SYS_ADMIN
     oom_score_adj: -800
     command: [/bin/tini, /usr/sbin/rngd, -f]
+  - name: nginx
+    image: "nginx"
+    capabilities:
+     - CAP_NET_BIND_SERVICE
+     - CAP_CHOWN
+     - CAP_SETUID
+     - CAP_SETGID
+    network_mode: host
 database:
   - file: etc/docker/daemon.json
     value: '{"debug": true}'


### PR DESCRIPTION
- split out config processing a bit
- just use `capabilities` not `cap-add` and `cap-drop`
- allow use of CAP_ prefix on capabilities, as this is what `runc` uses
- add nginx to example config
- fix bind mounts

Signed-off-by: Justin Cormack <justin.cormack@docker.com>