### PR TITLE
Use containerd to run containers

### DIFF
--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
+  - linuxkit/init:42fe8cb1508b3afed39eb89821906e3cc7a70551
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
+  - linuxkit/containerd:fe1b7f438a234cb6481c6538295115eac2a0596d
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7-alpine3.5
+FROM golang:1.8-alpine
 RUN \
   apk update && apk upgrade -a && \
   apk add --no-cache \
@@ -9,10 +9,10 @@ RUN \
   linux-headers \
   make \
   && true
-ENV CONTAINERD_COMMIT=e5c8c5634a1fa82da41c1b707f8a9889bcfca248
+ENV CONTAINERD_COMMIT=ffe684b017252262431e157741406d4e1fb22831
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
-  git clone https://github.com/containerd/containerd.git
+  git clone https://github.com/justincormack/containerd.git
 WORKDIR $GOPATH/src/github.com/containerd/containerd
 RUN git checkout $CONTAINERD_COMMIT
 RUN make binaries GO_GCFLAGS="-buildmode pie --ldflags '-extldflags \"-fno-PIC -static\"'"

--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -2,7 +2,7 @@ SHA_IMAGE=alpine:3.5@sha256:dfbd4a3a8ebca874ebd2474f044a0b33600d4523d03b0df76e5c
 
 .PHONY: tag push
 
-BASE=golang:1.7-alpine3.5
+BASE=golang:1.8-alpine
 IMAGE=containerd
 
 default: push

--- a/pkg/init/etc/init.d/containers
+++ b/pkg/init/etc/init.d/containers
@@ -15,7 +15,6 @@ then
 fi
 
 # start service containers
-# temporarily using runc not containerd
 
 if [ -d /containers/services ]
 then
@@ -25,7 +24,7 @@ then
 		/bin/mount --bind "$f/rootfs" "$f/rootfs"
 		mount -o remount,rw "$f/rootfs"
 		log="/var/log/$base.log"
-		/sbin/start-stop-daemon --start --pidfile /run/$base.pid --exec /usr/bin/runc -- run --bundle "$f" --pid-file /run/$base.pid "$(basename $f)" </dev/null 2>$log >$log &
+		ctr run --runtime-config "$f/config.json" --rootfs "$f/rootfs" --id "$(basename $f)" </dev/null 2>$log >$log &
 		printf " - $base\n"
 	done
 fi


### PR DESCRIPTION
Because we are not yet using the image store, this requires a
patched `ctr` that can run a specified rootfs rather than an
image.

We will switch to the image store later, but this requires
extensive build changes.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>