### PR TITLE
Use Go code to extract rootfs from system containers

### DIFF
--- a/tools/riddler/riddler.sh
+++ b/tools/riddler/riddler.sh
@@ -3,15 +3,12 @@
 set -e
 
 # arguments are image name, prefix, then arguments passed to Docker
-# eg ./riddler.sh alpine:3.4 / --read-only alpine:3.4 ls
-# This script will output a tarball under prefix/ with rootfs and config.json
+# eg ./riddler.sh alpine:3.4 --read-only alpine:3.4 ls
+# This script will output config.json
 
 IMAGE="$1"; shift
-PREFIX="$1"; shift
 
 cd /tmp
-mkdir -p /tmp/$PREFIX
-cd /tmp/$PREFIX
 
 # riddler always adds the apparmor options if this is not present
 EXTRA_OPTIONS="--security-opt apparmor=unconfined"
@@ -22,7 +19,7 @@ riddler $CONTAINER > /dev/null
 docker rm $CONTAINER > /dev/null
 
 # unfixed known issues
-# noNewPrivileges is always set by riddler, but that is fine for our use cases
+# noNewPrivileges is always set by riddler
 
 # These fixes should be removed when riddler is fixed
 # process.rlimits, just a constant at present, not useful
@@ -47,16 +44,5 @@ cat config.json.orig | \
   jq 'if .root.readonly==true then .mounts = (.mounts|map(if .destination=="/dev" then .options |= .+ ["ro"] else . end)) else . end' | \
   jq '.mounts = if .process.capabilities | length != 38 then (.mounts|map(if .destination=="/sys" then .options |= .+ ["ro"] else . end)) else . end' \
   > config.json
-rm config.json.orig
 
-# extract rootfs
-EXCLUDE="--exclude .dockerenv --exclude Dockerfile \
-        --exclude dev/console --exclude dev/pts --exclude dev/shm \
-        --exclude etc/hostname --exclude etc/hosts --exclude etc/resolv.conf"
-mkdir -p rootfs
-CONTAINER="$(docker create $IMAGE /dev/null)"
-docker export "$CONTAINER" | tar -xf - -C rootfs $EXCLUDE
-docker rm "$CONTAINER" > /dev/null
-
-cd /tmp
-tar cf - .
+cat config.json


### PR DESCRIPTION
- this removes the use of riddler to extract the rootfs, use code
  we were using for rootfs. riddler now just geenrates the config,
  next stage is to generate this ourselves
- change the naming of the daemons so no longer include number as we
  do not guarantee ordering as they start up simultaneously

Signed-off-by: Justin Cormack <justin.cormack@docker.com>