### PR TITLE
Remount rootfs as read-only after init, /var and /containers mounted as rw

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
-init: "mobylinux/init:c0007f0cdf1ef821a981fcc676e3f1c2dd9ab5b1"
+init: "mobylinux/init:0b2b3811f6397c4367a4480a53837d41a8d7b3a9"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:c0007f0cdf1ef821a981fcc676e3f1c2dd9ab5b1"
+init: "mobylinux/init:0b2b3811f6397c4367a4480a53837d41a8d7b3a9"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:c0007f0cdf1ef821a981fcc676e3f1c2dd9ab5b1"
+init: "mobylinux/init:0b2b3811f6397c4367a4480a53837d41a8d7b3a9"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=tty0 page_poison=1"
-init: "mobylinux/init:c0007f0cdf1ef821a981fcc676e3f1c2dd9ab5b1"
+init: "mobylinux/init:0b2b3811f6397c4367a4480a53837d41a8d7b3a9"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/moby.yml
+++ b/moby.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
-init: "mobylinux/init:c0007f0cdf1ef821a981fcc676e3f1c2dd9ab5b1"
+init: "mobylinux/init:0b2b3811f6397c4367a4480a53837d41a8d7b3a9"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/pkg/init/etc/init.d/rcS
+++ b/pkg/init/etc/init.d/rcS
@@ -106,3 +106,12 @@ ip link set lo up
 mkdir /tmp/etc
 mv /etc/resolv.conf /tmp/etc/resolv.conf
 ln -snf /tmp/etc/resolv.conf /etc/resolv.conf
+
+# remount rootfs as readonly
+mount -o remount,ro /
+
+# bind and remount containers and var as read-write
+mount -o bind /containers /containers
+mount -o bind /var /var
+mount -o remount,rw,relatime /containers /containers
+mount -o remount,rw,nodev,nosuid,relatime /var /var

--- a/test/ltp/test-ltp.yml
+++ b/test/ltp/test-ltp.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
-init: "mobylinux/init:c0007f0cdf1ef821a981fcc676e3f1c2dd9ab5b1"
+init: "mobylinux/init:0b2b3811f6397c4367a4480a53837d41a8d7b3a9"
 system:
   - name: ltp
     image: "mobylinux/test-ltp-20170116:fdca2d1bb019b1d51e722e6032c82c7933d4b870"

--- a/test/test.yml
+++ b/test/test.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
-init: "mobylinux/init:c0007f0cdf1ef821a981fcc676e3f1c2dd9ab5b1"
+init: "mobylinux/init:0b2b3811f6397c4367a4480a53837d41a8d7b3a9"
 system:
   - name: binfmt
     image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"

--- a/test/virtsock/test-virtsock-server.yml
+++ b/test/virtsock/test-virtsock-server.yml
@@ -5,7 +5,7 @@ kernel:
   # image: "mobylinux/kernel:4.9.14-0"
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:c0007f0cdf1ef821a981fcc676e3f1c2dd9ab5b1"
+init: "mobylinux/init:0b2b3811f6397c4367a4480a53837d41a8d7b3a9"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"


### PR DESCRIPTION
I mounted `/var` and `/containers` as read-write tmpfs, and had to do some symlinking for `/etc/resolv.conf` for dhcpd (as described in https://github.com/docker/moby/issues/583)

I'm wondering if we should change any of the attributes for `/var` and/or `/containers`, or make any changes that would move in the direction of something like https://github.com/docker/moby/issues/1285
 
Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>