### PR TITLE
Add qcow2 output support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ disk.img.*
 *.tar.gz
 *.vhdx
 *.efi
+*.qcow2
 *-bzImage

--- a/output.go
+++ b/output.go
@@ -12,6 +12,7 @@ const (
 	bios = "mobylinux/mkimage-iso-bios:489b1f054a77a8f379d0bfc6cd91639b4db6b67c@sha256:0f058951aac4367d132682aa19eeb5cdcb05600a5d51fe5d0fcbd97b03ae4f87"
 	efi  = "mobylinux/mkimage-iso-efi:b210c58e096e53082d35b28fa2b52dba6ae200c8@sha256:10c2789bf5fbd27c35c5fe2f3b97f75a7108bbde389d0f5ed750e3e2dae95376"
 	gce  = "mobylinux/mkimage-gce:2039be4e39e855d1845aee188e266bba3f1d2eed@sha256:e12f76003fd9eaa0c6f39f149db5998cf56de42539b989c994893c8344ca69c0"
+	qcow = "mobylinux/mkimage-qcow:9b3632f111675898ed3a22ac71897e735b5a8364@sha256:2132cf3fb593d65f09c8d109d40e1fad138d81485d4750fc29a7f54611d78d35"
 	vhd  = "mobylinux/mkimage-vhd:73c80e433bf717578c507621a84fd58cec27fe95@sha256:0ae1eda2d6592f309977dc4b25cca120cc4e2ee2cc786e88fdc2761c0d49cb14"
 )
 
@@ -35,6 +36,11 @@ func outputs(m *Moby, base string, bzimage []byte, initrd []byte) error {
 			}
 		case "gce-img":
 			err := outputImg(gce, base+".img.tar.gz", bzimage, initrd, m.Kernel.Cmdline)
+			if err != nil {
+				return fmt.Errorf("Error writing %s output: %v", o.Format, err)
+			}
+		case "qcow", "qcow2":
+			err := outputImg(qcow, base+".qcow2", bzimage, initrd, m.Kernel.Cmdline)
 			if err != nil {
 				return fmt.Errorf("Error writing %s output: %v", o.Format, err)
 			}

--- a/tools/mkimage-qcow/Dockerfile
+++ b/tools/mkimage-qcow/Dockerfile
@@ -1,0 +1,5 @@
+FROM mobylinux/guestfs:69698aca5bfcb8c4d3a3bbe6d8656be155bf8cd6@sha256:703a7372ada5b3db64a11bc8c60eec06659a1052d9296fa0c556ed3faf75c182
+
+COPY . .
+
+ENTRYPOINT [ "/make-qcow" ]

--- a/tools/mkimage-qcow/Makefile
+++ b/tools/mkimage-qcow/Makefile
@@ -1,0 +1,27 @@
+.PHONY: tag push
+
+IMAGE=mkimage-qcow
+
+default: push
+
+hash: Dockerfile make-qcow
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --entrypoint sh --rm $(IMAGE):build -c "(cat $^; apt list --installed 2>/dev/null) | sha1sum" | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/tools/mkimage-qcow/make-qcow
+++ b/tools/mkimage-qcow/make-qcow
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+set -e
+
+mkdir -p /tmp/image
+cd /tmp/image
+
+# input is a tarball of vmlinuz64 and initrd.img on stdin
+# output is a qcow2 on stdout
+
+mkdir -p files
+
+cd files
+
+# extract. As guestfs base is currently Debian, no compression support
+# only if stdin is a tty, if so need files volume mounted...
+[ -t 0 ] || tar xf -
+
+INITRD="$(find . -name '*.img')"
+KERNEL="$(find . -name vmlinuz64 -or -name '*bzImage')"
+CMDLINE="$*"
+
+[ "$KERNEL" = "./vmlinuz64" ] || mv "$KERNEL" vmlinuz64
+[ "$INITRD" = "./initrd.img" ] || mv "$INITRD" initrd.img
+
+# clean up subdirectories
+find . -mindepth 1 -maxdepth 1 -type d | xargs rm -rf
+
+CFG="DEFAULT linux
+LABEL linux
+    KERNEL /vmlinuz64
+    INITRD /initrd.img
+    APPEND ${CMDLINE}
+"
+
+printf "$CFG" > syslinux.cfg
+
+cd ..
+
+tar cf files.tar -C files .
+
+virt-make-fs --size=1G --type=ext4 --partition files.tar --format=qcow2 disk.qcow
+
+guestfish -a disk.qcow -m /dev/sda1 <<EOF
+  upload /usr/lib/SYSLINUX/mbr.bin /mbr.bin
+  copy-file-to-device /mbr.bin /dev/sda size:440
+  rm /mbr.bin
+  extlinux /
+  part-set-bootable /dev/sda 1 true
+EOF
+
+# compress qcow
+qemu-img convert -f qcow2 -O qcow2 -c disk.qcow disk.qcow2 1>&2
+
+cat disk.qcow2


### PR DESCRIPTION
- outputs compressed qcow2 image
- 1GB underlying size, may need changing

Signed-off-by: Justin Cormack <justin.cormack@docker.com>