### PR TITLE
logs: separate daemon container logs into separate files

### DIFF
--- a/base/init/etc/init.d/containers
+++ b/base/init/etc/init.d/containers
@@ -6,8 +6,6 @@
 
 # start system containers
 # temporarily using runc not containerd
-LOG=/var/log/system-containers.log
-touch $LOG
 
 if [ -d /containers/system ]
 then
@@ -24,7 +22,8 @@ then
 	for f in $(find /containers/daemon -mindepth 1 -maxdepth 1 | sort)
 	do
 		base="$(basename $f)"
-		/sbin/start-stop-daemon --start --pidfile /run/$base.pid --exec /usr/bin/runc -- run --bundle "$f" --pid-file /run/$base.pid "$(basename $f)" </dev/null 2>$LOG >$LOG &
+		log="/var/log/$base.log"
+		/sbin/start-stop-daemon --start --pidfile /run/$base.pid --exec /usr/bin/runc -- run --bundle "$f" --pid-file /run/$base.pid "$(basename $f)" </dev/null 2>$log >$log &
 		printf " - $base\n"
 	done
 fi

--- a/examples/gcp.yaml
+++ b/examples/gcp.yaml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:65d6491c93fbf2a65fa19305da6ac245b8070526"
+init: "mobylinux/init:1402058c0f90adf2b12fcfb8332b334c7e9c5d8c"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/examples/sshd.yaml
+++ b/examples/sshd.yaml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:65d6491c93fbf2a65fa19305da6ac245b8070526"
+init: "mobylinux/init:1402058c0f90adf2b12fcfb8332b334c7e9c5d8c"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/moby.yaml
+++ b/moby.yaml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:65d6491c93fbf2a65fa19305da6ac245b8070526"
+init: "mobylinux/init:1402058c0f90adf2b12fcfb8332b334c7e9c5d8c"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/test.yaml
+++ b/test.yaml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
-init: "mobylinux/init:65d6491c93fbf2a65fa19305da6ac245b8070526"
+init: "mobylinux/init:1402058c0f90adf2b12fcfb8332b334c7e9c5d8c"
 system:
   - name: binfmt
     image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"

--- a/tools/test-ltp/test-ltp.yaml
+++ b/tools/test-ltp/test-ltp.yaml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
-init: "mobylinux/init:2f1b5c1be1157cb17e5b1e6dee171dccdebb5277"
+init: "mobylinux/init:1402058c0f90adf2b12fcfb8332b334c7e9c5d8c"
 system:
   - name: ltp
     image: "mobylinux/test-ltp-20170116:fdca2d1bb019b1d51e722e6032c82c7933d4b870"


### PR DESCRIPTION
Instead of a single `/var/log/system-containers.log`, give each daemon container its own log at `/var/log/$basename.log` (ex: `/var/log/000-nginx.log`)

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>