### PR TITLE
cli: Add option to specify hyperkit to use

### DIFF
--- a/src/cmd/moby/run_hyperkit.go
+++ b/src/cmd/moby/run_hyperkit.go
@@ -21,6 +21,7 @@ func runHyperKit(args []string) {
 		fmt.Printf("Options:\n")
 		hyperkitCmd.PrintDefaults()
 	}
+	runHyperKit := hyperkitCmd.String("hyperkit", "", "Path to hyperkit binary (if not in default location)")
 	runCPUs := hyperkitCmd.Int("cpus", 1, "Number of CPUs")
 	runMem := hyperkitCmd.Int("mem", 1024, "Amount of memory in MB")
 	runDiskSz := hyperkitCmd.Int("disk-size", 0, "Size of Disk in MB")
@@ -34,10 +35,10 @@ func runHyperKit(args []string) {
 		prefix = remArgs[0]
 	}
 
-	runHyperKitInternal(*runCPUs, *runMem, *runDiskSz, *runDisk, prefix)
+	runHyperKitInternal(*runHyperKit, *runCPUs, *runMem, *runDiskSz, *runDisk, prefix)
 }
 
-func runHyperKitInternal(cpus, mem, diskSz int, disk, prefix string) {
+func runHyperKitInternal(hyperkitPath string, cpus, mem, diskSz int, disk, prefix string) {
 	cmdline, err := ioutil.ReadFile(prefix + "-cmdline")
 	if err != nil {
 		log.Fatalf("Cannot open cmdline file: %v", err)
@@ -47,7 +48,7 @@ func runHyperKitInternal(cpus, mem, diskSz int, disk, prefix string) {
 		disk = prefix + "-disk.img"
 	}
 
-	h, err := hyperkit.New("", "", "auto", disk)
+	h, err := hyperkit.New(hyperkitPath, "", "auto", disk)
 	if err != nil {
 		log.Fatalln("Error creating hyperkit: ", err)
 	}


### PR DESCRIPTION
Some users seem to have Docker for Mac/hyperkit in a non-standard
path. Allow them to specify the path to the hyperkit executable.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

resolves: #1442 