### PR TITLE
Fix accidental removal of /etc/mtab from images

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,7 +50,7 @@ type MobyImage struct {
 	ReadOnly     bool `yaml:"read_only"`
 }
 
-const riddler = "mobylinux/riddler:8fe62ff02b9d28767554105b55d4613db3e77429@sha256:42b7f5c81fb85f8afb17548e00e5b81cfa4818c192e1199d61850491a178b0da"
+const riddler = "mobylinux/riddler:c23ab4b6e2a2a4ebd4dd51a059cef7f270da72cb@sha256:7e7744b2f554518411633200db98e599782b120e323348495f43f540de26f7b6"
 
 // NewConfig parses a config file
 func NewConfig(config []byte) (*Moby, error) {

--- a/tools/riddler/riddler.sh
+++ b/tools/riddler/riddler.sh
@@ -52,7 +52,7 @@ rm config.json.orig
 # extract rootfs
 EXCLUDE="--exclude .dockerenv --exclude Dockerfile \
         --exclude dev/console --exclude dev/pts --exclude dev/shm \
-        --exclude etc/hostname --exclude etc/hosts --exclude etc/mtab --exclude etc/resolv.conf"
+        --exclude etc/hostname --exclude etc/hosts --exclude etc/resolv.conf"
 mkdir -p rootfs
 CONTAINER="$(docker create $IMAGE /dev/null)"
 docker export "$CONTAINER" | tar -xf - -C rootfs $EXCLUDE


### PR DESCRIPTION
This was breaking some containers that use it, was a mistake.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>