### PR TITLE
Revert Command->Args but remove from yaml where not needed

### DIFF
--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -16,7 +16,6 @@ system:
     binds:
      - /proc/sys/fs/binfmt_misc:/binfmt_misc
     readonly: true
-    command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
   - name: metadata-gcp
     image: "mobylinux/metadata-gcp:7fc3dd5ef92e0408fb3f76048bbaae88bbb55ad9"
     binds:
@@ -34,7 +33,6 @@ daemon:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
-    command: [/bin/tini, /usr/sbin/rngd, -f]
   - name: sshd
     image: "mobylinux/sshd:4f8452ddaff703416fd7452fcd9693b96b23e847"
     capabilities:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -14,14 +14,12 @@ system:
     image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
     binds:
      - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
 daemon:
   - name: rngd
     image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"
     capabilities:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
-    command: [/bin/tini, /usr/sbin/rngd, -f]
   - name: sshd
     image: "mobylinux/sshd:4f8452ddaff703416fd7452fcd9693b96b23e847"
     capabilities:

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -16,7 +16,6 @@ system:
     binds:
      - /proc/sys/fs/binfmt_misc:/binfmt_misc
     readonly: true
-    command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
 daemon:
   - name: rngd
     image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"
@@ -24,7 +23,6 @@ daemon:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
-    command: [/bin/tini, /usr/sbin/rngd, -f]
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/moby.yml
+++ b/moby.yml
@@ -16,7 +16,6 @@ system:
     binds:
      - /proc/sys/fs/binfmt_misc:/binfmt_misc
     readonly: true
-    command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
 daemon:
   - name: rngd
     image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"
@@ -24,7 +23,6 @@ daemon:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
-    command: [/bin/tini, /usr/sbin/rngd, -f]
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -16,7 +16,6 @@ system:
     binds:
      - /proc/sys/fs/binfmt_misc:/binfmt_misc
     readonly: true
-    command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
 daemon:
   - name: rngd
     image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"
@@ -24,7 +23,6 @@ daemon:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
-    command: [/bin/tini, /usr/sbin/rngd, -f]
   - name: dhcp-client
     net: host
     image: "mobylinux/dhcp-client:f40cafe2ade4b115704750a85d21eb35b1116b91"

--- a/projects/selinux/selinux.yml
+++ b/projects/selinux/selinux.yml
@@ -18,7 +18,6 @@ daemon:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
-    command: [/bin/tini, /usr/sbin/rngd, -f]
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'

--- a/projects/wireguard/examples/wireguard.yml
+++ b/projects/wireguard/examples/wireguard.yml
@@ -18,7 +18,6 @@ daemon:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
-    command: [/bin/tini, /usr/sbin/rngd, -f]
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'

--- a/src/cmd/moby/config.go
+++ b/src/cmd/moby/config.go
@@ -45,7 +45,7 @@ type MobyImage struct {
 	Mounts           []specs.Mount
 	Binds            []string
 	Tmpfs            []string
-	Args             []string
+	Command          []string
 	Env              []string
 	Cwd              string
 	Net              string
@@ -95,8 +95,8 @@ func ConfigToOCI(image *MobyImage) ([]byte, error) {
 	}
 
 	args := append(config.Entrypoint, config.Cmd...)
-	if len(image.Args) != 0 {
-		args = image.Args
+	if len(image.Command) != 0 {
+		args = image.Command
 	}
 	env := config.Env
 	if len(image.Env) != 0 {

--- a/test/test.yml
+++ b/test/test.yml
@@ -8,7 +8,6 @@ system:
     binds:
      - /proc/sys/fs/binfmt_misc:/binfmt_misc
     readonly: true
-    command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
   - name: check
     image: "mobylinux/check:c9e41ab96b3ea6a3ced97634751e20d12a5bf52f"
     pid: host

--- a/test/virtsock/test-virtsock-server.yml
+++ b/test/virtsock/test-virtsock-server.yml
@@ -22,12 +22,9 @@ daemon:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
-    command: [/bin/tini, /usr/sbin/rngd, -f]
   - name: virtsock-server
     image: "mobylinux/test-virtsock:35fea96fd01f6edb67021c494ddf098fdb8bbca0"
     readonly: true
-    command: [/bin/tini, /bin/virtsock_stress, -s, -v, 1]
-
 outputs:
   - format: kernel+initrd
   - format: iso-bios


### PR DESCRIPTION
In the riddler change I changed "command" in the yaml to "args"
but did not change the files. In fact we basically used the
default command everywhere so this did not actually break.

Remove the unnecessary "command" lines to simplify yaml.

Revert the command to args change for now as I think I prefer
command, but its easier to switch now. Need to think if the
entrypoint/command distinction matters before finalizing.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>