### PR TITLE
moby: Add system disk and disk size parameter to GCP

### DIFF
--- a/src/cmd/moby/run_gcp.go
+++ b/src/cmd/moby/run_gcp.go
@@ -10,16 +10,18 @@ import (
 )
 
 const (
-	defaultZone    = "europe-west1-d"
-	defaultMachine = "g1-small"
-	zoneVar        = "MOBY_GCP_ZONE"
-	machineVar     = "MOBY_GCP_MACHINE"
-	keysVar        = "MOBY_GCP_KEYS"
-	projectVar     = "MOBY_GCP_PROJECT"
-	bucketVar      = "MOBY_GCP_BUCKET"
-	familyVar      = "MOBY_GCP_FAMILY"
-	publicVar      = "MOBY_GCP_PUBLIC"
-	nameVar        = "MOBY_GCP_IMAGE_NAME"
+	defaultZone     = "europe-west1-d"
+	defaultMachine  = "g1-small"
+	defaultDiskSize = 1
+	zoneVar         = "MOBY_GCP_ZONE"
+	machineVar      = "MOBY_GCP_MACHINE"
+	keysVar         = "MOBY_GCP_KEYS"
+	projectVar      = "MOBY_GCP_PROJECT"
+	bucketVar       = "MOBY_GCP_BUCKET"
+	familyVar       = "MOBY_GCP_FAMILY"
+	publicVar       = "MOBY_GCP_PUBLIC"
+	nameVar         = "MOBY_GCP_IMAGE_NAME"
+	diskSizeVar     = "MOBY_GCP_DISK_SIZE"
 )
 
 // Process the run arguments and execute run
@@ -41,6 +43,8 @@ func runGcp(args []string) {
 	publicFlag := gcpCmd.Bool("public", false, "Select if file on GS should be public. *Optional* when 'prefix' is a filename")
 	familyFlag := gcpCmd.String("family", "", "GCP Image Family. A group of images where the family name points to the most recent image. *Optional* when 'prefix' is a filename")
 	nameFlag := gcpCmd.String("img-name", "", "Overrides the Name used to identify the file in Google Storage, Image and Instance. Defaults to [name]")
+	diskSizeFlag := gcpCmd.Int("disk-size", 0, "Size of system disk in GB")
+
 	if err := gcpCmd.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
 	}
@@ -61,6 +65,7 @@ func runGcp(args []string) {
 	public := getBoolValue(publicVar, *publicFlag)
 	family := getStringValue(familyVar, *familyFlag, "")
 	name := getStringValue(nameVar, *nameFlag, "")
+	diskSize := getIntValue(diskSizeVar, *diskSizeFlag, defaultDiskSize)
 
 	client, err := NewGCPClient(keys, project)
 	if err != nil {
@@ -93,7 +98,7 @@ func runGcp(args []string) {
 		name = prefix
 	}
 
-	if err = client.CreateInstance(name, prefix, zone, machine, true); err != nil {
+	if err = client.CreateInstance(name, prefix, zone, machine, diskSize, true); err != nil {
 		log.Fatal(err)
 	}
 

--- a/src/cmd/moby/util.go
+++ b/src/cmd/moby/util.go
@@ -1,6 +1,9 @@
 package main
 
-import "os"
+import (
+	"os"
+	"strconv"
+)
 
 func getStringValue(envKey string, flagVal string, defaultVal string) string {
 	var res string
@@ -18,6 +21,31 @@ func getStringValue(envKey string, flagVal string, defaultVal string) string {
 
 	// if we still don't have a value, use the default
 	if res == "" {
+		res = defaultVal
+	}
+	return res
+}
+
+func getIntValue(envKey string, flagVal int, defaultVal int) int {
+	var res int
+
+	// If defined, take the env variable
+	if _, ok := os.LookupEnv(envKey); ok {
+		var err error
+		res, err = strconv.Atoi(os.Getenv(envKey))
+		if err != nil {
+			res = 0
+		}
+	}
+
+	// If a flag is specified, this value takes precedence
+	// Ignore cases where the flag carries the default value
+	if flagVal > 0 {
+		res = flagVal
+	}
+
+	// if we still don't have a value, use the default
+	if res == 0 {
 		res = defaultVal
 	}
 	return res


### PR DESCRIPTION
This makes gcp behave in a similar way to the qemu backend.
The minimum size on GCP 1GB, whereas qemu uses 256MB.
Without this, the LTP tests fail on GCP.

Signed-off-by: Dave Tucker <dt@docker.com>