### PR TITLE
qemu: Enable KVM support and switch to Q35

### DIFF
--- a/scripts/qemu.sh
+++ b/scripts/qemu.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-QEMU_IMAGE=mobylinux/qemu:2e63db70759e37de6f9cc5cdf67c15f3aa8373c8@sha256:958c6bb1fca426cadf7a3664b8c019eba9f9e2ad4f6b4f3ed02d766fe5e709e4
+QEMU_IMAGE=mobylinux/qemu:97973fb6721778c639676812ccb8bc3332e0a542@sha256:c08dac641a75fda3232a8ff3250f23d743aeac12aa4db02ec7926a42b79b0e69
 
 # if not interactive
 if [ ! -t 0 -a -z "$1" ]
@@ -29,8 +29,11 @@ then
 	echo "$FILE2" | grep -q '^/' || FILE2="$PWD/$FILE2"
 fi
 
+if [ -c "/dev/kvm" ] ; then
+    DEVKVM="--device=/dev/kvm"
+fi
 BASE=$(basename "$FILE")
 MOUNTS="-v $FILE:/tmp/$BASE"
 BASE2=$(basename "$FILE2")
 [ ! -z "$FILE2" ] && MOUNTS="$MOUNTS -v $FILE2:/tmp/$BASE2"
-docker run -it --rm $MOUNTS "$QEMU_IMAGE" $CMDLINE
+docker run -it --rm $MOUNTS $DEVKVM "$QEMU_IMAGE" $CMDLINE

--- a/tools/qemu/qemu.sh
+++ b/tools/qemu/qemu.sh
@@ -44,4 +44,4 @@ then
 	CMDLINE="console=ttyS0"
 fi
 
-qemu-system-x86_64 -device virtio-rng-pci -serial stdio -vnc none -m 1024 -append "${CMDLINE}" $ARGS
+qemu-system-x86_64 -machine q35,accel=kvm:tcg -device virtio-rng-pci -serial stdio -vnc none -m 1024 -append "${CMDLINE}" $ARGS


### PR DESCRIPTION
Passing accel=kvm:tcg causes it to try KVM first if available with a fallback
to TCG (emulated/JIT mode) if it is not available. With this the boot logs gain:

+Hypervisor detected: KVM

and also

-Booting paravirtualized kernel on bare hardware
+Booting paravirtualized kernel on KVM

Among various other noise.

If I rename my host /dev/kvm then this is reversed, although with the following
message:

  Could not access KVM kernel module: No such file or directory
  failed to initialize KVM: No such file or directory
  Back to tcg accelerator.

Q35 is a more modern emulated platform based on the ICH9 host chipset rather
than the default "pc" I440FX (Pentium Pro / Pentium II era) emulation. See
http://wiki.qemu-project.org/Features/Q35 for more info. Switching to Q35 is
not a requirement for enabling KVM but seemed like a reasonable change.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>