### PR TITLE
kernel: Update to 4.9.18/4.10.6/4.4.57

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -19,18 +19,18 @@ all:	bzImage tag
 #
 # IMAGE_VERSION is used to determine if a new image should be pushed to hub.
 ifeq ($(KERNEL),v4.4)
-KERNEL_VERSION=4.4.56
+KERNEL_VERSION=4.4.57
 IMAGE_VERSION=$(KERNEL_VERSION)-0
 IMAGE_MAJOR_VERSION=4.4.x
 DEPS=Dockerfile.4.4 Makefile kernel_config kernel_config.debug kernel_config.4.4 patches-4.4
 else
 ifeq ($(KERNEL),v4.10)
-KERNEL_VERSION=4.10.5
+KERNEL_VERSION=4.10.6
 IMAGE_VERSION=$(KERNEL_VERSION)-0
 IMAGE_MAJOR_VERSION=4.10.x
 DEPS=Dockerfile.4.10 Makefile kernel_config kernel_config.debug patches-4.10
 else
-KERNEL_VERSION=4.9.17
+KERNEL_VERSION=4.9.18
 IMAGE_VERSION=$(KERNEL_VERSION)-0
 IMAGE_MAJOR_VERSION=4.9.x
 DEPS=Dockerfile Makefile kernel_config kernel_config.debug patches-4.9

--- a/kernel/patches-4.10/0001-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.10/0001-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From acd67b5a33dc9c39bb76ef4788e59f412d39edb4 Mon Sep 17 00:00:00 2001
+From 3be38bf120ec1165e991ed223b1f64f8105ab76e Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Thu, 21 Jul 2016 16:04:38 -0600
 Subject: [PATCH 1/4] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.10/0002-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.10/0002-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From f592e381a0231264f876d289f0947d42db01e3f6 Mon Sep 17 00:00:00 2001
+From 350d124854fcb5ecfe9347fb4b893d27d6b6660e Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 2/4] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.10/0003-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.10/0003-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 22e8a7b1d3c4dd0f70ac49cf7ccd2ae84d759290 Mon Sep 17 00:00:00 2001
+From 15a8be4e26e2ab23e2bff953aed060f0cb5fab39 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 3/4] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.10/0004-Drivers-hv-vmbus-Don-t-leak-memory-when-a-channel-is.patch
+++ b/kernel/patches-4.10/0004-Drivers-hv-vmbus-Don-t-leak-memory-when-a-channel-is.patch
@@ -1,4 +1,4 @@
-From 51264740f74056be648834a1e96b3f4600d627e8 Mon Sep 17 00:00:00 2001
+From be86c6dee392d2f7d4b42b7c191c429ac5e3f263 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Sun, 12 Mar 2017 20:00:30 -0700
 Subject: [PATCH 4/4] Drivers: hv: vmbus: Don't leak memory when a channel is

--- a/kernel/patches-4.4/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
+++ b/kernel/patches-4.4/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
@@ -1,4 +1,4 @@
-From 5e12acc5d38a33667498957b57d3b86e85d71f24 Mon Sep 17 00:00:00 2001
+From f609cbcf7e261fecf0285dafe9960de7bc946ba2 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 17 Dec 2015 16:53:43 +0800
 Subject: [PATCH 01/44] virtio: make find_vqs() checkpatch.pl-friendly

--- a/kernel/patches-4.4/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
+++ b/kernel/patches-4.4/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
@@ -1,4 +1,4 @@
-From 612f8312f280c0b87f855a270d33e9330cf68c86 Mon Sep 17 00:00:00 2001
+From 47fddf67540bce994ef48320af50780069a4487a Mon Sep 17 00:00:00 2001
 From: Julia Lawall <julia.lawall@lip6.fr>
 Date: Sat, 21 Nov 2015 18:39:17 +0100
 Subject: [PATCH 02/44] VSOCK: constify vmci_transport_notify_ops structures

--- a/kernel/patches-4.4/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
+++ b/kernel/patches-4.4/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
@@ -1,4 +1,4 @@
-From cd1c3d1b54de4cc16c9069d09602b16f81c0dd91 Mon Sep 17 00:00:00 2001
+From 71330f083c95bf08f9003dde832336a1fe59332c Mon Sep 17 00:00:00 2001
 From: Claudio Imbrenda <imbrenda@linux.vnet.ibm.com>
 Date: Tue, 22 Mar 2016 17:05:52 +0100
 Subject: [PATCH 03/44] AF_VSOCK: Shrink the area influenced by prepare_to_wait

--- a/kernel/patches-4.4/0004-vsock-make-listener-child-lock-ordering-explicit.patch
+++ b/kernel/patches-4.4/0004-vsock-make-listener-child-lock-ordering-explicit.patch
@@ -1,4 +1,4 @@
-From 232ab4b0f3fb1d2fcc1af5b527edfd147a611a83 Mon Sep 17 00:00:00 2001
+From 5258b00ab6d2cc6180ac1c8d938b0f949fa3a70c Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 23 Jun 2016 16:28:58 +0100
 Subject: [PATCH 04/44] vsock: make listener child lock ordering explicit

--- a/kernel/patches-4.4/0005-VSOCK-transport-specific-vsock_transport-functions.patch
+++ b/kernel/patches-4.4/0005-VSOCK-transport-specific-vsock_transport-functions.patch
@@ -1,4 +1,4 @@
-From c86fe45425ee5a04601a232c0d4ffc17608eff45 Mon Sep 17 00:00:00 2001
+From 0a646670d90865b154390820c6150ec72e0f4fca Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:30 +0100
 Subject: [PATCH 05/44] VSOCK: transport-specific vsock_transport functions

--- a/kernel/patches-4.4/0006-VSOCK-defer-sock-removal-to-transports.patch
+++ b/kernel/patches-4.4/0006-VSOCK-defer-sock-removal-to-transports.patch
@@ -1,4 +1,4 @@
-From 0194d0bb926846d6bca6cd9a7b9cd35483d872d2 Mon Sep 17 00:00:00 2001
+From 96ec12e1052d002eb024d19e016682729e3cc8cf Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:31 +0100
 Subject: [PATCH 06/44] VSOCK: defer sock removal to transports

--- a/kernel/patches-4.4/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
+++ b/kernel/patches-4.4/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
@@ -1,4 +1,4 @@
-From 09a9119cde42487ae8193fc97916f69574203af8 Mon Sep 17 00:00:00 2001
+From 8fbd614bbb155c91ef7b420b2a654ef8c53d67e0 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:32 +0100
 Subject: [PATCH 07/44] VSOCK: Introduce virtio_vsock_common.ko

--- a/kernel/patches-4.4/0008-VSOCK-Introduce-virtio_transport.ko.patch
+++ b/kernel/patches-4.4/0008-VSOCK-Introduce-virtio_transport.ko.patch
@@ -1,4 +1,4 @@
-From 2acff6b7a935a385a0999db2f31f48efaca9fd74 Mon Sep 17 00:00:00 2001
+From bc950a7d03d15e59bac430c0a77e7418db614bd8 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:33 +0100
 Subject: [PATCH 08/44] VSOCK: Introduce virtio_transport.ko

--- a/kernel/patches-4.4/0009-VSOCK-Introduce-vhost_vsock.ko.patch
+++ b/kernel/patches-4.4/0009-VSOCK-Introduce-vhost_vsock.ko.patch
@@ -1,4 +1,4 @@
-From 26b96af0185d0dfcbf2cb3afa1862a12d1ba9266 Mon Sep 17 00:00:00 2001
+From 8c891d7e147e4515c22b67216776a05cd232f638 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:34 +0100
 Subject: [PATCH 09/44] VSOCK: Introduce vhost_vsock.ko

--- a/kernel/patches-4.4/0010-VSOCK-Add-Makefile-and-Kconfig.patch
+++ b/kernel/patches-4.4/0010-VSOCK-Add-Makefile-and-Kconfig.patch
@@ -1,4 +1,4 @@
-From 295b275545b3a0b70e95a41b36ea8d7efb5e4118 Mon Sep 17 00:00:00 2001
+From 6fb88b14e8b096eb0c6d490eaafabff87fa40d69 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:35 +0100
 Subject: [PATCH 10/44] VSOCK: Add Makefile and Kconfig

--- a/kernel/patches-4.4/0011-VSOCK-Use-kvfree.patch
+++ b/kernel/patches-4.4/0011-VSOCK-Use-kvfree.patch
@@ -1,4 +1,4 @@
-From 879a69af16683d9a094559ec2265e7b377866306 Mon Sep 17 00:00:00 2001
+From 39f091319312580b581a4f64de76c73466dd20e2 Mon Sep 17 00:00:00 2001
 From: Wei Yongjun <weiyj.lk@gmail.com>
 Date: Tue, 2 Aug 2016 13:50:42 +0000
 Subject: [PATCH 11/44] VSOCK: Use kvfree()

--- a/kernel/patches-4.4/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
+++ b/kernel/patches-4.4/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
@@ -1,4 +1,4 @@
-From 9e02eb938fd8f565615e638c088fa66bc1aef706 Mon Sep 17 00:00:00 2001
+From ad5fde73d72766b69445ef6b94740912b962542b Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 4 Aug 2016 14:52:53 +0100
 Subject: [PATCH 12/44] vhost/vsock: fix vhost virtio_vsock_pkt use-after-free

--- a/kernel/patches-4.4/0013-virtio-vsock-fix-include-guard-typo.patch
+++ b/kernel/patches-4.4/0013-virtio-vsock-fix-include-guard-typo.patch
@@ -1,4 +1,4 @@
-From 8766952865ef882300fffdaf15b92c9f7d55b10b Mon Sep 17 00:00:00 2001
+From 8c5b0e95393280c29bda5c87f921470dee326829 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Fri, 5 Aug 2016 13:52:09 +0100
 Subject: [PATCH 13/44] virtio-vsock: fix include guard typo

--- a/kernel/patches-4.4/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
+++ b/kernel/patches-4.4/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
@@ -1,4 +1,4 @@
-From 1db43ebf78e63c1aa6aec286762e124985e159e0 Mon Sep 17 00:00:00 2001
+From b62b8ac0df932a45659e98a0072f53a281fde234 Mon Sep 17 00:00:00 2001
 From: Gerard Garcia <ggarcia@deic.uab.cat>
 Date: Wed, 10 Aug 2016 17:24:34 +0200
 Subject: [PATCH 14/44] vhost/vsock: drop space available check for TX vq

--- a/kernel/patches-4.4/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/kernel/patches-4.4/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,4 +1,4 @@
-From 93842085264c9dbc2ccf2a783f6af7ef7ea1c122 Mon Sep 17 00:00:00 2001
+From c6a4cf264d47cca0609ae25bc53fe9659fa74759 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
 Subject: [PATCH 15/44] VSOCK: Only allow host network namespace to use

--- a/kernel/patches-4.4/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
+++ b/kernel/patches-4.4/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
@@ -1,4 +1,4 @@
-From cc421fff7dfb83519158eeccd348ca3b968c8da4 Mon Sep 17 00:00:00 2001
+From e79159e1fe83564499dcdf8b3246c6c8021f8f44 Mon Sep 17 00:00:00 2001
 From: Jake Oshins <jakeo@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:41 -0800
 Subject: [PATCH 16/44] drivers:hv: Define the channel type for Hyper-V PCI

--- a/kernel/patches-4.4/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
+++ b/kernel/patches-4.4/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
@@ -1,4 +1,4 @@
-From f676eae840f5b6ce74421de82fbdaf912fb7fae9 Mon Sep 17 00:00:00 2001
+From d3203316d4990cbfed4d9fa6849c82f6bf17698e Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:43 -0800
 Subject: [PATCH 17/44] Drivers: hv: vmbus: Use uuid_le type consistently
@@ -30,7 +30,7 @@ index a562318b856b..339277b76468 100644
  			perf_chn = true;
  			break;
 diff --git a/drivers/hv/vmbus_drv.c b/drivers/hv/vmbus_drv.c
-index 509ed9731630..6ce2bf81dae3 100644
+index 802dcb409030..f1fbb6b98f5c 100644
 --- a/drivers/hv/vmbus_drv.c
 +++ b/drivers/hv/vmbus_drv.c
 @@ -533,7 +533,7 @@ static int vmbus_uevent(struct device *device, struct kobj_uevent_env *env)

--- a/kernel/patches-4.4/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
+++ b/kernel/patches-4.4/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
@@ -1,4 +1,4 @@
-From f952ef62880a08a1cc3359659ced549efa9a0d32 Mon Sep 17 00:00:00 2001
+From 660faacaab63072bd6cce85a15b9f12172e957d6 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:44 -0800
 Subject: [PATCH 18/44] Drivers: hv: vmbus: Use uuid_le_cmp() for comparing
@@ -29,7 +29,7 @@ index 339277b76468..9b4525c56376 100644
  			break;
  		}
 diff --git a/drivers/hv/vmbus_drv.c b/drivers/hv/vmbus_drv.c
-index 6ce2bf81dae3..7973aa55fec8 100644
+index f1fbb6b98f5c..e71f3561dbab 100644
 --- a/drivers/hv/vmbus_drv.c
 +++ b/drivers/hv/vmbus_drv.c
 @@ -535,7 +535,7 @@ static const uuid_le null_guid;

--- a/kernel/patches-4.4/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
+++ b/kernel/patches-4.4/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
@@ -1,4 +1,4 @@
-From 117a02eb9d9b39deb531f13d41cdf9c94529e194 Mon Sep 17 00:00:00 2001
+From 0d08fd09131b9376891a20832cb032b57eb0b7e4 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:48 -0800
 Subject: [PATCH 19/44] Drivers: hv: vmbus: do sanity check of channel state in

--- a/kernel/patches-4.4/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
+++ b/kernel/patches-4.4/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
@@ -1,4 +1,4 @@
-From da2a577174d79446488b2c4a3043ad61ec5b805d Mon Sep 17 00:00:00 2001
+From 4a11c27e225efac7b5c83293b35b491e6fc206fa Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:50 -0800
 Subject: [PATCH 20/44] Drivers: hv: vmbus: release relid on error in

--- a/kernel/patches-4.4/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
+++ b/kernel/patches-4.4/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
@@ -1,4 +1,4 @@
-From 608be9f80b46b13603f454a099516914c8ca5251 Mon Sep 17 00:00:00 2001
+From 8fd76670d0030231caf284661cd41b31f50919aa Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:51 -0800
 Subject: [PATCH 21/44] Drivers: hv: vmbus: channge
@@ -99,7 +99,7 @@ index 4fc2e8836e60..521f48ed188e 100644
  	return found_channel;
  }
 diff --git a/drivers/hv/hyperv_vmbus.h b/drivers/hv/hyperv_vmbus.h
-index 12156db2e88e..50b1de7439cf 100644
+index 75e383e6d03d..9a95beb87015 100644
 --- a/drivers/hv/hyperv_vmbus.h
 +++ b/drivers/hv/hyperv_vmbus.h
 @@ -683,7 +683,7 @@ struct vmbus_connection {

--- a/kernel/patches-4.4/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
+++ b/kernel/patches-4.4/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
@@ -1,4 +1,4 @@
-From 519c5f0747e3e01ec2d001c821783b5e489c216b Mon Sep 17 00:00:00 2001
+From 7f5f3108931dd156d30f6aa01b1828be2996c4f6 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Mon, 14 Dec 2015 19:02:00 -0800
 Subject: [PATCH 22/44] Drivers: hv: remove code duplication between

--- a/kernel/patches-4.4/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
+++ b/kernel/patches-4.4/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
@@ -1,4 +1,4 @@
-From 069f9c45cd43deed1a4be96fdbda43c5c4a4b9ea Mon Sep 17 00:00:00 2001
+From 78aba226343625e407c1e35b0a8d8872cfa689d1 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Dec 2015 12:21:22 -0800
 Subject: [PATCH 23/44] Drivers: hv: vmbus: fix the building warning with

--- a/kernel/patches-4.4/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
+++ b/kernel/patches-4.4/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
@@ -1,4 +1,4 @@
-From 78982eba129722cc52e93a653a488e2808dbc378 Mon Sep 17 00:00:00 2001
+From cc4d402849a6594f8939795f2ee25ed490481f19 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Tue, 15 Dec 2015 16:27:27 -0800
 Subject: [PATCH 24/44] Drivers: hv: vmbus: Treat Fibre Channel devices as

--- a/kernel/patches-4.4/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
+++ b/kernel/patches-4.4/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
@@ -1,4 +1,4 @@
-From 42ecff880b8b4eddaabadebc98a09dff0addb50e Mon Sep 17 00:00:00 2001
+From 0ffbed6c39e20d8871354ada8d71acbea5436de8 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Fri, 25 Dec 2015 20:00:30 -0800
 Subject: [PATCH 25/44] Drivers: hv: vmbus: Add vendor and device atttributes
@@ -259,7 +259,7 @@ index 763d0c19c16f..d6c611457601 100644
  	    (vmbus_proto_version == VERSION_WIN7) || (!perf_chn)) {
  		/*
 diff --git a/drivers/hv/vmbus_drv.c b/drivers/hv/vmbus_drv.c
-index 7973aa55fec8..de7130c58a62 100644
+index e71f3561dbab..f688c051ca17 100644
 --- a/drivers/hv/vmbus_drv.c
 +++ b/drivers/hv/vmbus_drv.c
 @@ -480,6 +480,24 @@ static ssize_t channel_vp_mapping_show(struct device *dev,

--- a/kernel/patches-4.4/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
+++ b/kernel/patches-4.4/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
@@ -1,4 +1,4 @@
-From 16e153c452824c7a2dd3fa2fd57268cbd2b379a9 Mon Sep 17 00:00:00 2001
+From dde5ae12edb1fe8eafc8149c588663f2c4467392 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:37 -0800
 Subject: [PATCH 26/44] Drivers: hv: vmbus: add a helper function to set a

--- a/kernel/patches-4.4/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
+++ b/kernel/patches-4.4/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
@@ -1,4 +1,4 @@
-From 1c95c1cc09e4dafccb0cd338979d20e73a0b22f3 Mon Sep 17 00:00:00 2001
+From 395b20806a2c2df902dcb7413d4c47ff70bd8a18 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:38 -0800
 Subject: [PATCH 27/44] Drivers: hv: vmbus: define the new offer type for

--- a/kernel/patches-4.4/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
+++ b/kernel/patches-4.4/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
@@ -1,4 +1,4 @@
-From 1a1b2e1d15bea2b37e4f683cfc6dc95426be15db Mon Sep 17 00:00:00 2001
+From a81d89d49e989e620b801d19c21f1fa793c506b3 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:39 -0800
 Subject: [PATCH 28/44] Drivers: hv: vmbus: vmbus_sendpacket_ctl: hvsock: avoid

--- a/kernel/patches-4.4/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
+++ b/kernel/patches-4.4/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
@@ -1,4 +1,4 @@
-From 4b861e32386a9cfc1d24faae4ee3f06f44281cb1 Mon Sep 17 00:00:00 2001
+From 95be5eb3975f43a75f80b9414387c90b296cc82a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:40 -0800
 Subject: [PATCH 29/44] Drivers: hv: vmbus: define a new VMBus message type for

--- a/kernel/patches-4.4/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
+++ b/kernel/patches-4.4/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
@@ -1,4 +1,4 @@
-From 1aa9eab5b9303e3a5d3e95e3cac6d7c5055462c4 Mon Sep 17 00:00:00 2001
+From 9c4c8be9ef0fb7bd67145dade8082754b686b8d0 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:41 -0800
 Subject: [PATCH 30/44] Drivers: hv: vmbus: add a hvsock flag in struct
@@ -20,7 +20,7 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
  2 files changed, 18 insertions(+)
 
 diff --git a/drivers/hv/vmbus_drv.c b/drivers/hv/vmbus_drv.c
-index de7130c58a62..03fc5d317b22 100644
+index f688c051ca17..a220efc297c4 100644
 --- a/drivers/hv/vmbus_drv.c
 +++ b/drivers/hv/vmbus_drv.c
 @@ -585,6 +585,10 @@ static int vmbus_match(struct device *device, struct device_driver *driver)

--- a/kernel/patches-4.4/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
+++ b/kernel/patches-4.4/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
@@ -1,4 +1,4 @@
-From 193cdd556c56f5e3680e569c03bb8e6a7fe96d81 Mon Sep 17 00:00:00 2001
+From 109111b9519f6c6128da5115e24e18410e69f1a2 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:42 -0800
 Subject: [PATCH 31/44] Drivers: hv: vmbus: add a per-channel rescind callback

--- a/kernel/patches-4.4/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
+++ b/kernel/patches-4.4/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
@@ -1,4 +1,4 @@
-From 18fa7fe2daa6b3b17b64dfdded56b26c38481ec5 Mon Sep 17 00:00:00 2001
+From 08f9e7c593d157ce4dc03c2a4856fd84971a7cbd Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:43 -0800
 Subject: [PATCH 32/44] Drivers: hv: vmbus: add an API

--- a/kernel/patches-4.4/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
+++ b/kernel/patches-4.4/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
@@ -1,4 +1,4 @@
-From 6dff61b3ec25d9d10e248688e1a8e58a5f9d6dfe Mon Sep 17 00:00:00 2001
+From 6cf4900b125efa655cac0855f71caaf37d129087 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:45 -0800
 Subject: [PATCH 33/44] Drivers: hv: vmbus: Give control over how the ring
@@ -111,7 +111,7 @@ index cf311be88cb4..b40f429aaa13 100644
  	spin_lock_init(&channel->lock);
  
 diff --git a/drivers/hv/hyperv_vmbus.h b/drivers/hv/hyperv_vmbus.h
-index 50b1de7439cf..89bb5591498e 100644
+index 9a95beb87015..9976774d6abc 100644
 --- a/drivers/hv/hyperv_vmbus.h
 +++ b/drivers/hv/hyperv_vmbus.h
 @@ -617,7 +617,7 @@ void hv_ringbuffer_cleanup(struct hv_ring_buffer_info *ring_info);

--- a/kernel/patches-4.4/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
+++ b/kernel/patches-4.4/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
@@ -1,4 +1,4 @@
-From b69e0416edf6d148c25b0098f6bf53bf583ab1a1 Mon Sep 17 00:00:00 2001
+From 8c1531920129543abc16064dfa975e0c43479ac1 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:16 -0800
 Subject: [PATCH 34/44] Drivers: hv: vmbus: avoid wait_for_completion() on
@@ -61,7 +61,7 @@ index 09c08b56e3dc..78b8be87844c 100644
  	if (vmbus_connection.work_queue) {
  		drain_workqueue(vmbus_connection.work_queue);
 diff --git a/drivers/hv/hyperv_vmbus.h b/drivers/hv/hyperv_vmbus.h
-index 89bb5591498e..f424c2df6c19 100644
+index 9976774d6abc..4aadad6a0cde 100644
 --- a/drivers/hv/hyperv_vmbus.h
 +++ b/drivers/hv/hyperv_vmbus.h
 @@ -756,7 +756,7 @@ void hv_vss_onchannelcallback(void *);
@@ -74,7 +74,7 @@ index 89bb5591498e..f424c2df6c19 100644
  static inline void hv_poll_channel(struct vmbus_channel *channel,
  				   void (*cb)(void *))
 diff --git a/drivers/hv/vmbus_drv.c b/drivers/hv/vmbus_drv.c
-index 03fc5d317b22..b0cc6fd74fd0 100644
+index a220efc297c4..d9801855ad4e 100644
 --- a/drivers/hv/vmbus_drv.c
 +++ b/drivers/hv/vmbus_drv.c
 @@ -1276,7 +1276,7 @@ static void hv_kexec_handler(void)
@@ -85,7 +85,7 @@ index 03fc5d317b22..b0cc6fd74fd0 100644
 +	vmbus_initiate_unload(false);
  	for_each_online_cpu(cpu)
  		smp_call_function_single(cpu, hv_synic_cleanup, NULL, 1);
- 	hv_cleanup();
+ 	hv_cleanup(false);
 @@ -1284,7 +1284,7 @@ static void hv_kexec_handler(void)
  
  static void hv_crash_handler(struct pt_regs *regs)

--- a/kernel/patches-4.4/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
+++ b/kernel/patches-4.4/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
@@ -1,4 +1,4 @@
-From 5d1d4b91557b1da1616c609bb4ddf6d5c69aba64 Mon Sep 17 00:00:00 2001
+From 297cc0460b13aaafefa3b36f59b34f554a94a273 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:18 -0800
 Subject: [PATCH 35/44] Drivers: hv: vmbus: avoid unneeded compiler

--- a/kernel/patches-4.4/0036-kcm-Kernel-Connection-Multiplexor-module.patch
+++ b/kernel/patches-4.4/0036-kcm-Kernel-Connection-Multiplexor-module.patch
@@ -1,4 +1,4 @@
-From 6cf39464182a478b0b970bb61beb951c1403c870 Mon Sep 17 00:00:00 2001
+From a0c7198f3417369926962219c6b7a15b6bd4bc2e Mon Sep 17 00:00:00 2001
 From: Tom Herbert <tom@herbertland.com>
 Date: Mon, 7 Mar 2016 14:11:06 -0800
 Subject: [PATCH 36/44] kcm: Kernel Connection Multiplexor module

--- a/kernel/patches-4.4/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From 1626059f9c292ab2efb0a43bfd9aa471ee6f414c Mon Sep 17 00:00:00 2001
+From 5e39f91f019412407ed0e28f7f0a7502d7883258 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:51:09 -0700
 Subject: [PATCH 37/44] net: add the AF_KCM entries to family name tables

--- a/kernel/patches-4.4/0038-net-Add-Qualcomm-IPC-router.patch
+++ b/kernel/patches-4.4/0038-net-Add-Qualcomm-IPC-router.patch
@@ -1,4 +1,4 @@
-From 2ed9956f8a8aca0459c1d750da67e9fae83a8c7a Mon Sep 17 00:00:00 2001
+From c95c1bb451b392a6c6917b6140f0ec5b943c2523 Mon Sep 17 00:00:00 2001
 From: Courtney Cavin <courtney.cavin@sonymobile.com>
 Date: Wed, 27 Apr 2016 12:13:03 -0700
 Subject: [PATCH 38/44] net: Add Qualcomm IPC router

--- a/kernel/patches-4.4/0039-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.4/0039-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From e2163449aa0c1e0b7ca58beaff4a0e4da1b76bca Mon Sep 17 00:00:00 2001
+From 51ea1e21ce9aeefabac1c60545df6facbff79073 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 15 May 2016 09:53:11 -0700
 Subject: [PATCH 39/44] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.4/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From c10ff3a93c84f1d801df6c9f4296e07a9824cadd Mon Sep 17 00:00:00 2001
+From b4376d9a14b091c9db022998d31f57d419836293 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:53:08 -0700
 Subject: [PATCH 40/44] net: add the AF_HYPERV entries to family name tables

--- a/kernel/patches-4.4/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
+++ b/kernel/patches-4.4/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
@@ -1,4 +1,4 @@
-From c36c66b25dccf64c56b32800ec295176207f1106 Mon Sep 17 00:00:00 2001
+From 773bb65bd15a0be1de10b24abd7574921aae3d37 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 21 May 2016 16:55:50 +0800
 Subject: [PATCH 41/44] Drivers: hv: vmbus: fix the race when querying &

--- a/kernel/patches-4.4/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.4/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From d8f67c520bfaa33ef0bb64411b70f51ace68fd6a Mon Sep 17 00:00:00 2001
+From f2c5c2999fbeed4c04ac054273e86626e1626f23 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 42/44] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.4/0043-fs-add-filp_clone_open-API.patch
+++ b/kernel/patches-4.4/0043-fs-add-filp_clone_open-API.patch
@@ -1,4 +1,4 @@
-From c21ddf0ef2ed8a9e05d7ea906d85aee86a2184ea Mon Sep 17 00:00:00 2001
+From 5fc2cf4e57f189396851d1954af1b502ab9da55c Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:49:38 -0800
 Subject: [PATCH 43/44] fs: add filp_clone_open API

--- a/kernel/patches-4.4/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
+++ b/kernel/patches-4.4/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
@@ -1,4 +1,4 @@
-From ffafa45734a36cfe27d10ff731785440c39f53fc Mon Sep 17 00:00:00 2001
+From 680928026b4253ea4df25a932ca10198aa440ab6 Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:51:16 -0800
 Subject: [PATCH 44/44] binfmt_misc: add persistent opened binary handler for

--- a/kernel/patches-4.9/0001-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9/0001-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 6ebb6fc113b41112479233a32ba7845bf0765fef Mon Sep 17 00:00:00 2001
+From fb994fc98cd8e945230494ba2750b93805dc2a88 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 1/8] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9/0002-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9/0002-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 81ffd549906270aec7cf38aa098f8f0296c4fe92 Mon Sep 17 00:00:00 2001
+From 1bca2f8a8059291f0b3f24f11694eafafb413886 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 2/8] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9/0003-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9/0003-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From f9946a9224a088c80e6340696b0f9cdc4da5847c Mon Sep 17 00:00:00 2001
+From 9db0219d4a8338b91da3a57e61b0238412980596 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 3/8] Drivers: hv: utils: Fix the mapping between host version

--- a/kernel/patches-4.9/0004-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9/0004-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From 5a3d8779d9a335409e9343b6255f0ec76eed11cd Mon Sep 17 00:00:00 2001
+From c3e4ab7b456d60a2672cbad46ba0ca31b18ff03b Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 4/8] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9/0005-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9/0005-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From 0b2d379f07a067e1ce673658273cbd61cf2fea20 Mon Sep 17 00:00:00 2001
+From dc9e5688dad32ec5874c767b6660665d014a1e45 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 5/8] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9/0006-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9/0006-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From 526abebd5a31f44b7819f2e9fc92073297b8b59c Mon Sep 17 00:00:00 2001
+From 0fd2ca415da1435d5fee3fab638bd5fdc2e1a432 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 6/8] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9/0007-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9/0007-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From f124575a9f1bfe890a2307211afc433ec9d6bd38 Mon Sep 17 00:00:00 2001
+From ae3d3b814fdd28fe77eb7ec2e7b32046d3b11fcb Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 7/8] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9/0008-Drivers-hv-vmbus-Don-t-leak-memory-when-a-channel-is.patch
+++ b/kernel/patches-4.9/0008-Drivers-hv-vmbus-Don-t-leak-memory-when-a-channel-is.patch
@@ -1,4 +1,4 @@
-From ba6078e0069da20c0aebcab38a6d76e371d61da6 Mon Sep 17 00:00:00 2001
+From a8c7a3307f4a4a2cff3cd66ae90aeb45c2cfe017 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Sun, 12 Mar 2017 20:00:30 -0700
 Subject: [PATCH 8/8] Drivers: hv: vmbus: Don't leak memory when a channel is


### PR DESCRIPTION
For 4.9.18 and 4.10.6 cherry-picked the VMBus leak fix
from Linus' tree instead of char-misc.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>