### PR TITLE
Allow to pull-in system containers whitout running them on startup

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ type Moby struct {
 	}
 	Init   string
 	System []MobyImage
+	Image  []MobyImage
 	Daemon []MobyImage
 	Files  []struct {
 		Path     string

--- a/main.go
+++ b/main.go
@@ -194,6 +194,16 @@ func build(m *Moby) {
 		containers = append(containers, buffer)
 	}
 
+	for i, image := range m.Image {
+		args := ConfigToRun(i, "image", &image)
+		out, err := dockerRun(args...)
+		if err != nil {
+			log.Fatalf("Failed to build container tarball: %v", err)
+		}
+		buffer := bytes.NewBuffer(out)
+		containers = append(containers, buffer)
+	}
+
 	for i, image := range m.Daemon {
 		args := ConfigToRun(i, "daemon", &image)
 		out, err := dockerRun(args...)


### PR DESCRIPTION
I am not sure about the name, maybe it should be `media` or something else?

This is useful if some system services want to start other service later on (not necessary on startup).