### PR TITLE
demo: Remove jq and sfdisk from etcd image

### DIFF
--- a/projects/demo/etcd/Dockerfile
+++ b/projects/demo/etcd/Dockerfile
@@ -1,9 +1,4 @@
-# A dockerfile to build an etcd container image from the upstream one
-# with a script as entry point
 FROM quay.io/coreos/etcd:v3.1.5
-
-# sfdisk and jq re required to mount the disk
-RUN apk add --no-cache sfdisk jq
 
 COPY ./etcd.sh /
 


### PR DESCRIPTION
They are no longer needed as the mounting happens in the
mount container.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>