### PR TITLE
init: Direct daemon container logs files to separate files.

### DIFF
--- a/base/init/etc/init.d/containers
+++ b/base/init/etc/init.d/containers
@@ -6,8 +6,6 @@
 
 # start system containers
 # temporarily using runc not containerd
-LOG=/var/log/system-containers.log
-touch $LOG
 
 if [ -d /containers/system ]
 then
@@ -24,6 +22,8 @@ then
 	for f in $(find /containers/daemon -mindepth 1 -maxdepth 1 | sort)
 	do
 		base="$(basename $f)"
+		LOG=/var/log/system-container-"$base".log
+		touch $LOG
 		/sbin/start-stop-daemon --start --pidfile /run/$base.pid --exec /usr/bin/runc -- run --bundle "$f" --pid-file /run/$base.pid "$(basename $f)" </dev/null 2>$LOG >$LOG &
 		printf " - $base\n"
 	done

--- a/examples/sshd.yaml
+++ b/examples/sshd.yaml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:c1229050671f22671f98fd401279b0f5f1e461f8"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:65d6491c93fbf2a65fa19305da6ac245b8070526"
+init: "mobylinux/init:141220ebd119f5838c3db1a0dcc4704d972744bd"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/moby.yaml
+++ b/moby.yaml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:c1229050671f22671f98fd401279b0f5f1e461f8"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:65d6491c93fbf2a65fa19305da6ac245b8070526"
+init: "mobylinux/init:141220ebd119f5838c3db1a0dcc4704d972744bd"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/test.yaml
+++ b/test.yaml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:c1229050671f22671f98fd401279b0f5f1e461f8"
   cmdline: "console=ttyS0"
-init: "mobylinux/init:65d6491c93fbf2a65fa19305da6ac245b8070526"
+init: "mobylinux/init:141220ebd119f5838c3db1a0dcc4704d972744bd"
 system:
   - name: binfmt
     image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"


### PR DESCRIPTION
The existing arrangement was overwriting the same file (apparently racy, since
it seems the last container didn't always win). Direct the logs to named files
instead, not ideal but certainly better.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>