### PR TITLE
kernel: stable kernel bump to 4.9.22

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -30,7 +30,7 @@ IMAGE_VERSION=$(KERNEL_VERSION)-0
 IMAGE_MAJOR_VERSION=4.10.x
 DEPS=Dockerfile.4.10 Makefile kernel_config kernel_config.debug patches-4.10
 else
-KERNEL_VERSION=4.9.21
+KERNEL_VERSION=4.9.22
 IMAGE_VERSION=$(KERNEL_VERSION)-0
 IMAGE_MAJOR_VERSION=4.9.x
 DEPS=Dockerfile Makefile kernel_config kernel_config.debug patches-4.9

--- a/kernel/kernel_config
+++ b/kernel/kernel_config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.19 Kernel Configuration
+# Linux/x86 4.9.22 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y


### PR DESCRIPTION
same question as in #1623, should I be force pushing to the 4.9.x tag somehow?