### PR TITLE
Rework how /var is mounted

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - mobylinux/init:4a731380d1d9b29472c7de165a1cdf93136ab1e7
+  - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - mobylinux/init:4a731380d1d9b29472c7de165a1cdf93136ab1e7
+  - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - mobylinux/init:4a731380d1d9b29472c7de165a1cdf93136ab1e7
+  - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=tty0 page_poison=1"
 init:
-  - mobylinux/init:4a731380d1d9b29472c7de165a1cdf93136ab1e7
+  - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/moby.yml
+++ b/moby.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - mobylinux/init:4a731380d1d9b29472c7de165a1cdf93136ab1e7
+  - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/pkg/init/etc/init.d/containers
+++ b/pkg/init/etc/init.d/containers
@@ -8,6 +8,7 @@ then
 	do
 		base="$(basename $f)"
 		/bin/mount --bind "$f/rootfs" "$f/rootfs"
+		mount -o remount,rw "$f/rootfs"
 		/usr/bin/runc run --bundle "$f" "$(basename $f)"
 		printf " - $base\n"
 	done
@@ -22,6 +23,7 @@ then
 	do
 		base="$(basename $f)"
 		/bin/mount --bind "$f/rootfs" "$f/rootfs"
+		mount -o remount,rw "$f/rootfs"
 		log="/var/log/$base.log"
 		/sbin/start-stop-daemon --start --pidfile /run/$base.pid --exec /usr/bin/runc -- run --bundle "$f" --pid-file /run/$base.pid "$(basename $f)" </dev/null 2>$log >$log &
 		printf " - $base\n"

--- a/pkg/init/etc/init.d/rcS
+++ b/pkg/init/etc/init.d/rcS
@@ -107,17 +107,10 @@ mkdir /tmp/etc
 mv /etc/resolv.conf /tmp/etc/resolv.conf
 ln -snf /tmp/etc/resolv.conf /etc/resolv.conf
 
-# mount rootfs as rshared
-mount --make-rshared /
-
 # remount rootfs as readonly
 mount -o remount,ro /
 
-# bind and remount containers as read-write but private
-mount -o bind /containers /containers
-mount -o remount,rw,relatime /containers /containers
-mount --make-private /containers
-
-# make /var its own tmpfs mount point
-mount -n -t tmpfs var /var -o nodev,nosuid,noexec,relatime,size=10%,mode=755
+# make /var writeable and shared
+mount -o bind /var /var
+mount -o remount,rw,nodev,nosuid,noexec,relatime /var /var
 mount --make-rshared /var

--- a/projects/demo/etcd/etcd.yml
+++ b/projects/demo/etcd/etcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - mobylinux/init:4a731380d1d9b29472c7de165a1cdf93136ab1e7
+  - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel-landlock:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - mobylinux/init:4a731380d1d9b29472c7de165a1cdf93136ab1e7
+  - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/test/ltp/test-ltp.yml
+++ b/test/ltp/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - mobylinux/init:4a731380d1d9b29472c7de165a1cdf93136ab1e7
+  - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/test/test.yml
+++ b/test/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - mobylinux/init:4a731380d1d9b29472c7de165a1cdf93136ab1e7
+  - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/test/virtsock/test-virtsock-server.yml
+++ b/test/virtsock/test-virtsock-server.yml
@@ -6,7 +6,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - mobylinux/init:4a731380d1d9b29472c7de165a1cdf93136ab1e7
+  - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935


### PR DESCRIPTION
Instead of mounting a new filesystem, revert to doing a `rw` bind.

However do not make `/` `rshared`, just `/var` as that is where we expect
filesystems to be mounted for persistence. Also only make the actual
container rootfs writeable, not the whole directory.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>