### PR TITLE
add policycoreutils to the base image

### DIFF
--- a/base/init/Dockerfile
+++ b/base/init/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.5
 
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 RUN \
   apk --no-cache update && \
   apk --no-cache upgrade -a && \
@@ -7,6 +8,7 @@ RUN \
   dhcpcd \
   e2fsprogs \
   e2fsprogs-extra \
+  policycoreutils \
   && rm -rf /var/cache/apk/*
 
 COPY . ./

--- a/moby.yaml
+++ b/moby.yaml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:d6d115d601e78f7909d4a2ff7eb4caa3fff65271"
+init: "mobylinux/init:6c08e7434c247b88c0699655d4a76d78d746739d"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"


### PR DESCRIPTION
Note that this brings in alpine edge/testing, since that's the only place
that policycoreutils exists for now. (so we may not want to merge this, but
I'll put it up any way for discussion.)

Signed-off-by: Tycho Andersen <tycho@docker.com>