### PR TITLE
Added install support on make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ ifeq ($(GOOS),darwin)
 default: bin/infrakit-instance-hyperkit
 endif
 
+PREFIX?=/usr/local/
+
 MOBY_DEPS=$(wildcard src/cmd/moby/*.go) Makefile vendor.conf
 MOBY_DEPS+=$(wildcard src/initrd/*.go) $(wildcard src/pad4/*.go)
 bin/moby: $(MOBY_DEPS) | bin
@@ -45,6 +47,9 @@ test-qemu-efi: test-efi.iso
 
 bin:
 	mkdir -p $@
+
+install:
+	cp -R ./bin/* $(PREFIX)/bin
 
 define check_test_log
 	@cat $1 |grep -q 'Moby test suite PASSED'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ LinuxKit, a toolkit for building custom minimal, immutable Linux distributions.
 ### Build the `moby` tool
 
 Simple build instructions: use `make` to build. This will build the customisation tool in `bin/`. Add this
-to your `PATH` or copy it to somewhere in your `PATH` eg `sudo cp bin/moby /usr/local/bin/`.
+to your `PATH` or copy it to somewhere in your `PATH` eg `sudo cp bin/moby /usr/local/bin/`. Or you can use `sudo make install`.
 
 If you already have `go` installed you can use `go get -u github.com/docker/moby/src/cmd/moby` to install
 the `moby` tool, and then use `moby build linuxkit.yml` to build the example configuration. You


### PR DESCRIPTION
Fixed #1544

I added `make install` support. By default it does:

```
cp -r ./bin/* /usr/local/bin
```

There is a env var `$PREFIX` in make. By default it's `/usr/local`