### PR TITLE
vendor: Fix iso9660wrap hash

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/jmespath/go-jmespath bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 github.com/mitchellh/go-ps 4fdf99ab29366514c69ccccddab5dc58b8d84062
 github.com/opencontainers/runtime-spec d094a5c9c1997ab086197b57e9378fabed394d92
 github.com/pkg/errors ff09b135c25aae272398c51a07235b90a75aa4f0
-github.com/rneugeba/iso9660wrap 9c7eaf5ac74b2416be8b7b8d1f35b9af44a6e4fa
+github.com/rneugeba/iso9660wrap 4606f848a055435cdef85305960b0e1bb788d506
 github.com/satori/go.uuid b061729afc07e77a8aa4fad0a2fd840958f1942a
 github.com/spf13/cobra 7be4beda01ec05d0b93d80b3facd2b6f44080d94
 github.com/spf13/pflag 9ff6c6923cfffbcd502984b8e0c80539a94968b7


### PR DESCRIPTION
vendor.conf got messed up on a previous merge conflict. Update
the git hash to reflect the version checked into vendor/github.com/rneugeba

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>