### PR TITLE
Make / rshared

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=tty0 page_poison=1"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/pkg/init/etc/init.d/rcS
+++ b/pkg/init/etc/init.d/rcS
@@ -109,3 +109,6 @@ mount -o remount,ro /
 mount -o bind /var /var
 mount -o remount,rw,nodev,nosuid,noexec,relatime /var /var
 mount --make-rshared /var
+
+# make / rshared
+mount --make-rshared /

--- a/projects/demo/etcd/etcd.yml
+++ b/projects/demo/etcd/etcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel-landlock:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/test/docker-bench/test-docker-bench.yml
+++ b/test/docker-bench/test-docker-bench.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/test/ltp/test-ltp.yml
+++ b/test/ltp/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/test/test.yml
+++ b/test/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/test/virtsock/test-virtsock-server.yml
+++ b/test/virtsock/test-virtsock-server.yml
@@ -6,7 +6,7 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - mobylinux/init:e10e2efc1b78ef41d196175cbc07e069391f406e
+  - mobylinux/init:8375addb923b8b88b2209740309c92aa5f2a4f9d
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935


### PR DESCRIPTION
Previously only `/var` was `rshared` but some people need to share
mounts in `/opt` etc so let us make everything `rshared` for now.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>