### PR TITLE
Make sshd output to stderr not syslog

### DIFF
--- a/base/sshd/usr/bin/ssh.sh
+++ b/base/sshd/usr/bin/ssh.sh
@@ -3,4 +3,4 @@
 KEYS=$(find /etc/ssh -name 'ssh_host_*_key')
 [ -z "$KEYS" ] && ssh-keygen -A >/dev/null 2>/dev/null
 
-exec /usr/sbin/sshd -D
+exec /usr/sbin/sshd -D -e

--- a/examples/gcp.yaml
+++ b/examples/gcp.yaml
@@ -36,7 +36,7 @@ daemon:
     read_only: true
     command: [/bin/tini, /usr/sbin/rngd, -f]
   - name: sshd
-    image: "mobylinux/sshd:3940f3fa07da1b6adab975112894b103b3c491f1"
+    image: "mobylinux/sshd:4f8452ddaff703416fd7452fcd9693b96b23e847"
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN

--- a/examples/sshd.yaml
+++ b/examples/sshd.yaml
@@ -23,7 +23,7 @@ daemon:
     oom_score_adj: -800
     command: [/bin/tini, /usr/sbin/rngd, -f]
   - name: sshd
-    image: "mobylinux/sshd:3940f3fa07da1b6adab975112894b103b3c491f1"
+    image: "mobylinux/sshd:4f8452ddaff703416fd7452fcd9693b96b23e847"
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN


### PR DESCRIPTION
This way we get to see the logs.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>