### PR TITLE
Default to non experimental mode

### DIFF
--- a/alpine/packages/docker/etc/init.d/docker
+++ b/alpine/packages/docker/etc/init.d/docker
@@ -80,12 +80,6 @@ start()
 	# Set Docker to debug debug if not specified in daemon.json
 	cat /etc/docker/daemon.json | jq -e 'has("debug")' > /dev/null || DOCKER_OPTS="${DOCKER_OPTS} --debug"
 
-	# Set experimental=true if not specified in daemon.json and on 1.13+
-	if dockerd --help | grep -q -- --experimental
-	then
-		cat /etc/docker/daemon.json | jq -e 'has("experimental")' > /dev/null || DOCKER_OPTS="${DOCKER_OPTS} --experimental"
-	fi
-
 	# On GCP, send logs to Google Cloud Logging
 	# Disabled because of https://github.com/docker/docker/issues/29344
 	# [ $(mobyplatform) = "gcp" ] && DOCKER_OPTS="${DOCKER_OPTS} --log-driver=gcplogs"


### PR DESCRIPTION
Editions should set experimental in `daemon.json` if they want to
have it set.

See #1076 and https://github.com/docker/pinata/issues/6424

Signed-off-by: Justin Cormack <justin.cormack@docker.com>