### PR TITLE
Add a runner for UEFI ISOs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-test.log
+*.log
 Dockerfile.media
 /bin
 disk.img.*

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,19 @@ test-initrd.img: bin/moby test/test.yml
 test-bzImage: test-initrd.img
 
 # interactive versions need to use volume mounts
-.PHONY: qemu qemu-iso
+.PHONY: qemu qemu-iso qemu-efi test-qemu-efi
 qemu: moby-initrd.img moby-bzImage moby-cmdline
 	./scripts/qemu.sh moby-initrd.img moby-bzImage "$(shell cat moby-cmdline)"
 
 qemu-iso: alpine/mobylinux-bios.iso
 	./scripts/qemu.sh $^
+
+qemu-efi: moby-efi.iso
+	./scripts/qemu.sh $^
+
+test-qemu-efi: test-efi.iso
+	./scripts/qemu.sh $^ 2>&1 | tee test-efi.log
+	$(call check_test_log, test-efi.log)
 
 bin:
 	mkdir -p $@

--- a/scripts/qemu.sh
+++ b/scripts/qemu.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-QEMU_IMAGE=mobylinux/qemu:75ef01c780850daf78ee45078606eb740a999edf@sha256:ec93951816b57d86f7a90c129a5580e083093e5a92263d0d2be6822daa2162dd
+QEMU_IMAGE=mobylinux/qemu:ac2f8d3258d09541f0dab7529f62bb7e9b9bb79c@sha256:b60d1421937b0ebf4846341a1cda1ca00f44a45553d5494080b2ca8aac468773
 
 # if not interactive
 if [ ! -t 0 -a -z "$1" ]

--- a/tools/qemu/Dockerfile
+++ b/tools/qemu/Dockerfile
@@ -1,4 +1,6 @@
-FROM alpine:3.5
+FROM alpine:edge
+
+COPY repositories /etc/apk/
 
 RUN \
   apk update && apk upgrade && \
@@ -7,6 +9,7 @@ RUN \
   qemu-img \
   qemu-system-arm \
   qemu-system-x86_64 \
+  ovmf@testing \
   && true
 
 COPY . .

--- a/tools/qemu/Makefile
+++ b/tools/qemu/Makefile
@@ -5,7 +5,7 @@ IMAGE=qemu
 
 default: push
 
-hash: Dockerfile qemu.sh
+hash: Dockerfile qemu.sh repositories
 	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
 	docker run --rm --entrypoint /bin/sh $(IMAGE):build -c 'cat Dockerfile qemu.sh /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > $@

--- a/tools/qemu/repositories
+++ b/tools/qemu/repositories
@@ -1,0 +1,2 @@
+http://dl-cdn.alpinelinux.org/alpine/edge/main
+@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing


### PR DESCRIPTION
Fixes #480

I suggest we refrain from merging until I've been able to test with a 
moby-efi.iso. That's impossible until #1362 is fixed

Signed-off-by: Dave Tucker <dt@docker.com>