### PR TITLE
test: run docker bench container

### DIFF
--- a/test/docker-bench/Dockerfile
+++ b/test/docker-bench/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:3.5
+RUN apk update && apk upgrade && apk add --no-cache bash curl
+ADD . ./
+
+# Also add docker
+ENV DOCKER_BUCKET get.docker.com
+ENV DOCKER_VERSION 17.04.0-ce
+ENV DOCKER_SHA256 c52cff62c4368a978b52e3d03819054d87bcd00d15514934ce2e0e09b99dd100
+
+# Downloads docker but only installs the client
+RUN set -x \
+	&& curl -fSL "https://${DOCKER_BUCKET}/builds/$(uname -s)/$(uname -m)/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+	&& echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
+	&& tar -xzvf docker.tgz \
+	&& mv docker/docker /usr/bin/ \
+	&& rm -rf docker \
+	&& rm docker.tgz \
+	&& docker -v
+
+COPY . ./
+
+ENTRYPOINT ["/bin/sh", "/bench_runner.sh"]

--- a/test/docker-bench/Makefile
+++ b/test/docker-bench/Makefile
@@ -1,0 +1,29 @@
+.PHONY: tag push
+
+BASE=alpine:3.5
+IMAGE=test-docker-bench
+
+default: push
+
+hash: Dockerfile bench_runner.sh
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c "cat $^ /lib/apk/db/installed | sha1sum" | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/test/docker-bench/bench_runner.sh
+++ b/test/docker-bench/bench_runner.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "waiting for docker socket to be available..."
+
+# wait for the docker runc container
+while [ ! -e /var/run/docker.sock ]; do sleep 1; done
+
+echo "found docker socket, starting docker bench..."
+
+docker run -i --net host --pid host --cap-add audit_control -v /var/lib:/var/lib -v /var/run/docker.sock:/var/run/docker.sock --label docker_bench_security docker/docker-bench-security

--- a/test/docker-bench/test-docker-bench.yml
+++ b/test/docker-bench/test-docker-bench.yml
@@ -1,0 +1,84 @@
+kernel:
+  image: "mobylinux/kernel:4.9.x"
+  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+init:
+  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
+  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
+  - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+onboot:
+  - name: sysctl
+    image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
+    net: host
+    pid: host
+    ipc: host
+    capabilities:
+     - CAP_SYS_ADMIN
+    readonly: true
+  - name: sysfs
+    image: mobylinux/sysfs:6c1d06f28ddd9681799d3950cddf044b930b221c
+  - name: binfmt
+    image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
+    binds:
+     - /proc/sys/fs/binfmt_misc:/binfmt_misc
+    readonly: true
+  - name: format
+    image: "mobylinux/format:53748000acf515549d398e6ae68545c26c0f3a2e"
+    binds:
+     - /dev:/dev
+    capabilities:
+     - CAP_SYS_ADMIN
+     - CAP_MKNOD
+  - name: mount
+    image: "mobylinux/mount:d2669e7c8ddda99fa0618a414d44261eba6e299a"
+    binds:
+     - /dev:/dev
+     - /var:/var:rshared,rbind
+    capabilities:
+     - CAP_SYS_ADMIN
+    rootfsPropagation: shared
+    command: ["/mount.sh", "/var/lib/docker"]
+services:
+  - name: rngd
+    image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"
+    capabilities:
+     - CAP_SYS_ADMIN
+    oomScoreAdj: -800
+    readonly: true
+  - name: dhcpcd
+    image: "mobylinux/dhcpcd:57a8ef29d3a910645b2b24c124f9ce9ef53ce703"
+    binds:
+     - /var:/var
+     - /tmp/etc:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    oomScoreAdj: -800
+  - name: docker
+    image: "mobylinux/docker-ce:741bf21513328f674e0cdcaa55492b0b75974e08"
+    capabilities:
+     - all
+    net: host
+    mounts:
+     - type: cgroup
+       options: ["rw","nosuid","noexec","nodev","relatime"]
+    binds:
+     - /var/lib/docker:/var/lib/docker
+     - /lib/modules:/lib/modules
+     - /run:/var/run
+  - name: test-docker-bench
+    image: "mobylinux/test-docker-bench:2f941429d874c5dcf05e38005affb4f10192e1a8"
+    ipc: host
+    pid: host
+    net: host
+    binds:
+     - /run:/var/run
+    capabilities:
+     - all
+trust:
+  image:
+    - mobylinux/kernel
+outputs:
+  - format: kernel+initrd


### PR DESCRIPTION
Inspired from #686 

Note that I couldn't find a good way of getting the service container logs from docker bench to the main console.  I tried playing with mounting `/dev` and redirecting output, but might have had the wrong incantation.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>