### PR TITLE
tests: update ltp test configuration

### DIFF
--- a/test/ltp/Dockerfile.pkg
+++ b/test/ltp/Dockerfile.pkg
@@ -1,4 +1,4 @@
 FROM debian:jessie-slim@sha256:2a14128195ab26b1c56c5773dda9def9b909c2e01596ef9108e2295d418210a3
 ADD . /
 WORKDIR /opt/ltp
-ENTRYPOINT ["./runltplite.sh"]
+ENTRYPOINT ["/bin/sh", "/check.sh"]

--- a/test/ltp/Makefile
+++ b/test/ltp/Makefile
@@ -17,10 +17,10 @@ IMAGE=test-ltp-$(LTP_VERSION)
 # because the ltp binaries will change everytime we build. Ideally, we
 # would calculate the hash from the source and the apt-get cache, but
 # it's not that critical.
-hash: Dockerfile.pkg ltp.tar $(DEPS)
+hash: Dockerfile.pkg ltp.tar check.sh $(DEPS)
 	tar xf ltp.tar
-	tar cf - Dockerfile.pkg opt | docker build --no-cache -t $(IMAGE):build -f Dockerfile.pkg -
-	cat Dockerfile.pkg $(DEPS) | DOCKER_CONTENT_TRUST=1 docker run --rm -i $(SHASUM) sha1sum | sed 's/ .*//' > $@
+	tar cf - Dockerfile.pkg opt check.sh | docker build --no-cache -t $(IMAGE):build -f Dockerfile.pkg -
+	cat Dockerfile.pkg check.sh $(DEPS) | DOCKER_CONTENT_TRUST=1 docker run --rm -i $(SHASUM) sha1sum | sed 's/ .*//' > $@
 
 push: hash
 	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \

--- a/test/ltp/check.sh
+++ b/test/ltp/check.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+sh runltplite.sh -p -l /ltp.log
+cat /ltp.log
+
+baseline="$(cat /etc/ltp/baseline)"
+failures="$( grep "Total Failures" /ltp.log | awk '{print $3}')"
+
+if [ $((failures <= baseline)) -ne 0 ]
+then
+	printf "LTP test suite PASSED\n"
+else
+	printf "LTP test suite FAILED\n"
+	exit 1
+fi

--- a/test/ltp/test-ltp.yml
+++ b/test/ltp/test-ltp.yml
@@ -8,25 +8,25 @@ init:
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: ltp
-    image: "mobylinux/test-ltp-20170116:fdca2d1bb019b1d51e722e6032c82c7933d4b870"
+    image: "mobylinux/test-ltp-20170116:d4722477c11e0006d6e5529efe241b6ae70ff3a9" 
     net: host
     pid: host
-    capabilities:
-     - CAP_SYS_ADMIN
-services:
-  - name: dhcpcd
-    image: "mobylinux/dhcpcd:0d4012269cb142972fed8542fbdc3ff5a7b695cd"
     binds:
-     - /var:/var
-     - /tmp:/etc
+     - /etc/ltp/baseline:/etc/ltp/baseline
     capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    oomScoreAdj: -800
+     - all
+services:
+  - name: poweroff
+    image: "mobylinux/poweroff:961412b8ef5c5285de0d40ec076701d955eaa084"
+    pid: host
+    capabilities:
+      - CAP_SYS_BOOT
+    readonly: true
 files:
+  - path: /etc/ltp/baseline
+    contents: "100"
 outputs:
   - format: kernel+initrd
   - format: iso-bios
   - format: iso-efi
+  - format: gcp-img

--- a/test/poweroff/Dockerfile
+++ b/test/poweroff/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.5
+ADD . ./
+ENTRYPOINT ["/bin/sh", "/poweroff.sh"]

--- a/test/poweroff/Makefile
+++ b/test/poweroff/Makefile
@@ -1,0 +1,29 @@
+.PHONY: tag push
+
+BASE=alpine:3.5
+IMAGE=poweroff
+
+default: push
+
+hash: Dockerfile poweroff.sh
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c "cat $^ /lib/apk/db/installed | sha1sum" | sed 's/ .*//' > hash
+
+push: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash) && \
+		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build mobylinux/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/test/poweroff/poweroff.sh
+++ b/test/poweroff/poweroff.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+TIMEOUT=${1:-30}  
+sleep "${TIMEOUT}"
+
+/sbin/poweroff -f


### PR DESCRIPTION
- grant all capabilities
- generate human readable output
- add a check.sh script to see if the tests passed/failed
- add a poweroff image to handle powering off the vm

Fixes: #1443 

Signed-off-by: Dave Tucker <dt@docker.com>