### PR TITLE
tools: Calculate EFI ESP FAT FS size based on contents.

### DIFF
--- a/output.go
+++ b/output.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	bios = "mobylinux/mkimage-iso-bios:489b1f054a77a8f379d0bfc6cd91639b4db6b67c@sha256:0f058951aac4367d132682aa19eeb5cdcb05600a5d51fe5d0fcbd97b03ae4f87"
-	efi  = "mobylinux/mkimage-iso-efi:b210c58e096e53082d35b28fa2b52dba6ae200c8@sha256:10c2789bf5fbd27c35c5fe2f3b97f75a7108bbde389d0f5ed750e3e2dae95376"
+	efi  = "mobylinux/mkimage-iso-efi:d86021840d2180422bd2f59dcff2fcfb5aea6ad1@sha256:00a6dc21073a24763bc667cadd90c42b69cd69579f8036d6d794b42cbb583142"
 	gce  = "mobylinux/mkimage-gce:2039be4e39e855d1845aee188e266bba3f1d2eed@sha256:e12f76003fd9eaa0c6f39f149db5998cf56de42539b989c994893c8344ca69c0"
 	qcow = "mobylinux/mkimage-qcow:9b3632f111675898ed3a22ac71897e735b5a8364@sha256:2132cf3fb593d65f09c8d109d40e1fad138d81485d4750fc29a7f54611d78d35"
 	vhd  = "mobylinux/mkimage-vhd:73c80e433bf717578c507621a84fd58cec27fe95@sha256:0ae1eda2d6592f309977dc4b25cca120cc4e2ee2cc786e88fdc2761c0d49cb14"

--- a/tools/mkimage-iso-efi/Dockerfile
+++ b/tools/mkimage-iso-efi/Dockerfile
@@ -1,8 +1,9 @@
-FROM alpine:3.5
+FROM alpine:edge
 
 RUN \
   apk update && apk upgrade && \
   apk add --no-cache \
+  dosfstools \
   libarchive-tools \
   binutils \
   gummiboot \

--- a/tools/mkimage-iso-efi/make-efi
+++ b/tools/mkimage-iso-efi/make-efi
@@ -37,14 +37,15 @@ objcopy \
 
 # create a ISO with a EFI boot partition
 mkdir -p iso
-dd if=/dev/zero of=iso/efi.raw bs=1024 count=78000
-mkfs.vfat iso/efi.raw
-
+# Stuff it into a FAT filesystem, making it as small as possible.  511KiB
+# headroom seems to be enough; (x+31)/32*32 rounds up to multiple of 32.
+mkfs.vfat -v -C iso/efi.raw \
+        $(( ($(stat -c %s "mobylinux.efi") / 1024 + 511) \
+		/ 32 * 32 ))
 echo "mtools_skip_check=1" >> /etc/mtools.conf && \
 mmd -i iso/efi.raw ::/EFI
 mmd -i iso/efi.raw ::/EFI/BOOT
 mcopy -i iso/efi.raw mobylinux.efi ::/EFI/BOOT/BOOTX64.EFI
-
 xorriso -as mkisofs \
 	-R -f -e efi.raw -no-emul-boot -o mobylinux-efi.iso iso
 


### PR DESCRIPTION
This requires switching to the dosfstools from alpine:edge since neither the
busybox nor alpine:3.5 dosfstools supports the -C option (in fact alpine:3.5
only has mkfs.fat and not mkfs.vfat).

The 511k slack seems like a lot to me, but 256k was somehow not enough.

Fixes #1304.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>