### PR TITLE
Fix for prefix for linuxkit

### DIFF
--- a/src/cmd/moby/run_vmware.go
+++ b/src/cmd/moby/run_vmware.go
@@ -151,6 +151,13 @@ func buildVMX(cpus int, mem int, diskPath string, prefix string) string {
 
 	if diskPath != "" {
 		returnString += fmt.Sprintf(vmxDisk, diskPath)
+	} else {
+		vmdkPath := prefix + ".vmdk"
+		if _, err := os.Stat(vmdkPath); os.IsNotExist(err) {
+			log.Fatalf("File [%s] does not exist in current directory", vmdkPath)
+		} else {
+			returnString += fmt.Sprintf(vmxDisk, vmdkPath)
+		}
 	}
 
 	returnString += vmxPCI


### PR DESCRIPTION
Signed-off-by: Dan Finneran <daniel.finneran@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I've added in the capability to look for the `vmdk` from the use of the prefix

**- How I did it**
Duplicated the same functionality from `qemu` and `hypervisor`

**- How to verify it**
`./moby run vmware vmware`
 
**- Description for the changelog**
Modified the default behaviour of the `qemu` plugin to match  expected <prefix> behaviour.


**- A picture of a cute animal (not mandatory but encouraged)**