### PR TITLE
Fix typo that meant modules were missing from image

### DIFF
--- a/src/cmd/moby/build.go
+++ b/src/cmd/moby/build.go
@@ -194,7 +194,7 @@ func untarKernel(buf *bytes.Buffer, bzimageName, ktarName string) (*bytes.Buffer
 			}
 		case ktarName:
 			ktar = new(bytes.Buffer)
-			_, err := io.Copy(bzimage, tr)
+			_, err := io.Copy(ktar, tr)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
fix #1393 thanks @deitch

Signed-off-by: Justin Cormack <justin.cormack@docker.com>