### PR TITLE
Fix typo in `moby run`

### DIFF
--- a/src/cmd/moby/run_fallback.go
+++ b/src/cmd/moby/run_fallback.go
@@ -7,5 +7,5 @@ import (
 )
 
 func run(cpus, mem, diskSz int, userData string, args []string) {
-	log.Fatalf("'run' is not support yet on your OS")
+	log.Fatalf("'run' is not supported yet on your OS")
 }


### PR DESCRIPTION
Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>