### PR TITLE
config: Remove unused binfmt container

### DIFF
--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -15,11 +15,6 @@ onboot:
     capabilities:
      - CAP_SYS_ADMIN
     readonly: true
-  - name: binfmt
-    image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
   - name: metadata-gcp
     image: "mobylinux/metadata-gcp:7fc3dd5ef92e0408fb3f76048bbaae88bbb55ad9"
     binds:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -14,10 +14,6 @@ onboot:
     ipc: host
     capabilities:
      - CAP_SYS_ADMIN
-  - name: binfmt
-    image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
 services:
   - name: rngd
     image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -15,11 +15,6 @@ onboot:
     capabilities:
      - CAP_SYS_ADMIN
     readonly: true
-  - name: binfmt
-    image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
 services:
   - name: rngd
     image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -12,11 +12,6 @@ onboot:
     capabilities:
      - CAP_SYS_ADMIN
     readonly: true
-  - name: binfmt
-    image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
   - name: format
     image: "mobylinux/format:53748000acf515549d398e6ae68545c26c0f3a2e"
     binds:

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -12,11 +12,6 @@ onboot:
     capabilities:
      - CAP_SYS_ADMIN
     readonly: true
-  - name: binfmt
-    image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
 services:
   - name: rngd
     image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9@sha256:1c93c1db7196f6f71f8e300bc1d15f0376dd18e8891c8789d77c8ff19f3a9a92"

--- a/test/test.yml
+++ b/test/test.yml
@@ -7,11 +7,6 @@ init:
   - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
-  - name: binfmt
-    image: "mobylinux/binfmt:bdb754f25a5d851b4f5f8d185a43dfcbb3c22d01"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
   - name: check
     image: "mobylinux/check:c9e41ab96b3ea6a3ced97634751e20d12a5bf52f"
     pid: host


### PR DESCRIPTION
A few YAML files include the binfmt container, where it's not really
needed. Remove it to make the samples simpler.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>