### PR TITLE
Add ineffassign to go-compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: default
 VERSION="0.0" # dummy for now
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:90607983001c2789911afabf420394d51f78ced8@sha256:8b6566c6fd9f3bca31191b919449248d3cb1ca3a562276fca7199e93451d6596
+GO_COMPILE=linuxkit/go-compile:4513068d9a7e919e4ec42e2d7ee879ff5b95b7f5@sha256:bdfadbe3e4ec699ca45b67453662321ec270f2d1a1dbdbf09625776d3ebd68c5
 
 MOBY?=bin/moby
 GOOS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
@@ -20,12 +20,16 @@ endif
 MOBY_DEPS=$(wildcard src/cmd/moby/*.go) Makefile vendor.conf
 MOBY_DEPS+=$(wildcard src/initrd/*.go) $(wildcard src/pad4/*.go)
 bin/moby: $(MOBY_DEPS) | bin
-	tar cf - vendor src/initrd src/pad4 -C src/cmd/moby . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/docker/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ | tar xf -
+	tar cf - vendor src/initrd src/pad4 -C src/cmd/moby . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/docker/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
+	tar xf tmp_moby_bin.tar > $@
+	rm tmp_moby_bin.tar
 	touch $@
 
 INFRAKIT_DEPS=$(wildcard src/cmd/infrakit-instance-hyperkit/*.go) Makefile vendor.conf
 bin/infrakit-instance-hyperkit: $(INFRAKIT_DEPS) | bin
-	tar cf - vendor -C src/cmd/infrakit-instance-hyperkit . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/docker/moby -o $@ | tar xf -
+	tar cf - vendor -C src/cmd/infrakit-instance-hyperkit . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/docker/moby -o $@ > tmp_infrakit_instance_hyperkit_bin.tar
+	tar xf tmp_infrakit_instance_hyperkit_bin.tar > $@
+	rm tmp_infrakit_instance_hyperkit_bin.tar
 	touch $@
 
 test-initrd.img: $(MOBY) test/test.yml

--- a/tools/go-compile/Dockerfile
+++ b/tools/go-compile/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.5
 RUN apk update && apk add --no-cache build-base git go
 ENV GOPATH=/go PATH=$PATH:/go/bin
-RUN go get -u github.com/golang/lint/golint
-RUN go get -u github.com/LK4D4/vndr
+RUN go get -u github.com/golang/lint/golint && \
+    go get -u github.com/gordonklaus/ineffassign && \
+    go get -u github.com/LK4D4/vndr
 
 COPY . ./
 

--- a/tools/go-compile/compile.sh
+++ b/tools/go-compile/compile.sh
@@ -61,6 +61,9 @@ test -z $(GOOS=linux go tool vet -printf=false . 2>&1 | grep -v vendor/ | tee /d
 >&2 echo "golint..."
 test -z $(find . -type f -name "*.go" -not -path "*/vendor/*" -not -name "*.pb.*" -exec golint {} \; | tee /dev/stderr)
 
+>&2 echo "ineffassign..."
+test -z $(find . -type f -name "*.go" -not -path "*/vendor/*" -not -name "*.pb.*" -exec ineffassign {} \; | tee /dev/stderr)
+
 >&2 echo "go build..."
 
 if [ "$GOOS" = "darwin" ]


### PR DESCRIPTION
`ineffassign` will tell you if you've assigned to a variable but then fail to actually use it.  Especially helpful for ensuring error checking.  I've only updated the top-level Makefile, but can also update pkgs and can rebuild if we'd like.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>