### PR TITLE
Add initial support for specifying the output type

### DIFF
--- a/moby/config.go
+++ b/moby/config.go
@@ -19,6 +19,9 @@ type Moby struct {
 		Path     string
 		Contents string
 	}
+	Outputs []struct {
+		Format string
+	}
 }
 
 type MobyImage struct {

--- a/moby/moby.yaml
+++ b/moby/moby.yaml
@@ -23,3 +23,5 @@ system:
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'
+outputs:
+  - format: kernel+initrd


### PR DESCRIPTION
Currently only supports kernel+initrd output but will add the rest
soon.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>