### PR TITLE
docs: add a security-events.md

### DIFF
--- a/docs/security-events.md
+++ b/docs/security-events.md
@@ -1,9 +1,13 @@
-The incomplete list below is an assement of some CVEs, and Moby's resillience
-to them.
+# Moby Security Events
 
-Bugs mitigated:
+The incomplete list below is an assessment of some CVEs, and Moby's resilience
+(or not) to them.
+
+### Bugs mitigated:
 
 * [CVE-2017-2636](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-2636)
   ([exploit post](https://a13xp0p0v.github.io/2017/03/24/CVE-2017-2636.html)):
   This CVE requires `CONFIG_N_HDLC={y|m}`, which Moby does not specify, and so
   is not vulnerable.
+
+### Bugs not mitigated:


### PR DESCRIPTION
In the same vein as [1], let's start talking about security events. I
suppose we want to talk about security events as well as non-events,
though, to give a little discussion about post moretem. But we can rename
this to security-non-events if we want.

[1]: https://github.com/docker/docker.github.io/blob/master/engine/security/non-events.md

Signed-off-by: Tycho Andersen <tycho@docker.com>