### PR TITLE
pkg/init: ruinc and containerd binaries depend on Makefile

### DIFF
--- a/pkg/init/Makefile
+++ b/pkg/init/Makefile
@@ -9,11 +9,11 @@ START_STOP_DAEMON=sbin/start-stop-daemon
 
 default: push
 
-$(RUNC_BINARY):
+$(RUNC_BINARY): Makefile
 	mkdir -p $(dir $@)
 	docker run --rm --net=none $(RUNC_IMAGE) tar cf - $@ | tar xf -
 
-$(CONTAINERD_BINARIES):
+$(CONTAINERD_BINARIES): Makefile
 	mkdir -p $(dir $@)
 	docker run --rm --net=none $(CONTAINERD_IMAGE) tar cf - $@ | tar xf -
 


### PR DESCRIPTION
Since Makefile contains the hashes we need a dependency otherwise changing the
hashes does not necessarily result in the binaries getting updated.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>