### PR TITLE
swarmd: use standard init

### DIFF
--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -1,7 +1,7 @@
 kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
-init: "mobylinux/init:1ceddd8914f233fdc8a2c2f1de9569bb3a562a52"
+init: "mobylinux/init:00c3a5bbfd9794f4a3187fcc4a9f0c826c46d474"
 system:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
@@ -46,7 +46,6 @@ daemon:
       - /run/containerd/containerd.sock:/run/containerd/containerd.sock
       - /var/lib/containerd:/var/lib/containerd
       - /etc/resolv.conf:/etc/resolv.conf
-      - /etc/ssl:/etc/ssl
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'

--- a/projects/swarmd/swarmd/.gitignore
+++ b/projects/swarmd/swarmd/.gitignore
@@ -1,0 +1,3 @@
+hash
+swarmd.tag
+swarmd.tar


### PR DESCRIPTION
In #1485 I was still using a local mobylinux/init containing #1436, even though
I had included the necessary files in the swarmd container.

Switch to the current standard init package and drop the unnecessary bind.

Also `git add .gitignore` which I forgot last time too.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>