### PR TITLE
GCP image handling enhancements

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,9 @@ type Moby struct {
 		Format  string
 		Project string
 		Bucket  string
+		Family  string
 		Public  bool
+		Replace bool
 	}
 }
 

--- a/examples/gcp.yaml
+++ b/examples/gcp.yaml
@@ -42,3 +42,5 @@ outputs:
   - format: gce
     project: moby
     bucket: mobytestjustin
+    family: moby-dev
+    replace: true

--- a/output.go
+++ b/output.go
@@ -63,7 +63,7 @@ func outputs(m *Moby, base string, bzimage []byte, initrd []byte) error {
 			if err != nil {
 				return fmt.Errorf("Error copying to Google Storage: %v", err)
 			}
-			err = imageGS(base, o.Project, "https://storage.googleapis.com/"+o.Bucket+"/"+base+".img.tar.gz")
+			err = imageGS(base, o.Project, "https://storage.googleapis.com/"+o.Bucket+"/"+base+".img.tar.gz", o.Family, o.Replace)
 			if err != nil {
 				return fmt.Errorf("Error creating Google Compute Image: %v", err)
 			}


### PR DESCRIPTION
- the `public` option was not previously implemented
- add `replace` only for GCP images which will error otherwise. Only
  recommended for use in development, in production use the `--name` option
  to provide a different name eaxch time. Note only applies to GCP images,
  will document these options properly soon.
- add a `family` option; this allows you to upload many images and the
  user can select the latest using the `family` option instead of a specific
  image.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>