### PR TITLE
moby: Log error when the kernel untar fails

### DIFF
--- a/src/cmd/moby/build.go
+++ b/src/cmd/moby/build.go
@@ -107,7 +107,7 @@ func build(name string, args []string) {
 	buf := bytes.NewBuffer(out)
 	bzimage, ktar, err := untarKernel(buf, bzimageName, ktarName)
 	if err != nil {
-		log.Fatalf("Could not extract bzImage and kernel filesystem from tarball")
+		log.Fatalf("Could not extract bzImage and kernel filesystem from tarball. %v", err)
 	}
 	containers = append(containers, ktar)
 


### PR DESCRIPTION
Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>