### PR TITLE
Make each rootfs a mountpoint by binding

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - mobylinux/init:02f05d99b4eb9cd9223bb5915f4070cf7b67c862
+  - mobylinux/init:c394f4bf59566206e5036798c058a9894a7e0fc8
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:68bb523deea09da293d675cbf88474eced540b8c
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - mobylinux/init:02f05d99b4eb9cd9223bb5915f4070cf7b67c862
+  - mobylinux/init:c394f4bf59566206e5036798c058a9894a7e0fc8
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:68bb523deea09da293d675cbf88474eced540b8c
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - mobylinux/init:02f05d99b4eb9cd9223bb5915f4070cf7b67c862
+  - mobylinux/init:c394f4bf59566206e5036798c058a9894a7e0fc8
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:68bb523deea09da293d675cbf88474eced540b8c
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=tty0 page_poison=1"
 init:
-  - mobylinux/init:02f05d99b4eb9cd9223bb5915f4070cf7b67c862
+  - mobylinux/init:c394f4bf59566206e5036798c058a9894a7e0fc8
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:68bb523deea09da293d675cbf88474eced540b8c
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/moby.yml
+++ b/moby.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - mobylinux/init:02f05d99b4eb9cd9223bb5915f4070cf7b67c862
+  - mobylinux/init:c394f4bf59566206e5036798c058a9894a7e0fc8
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:68bb523deea09da293d675cbf88474eced540b8c
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/pkg/init/etc/init.d/containers
+++ b/pkg/init/etc/init.d/containers
@@ -7,6 +7,7 @@ then
 	for f in $(find /containers/onboot -mindepth 1 -maxdepth 1 | sort)
 	do
 		base="$(basename $f)"
+		/bin/mount --bind "$f/rootfs" "$f/rootfs"
 		/usr/bin/runc run --bundle "$f" "$(basename $f)"
 		printf " - $base\n"
 	done
@@ -20,6 +21,7 @@ then
 	for f in $(find /containers/services -mindepth 1 -maxdepth 1 | sort)
 	do
 		base="$(basename $f)"
+		/bin/mount --bind "$f/rootfs" "$f/rootfs"
 		log="/var/log/$base.log"
 		/sbin/start-stop-daemon --start --pidfile /run/$base.pid --exec /usr/bin/runc -- run --bundle "$f" --pid-file /run/$base.pid "$(basename $f)" </dev/null 2>$log >$log &
 		printf " - $base\n"

--- a/test/ltp/test-ltp.yml
+++ b/test/ltp/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - mobylinux/init:02f05d99b4eb9cd9223bb5915f4070cf7b67c862
+  - mobylinux/init:c394f4bf59566206e5036798c058a9894a7e0fc8
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:68bb523deea09da293d675cbf88474eced540b8c
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/test/test.yml
+++ b/test/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - mobylinux/init:02f05d99b4eb9cd9223bb5915f4070cf7b67c862
+  - mobylinux/init:c394f4bf59566206e5036798c058a9894a7e0fc8
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:68bb523deea09da293d675cbf88474eced540b8c
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/test/virtsock/test-virtsock-server.yml
+++ b/test/virtsock/test-virtsock-server.yml
@@ -6,7 +6,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - mobylinux/init:02f05d99b4eb9cd9223bb5915f4070cf7b67c862
+  - mobylinux/init:c394f4bf59566206e5036798c058a9894a7e0fc8
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:68bb523deea09da293d675cbf88474eced540b8c
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935


### PR DESCRIPTION
Otherwise shared mounts do not work correctly with `runc`.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>