### PR TITLE
infrakit: Use the `moby` tool naming convention to select moby builds

### DIFF
--- a/tools/infrakit.hyperkit/README.md
+++ b/tools/infrakit.hyperkit/README.md
@@ -34,7 +34,7 @@ Then start the hyperkit plugin:
 ./build/infrakit-instance-hyperkit
 ```
 
-Next, you can commit a new configuration. There is a sample infrakit config file in `hyperkit.json` which assumes that the directory `./vms/default` contains the `vmlinuz64` and `initrd.img` image to boot.
+Next, you can commit a new configuration. There is a sample infrakit config file in `hyperkit.json`. It assumes that you have a default moby build in the top-level directory. The `Moby` property needs to be of the form `<dir>/<prefix>` and assumes that the kernel and initrd images are called `<prefix>-bzImage` and `<prefix>-initrd.img` respectively (this is the convention used by the `moby` tool).
 ```
 infrakit group commit hyperkit.json
 ```

--- a/tools/infrakit.hyperkit/cmd/instance.go
+++ b/tools/infrakit.hyperkit/cmd/instance.go
@@ -242,8 +242,8 @@ const hyperkitArgs = "-A -u -F {{.VMLocation}}/hyperkit.pid " +
 	"-s 2:0,virtio-vpnkit,path={{.VPNKitSock}} " +
 	"-l com1,autopty={{.VMLocation}}/tty,log={{.VMLocation}}/console-ring"
 const hyperkitKernArgs = "kexec," +
-	"{{.Properties.Moby}}/vmlinuz64," +
-	"{{.Properties.Moby}}/initrd.img," +
+	"{{.Properties.Moby}}-bzImage," +
+	"{{.Properties.Moby}}-initrd.img," +
 	"earlyprintk=serial console=ttyS0 panic=1 vsyscall=emulate page_poison=1 ntp=gateway"
 
 func (v hyperkitPlugin) execHyperKit(params map[string]interface{}) error {

--- a/tools/infrakit.hyperkit/hyperkit.json
+++ b/tools/infrakit.hyperkit/hyperkit.json
@@ -7,7 +7,7 @@
         "Instance": {
             "Plugin": "instance-hyperkit",
             "Properties": {
-                "Moby": "./vms/default",
+                "Moby": "../../moby",
                 "Disk" : 512,
                 "CPUs" : 2,
                 "Memory" : 1024


### PR DESCRIPTION
the `moby` tool uses a prefix for the build output. Specify the prefix
(and optional path) in the `Moby` property in the JSON instead of assuming
a different path for each initrd/kernel.

Also, adopt the new name for the kernel image (vmlinuz64 -> <prefix>-bzImage).

This should make it simpler to boot up hyperkit with Moby images
build from by the moby tool.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>