### PR TITLE
Disable log driver for docker run

### DIFF
--- a/src/cmd/moby/docker.go
+++ b/src/cmd/moby/docker.go
@@ -24,7 +24,7 @@ func dockerRun(args ...string) ([]byte, error) {
 	if err != nil {
 		return []byte{}, errors.New("Docker does not seem to be installed")
 	}
-	args = append([]string{"run", "--rm"}, args...)
+	args = append([]string{"run", "--rm", "--log-driver=none"}, args...)
 	cmd := exec.Command(docker, args...)
 
 	stderrPipe, err := cmd.StderrPipe()


### PR DESCRIPTION
We are generally outputting to stdout pipe which the log driver does
not cope with very well; always did this in older builds.

Saves another 5% of build time.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>