### PR TITLE
Make clean cleaner, and ignore more output disks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 test.log
 Dockerfile.media
 /bin
-disk.img.*
 *.swp
 *.img
 *.tag

--- a/Makefile
+++ b/Makefile
@@ -93,4 +93,4 @@ ci-pr:
 
 .PHONY: clean
 clean:
-	rm -rf bin disk.img test.log *-initrd.img *-bzImage *-cmdline *.iso *.tar.gz *.qcow2 *.vhd
+	rm -rf bin *.log *-bzImage *-cmdline *.img *.iso *.tar.gz *.qcow2 *.vhd


### PR DESCRIPTION
nit edits to clean and ignore files like `moby-disk.img` that are generated by the `moby run` tooling

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>