### PR TITLE
kernel: Make 'tag' the default target

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,6 +1,6 @@
 DEBUG ?= 0
 
-all:	bzImage push
+all:	bzImage tag
 
 # We push the image to hub twice, once with the full kernel version of
 # "mobylinux/kernel:<kernel version>.<major version>.<minor version>-<n>",


### PR DESCRIPTION
This is a stop-gap to prevent accidental push of kernel
images to hub until we sort out doing this from CI.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>