### PR TITLE
demo: Initial etcd cluster setup with InfraKit

### DIFF
--- a/projects/demo/etcd/README.md
+++ b/projects/demo/etcd/README.md
@@ -5,8 +5,10 @@ Docker for Mac container to bootstrap the cluster. For a cloud based demo, we'd 
 
 The moby `etcd` package is build with [build-pkg.sh](./build-pkg.sh). It take the official `etcd` container and adds a [script](./etcd.sh) to start `etcd`.
 
-To run (for now):
 
+## Simple single node cluster
+
+- Edit `./dfm-setup.sh` and set `NUMPEERS` to `1`
 - Start the etcd bootstrap container in on window:
 ```
 ./dfm-setup.sh
@@ -17,4 +19,45 @@ To run (for now):
 ./build-pkg.sh
 moby build etcd
 moby run etcd
+```
+
+## InfraKit cluster setup
+
+This should create a HyperKit based, InfraKit managed `etcd` cluster with 5 `etcd` instances.
+
+#### Infrakit setup
+You need the [infrakit](https://github.com/docker/infrakit) binaries for this. I normally compile from source using `make build-in-container`. The below was tried with commit `2153cbb0c28d450d271bbcdb9b3765eb486a9ac9`
+
+- Make sure you start from scratch
+```
+rm -rf ~/.infrakit
+```
+- Start the infrakit plugins, each in it's own window from the root of the infrakit source tree:
+```
+./build/infrakit-group-default
+```
+```
+./build/infrakit-flavor-vanilla
+```
+- Start the hyperkit instance plugin from this directory:
+```
+../../../bin/infrakit-instance-hyperkit
+```
+
+#### etcd setup
+
+- Start the bootstrap `etcd`:
+```
+./dfm-setup.sh
+```
+
+- Commit the infrakit config:
+```
+~/src/docker/infrakit/build/infrakit group commit infrakit.json
+```
+
+To check if everything is fine, note down the IP address from one of
+the nodes and then:
+```
+docker run --rm -t quay.io/coreos/etcd:v3.1.5 etcdctl --endpoints http://192.168.65.24:2379 member list
 ```

--- a/projects/demo/etcd/dfm-setup.sh
+++ b/projects/demo/etcd/dfm-setup.sh
@@ -15,7 +15,7 @@ set -x
 set -v
 
 # Change depending on the cluster size
-NUMPEERS=1
+NUMPEERS=5
 
 # Start a local etcd for bootstrapping
 NAME=etcd-bootstrap

--- a/projects/demo/etcd/infrakit.json
+++ b/projects/demo/etcd/infrakit.json
@@ -1,0 +1,28 @@
+{
+    "ID": "cattle",
+    "Properties": {
+        "Allocation": {
+            "Size": 5
+        },
+        "Instance": {
+            "Plugin": "instance-hyperkit",
+            "Properties": {
+                "Moby": "etcd",
+                "Disk" : 0,
+                "CPUs" : 1,
+                "Memory" : 512
+            }
+        },
+        "Flavor": {
+            "Plugin": "flavor-vanilla",
+            "Properties": {
+                "Init": [
+                ],
+                "Tags": {
+                    "tier": "etcd-cluster",
+                    "project": "infrakit"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This just sets up the initial cluster via bootstrap.

It does *not* manage state changes correctly afterwards. If one
node crashes (get's killed) it InfraKit will start a new node,
but the new node does not join the cluster (and the old node
is not removed, either).

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>