### PR TITLE
[WIP] Support launching containers in outer-kernel mode for moby-okernel demo

### DIFF
--- a/projects/okernel/Dockerfile.kvmod
+++ b/projects/okernel/Dockerfile.kvmod
@@ -1,0 +1,5 @@
+FROM alpine:3.5
+
+COPY ./kvmod .
+
+CMD ["insmod", "/root/kvmod/kernel_vuln.ko"]

--- a/projects/okernel/Dockerfile.okernel
+++ b/projects/okernel/Dockerfile.okernel
@@ -1,14 +1,18 @@
 FROM mobylinux/alpine-build-kernel:0e893fbf6fa7638d2f23354de03ea11017bb8065@sha256:3ef3f9d11f0802b759dbd9c43a7706cf0ec37263c99ae90e2b10c29ea85739fa
 
-ARG KERNEL_PREFIX
+#ARG KERNEL_PREFIX
 ARG KERNEL_VERSION
 ARG DEBUG=0
+ARG PROXY
 
-ENV KERNEL_SOURCE=https://github.com/linux-okernel/linux-okernel/archive/ok-${KERNEL_VERSION}.tar.gz
+#ENV KERNEL_SOURCE=https://github.com/linux-okernel/linux-okernel/archive/ok-${KERNEL_VERSION}.tar.gz
+ENV KERNEL_SOURCE=https://github.com/linux-okernel/linux-okernel/archive/linux-okernel.tar.gz
 
-RUN curl -fsSL -o linux-${KERNEL_PREFIX}${KERNEL_VERSION}.tar.gz ${KERNEL_SOURCE}
+ENV USPACE_SOURCE=https://github.com/linux-okernel/linux-okernel-components/archive/master.tar.gz
 
-RUN cat linux-${KERNEL_PREFIX}${KERNEL_VERSION}.tar.gz | tar --absolute-names -xz &&  mv /linux-${KERNEL_PREFIX}${KERNEL_VERSION} /linux
+RUN curl -fsSL -x ${PROXY} -o linux-${KERNEL_VERSION}.tar.gz ${KERNEL_SOURCE}
+
+RUN cat linux-${KERNEL_VERSION}.tar.gz | tar --absolute-names -xz && mv /linux-okernel-linux-okernel /linux
 
 # NOTE: This currently re-uses the 4.9 kernel config with CONFIG_OKERNEL set
 COPY kernel_config.okernel /linux/arch/x86/configs/x86_64_defconfig
@@ -31,6 +35,7 @@ RUN cd /linux && \
     make defconfig && \
     make oldconfig && \
     make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie"
+
 RUN cd /linux && \
     make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install && \
     ( DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdepth 1)) && \
@@ -53,3 +58,16 @@ RUN DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdept
     ( cd /tmp && tar cf /kernel-dev.tar usr/src )
 
 RUN printf "KERNEL_SOURCE=${KERNEL_SOURCE}\n" > /kernel-source-info
+
+# Build kernel module from linux-okernel-components
+RUN curl -fsSL -x ${PROXY} -o okernel-userspace.tar.gz ${USPACE_SOURCE}
+
+RUN cat okernel-userspace.tar.gz | tar --absolute-names -xz && mv /linux-okernel-components-master /ok_components
+
+WORKDIR /ok_components/test_mappings/kvmod
+RUN sed -i 's_~/linux-okernel_/linux_' Makefile
+RUN make
+RUN mkdir -p /tmp/root/kvmod && cp kernel_vuln.ko /tmp/root/kvmod
+WORKDIR /tmp
+RUN tar cf /kernel_vuln.tar root
+WORKDIR /

--- a/projects/okernel/Makefile
+++ b/projects/okernel/Makefile
@@ -18,40 +18,35 @@ all:	bzImage tag
 # frequently.
 #
 # IMAGE_VERSION is used to determine if a new image should be pushed to hub.
-ifeq ($(KERNEL),v4.4)
-KERNEL_VERSION=4.4.56
+
+KERNEL_VERSION=4.11-rc4
 IMAGE_VERSION=$(KERNEL_VERSION)-0
-IMAGE_MAJOR_VERSION=4.4.x
-DEPS=Dockerfile.4.4 Makefile kernel_config kernel_config.debug kernel_config.4.4 patches-4.4
-else
-ifeq ($(KERNEL),v4.10)
-KERNEL_VERSION=4.10.5
-IMAGE_VERSION=$(KERNEL_VERSION)-0
-IMAGE_MAJOR_VERSION=4.10.x
-DEPS=Dockerfile.4.10 Makefile kernel_config kernel_config.debug patches-4.10
-else
-KERNEL_VERSION=4.9.17
-IMAGE_VERSION=$(KERNEL_VERSION)-0
-IMAGE_MAJOR_VERSION=4.9.x
-DEPS=Dockerfile Makefile kernel_config kernel_config.debug patches-4.9
-endif
-endif
+IMAGE_MAJOR_VERSION=4.11.x
+DEPS=Dockerfile.okernel Makefile kernel_config.okernel Dockerfile.kvmod
+
+PROXY_URL=$(HTTP_PROXY)
 
 kernel.tag: $(DEPS)
+ifdef PROXY_URL
+	BUILD=$$( tar cf - $^ | docker build -f $< --build-arg DEBUG=$(DEBUG) --build-arg KERNEL_VERSION=$(KERNEL_VERSION) --build-arg PROXY=$(PROXY_URL) -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && echo "$$BUILD" > $@
+else
 	BUILD=$$( tar cf - $^ | docker build -f $< --build-arg DEBUG=$(DEBUG) --build-arg KERNEL_VERSION=$(KERNEL_VERSION) -q - ) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && echo "$$BUILD" > $@
+endif
 
 bzImage: kernel.tag
 	rm -rf etc/kernel-patches
-	mkdir -p x86_64 etc lib usr sbin etc/kernel-patches
-	docker run --rm --net=none --log-driver=none $(shell cat kernel.tag) tar cf - bzImage kernel-dev.tar kernel-headers.tar vmlinux kernel-modules.tar | tar xf - -C x86_64
+	mkdir -p x86_64 etc lib usr sbin etc/kernel-patches kvmod
+	docker run --rm --net=none --log-driver=none $(shell cat kernel.tag) tar cf - bzImage kernel-dev.tar kernel-headers.tar vmlinux kernel-modules.tar kernel_vuln.tar | tar xf - -C x86_64
 	cp x86_64/kernel-modules.tar kernel.tar
+	cp x86_64/kernel_vuln.tar kernel_vuln.tar
+	tar xf kernel_vuln.tar -C kvmod
 	cp x86_64/bzImage $@
 
 .PHONY: image push tag
 
 MEDIA_TOYBOX=mobylinux/toybox-media:0a26fe5f574e444849983f9c4148ef74b3804d55@sha256:5ac38f77b66deb194c9016591b9b096e81fcdc9f7c3e6d01566294a6b4b4ebd2
 
-BASE="$MEDIA_TOYBOX"
+#BASE="$MEDIA_TOYBOX"
 IMAGE=kernel
 
 default: push
@@ -59,8 +54,9 @@ default: push
 Dockerfile.media:
 	printf "FROM $(MEDIA_TOYBOX)\nADD . /\n" > $@
 
-image: Dockerfile.media bzImage kernel.tar $(DEPS)
+image: Dockerfile.media bzImage kernel.tar Dockerfile.kvmod kvmod/root/kvmod/kernel_vuln.ko $(DEPS)
 	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -f Dockerfile.media -
+	tar cf - $^ | docker build --no-cache -t ok-kvmod:$(IMAGE_VERSION) -f Dockerfile.kvmod -
 
 push: image
 	docker pull mobylinux/$(IMAGE):$(IMAGE_VERSION) || \
@@ -79,6 +75,6 @@ tag: image
 
 .PHONY: clean
 clean:
-	rm -rf x86_64 lib usr sbin kernel.tag Dockerfile.media bzImage kernel.tar
+	rm -rf x86_64 lib usr sbin kernel.tag Dockerfile.media bzImage kernel.tar kernel_vuln.tar kvmod
 
 .DELETE_ON_ERROR:


### PR DESCRIPTION
The changes to the build files below enable building an okernel-based kernel (currently based on v4.11-rc4) and an associated kernel module that emulates a kernel vulnerability for demo purposes, from the linux-okernel public GitHub sources.

In order to give a basic demonstration of the split kernel mechanism, we need to be able to launch two userspace processes in outer kernel mode, typically in two containers. This involves  one of the containers (pmc-app in the example below) mounting a host /dev/okernel device.

I am currently using the following yaml file:
```
kernel:
  image: "mobylinux/kernel:4.11.x"
  cmdline: "console=tty0 page_poison=1"
init: "mobylinux/init:83b229223adbdd5ae38f39b4754e61b951529664"
system:
  - name: sysctl
    image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
    network_mode: host
    pid: host
    ipc: host
    capabilities:
     - CAP_SYS_ADMIN
    read_only: true
  - name: binfmt
    image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
    binds:
     - /proc/sys/fs/binfmt_misc:/binfmt_misc
    read_only: true
    command: [/usr/bin/binfmt, -dir, /etc/binfmt.d/, -mount, /binfmt_misc]
  - name: load_kvmod
    image: "ok-kvmod:4.11-rc4-0"
    capabilities:
     - CAP_SYS_ADMIN
     - CAP_SYS_MODULE
    privileged: true
    command: [/sbin/insmod, /root/kvmod/kernel_vuln.ko]
    network_mode: none
daemon:
  - name: rngd
    image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"
    capabilities:
     - CAP_SYS_ADMIN
    oom_score_adj: -800
    read_only: true
    command: [/bin/tini, /usr/sbin/rngd, -f]
  - name: pmc-app
    image: "pmc-app:latest"
    capabilities:
     - CAP_SYS_ADMIN
    devices:
     - "/dev/okernel:/dev/okernel"
    network_mode: none
files:
  - path: etc/docker/daemon.json
    contents: '{"debug": true}'
outputs:
  - format: kernel+initrd
  - format: iso-bios

```
However, the log of the 'pmc-app' container under /var/log reports "failed to open ioctl device (/dev/okernel)". Is device mounting supported in moby?