### PR TITLE
Initial swarmkit package

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -16,6 +16,7 @@ If you want to create a project, please submit a pull request to create a new di
 - [OKernel](okernel/) intra-kernel protection using EPT (HPE)
 - [eBPF](ebpf/) iovisor eBPF tools
 - [AWS](aws/) AWS build support
+- [Swarmd](swarmd) Standalone swarmkit based orchestrator
 
 ## Current projects not yet documented
 - Clear Linux integration (Intel)

--- a/projects/swarmd/README.md
+++ b/projects/swarmd/README.md
@@ -1,0 +1,29 @@
+### swarmd package
+
+This adds a `swarmd` package for Moby which contains the standalone
+swarmkit orchestration daemon (`swarmd`) and CLI tool (`swarmctl`).
+
+The package tracks [docker/swarmkit#1965][PR1965] which
+is a WIP PR adding a containerd executor to swarmkit.
+
+With a suitable moby image (such as `swarmd.yml` from this directory)
+something like this should work:
+
+    runc exec swarmd swarmctl service create --image docker.io/library/nginx:alpine --name nginx
+    runc exec swarmd swarmctl service ls
+
+### TODO
+
+Currently the swarm state directory needs to be at a path which is
+identical from the PoV of both the `containerd` and `swarmd`
+processes. For now this means that the swarmkit state is put in
+`/var/lib/containerd/swarmd`.
+
+Bootstrapping a cluster needs more invesigation. Tokens and join
+addresses can currently only be passed on the `swarmd` command line
+which is inconvenient for automated image deployment.
+
+Swarmkit [PR 1965][PR1965] also contains a number of TODOs which are not
+separately listed here.
+
+[PR1665]: https://github.com/docker/swarmkit/pull/1965

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -1,0 +1,56 @@
+kernel:
+  image: "mobylinux/kernel:4.9.x"
+  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+init: "mobylinux/init:1ceddd8914f233fdc8a2c2f1de9569bb3a562a52"
+system:
+  - name: sysctl
+    image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
+    net: host
+    pid: host
+    ipc: host
+    capabilities:
+     - CAP_SYS_ADMIN
+    readonly: true
+  - name: binfmt
+    image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
+    binds:
+     - /proc/sys/fs/binfmt_misc:/binfmt_misc
+    readonly: true
+daemon:
+  - name: rngd
+    image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"
+    capabilities:
+     - CAP_SYS_ADMIN
+    oomScoreAdj: -800
+    readonly: true
+  - name: swarmd
+    image: "mobylinux/swarmd:cf11a7626278ebf17efe2780c138b4e626b02c73@sha256:7b31bb4482e6823d2aec291d13782669c22bc03c9fac1dfd7ed207d942c3c061"
+    command: ["/usr/bin/swarmd", "--containerd-addr=/run/containerd/containerd.sock", "--log-level=debug", "--state-dir=/var/lib/containerd/swarmd"]
+    capabilities:
+     - CAP_CHOWN
+     - CAP_DAC_OVERRIDE
+     - CAP_FSETID
+     - CAP_FOWNER
+     - CAP_MKNOD
+     - CAP_NET_RAW
+     - CAP_SETGID
+     - CAP_SETUID
+     - CAP_SETFCAP
+     - CAP_SETPCAP
+     - CAP_NET_BIND_SERVICE
+     - CAP_SYS_CHROOT
+     - CAP_KILL
+     - CAP_AUDIT_WRITE
+    net: host
+    binds:
+      - /run/containerd/containerd.sock:/run/containerd/containerd.sock
+      - /var/lib/containerd:/var/lib/containerd
+      - /etc/resolv.conf:/etc/resolv.conf
+      - /etc/ssl:/etc/ssl
+files:
+  - path: etc/docker/daemon.json
+    contents: '{"debug": true}'
+outputs:
+  - format: kernel+initrd
+  - format: iso-bios
+  - format: iso-efi

--- a/projects/swarmd/swarmd/Dockerfile.build
+++ b/projects/swarmd/swarmd/Dockerfile.build
@@ -1,0 +1,36 @@
+FROM golang:1.7-alpine3.5
+
+RUN \
+  apk update && apk upgrade && \
+  apk add --no-cache \
+  ca-certificates \
+  gcc \
+  git \
+  libc-dev \
+  make \
+  && true
+
+WORKDIR /
+COPY Dockerfile.build Dockerfile.pkg Makefile /build/
+
+# PR https://github.com/docker/swarmkit/pull/1965 from ijc25/containerd
+ENV SWARMKIT_PR=1965
+ENV SWARMKIT_COMMIT=82e9f43d84e9a0586903392cbe5bbac15fdbf552
+
+RUN mkdir -p $GOPATH/src/github.com/docker && \
+  cd $GOPATH/src/github.com/docker && \
+  git clone https://github.com/docker/swarmkit.git
+WORKDIR $GOPATH/src/github.com/docker/swarmkit
+RUN [ -z "$SWARMKIT_PR" ] || git fetch origin pull/$SWARMKIT_PR/head
+RUN git checkout $SWARMKIT_COMMIT
+
+RUN make binaries GO_GCFLAGS="-buildmode pie --ldflags '-extldflags \"-fno-PIC -static\"'"
+
+RUN mkdir -p /build/dist/usr/bin/ /build/dist/etc
+RUN cp bin/swarmd bin/swarmctl /build/dist/usr/bin/
+RUN strip /build/dist/usr/bin/swarmd /build/dist/usr/bin/swarmctl
+
+RUN cp -r /etc/ssl /build/dist/etc/ssl
+
+WORKDIR /build
+CMD ["/bin/tar", "cf", "-", "-C", "dist", "."]

--- a/projects/swarmd/swarmd/Dockerfile.pkg
+++ b/projects/swarmd/swarmd/Dockerfile.pkg
@@ -1,0 +1,4 @@
+FROM scratch
+WORKDIR /
+ADD swarmd.tar .
+CMD ["/usr/bin/swarmd", "--containerd-addr=/run/containerd/containerd.sock", "--log-level=debug", "--state-dir=/var/lib/swarmd"]

--- a/projects/swarmd/swarmd/Makefile
+++ b/projects/swarmd/swarmd/Makefile
@@ -1,0 +1,38 @@
+.PHONY: tag push clean container
+all: push
+
+SHASUM=alpine:3.5
+IMAGE=swarmd
+DEPS=Dockerfile.build Makefile
+
+# Include  Dockerfile.pkg here so hash works
+swarmd.tag: $(DEPS) Dockerfile.pkg
+	BUILD=$$(tar cf - $^ | docker build -f $< -q -) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && echo "$$BUILD" > $@
+
+swarmd.tar: swarmd.tag
+	docker run --rm --net=none --log-driver=none $(shell cat swarmd.tag) > $@
+
+container: Dockerfile.pkg swarmd.tar
+	tar cf - $^ | docker build --no-cache -f $< -t $(IMAGE):build -
+
+hash: $(DEPS) Dockerfile.pkg
+	find $^ -type f | xargs cat  | DOCKER_CONTENT_TRUST=1 docker run --rm -i $(SHASUM) sha1sum | sed 's/ .*//' > $@
+
+push: hash container
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash container
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+	rm -f swarmd.tag swarmd.tar
+
+.DELETE_ON_ERROR:


### PR DESCRIPTION
This is based on https://github.com/docker/swarmkit/pull/1965 which adds a
direct containerd executor to swarmkit. It is very much a work in progress.

With a suitable moby image (such as projects/swarmd/swarmd.yml) something like
this should work:

runc exec swarmd swarmctl service create --image docker.io/library/nginx:alpine --name nginx
runc exec swarmd swarmctl service ls

Signed-off-by: Ian Campbell <ian.campbell@docker.com>