### PR TITLE
Add ca-certificates to base

### DIFF
--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:83b229223adbdd5ae38f39b4754e61b951529664"
+init: "mobylinux/init:25d26f0e1cd563a9dbbb25651a102f7e690dc6e2"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:83b229223adbdd5ae38f39b4754e61b951529664"
+init: "mobylinux/init:25d26f0e1cd563a9dbbb25651a102f7e690dc6e2"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=tty0 page_poison=1"
-init: "mobylinux/init:83b229223adbdd5ae38f39b4754e61b951529664"
+init: "mobylinux/init:25d26f0e1cd563a9dbbb25651a102f7e690dc6e2"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/moby.yml
+++ b/moby.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
-init: "mobylinux/init:83b229223adbdd5ae38f39b4754e61b951529664"
+init: "mobylinux/init:25d26f0e1cd563a9dbbb25651a102f7e690dc6e2"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -4,6 +4,7 @@ RUN \
   apk --no-cache update && \
   apk --no-cache upgrade -a && \
   apk --no-cache add \
+  ca-certificates \
   dhcpcd \
   && rm -rf /var/cache/apk/*
 

--- a/test/ltp/test-ltp.yml
+++ b/test/ltp/test-ltp.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
-init: "mobylinux/init:83b229223adbdd5ae38f39b4754e61b951529664"
+init: "mobylinux/init:25d26f0e1cd563a9dbbb25651a102f7e690dc6e2"
 system:
   - name: ltp
     image: "mobylinux/test-ltp-20170116:fdca2d1bb019b1d51e722e6032c82c7933d4b870"

--- a/test/test.yml
+++ b/test/test.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
-init: "mobylinux/init:83b229223adbdd5ae38f39b4754e61b951529664"
+init: "mobylinux/init:25d26f0e1cd563a9dbbb25651a102f7e690dc6e2"
 system:
   - name: binfmt
     image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"

--- a/test/virtsock/test-virtsock-server.yml
+++ b/test/virtsock/test-virtsock-server.yml
@@ -5,7 +5,7 @@ kernel:
   # image: "mobylinux/kernel:4.9.14-0"
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
-init: "mobylinux/init:83b229223adbdd5ae38f39b4754e61b951529664"
+init: "mobylinux/init:25d26f0e1cd563a9dbbb25651a102f7e690dc6e2"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"


### PR DESCRIPTION
This useful for bind-mounting into `FROM scratch` containers and seems like the
sort of thing we might want different containers to have a consistent view of.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>