### PR TITLE
Add a WIP example to run sshd

### DIFF
--- a/examples/sshd.yaml
+++ b/examples/sshd.yaml
@@ -1,0 +1,45 @@
+kernel:
+  image: "mobylinux/kernel:c1229050671f22671f98fd401279b0f5f1e461f8"
+  cmdline: "console=ttyS0 page_poison=1"
+init: "mobylinux/init:65d6491c93fbf2a65fa19305da6ac245b8070526"
+system:
+  - name: sysctl
+    image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
+    network_mode: host
+    pid: host
+    ipc: host
+    capabilities:
+     - CAP_SYS_ADMIN
+  - name: binfmt
+    image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
+    binds:
+     - /proc/sys/fs/binfmt_misc:/binfmt_misc
+    command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
+daemon:
+  - name: rngd
+    image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"
+    capabilities:
+     - CAP_SYS_ADMIN
+    oom_score_adj: -800
+    command: [/bin/tini, /usr/sbin/rngd, -f]
+  - name: sshd
+    image: "mobylinux/sshd:3940f3fa07da1b6adab975112894b103b3c491f1"
+    capabilities:
+     - CAP_NET_BIND_SERVICE
+     - CAP_CHOWN
+     - CAP_SETUID
+     - CAP_SETGID
+     - CAP_DAC_OVERRIDE
+     - CAP_SYS_CHROOT
+    network_mode: host
+    binds:
+     - /root/.ssh:/root/.ssh
+     - /etc/resolv.conf:/etc/resolv.conf
+    pid: host
+files:
+  - path: root/.ssh/authorized_keys
+    contents: '#your ssh key here'
+outputs:
+  - format: kernel+initrd
+  - format: iso-bios
+  - format: iso-efi


### PR DESCRIPTION
- Currently only works if you add your ssh key in the example yaml, but will replace
with metadata support shortly.
- sshd logging not yet configured (needs to share syslog socket).

Signed-off-by: Justin Cormack <justin.cormack@docker.com>