### PR TITLE
catch and handle errors in src/cmd/moby

### DIFF
--- a/src/cmd/moby/build.go
+++ b/src/cmd/moby/build.go
@@ -27,7 +27,9 @@ func build(args []string) {
 	buildName := buildCmd.String("name", "", "Name to use for output files")
 	buildPull := buildCmd.Bool("pull", false, "Always pull images")
 
-	buildCmd.Parse(args)
+	if err := buildCmd.Parse(args); err != nil {
+		log.Fatal("Unable to parse args")
+	}
 	remArgs := buildCmd.Args()
 
 	if len(remArgs) == 0 {

--- a/src/cmd/moby/gcp.go
+++ b/src/cmd/moby/gcp.go
@@ -401,10 +401,15 @@ func (g GCPClient) ConnectToInstanceSerialPort(instance, zone string) error {
 		}
 	}
 
-	session.RequestPty("xterm", termHeight, termWidth, ssh.TerminalModes{
+	if err = session.RequestPty("xterm", termHeight, termWidth, ssh.TerminalModes{
 		ssh.ECHO: 1,
-	})
-	session.Shell()
+	}); err != nil {
+		return err
+	}
+
+	if err = session.Shell(); err != nil {
+		return err
+	}
 
 	err = session.Wait()
 	//exit <- true

--- a/src/cmd/moby/run_gcp.go
+++ b/src/cmd/moby/run_gcp.go
@@ -41,7 +41,9 @@ func runGcp(args []string) {
 	publicFlag := gcpCmd.Bool("public", false, "Select if file on GS should be public. *Optional* when 'prefix' is a filename")
 	familyFlag := gcpCmd.String("family", "", "GCP Image Family. A group of images where the family name points to the most recent image. *Optional* when 'prefix' is a filename")
 	nameFlag := gcpCmd.String("img-name", "", "Overrides the Name used to identify the file in Google Storage, Image and Instance. Defaults to [name]")
-	gcpCmd.Parse(args)
+	if err := gcpCmd.Parse(args); err != nil {
+		log.Fatal("Unable to parse args")
+	}
 
 	remArgs := gcpCmd.Args()
 	if len(remArgs) == 0 {

--- a/src/cmd/moby/run_hyperkit.go
+++ b/src/cmd/moby/run_hyperkit.go
@@ -30,7 +30,9 @@ func runHyperKit(args []string) {
 	data := hyperkitCmd.String("data", "", "Metadata to pass to VM (either a path to a file or a string)")
 	ipStr := hyperkitCmd.String("ip", "", "IP address for the VM")
 
-	hyperkitCmd.Parse(args)
+	if err := hyperkitCmd.Parse(args); err != nil {
+		log.Fatal("Unable to parse args")
+	}
 	remArgs := hyperkitCmd.Args()
 	if len(remArgs) == 0 {
 		fmt.Println("Please specify the prefix to the image to boot\n")
@@ -59,7 +61,9 @@ func runHyperKit(args []string) {
 		if err != nil {
 			log.Fatalf("Cannot write user data ISO: %v", err)
 		}
-		outfh.Close()
+		if err = outfh.Close(); err != nil {
+			log.Fatalf("Cannot close output ISO: %v", err)
+		}
 	}
 
 	uuidStr := ""

--- a/src/cmd/moby/run_qemu.go
+++ b/src/cmd/moby/run_qemu.go
@@ -36,7 +36,9 @@ func runQemu(args []string) {
 	qemuCPUs := qemuFlags.String("cpus", "1", "Number of CPUs")
 	qemuMem := qemuFlags.String("mem", "1024", "Amount of memory in MB")
 
-	qemuFlags.Parse(args)
+	if err := qemuFlags.Parse(args); err != nil {
+		log.Fatal("Unable to parse args")
+	}
 	remArgs := qemuFlags.Args()
 
 	if len(remArgs) == 0 {

--- a/src/cmd/moby/run_vmware.go
+++ b/src/cmd/moby/run_vmware.go
@@ -70,7 +70,9 @@ func runVMware(args []string) {
 	runMem := vmwareArgs.Int("mem", 1024, "Amount of memory in MB")
 	runDisk := vmwareArgs.String("disk", "", "Path to disk image to use")
 
-	vmwareArgs.Parse(args)
+	if err := vmwareArgs.Parse(args); err != nil {
+		log.Fatal("Unable to parse args")
+	}
 	remArgs := vmwareArgs.Args()
 
 	if len(remArgs) == 0 {


### PR DESCRIPTION
Handle more previously unchecked errors.

I used [`errcheck`](https://github.com/kisielk/errcheck) to find these, which we can add to `go-compile` but I'd need to figure out the best way to make it worth with our vendoring structure 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>