### PR TITLE
added the capability to produce a vmdk file through Moby

### DIFF
--- a/examples/vmware.yaml
+++ b/examples/vmware.yaml
@@ -1,0 +1,41 @@
+kernel:
+  image: "mobylinux/kernel:4.9.x"
+  cmdline: "console=tty0 page_poison=1"
+init: "mobylinux/init:d6d115d601e78f7909d4a2ff7eb4caa3fff65271"
+system:
+  - name: sysctl
+    image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
+    network_mode: host
+    pid: host
+    ipc: host
+    capabilities:
+     - CAP_SYS_ADMIN
+    read_only: true
+  - name: binfmt
+    image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
+    binds:
+     - /proc/sys/fs/binfmt_misc:/binfmt_misc
+    read_only: true
+    command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
+daemon:
+  - name: rngd
+    image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"
+    capabilities:
+     - CAP_SYS_ADMIN
+    oom_score_adj: -800
+    read_only: true
+    command: [/bin/tini, /usr/sbin/rngd, -f]
+  - name: nginx
+    image: "nginx:alpine"
+    capabilities:
+     - CAP_NET_BIND_SERVICE
+     - CAP_CHOWN
+     - CAP_SETUID
+     - CAP_SETGID
+     - CAP_DAC_OVERRIDE
+    network_mode: host
+files:
+  - path: etc/docker/daemon.json
+    contents: '{"debug": true}'
+outputs:
+  - format: vmdk

--- a/src/cmd/moby/output.go
+++ b/src/cmd/moby/output.go
@@ -14,6 +14,7 @@ const (
 	gce  = "mobylinux/mkimage-gce:2039be4e39e855d1845aee188e266bba3f1d2eed@sha256:e12f76003fd9eaa0c6f39f149db5998cf56de42539b989c994893c8344ca69c0"
 	qcow = "mobylinux/mkimage-qcow:9b3632f111675898ed3a22ac71897e735b5a8364@sha256:2132cf3fb593d65f09c8d109d40e1fad138d81485d4750fc29a7f54611d78d35"
 	vhd  = "mobylinux/mkimage-vhd:73c80e433bf717578c507621a84fd58cec27fe95@sha256:0ae1eda2d6592f309977dc4b25cca120cc4e2ee2cc786e88fdc2761c0d49cb14"
+	vmdk = "mobylinux/mkimage-vmdk:1de360a30f3ac6a91d4eae1ae4611cea4b82f22a@sha256:d7e65edc6dd88f6e12dcb0d749d4c7e5793d1250e548b58c105dbfd082940787"
 )
 
 func outputs(m *Moby, base string, bzimage []byte, initrd []byte) error {
@@ -74,6 +75,11 @@ func outputs(m *Moby, base string, bzimage []byte, initrd []byte) error {
 			}
 		case "vhd":
 			err := outputImg(vhd, base+".vhd", bzimage, initrd, m.Kernel.Cmdline)
+			if err != nil {
+				return fmt.Errorf("Error writing %s output: %v", o.Format, err)
+			}
+		case "vmdk":
+			err := outputImg(vmdk, base+".vmdk", bzimage, initrd, m.Kernel.Cmdline)
 			if err != nil {
 				return fmt.Errorf("Error writing %s output: %v", o.Format, err)
 			}

--- a/tools/mkimage-vmdk/Dockerfile
+++ b/tools/mkimage-vmdk/Dockerfile
@@ -1,0 +1,5 @@
+FROM mobylinux/guestfs:69698aca5bfcb8c4d3a3bbe6d8656be155bf8cd6@sha256:703a7372ada5b3db64a11bc8c60eec06659a1052d9296fa0c556ed3faf75c182
+
+COPY . .
+
+ENTRYPOINT [ "/make-vmdk" ]

--- a/tools/mkimage-vmdk/Makefile
+++ b/tools/mkimage-vmdk/Makefile
@@ -1,0 +1,27 @@
+.PHONY: tag push
+
+IMAGE=mkimage-vmdk
+
+default: push
+
+hash: Dockerfile make-vmdk
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --entrypoint sh --rm $(IMAGE):build -c "(cat $^; apt list --installed 2>/dev/null) | sha1sum" | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/tools/mkimage-vmdk/make-vmdk
+++ b/tools/mkimage-vmdk/make-vmdk
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+set -e
+
+mkdir -p /tmp/image
+cd /tmp/image
+
+# input is a tarball of vmlinuz64 and initrd.img on stdin
+# output is a vmdk on stdout
+
+mkdir -p files
+
+cd files
+
+# extract. As guestfs base is currently Debian, no compression support
+# only if stdin is a tty, if so need files volume mounted...
+[ -t 0 ] || tar xf -
+
+INITRD="$(find . -name '*.img')"
+KERNEL="$(find . -name vmlinuz64 -or -name '*bzImage')"
+CMDLINE="$*"
+
+[ "$KERNEL" = "./vmlinuz64" ] || mv "$KERNEL" vmlinuz64
+[ "$INITRD" = "./initrd.img" ] || mv "$INITRD" initrd.img
+
+# clean up subdirectories
+find . -mindepth 1 -maxdepth 1 -type d | xargs rm -rf
+
+CFG="DEFAULT linux
+LABEL linux
+    KERNEL /vmlinuz64
+    INITRD /initrd.img
+    APPEND ${CMDLINE}
+"
+
+printf "$CFG" > syslinux.cfg
+
+cd ..
+
+tar cf files.tar -C files .
+
+# Disk is created in qcow format, testing needed to see if raw->vmdk conversion makes any efficency gains
+virt-make-fs --size=1G --type=ext4 --partition files.tar --format=qcow2 disk.qcow
+
+guestfish -a disk.qcow -m /dev/sda1 <<EOF
+  upload /usr/lib/SYSLINUX/mbr.bin /mbr.bin
+  copy-file-to-device /mbr.bin /dev/sda size:440
+  rm /mbr.bin
+  extlinux /
+  part-set-bootable /dev/sda 1 true
+EOF
+
+# compress qcow image to VMware Disk format
+qemu-img convert -f qcow2 -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 -c disk.qcow disk.vmdk 1>&2
+
+cat disk.vmdk


### PR DESCRIPTION
Currently will follow the same path as other outputs and build a VMware compliant disk image that can then be booted and used with VMware Fusion and Workstation. 

To work with vSphere(ESXi) then the disk image needs to be inflated using the `vmfs-tools` command in the vSphere cli. Also typically VMware VMs expose console output to a virtual console and they don't tend to use a serial device so output to tty0 instead of serial or ttyS0.