### PR TITLE
better debugging output in some error cases

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,11 +26,7 @@ func dockerRun(args ...string) ([]byte, error) {
 	}
 	args = append([]string{"run", "--rm"}, args...)
 	cmd := exec.Command(docker, args...)
-	out, err := cmd.Output()
-	if err != nil {
-		return []byte{}, err
-	}
-	return out, nil
+	return cmd.CombinedOutput()
 }
 
 func dockerRunInput(input io.Reader, args ...string) ([]byte, error) {
@@ -122,7 +118,7 @@ func build(configfile string) {
 	)
 	out, err := dockerRun(m.Kernel, "tar", "cf", "-", bzimageName, ktarName)
 	if err != nil {
-		log.Fatalf("Failed to extract kernel image and tarball")
+		log.Fatalf("Failed to extract kernel image and tarball: %s", string(out))
 	}
 	buf := bytes.NewBuffer(out)
 	bzimage, ktar, err := untarKernel(buf, bzimageName, ktarName)


### PR DESCRIPTION
from:

2017/03/07 09:59:30 Failed to extract kernel image and tarball

to

2017/03/07 10:06:04 Failed to extract kernel image and tarball: Unable to find image 'mobylinux/kernel:7fa748810d7866797fd807a5682d5cb3c9c98111' locally

Signed-off-by: Tycho Andersen <tycho@docker.com>