### PR TITLE
moby: enable internet access for GCP VM's

### DIFF
--- a/src/cmd/moby/gcp.go
+++ b/src/cmd/moby/gcp.go
@@ -211,6 +211,11 @@ func (g GCPClient) CreateInstance(name, image, zone, machineType string, replace
 		NetworkInterfaces: []*compute.NetworkInterface{
 			{
 				Network: "global/networks/default",
+				AccessConfigs: []*compute.AccessConfig{
+					{
+						Type: "ONE_TO_ONE_NAT",
+					},
+				},
 			},
 		},
 		Metadata: &compute.Metadata{


### PR DESCRIPTION
Adds an "access config" with a type of "ONE_TO_ONE_NAT" that
allows an instance to obtain an ephemeral IP address and access the
internet

Fixes: #1591

Signed-off-by: Dave Tucker <dt@docker.com>