### PR TITLE
Changes required to run LTP tests in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ install:
 	cp -R ./bin/* $(PREFIX)/bin
 
 define check_test_log
-	@cat $1 |grep -q 'Kernel config test suite PASSED'
+	@cat $1 |grep -q 'test suite PASSED'
 endef
 
 .PHONY: test-hyperkit
@@ -71,16 +71,26 @@ test: test-initrd.img test-bzImage test-cmdline
 	tar cf - $^ | ./scripts/qemu.sh 2>&1 | tee test.log
 	$(call check_test_log, test.log)
 
+test-ltp.img.tar.gz: $(MOBY) test/ltp/test-ltp.yml
+	$(MOBY) build test/ltp/test-ltp.yml
+
+.PHONY: test-ltp
+test-ltp: $(MOBY) test-ltp.img.tar.gz
+	$(MOBY) run gcp -skip-cleanup -machine n1-highcpu-4 test-ltp.img.tar.gz | tee test-ltp.log
+	$(call check_test_log, test-ltp.log)
+
 .PHONY: ci ci-tag ci-pr
 ci:
 	$(MAKE) clean
 	$(MAKE)
 	$(MAKE) test
+	$(MAKE) test-ltp
 
 ci-tag:
 	$(MAKE) clean
 	$(MAKE)
 	$(MAKE) test
+	$(MAKE) test-ltp
 
 ci-pr:
 	$(MAKE) clean

--- a/src/cmd/moby/run_gcp.go
+++ b/src/cmd/moby/run_gcp.go
@@ -45,6 +45,7 @@ func runGcp(args []string) {
 	familyFlag := gcpCmd.String("family", "", "GCP Image Family. A group of images where the family name points to the most recent image. *Optional* when 'prefix' is a filename")
 	nameFlag := gcpCmd.String("img-name", "", "Overrides the Name used to identify the file in Google Storage, Image and Instance. Defaults to [name]")
 	diskSizeFlag := gcpCmd.Int("disk-size", 0, "Size of system disk in GB")
+	skipCleanup := gcpCmd.Bool("skip-cleanup", false, "Don't remove images or VMs")
 
 	if err := gcpCmd.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
@@ -107,7 +108,9 @@ func runGcp(args []string) {
 		log.Fatal(err)
 	}
 
-	if err = client.DeleteInstance(name, zone, true); err != nil {
-		log.Fatal(err)
+	if !*skipCleanup {
+		if err = client.DeleteInstance(name, zone, true); err != nil {
+			log.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
This PR introduces two changes required to add LTP tests to CI

- Adds a -skip-cleanup flag to moby run gcp to allow CI to perform cleanup
- Adds a make test-ltp target to the Makefile and adds this to the ci targets used for master and tags

LTP tests take 18-20 minutes to complete

Closes: #1230