### PR TITLE
Rename old repo to linuxkit/linuxkit to let the build work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,14 @@ PREFIX?=/usr/local/
 MOBY_DEPS=$(wildcard src/cmd/moby/*.go) Makefile vendor.conf
 MOBY_DEPS+=$(wildcard src/initrd/*.go) $(wildcard src/pad4/*.go)
 bin/moby: $(MOBY_DEPS) | bin
-	tar cf - vendor src/initrd src/pad4 -C src/cmd/moby . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/docker/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
+	tar cf - vendor src/initrd src/pad4 -C src/cmd/moby . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/linuxkit/linuxkit --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
 	tar xf tmp_moby_bin.tar > $@
 	rm tmp_moby_bin.tar
 	touch $@
 
 INFRAKIT_DEPS=$(wildcard src/cmd/infrakit-instance-hyperkit/*.go) Makefile vendor.conf
 bin/infrakit-instance-hyperkit: $(INFRAKIT_DEPS) | bin
-	tar cf - vendor -C src/cmd/infrakit-instance-hyperkit . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/docker/moby -o $@ > tmp_infrakit_instance_hyperkit_bin.tar
+	tar cf - vendor -C src/cmd/infrakit-instance-hyperkit . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/linuxkit/linuxkit -o $@ > tmp_infrakit_instance_hyperkit_bin.tar
 	tar xf tmp_infrakit_instance_hyperkit_bin.tar > $@
 	rm tmp_infrakit_instance_hyperkit_bin.tar
 	touch $@

--- a/src/cmd/moby/build.go
+++ b/src/cmd/moby/build.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/docker/moby/src/initrd"
+	"github.com/linuxkit/linuxkit/src/initrd"
 )
 
 // Process the build arguments and execute build


### PR DESCRIPTION
Hey, 
this is currently what happen when I type `make` on the master branch.

```
tar cf - vendor src/initrd src/pad4 -C src/cmd/moby . | docker run --rm --net=none --log-driver=none -i -e GOOS=darwin -e GOARCH=amd64 linuxkit/go-compile:4513068d9a7e919e4ec42e2d7ee879ff5b95b7f5@sha256:bdfadbe3e4ec699ca45b67453662321ec270f2d1a1dbdbf09625776d3ebd68c5 --package github.com/docker/moby --ldflags "-X main.GitCommit=d422c70ac6da78da3d32237735d86eb9001df384 -X main.Version="0.0" " -o bin/moby > tmp_moby_bin.tar
gofmt...
govet...
golint...
ineffassign...
go build...
src/initrd/initrd.go:10:2: cannot find package "github.com/linuxkit/linuxkit/src/pad4" in any of:
	/go/src/github.com/docker/moby/vendor/github.com/linuxkit/linuxkit/src/pad4 (vendor tree)
	/usr/lib/go/src/github.com/linuxkit/linuxkit/src/pad4 (from $GOROOT)
	/go/src/github.com/linuxkit/linuxkit/src/pad4 (from $GOPATH)
make: *** [bin/moby] Error 1
```

I change the src to the new path of repo. So it works for me. 