### PR TITLE
Use the real default containerd toml config

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
+  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
+  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
+  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
+  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/moby.yml
+++ b/moby.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
+  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/pkg/containerd/etc/containerd/config.toml
+++ b/pkg/containerd/etc/containerd/config.toml
@@ -1,0 +1,16 @@
+state = "/run/containerd"
+root = "/var/lib/containerd"
+snapshotter = "overlay"
+subreaper = false
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+
+[debug]
+  address = "/run/containerd/debug.sock"
+  level = "info"
+
+[metrics]
+  address = ""

--- a/projects/demo/etcd/etcd.yml
+++ b/projects/demo/etcd/etcd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
+  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/projects/demo/intro/intro.yml
+++ b/projects/demo/intro/intro.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - mobylinux/init:925c88f42d92d57cd36b656db1f8757b152163a7
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
+  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
 onboot:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
+  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/test/ltp/test-ltp.yml
+++ b/test/ltp/test-ltp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
+  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: ltp

--- a/test/test.yml
+++ b/test/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
+  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: check

--- a/test/virtsock/test-virtsock-server.yml
+++ b/test/virtsock/test-virtsock-server.yml
@@ -8,7 +8,7 @@ kernel:
 init:
   - mobylinux/init:671bdce1ed0803daeb35e83e4bcd576bb449ea35
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - mobylinux/containerd:c7f6ecdcbcb615a53edee556ba03c7c873bc8488
+  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl


### PR DESCRIPTION
Rather than an empty one.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>