### PR TITLE
database-mac: clean up /mnt/db after use

### DIFF
--- a/alpine/packages/mobyconfig/etc/init.d/database-mac
+++ b/alpine/packages/mobyconfig/etc/init.d/database-mac
@@ -18,6 +18,7 @@ start() {
 	[ $? -ne 0 ] && rm -rf /Database && printf "Could not mount configuration database\n" 1>&2 && eend 1
 	cp -a /mnt/db/branch/master/ro/com.docker.driver.amd64-linux/* /Database
 	umount /mnt/db
+	rmdir /mnt/db
 
 	eend 0
 }


### PR DESCRIPTION
Leaving this unnecessary directory in place caused docker/for-mac#1379.