### PR TITLE
Add openntpd container

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -56,6 +56,15 @@ services:
      - CAP_NET_RAW
     net: host
     oomScoreAdj: -800
+  - name: ntpd
+    image: "mobylinux/openntpd:a570316d7fc49ca1daa29bd945499f4963d227af"
+    capabilities:
+      - CAP_SYS_TIME
+      - CAP_SYS_NICE
+      - CAP_SYS_CHROOT
+      - CAP_SETUID
+      - CAP_SETGID
+    net: host
   - name: docker
     image: "mobylinux/docker-ce:741bf21513328f674e0cdcaa55492b0b75974e08"
     capabilities:

--- a/pkg/openntpd/Dockerfile
+++ b/pkg/openntpd/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.5
+
+RUN \
+  apk update && apk upgrade -a && \
+  apk add --no-cache \
+  openntpd \
+  && true
+
+COPY . .
+
+CMD ["/usr/sbin/ntpd", "-d", "-s"]

--- a/pkg/openntpd/Makefile
+++ b/pkg/openntpd/Makefile
@@ -1,0 +1,29 @@
+.PHONY: tag push clean container
+default: push
+
+IMAGE=openntpd
+
+BASE=alpine:3.5
+
+hash: Dockerfile etc/ntpd.conf
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm $(IMAGE):build sh -c 'cat $^ /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -rf hash
+
+.DELETE_ON_ERROR:

--- a/pkg/openntpd/etc/ntpd.conf
+++ b/pkg/openntpd/etc/ntpd.conf
@@ -1,0 +1,21 @@
+# $OpenBSD: ntpd.conf,v 1.3 2015/05/18 11:10:03 dtucker Exp $
+# sample ntpd configuration file, see ntpd.conf(5)
+
+# Addresses to listen on (ntpd does not listen by default)
+#listen on *
+
+# sync to a single server
+#server ntp.example.org
+
+# use a random selection of NTP Pool Time Servers
+# see http://support.ntp.org/bin/view/Servers/NTPPoolServers
+servers pool.ntp.org
+
+# use a specific local timedelta sensor (radio clock, etc)
+#sensor nmea0
+
+# use all detected timedelta sensors
+#sensor *
+
+# get the time constraint from a well-known HTTPS site
+# constraints from "https://www.google.com/"


### PR DESCRIPTION
Added to Docker example as Swarm mode likes time sync.

Note uses pool.ntp.org at present, on some providers it
should use a different source.

Constraints not enabled as they seem to have an issue;
possibly trying to set before network is up.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>