### PR TITLE
Read-only check container for testing, clean up error output

### DIFF
--- a/test.yaml
+++ b/test.yaml
@@ -10,10 +10,11 @@ system:
     read_only: true
     command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
   - name: check
-    image: "mobylinux/check:699ca8e3792dda19a6fd981f58b47c3be0e5d6ec"
+    image: "mobylinux/check:c9e41ab96b3ea6a3ced97634751e20d12a5bf52f"
     pid: host
     capabilities:
      - CAP_SYS_BOOT
+    read_only: true
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'

--- a/tools/check/check-kernel-config.sh
+++ b/tools/check/check-kernel-config.sh
@@ -5,7 +5,7 @@ set -e
 echo "starting kernel config sanity test with /proc/config.gz"
 
 # decompress /proc/config.gz from the Moby host
-zcat /proc/config.gz > unzipped_config
+UNZIPPED_CONFIG=$(zcat /proc/config.gz)
 
 kernelVersion="$(uname -r)"
 kernelMajor="${kernelVersion%%.*}"
@@ -14,57 +14,60 @@ kernelMinor="${kernelMinor%%.*}"
 
 # Most tests against https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project
 # Positive cases
-cat unzipped_config | grep CONFIG_BUG=y
-cat unzipped_config | grep CONFIG_DEBUG_KERNEL=y
-cat unzipped_config | grep CONFIG_DEBUG_RODATA=y
-cat unzipped_config | grep CONFIG_CC_STACKPROTECTOR=y
-cat unzipped_config | grep CONFIG_CC_STACKPROTECTOR_STRONG=y
-cat unzipped_config | grep CONFIG_STRICT_DEVMEM=y
-cat unzipped_config | grep CONFIG_SYN_COOKIES=y
-cat unzipped_config | grep CONFIG_DEBUG_CREDENTIALS=y
-cat unzipped_config | grep CONFIG_DEBUG_NOTIFIERS=y
-cat unzipped_config | grep CONFIG_DEBUG_LIST=y
-cat unzipped_config | grep CONFIG_SECCOMP=y
-cat unzipped_config | grep CONFIG_SECCOMP_FILTER=y
-cat unzipped_config | grep CONFIG_SECURITY=y
-cat unzipped_config | grep CONFIG_SECURITY_YAMA=y
-cat unzipped_config | grep CONFIG_PANIC_ON_OOPS=y
-cat unzipped_config | grep CONFIG_DEBUG_SET_MODULE_RONX=y
-cat unzipped_config | grep CONFIG_SYN_COOKIES=y
-cat unzipped_config | grep CONFIG_LEGACY_VSYSCALL_NONE=y
-cat unzipped_config | grep CONFIG_RANDOMIZE_BASE=y
+
+echo $UNZIPPED_CONFIG | grep -q CONFIG_BUG=y || (echo "CONFIG_BUG=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_DEBUG_KERNEL=y || (echo "CONFIG_DEBUG_KERNEL=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_DEBUG_RODATA=y || (echo "CONFIG_DEBUG_RODATA=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_CC_STACKPROTECTOR=y || (echo "CONFIG_CC_STACKPROTECTOR=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_CC_STACKPROTECTOR_STRONG=y || (echo "CONFIG_CC_STACKPROTECTOR_STRONG=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_STRICT_DEVMEM=y || (echo "CONFIG_STRICT_DEVMEM=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_SYN_COOKIES=y || (echo "CONFIG_SYN_COOKIES=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_DEBUG_CREDENTIALS=y || (echo "CONFIG_DEBUG_CREDENTIALS=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_DEBUG_NOTIFIERS=y || (echo "CONFIG_DEBUG_NOTIFIERS=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_DEBUG_LIST=y || (echo "CONFIG_DEBUG_LIST=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_SECCOMP=y || (echo "CONFIG_SECCOMP=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_SECCOMP_FILTER=y || (echo "CONFIG_SECCOMP_FILTER=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_SECURITY=y || (echo "CONFIG_SECURITY=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_SECURITY_YAMA=y || (echo "CONFIG_SECURITY_YAMA=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_PANIC_ON_OOPS=y || (echo "CONFIG_PANIC_ON_OOPS=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_DEBUG_SET_MODULE_RONX=y || (echo "CONFIG_DEBUG_SET_MODULE_RONX=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_SYN_COOKIES=y || (echo "CONFIG_SYN_COOKIES=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_LEGACY_VSYSCALL_NONE=y || (echo "CONFIG_LEGACY_VSYSCALL_NONE=y" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q CONFIG_RANDOMIZE_BASE=y || (echo "CONFIG_RANDOMIZE_BASE=y" && exit 1)
 
 # Conditional on kernel version
 if [ "$kernelMajor" -ge 4 -a "$kernelMinor" -ge 5 ]; then
-  cat unzipped_config | grep CONFIG_IO_STRICT_DEVMEM=y
-  cat unzipped_config | grep CONFIG_UBSAN=y
+  echo $UNZIPPED_CONFIG | grep -q CONFIG_IO_STRICT_DEVMEM=y || (echo "CONFIG_IO_STRICT_DEVMEM=y" && exit 1)
+  echo $UNZIPPED_CONFIG | grep -q CONFIG_UBSAN=y || (echo "CONFIG_UBSAN=y" && exit 1)
 fi
 if [ "$kernelMajor" -ge 4 -a "$kernelMinor" -ge 7 ]; then
-  cat unzipped_config | grep CONFIG_SLAB_FREELIST_RANDOM=y
+  echo $UNZIPPED_CONFIG | grep -q CONFIG_SLAB_FREELIST_RANDOM=y || (echo "CONFIG_SLAB_FREELIST_RANDOM=y" && exit 1)
 fi
 if [ "$kernelMajor" -ge 4 -a "$kernelMinor" -ge 8 ]; then
-  cat unzipped_config | grep CONFIG_HARDENED_USERCOPY=y
-  cat unzipped_config | grep CONFIG_RANDOMIZE_MEMORY=y
+  echo $UNZIPPED_CONFIG | grep -q CONFIG_HARDENED_USERCOPY=y || (echo "CONFIG_HARDENED_USERCOPY=y" && exit 1)
+  echo $UNZIPPED_CONFIG | grep -q CONFIG_RANDOMIZE_MEMORY=y || (echo "CONFIG_RANDOMIZE_MEMORY=y" && exit 1)
 fi
 
 # poisoning cannot be enabled in 4.4
 if [ "$kernelMajor" -ge 4 -a "$kernelMinor" -ge 9 ]; then
-  cat unzipped_config | grep CONFIG_PAGE_POISONING=y
-  cat unzipped_config | grep CONFIG_PAGE_POISONING_NO_SANITY=y
-  cat unzipped_config | grep CONFIG_PAGE_POISONING_ZERO=y
+  echo $UNZIPPED_CONFIG | grep -q CONFIG_PAGE_POISONING=y || (echo "CONFIG_PAGE_POISONING=y" && exit 1)
+  echo $UNZIPPED_CONFIG | grep -q CONFIG_PAGE_POISONING_NO_SANITY=y || (echo "CONFIG_PAGE_POISONING_NO_SANITY=y" && exit 1)
+  echo $UNZIPPED_CONFIG | grep -q CONFIG_PAGE_POISONING_ZERO=y || (echo "CONFIG_PAGE_POISONING_ZERO=y" && exit 1)
 fi
 
 if [ "$kernelMajor" -ge 4 -a "$kernelMinor" -ge 10 ]; then
-  cat unzipped_config | grep CONFIG_BUG_ON_DATA_CORRUPTION=y
+  echo $UNZIPPED_CONFIG | grep -q CONFIG_BUG_ON_DATA_CORRUPTION=y || (echo "CONFIG_BUG_ON_DATA_CORRUPTION=y" && exit 1)
 fi
 
 # Negative cases
-cat unzipped_config | grep 'CONFIG_ACPI_CUSTOM_METHOD is not set'
-cat unzipped_config | grep 'CONFIG_COMPAT_BRK is not set'
-cat unzipped_config | grep 'CONFIG_DEVKMEM is not set'
-cat unzipped_config | grep 'CONFIG_COMPAT_VDSO is not set'
-cat unzipped_config | grep 'CONFIG_KEXEC is not set'
-cat unzipped_config | grep 'CONFIG_HIBERNATION is not set'
-cat unzipped_config | grep 'CONFIG_LEGACY_PTYS is not set'
-cat unzipped_config | grep 'CONFIG_X86_X32 is not set'
-cat unzipped_config | grep 'CONFIG_MODIFY_LDT_SYSCALL is not set'
+echo $UNZIPPED_CONFIG | grep -q 'CONFIG_ACPI_CUSTOM_METHOD is not set' || (echo "CONFIG_ACPI_CUSTOM_METHOD is not set" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q 'CONFIG_COMPAT_BRK is not set' || (echo "CONFIG_COMPAT_BRK is not set" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q 'CONFIG_DEVKMEM is not set' || (echo "CONFIG_DEVKMEM is not set" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q 'CONFIG_COMPAT_VDSO is not set' || (echo "CONFIG_COMPAT_VDSO is not set" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q 'CONFIG_KEXEC is not set' || (echo "CONFIG_KEXEC is not set" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q 'CONFIG_HIBERNATION is not set' || (echo "CONFIG_HIBERNATION is not set" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q 'CONFIG_LEGACY_PTYS is not set' || (echo "CONFIG_LEGACY_PTYS is not set" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q 'CONFIG_X86_X32 is not set' || (echo "CONFIG_X86_X32 is not set" && exit 1)
+echo $UNZIPPED_CONFIG | grep -q 'CONFIG_MODIFY_LDT_SYSCALL is not set' || (echo "CONFIG_MODIFY_LDT_SYSCALL is not set" && exit 1)
+
+echo "kernel config test succeeded!"


### PR DESCRIPTION
use var instead of file for kernel config, quiet grep and also add an error echo to make failures more clear

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>