### PR TITLE
Output kernel command line to a file in the kernel+initrd output case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ disk.img.*
 *.efi
 *.qcow2
 *-bzImage
+*-cmdline

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ test-bzImage: test-initrd.img
 
 # interactive versions need to use volume mounts
 .PHONY: qemu qemu-iso
-qemu: moby-initrd.img moby-bzImage bin/moby moby.yaml
-	./scripts/qemu.sh moby-initrd.img moby-bzImage "$(shell bin/moby --cmdline moby.yaml)"
+qemu: moby-initrd.img moby-bzImage moby-cmdline
+	./scripts/qemu.sh moby-initrd.img moby-bzImage "$(shell cat moby-cmdline)"
 
 qemu-iso: alpine/mobylinux-bios.iso
 	./scripts/qemu.sh $^
@@ -63,13 +63,13 @@ define check_test_log
 	@cat $1 |grep -q 'Moby test suite PASSED'
 endef
 
-hyperkit-test: scripts/hyperkit.sh bin/com.docker.hyperkit bin/vpnkit test-initrd.img test-bzImage
+hyperkit-test: scripts/hyperkit.sh bin/com.docker.hyperkit bin/vpnkit test-initrd.img test-bzImage test-cmdline
 	rm -f disk.img
 	script -q /dev/null ./scripts/hyperkit.sh test | tee test.log
 	$(call check_test_log, test.log)
 
 .PHONY: test
-test: test-initrd.img test-bzImage
+test: test-initrd.img test-bzImage test-cmdline
 	tar cf - $^ | ./scripts/qemu.sh 2>&1 | tee test.log
 	$(call check_test_log, test.log)
 

--- a/main.go
+++ b/main.go
@@ -223,13 +223,11 @@ func build(m *Moby, name string) {
 }
 
 var (
-	conf    string
-	cmdline bool
-	name    string
+	conf string
+	name string
 )
 
 func main() {
-	flag.BoolVar(&cmdline, "cmdline", false, "Print the kernel command line and exit")
 	flag.StringVar(&name, "name", "", "Name to use for output files")
 	flag.Parse()
 
@@ -254,11 +252,6 @@ func main() {
 	m, err := NewConfig(config)
 	if err != nil {
 		log.Fatalf("Invalid config: %v", err)
-	}
-
-	if cmdline {
-		fmt.Printf("%s\n", m.Kernel.Cmdline)
-		return
 	}
 
 	build(m, name)

--- a/output.go
+++ b/output.go
@@ -20,7 +20,7 @@ func outputs(m *Moby, base string, bzimage []byte, initrd []byte) error {
 	for _, o := range m.Outputs {
 		switch o.Format {
 		case "kernel+initrd":
-			err := outputKernelInitrd(base, bzimage, initrd)
+			err := outputKernelInitrd(base, bzimage, initrd, m.Kernel.Cmdline)
 			if err != nil {
 				return fmt.Errorf("Error writing %s output: %v", o.Format, err)
 			}
@@ -156,7 +156,7 @@ func outputISO(image, filename string, bzimage []byte, initrd []byte, args ...st
 	return nil
 }
 
-func outputKernelInitrd(base string, bzimage []byte, initrd []byte) error {
+func outputKernelInitrd(base string, bzimage []byte, initrd []byte, cmdline string) error {
 	err := ioutil.WriteFile(base+"-initrd.img", initrd, os.FileMode(0644))
 	if err != nil {
 		return err
@@ -165,6 +165,10 @@ func outputKernelInitrd(base string, bzimage []byte, initrd []byte) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(base + "-bzImage " + base + "-initrd.img")
+	err = ioutil.WriteFile(base+"-cmdline", []byte(cmdline), os.FileMode(0644))
+	if err != nil {
+		return err
+	}
+	fmt.Println(base + "-bzImage " + base + "-initrd.img " + base + "-cmdline")
 	return nil
 }

--- a/scripts/hyperkit.sh
+++ b/scripts/hyperkit.sh
@@ -20,13 +20,13 @@ then
 	PREFIX="moby"
 	KERNEL="$PREFIX-bzImage"
 	INITRD="$PREFIX-initrd.img"
-	CMDLINE=$(bin/moby --cmdline ${PREFIX}.yaml)
+	CMDLINE="$PREFIX-cmdline"
 elif [ $# -eq 1 ]
 then
 	PREFIX="$1"
 	KERNEL="$PREFIX-bzImage"
 	INITRD="$PREFIX-initrd.img"
-	CMDLINE=$(bin/moby --cmdline ${PREFIX}.yaml)
+	CMDLINE="$PREFIX-cmdline"
 else
 	KERNEL=$1
 	INITRD=$2

--- a/scripts/qemu.sh
+++ b/scripts/qemu.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-QEMU_IMAGE=mobylinux/qemu:97973fb6721778c639676812ccb8bc3332e0a542@sha256:c08dac641a75fda3232a8ff3250f23d743aeac12aa4db02ec7926a42b79b0e69
+QEMU_IMAGE=mobylinux/qemu:75ef01c780850daf78ee45078606eb740a999edf@sha256:ec93951816b57d86f7a90c129a5580e083093e5a92263d0d2be6822daa2162dd
 
 # if not interactive
 if [ ! -t 0 -a -z "$1" ]

--- a/tools/qemu/qemu.sh
+++ b/tools/qemu/qemu.sh
@@ -15,6 +15,7 @@ ISO="$(find . -name '*.iso')"
 RAW="$(find . -name '*.raw')"
 INITRD="$(find . -name '*.img')"
 KERNEL="$(find . -name vmlinuz64 -or -name '*bzImage')"
+CMDLINE="$(find . -name '*-cmdline')"
 
 if [ -n "$ISO" ]
 then
@@ -38,7 +39,12 @@ fi
 
 echo "$ARGS" | grep -q systemdisk && qemu-img create -f raw systemdisk.img 256M
 
-CMDLINE="$*"
+if [ -n "${CMDLINE}" ]
+then
+	CMDLINE="$(cat $CMDLINE)"
+else
+	CMDLINE="$*"
+fi
 if [ -z "${CMDLINE}" ]
 then
 	CMDLINE="console=ttyS0"


### PR DESCRIPTION
Trying to find the relevant yaml file was an issue as we now support
`--name` and it might be in a different directory, so although it is
a bit verbose outputing a whole file at least it is more consistent.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>