### PR TITLE
Make the hyperkit script try harder to find executables

### DIFF
--- a/scripts/hyperkit.sh
+++ b/scripts/hyperkit.sh
@@ -2,6 +2,19 @@
 
 set -e
 
+DOCKER_HYPERKIT=/Applications/Docker.app/Contents/MacOS/com.docker.hyperkit
+DOCKER_VPNKIT=/Applications/Docker.app/Contents/MacOS/vpnkit
+
+[ -f bin/com.docker.hyperkit ] && HYPERKIT=bin/com.docker.hyperkit
+[ -f bin/vpnkit ] && VPNKIT=bin/vpnkit
+
+[ -f "$DOCKER_HYPERKIT" ] && HYPERKIT="$DOCKER_HYPERKIT"
+[ -f "$DOCKER_VPNKIT" ] && VPNKIT="$DOCKER_VPNKIT"
+
+command -v com.docker.hyperkit > /dev/null && HYPERKIT="$(command -v com.docker.hyperkit)"
+command -v hyperkit > /dev/null && HYPERKIT="$(command -v hyperkit)"
+command -v vpnkit > /dev/null && VPNKIT="$(command -v vpnkit)"
+
 if [ $# -eq 0 ]
 then
 	PREFIX="moby"
@@ -20,6 +33,7 @@ else
 	CMDLINE=$3
 fi
 
+# TODO start vpnkit if Docker for Mac not running
 SLIRP_SOCK="$HOME/Library/Containers/com.docker.docker/Data/s50"
 
 [ -f disk.img ] || dd if=/dev/zero of=disk.img bs=1048576 count=256
@@ -32,7 +46,7 @@ PCI_DEV="-s 0:0,hostbridge -s 31,lpc"
 RND="-s 5,virtio-rnd"
 LPC_DEV="-l com1,stdio"
 
-#bin/vpnkit --ethernet $SLIRP_SOCK &>/dev/null &
+#$VPNKIT --ethernet $SLIRP_SOCK &>/dev/null &
 #trap "kill $!; rm $SLIRP_SOCK" EXIT
 
-bin/com.docker.hyperkit -A $MEM $SMP $PCI_DEV $LPC_DEV $NET $IMG_HDD $RND -u -f kexec,$KERNEL,$INITRD,"$CMDLINE"
+$HYPERKIT -A $MEM $SMP $PCI_DEV $LPC_DEV $NET $IMG_HDD $RND -u -f kexec,$KERNEL,$INITRD,"$CMDLINE"


### PR DESCRIPTION
Currently if you just do `make` the hyperkit executables won't get
put in `bin/`, so try to extract from OSX.

This is temporary until get a better runner, but makes it nicer after `make clean`.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>