### PR TITLE
Migrate the Kubernetes shell to ash

### DIFF
--- a/projects/kubernetes/README.md
+++ b/projects/kubernetes/README.md
@@ -32,7 +32,7 @@ kubeadm-init.sh
 ```
 
 Once `kubeadm` exits, make sure to copy the `kubeadm join` arguments,
-and try `runc exec kubelet kubectl get nodes`.
+and try `kubectl get nodes` from within the master.
 
 To boot a node use:
 ```

--- a/projects/kubernetes/ssh_into_kubelet.sh
+++ b/projects/kubernetes/ssh_into_kubelet.sh
@@ -1,2 +1,2 @@
 #!/bin/bash -eux
-./ssh.sh -t "$1" nsenter --mount --target 1 runc exec --tty kubelet bash -l
+./ssh.sh -t "$1" nsenter --mount --target 1 runc exec --tty kubelet ash -l


### PR DESCRIPTION
The Kubernetes images have been migrated to Alpine Linux which
does not include bash by default.

Signed-off-by: Matt Bajor <matt@notevenremotelydorky.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated the ssh_into_kubelet.sh shell script to use ash shell

**- How I did it**

**- How to verify it**
Run through the Kubernetes project [README](projects/kubernetes/README.md) (specifically running `ssh_into_kubelet.sh`)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use ash when sshing to Kubernetes

**- A picture of a cute animal (not mandatory but encouraged)**
![](http://pulpbits.net/wp-content/uploads/2014/01/Baby-African-Grey-Parrot-330x220.jpg)