### PR TITLE
Sign mobylinux/kernel image on make sign

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -71,6 +71,15 @@ push: image
 	docker rmi $(IMAGE):build
 	rm -f hash
 
+sign: image
+	DOCKER_CONTENT_TRUST=1 docker pull mobylinux/$(IMAGE):$(IMAGE_VERSION) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(IMAGE_VERSION) && \
+		 DOCKER_CONTENT_TRUST=1 docker push mobylinux/$(IMAGE):$(IMAGE_VERSION) && \
+		 docker tag $(IMAGE):build mobylinux/$(IMAGE):$(IMAGE_MAJOR_VERSION) && \
+		 DOCKER_CONTENT_TRUST=1 docker push mobylinux/$(IMAGE):$(IMAGE_MAJOR_VERSION))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
 tag: image
 	(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(IMAGE_VERSION) && \
 	docker tag $(IMAGE):build mobylinux/$(IMAGE):$(IMAGE_MAJOR_VERSION))


### PR DESCRIPTION
I've setup a notary repo and keys for @rneugeba, myself, and @talex5 (CI).  I am the admin of this repo - I can set up shared secure storage for maintainers to manage the admin keys.

After importing your delegation private key with notary (`notary -d ~/.docker/trust key import ...`), docker will automatically pick up the key and use it to sign into your role(s).

I've set up a shared `targets/releases` role, as well as individual roles for ci, @rneugeba, and myself:

```
🐳 $ notary -s https://notary.docker.io -d ~/.docker/trust delegation list docker.io/mobylinux/kernel

ROLE                PATHS             KEY IDS                                                             THRESHOLD
----                -----             -------                                                             ---------
targets/ci          "" <all paths>    efe98d8d871c3e6e9f04857acfd50c32919c8301489fd6f9b7d8efb09699361e    1
targets/releases    "" <all paths>    efe98d8d871c3e6e9f04857acfd50c32919c8301489fd6f9b7d8efb09699361e    1
                                      a6c37cc2f99d3dd5c9f8515f0f442b2924493920779c8ff75e146f7bbf7511d2
                                      54b40bbbc0e93f49090a37ae7388864814eeafe66c4c761b08ce3329522cb264
targets/riyaz       "" <all paths>    a6c37cc2f99d3dd5c9f8515f0f442b2924493920779c8ff75e146f7bbf7511d2    1
targets/rolf        "" <all paths>    54b40bbbc0e93f49090a37ae7388864814eeafe66c4c761b08ce3329522cb264    1
``` 

I've also signed `mobylinux/kernel:4.9.x` by hand.  I can open a followup PR when we feel we're ready to verify the signature on pull from the moby tool.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>

wip: #1074