### PR TITLE
Add read-only option to containers, apply to all except nginx

### DIFF
--- a/config.go
+++ b/config.go
@@ -41,6 +41,7 @@ type MobyImage struct {
 	NetworkMode  string `yaml:"network_mode"`
 	Pid          string
 	Ipc          string
+	ReadOnly     bool `yaml:"read_only"`
 }
 
 const riddler = "mobylinux/riddler:7d4545d8b8ac2700971a83f12a3446a76db28c14@sha256:11b7310df6482fc38aa52b419c2ef1065d7b9207c633d47554e13aa99f6c0b72"
@@ -87,6 +88,9 @@ func ConfigToRun(order int, path string, image *MobyImage) []string {
 	}
 	for _, bind := range image.Binds {
 		args = append(args, "-v", bind)
+	}
+	if image.ReadOnly {
+		args = append(args, "--read-only")
 	}
 	// image
 	args = append(args, image.Image)

--- a/moby.yaml
+++ b/moby.yaml
@@ -10,10 +10,12 @@ system:
     ipc: host
     capabilities:
      - CAP_SYS_ADMIN
+    read_only: true
   - name: binfmt
     image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
     binds:
      - /proc/sys/fs/binfmt_misc:/binfmt_misc
+    read_only: true
     command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
 daemon:
   - name: rngd
@@ -21,6 +23,7 @@ daemon:
     capabilities:
      - CAP_SYS_ADMIN
     oom_score_adj: -800
+    read_only: true
     command: [/bin/tini, /usr/sbin/rngd, -f]
   - name: nginx
     image: "nginx:alpine"

--- a/test.yaml
+++ b/test.yaml
@@ -7,6 +7,7 @@ system:
     image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
     binds:
      - /proc/sys/fs/binfmt_misc:/binfmt_misc
+    read_only: true
     command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
   - name: check
     image: "mobylinux/check:699ca8e3792dda19a6fd981f58b47c3be0e5d6ec"


### PR DESCRIPTION
Didn't update nginx since it makes heavy use of its local fs for caching and other functionality.

As for binds: couldn't make binfmt use `:ro` because it writes to files such as `/binfmt_misc/register`

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>