### PR TITLE
Content Trust enforcement on pull and run where specified for kernel

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -56,5 +56,8 @@ daemon:
     binds:
      - /dev:/dev
      - /lib/modules:/lib/modules
+trust:
+  image:
+    - mobylinux/kernel
 outputs:
   - format: kernel+initrd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -72,6 +72,9 @@ daemon:
      - CAP_SETGID
      - CAP_DAC_OVERRIDE
     net: host
+trust:
+  image:
+    - mobylinux/kernel
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -50,6 +50,9 @@ daemon:
     binds:
      - /root/.ssh:/root/.ssh
      - /etc/resolv.conf:/etc/resolv.conf
+trust:
+  image:
+    - mobylinux/kernel
 files:
   - path: root/.ssh/authorized_keys
     contents: '#your ssh key here'

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -47,6 +47,9 @@ daemon:
      - CAP_SETGID
      - CAP_DAC_OVERRIDE
     net: host
+trust:
+  image:
+    - mobylinux/kernel
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'

--- a/moby.yml
+++ b/moby.yml
@@ -50,6 +50,9 @@ daemon:
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'
+trust:
+  image:
+    - mobylinux/kernel
 outputs:
   - format: kernel+initrd
   - format: iso-bios

--- a/src/cmd/moby/config.go
+++ b/src/cmd/moby/config.go
@@ -27,6 +27,7 @@ type Moby struct {
 	Init   []string
 	System []MobyImage
 	Daemon []MobyImage
+	Trust  TrustConfig
 	Files  []struct {
 		Path      string
 		Directory bool
@@ -41,6 +42,12 @@ type Moby struct {
 		Public  bool
 		Replace bool
 	}
+}
+
+// TrustConfig is the type of a content trust config
+type TrustConfig struct {
+	Image []string
+	Org   []string
 }
 
 // MobyImage is the type of an image config


### PR DESCRIPTION
Adds `contentTrust` field under `kernel`, following @justincormack's proposal. Succeeds quietly on success, notary error messages bubble up on failure:
```
🐳 $ bin/moby build -pull moby
Pull kernel image: mobylinux/kernel:4.9.14-0
FATA[0001] Could not pull image mobylinux/kernel:4.9.14-0: exit status 1: No trust data for 4.9.14-0
```

cc @talex5 for CI - your delegation key is setup for mobylinux/kernel and CI can sign with `make sign`

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>