### PR TITLE
Make the hyperkit script get the kernel command line if just passed a name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ endif
 
 .PHONY: hyperkit hyperkit-test
 hyperkit: scripts/hyperkit.sh bin/com.docker.hyperkit bin/vpnkit moby-initrd.img moby-bzImage moby.yaml
-	./scripts/hyperkit.sh moby "$(shell bin/moby --cmdline moby.yaml)"
+	./scripts/hyperkit.sh moby
 
 define check_test_log
 	@cat $1 |grep -q 'Moby test suite PASSED'
@@ -65,7 +65,7 @@ endef
 
 hyperkit-test: scripts/hyperkit.sh bin/com.docker.hyperkit bin/vpnkit test-initrd.img test-bzImage
 	rm -f disk.img
-	script -q /dev/null ./scripts/hyperkit.sh test "$(shell bin/moby --cmdline moby.yaml)" | tee test.log
+	script -q /dev/null ./scripts/hyperkit.sh test | tee test.log
 	$(call check_test_log, test.log)
 
 .PHONY: test

--- a/scripts/hyperkit.sh
+++ b/scripts/hyperkit.sh
@@ -2,12 +2,23 @@
 
 set -e
 
-PREFIX="moby"
-[ $# -ge 1 ] && PREFIX="$1"
-
-KERNEL="$PREFIX-bzImage"
-INITRD="$PREFIX-initrd.img"
-CMDLINE="$2"
+if [ $# -eq 0 ]
+then
+	PREFIX="moby"
+	KERNEL="$PREFIX-bzImage"
+	INITRD="$PREFIX-initrd.img"
+	CMDLINE=$(bin/moby --cmdline ${PREFIX}.yaml)
+elif [ $# -eq 1 ]
+then
+	PREFIX="$1"
+	KERNEL="$PREFIX-bzImage"
+	INITRD="$PREFIX-initrd.img"
+	CMDLINE=$(bin/moby --cmdline ${PREFIX}.yaml)
+else
+	KERNEL=$1
+	INITRD=$2
+	CMDLINE=$3
+fi
 
 SLIRP_SOCK="$HOME/Library/Containers/com.docker.docker/Data/s50"
 


### PR DESCRIPTION
This is all slightly annoying, maybe we should make a file for the CLI for
hyperkit, but this is better and fixes a bug that the test CLI was coming from moby,
and is easier to use with custom builds.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>