### PR TITLE
dhcpcd system container

### DIFF
--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:00c3a5bbfd9794f4a3187fcc4a9f0c826c46d474"
+init: "mobylinux/init:a27e32a8d6c8865d691fbfb4d0bbb93846cf7802"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
@@ -33,6 +33,17 @@ daemon:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
+  - name: dhcpcd
+      image: "mobylinux/dhcpcd:d01a17d211218f289e2bac601bfe9787d4fabaf2"
+      binds:
+       - /var:/var
+       - /tmp:/etc
+      capabilities:
+       - CAP_NET_ADMIN
+       - CAP_NET_BIND_SERVICE
+       - CAP_NET_RAW
+      net: host
+      oom_score_adj: -800
   - name: sshd
     image: "mobylinux/sshd:4f8452ddaff703416fd7452fcd9693b96b23e847"
     capabilities:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:00c3a5bbfd9794f4a3187fcc4a9f0c826c46d474"
+init: "mobylinux/init:a27e32a8d6c8865d691fbfb4d0bbb93846cf7802"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
@@ -20,6 +20,17 @@ daemon:
     capabilities:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
+  - name: dhcpcd
+    image: "mobylinux/dhcpcd:d01a17d211218f289e2bac601bfe9787d4fabaf2"
+    binds:
+     - /var:/var
+     - /tmp:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    oom_score_adj: -800
   - name: sshd
     image: "mobylinux/sshd:4f8452ddaff703416fd7452fcd9693b96b23e847"
     capabilities:

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=tty0 page_poison=1"
-init: "mobylinux/init:00c3a5bbfd9794f4a3187fcc4a9f0c826c46d474"
+init: "mobylinux/init:a27e32a8d6c8865d691fbfb4d0bbb93846cf7802"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
@@ -23,6 +23,17 @@ daemon:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
+  - name: dhcpcd
+    image: "mobylinux/dhcpcd:d01a17d211218f289e2bac601bfe9787d4fabaf2"
+    binds:
+     - /var:/var
+     - /tmp:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    oom_score_adj: -800
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/moby.yml
+++ b/moby.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
-init: "mobylinux/init:00c3a5bbfd9794f4a3187fcc4a9f0c826c46d474"
+init: "mobylinux/init:a27e32a8d6c8865d691fbfb4d0bbb93846cf7802"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
@@ -23,6 +23,17 @@ daemon:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
+  - name: dhcpcd
+    image: "mobylinux/dhcpcd:d01a17d211218f289e2bac601bfe9787d4fabaf2"
+    binds:
+     - /var:/var
+     - /tmp/etc:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    oom_score_adj: -800
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/pkg/dhcpcd/.gitignore
+++ b/pkg/dhcpcd/.gitignore
@@ -1,0 +1,5 @@
+bin
+dev
+proc
+sys
+usr

--- a/pkg/dhcpcd/10-mtu
+++ b/pkg/dhcpcd/10-mtu
@@ -1,0 +1,38 @@
+# Configure the MTU for the interface
+
+mtu_dir="$state_dir/mtu"
+
+set_mtu()
+{
+	local mtu=$1
+
+	if [ -w /sys/class/net/$interface/mtu ]; then
+		echo "$mtu" >/sys/class/net/$interface/mtu
+	else
+		ifconfig "$interface" mtu "$mtu"
+	fi
+}
+
+if [ "$reason" = PREINIT -a -e "$mtu_dir/$interface" ]; then
+	rm "$mtu_dir/$interface"
+elif [ -n "$new_interface_mtu" ] && $if_up; then
+	# The smalled MTU dhcpcd can work with is 576
+	if [ "$new_interface_mtu" -ge 576 ]; then
+		if set_mtu "$new_interface_mtu"; then
+			syslog info "$interface: MTU set to $new_interface_mtu"
+			# Save the MTU so we can restore it later
+			if [ ! -e "$mtu_dir/$interface" ]; then
+				mkdir -p "$mtu_dir"
+				echo "$ifmtu" > "$mtu_dir/$interface"
+			fi
+		fi
+	fi
+elif [ -e "$mtu_dir/$interface" ]; then
+	if $if_up || $if_down; then
+		# No MTU in this state, so restore the prior MTU
+		mtu=$(cat "$mtu_dir/$interface")
+		syslog info "$interface: MTU restored to $mtu"
+		set_mtu "$mtu"
+		rm "$mtu_dir/$interface"
+	fi
+fi

--- a/pkg/dhcpcd/Dockerfile
+++ b/pkg/dhcpcd/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.5
+
+RUN \
+  apk update && apk upgrade -a && \
+  apk add --no-cache \
+  dhcpcd \
+  openrc \
+  && true
+
+ADD dhcpcd.conf /dhcpcd.conf
+ADD start_dhcpcd.sh /usr/local/bin/start_dhcpcd.sh
+ADD 10-mtu /usr/lib/dhcpcd/dhcpcd-hooks/10-mtu
+
+CMD ["/usr/local/bin/start_dhcpcd.sh"]

--- a/pkg/dhcpcd/Makefile
+++ b/pkg/dhcpcd/Makefile
@@ -1,0 +1,34 @@
+.PHONY: tag push clean container
+default: push
+
+IMAGE=dhcpcd
+
+BASE=alpine:3.5
+
+DEPS=dhcpcd.conf 10-mtu start_dhcpcd.sh
+
+container: Dockerfile $(DEPS)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+
+hash: Dockerfile $(DEPS)
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm $(IMAGE):build sh -c '(cat /usr/local/bin/start_dhcpcd.sh /dhcpcd.conf /usr/lib/dhcpcd/dhcpcd-hooks/10-mtu /lib/apk/db/installed) | sha1sum' | sed 's/ .*//' > hash
+
+push: hash container
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash container
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -rf hash $(DIRS)
+
+.DELETE_ON_ERROR:

--- a/pkg/dhcpcd/dhcpcd.conf
+++ b/pkg/dhcpcd/dhcpcd.conf
@@ -1,0 +1,43 @@
+# Moby dhcpcd config
+
+# Only configure standard external ethernet
+allowinterfaces eth*
+
+# Inform the DHCP server of our hostname for DDNS.
+hostname
+
+# Use the hardware address of the interface for the Client ID.
+clientid
+# or
+# Use the same DUID + IAID as set in DHCPv6 for DHCPv4 ClientID as per RFC4361.
+# Some non-RFC compliant DHCP servers do not reply with this set.
+# In this case, comment out duid and enable clientid above.
+#duid
+
+# Persist interface configuration when dhcpcd exits.
+persistent
+
+# Rapid commit support.
+# Safe to enable by default because it requires the equivalent option set
+# on the server to actually work.
+option rapid_commit
+
+# A list of options to request from the DHCP server.
+option domain_name_servers, domain_name, domain_search, host_name
+option classless_static_routes
+# Most distributions have NTP support.
+option ntp_servers
+# Respect the network MTU. This is applied to DHCP routes.
+option interface_mtu
+
+# A ServerID is required by RFC2131.
+require dhcp_server_identifier
+
+# Generate Stable Private IPv6 Addresses instead of hardware based ones
+slaac private
+
+# Do not wait
+nodelay
+
+# Do not arp to check IP
+noarp

--- a/pkg/dhcpcd/start_dhcpcd.sh
+++ b/pkg/dhcpcd/start_dhcpcd.sh
@@ -1,0 +1,9 @@
+#!bin/sh
+
+set -ex
+
+ip link set eth0 up
+
+cp /dhcpcd.conf /etc/dhcpcd.conf
+
+/sbin/dhcpcd --nobackground

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -4,7 +4,6 @@ RUN \
   apk --no-cache update && \
   apk --no-cache upgrade -a && \
   apk --no-cache add \
-  dhcpcd \
   && rm -rf /var/cache/apk/*
 
 COPY . ./

--- a/pkg/init/etc/init.d/rcS
+++ b/pkg/init/etc/init.d/rcS
@@ -102,5 +102,7 @@ ip addr add 127.0.0.1/8 dev lo brd + scope host
 ip route add 127.0.0.0/8 dev lo scope host
 ip link set lo up
 
-# will be containerised
-/sbin/dhcpcd
+# for containerising dhcpcd and other containers that need writable etc
+mkdir /tmp/etc
+mv /etc/resolv.conf /tmp/etc/resolv.conf
+ln -snf /tmp/etc/resolv.conf /etc/resolv.conf

--- a/test/ltp/test-ltp.yml
+++ b/test/ltp/test-ltp.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
-init: "mobylinux/init:00c3a5bbfd9794f4a3187fcc4a9f0c826c46d474"
+init: "mobylinux/init:a27e32a8d6c8865d691fbfb4d0bbb93846cf7802"
 system:
   - name: ltp
     image: "mobylinux/test-ltp-20170116:fdca2d1bb019b1d51e722e6032c82c7933d4b870"
@@ -9,6 +9,18 @@ system:
     pid: host
     capabilities:
      - CAP_SYS_ADMIN
+daemon:
+  - name: dhcpcd
+    image: "mobylinux/dhcpcd:d01a17d211218f289e2bac601bfe9787d4fabaf2"
+    binds:
+     - /var:/var
+     - /tmp:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    oom_score_adj: -800
 files:
 outputs:
   - format: kernel+initrd

--- a/test/test.yml
+++ b/test/test.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
-init: "mobylinux/init:00c3a5bbfd9794f4a3187fcc4a9f0c826c46d474"
+init: "mobylinux/init:a27e32a8d6c8865d691fbfb4d0bbb93846cf7802"
 system:
   - name: binfmt
     image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
@@ -14,6 +14,18 @@ system:
     capabilities:
      - CAP_SYS_BOOT
     readonly: true
+daemon:
+  - name: dhcpcd
+    image: "mobylinux/dhcpcd:d01a17d211218f289e2bac601bfe9787d4fabaf2"
+    binds:
+     - /var:/var
+     - /tmp:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    oom_score_adj: -800
 outputs:
   - format: kernel+initrd
   - format: iso-bios

--- a/test/virtsock/test-virtsock-server.yml
+++ b/test/virtsock/test-virtsock-server.yml
@@ -5,7 +5,7 @@ kernel:
   # image: "mobylinux/kernel:4.9.14-0"
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:00c3a5bbfd9794f4a3187fcc4a9f0c826c46d474"
+init: "mobylinux/init:a27e32a8d6c8865d691fbfb4d0bbb93846cf7802"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
@@ -22,6 +22,17 @@ daemon:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
+  - name: dhcpcd
+    image: "mobylinux/dhcpcd:d01a17d211218f289e2bac601bfe9787d4fabaf2"
+    binds:
+     - /var:/var
+     - /tmp:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    oom_score_adj: -800
   - name: virtsock-server
     image: "mobylinux/test-virtsock:35fea96fd01f6edb67021c494ddf098fdb8bbca0"
     readonly: true


### PR DESCRIPTION
Also removes `dhcpcd` from the `rcS` init script and `init` image.  Only added to `moby.yaml` but can add to more.

Can update #1298 after merging this.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>