### PR TITLE
typo fixes

### DIFF
--- a/projects/miragesdk/roadmap.md
+++ b/projects/miragesdk/roadmap.md
@@ -19,7 +19,7 @@
                |-----------------|                      |----------------|
                |                 |                      |                |
 <-- audit ---  |  config store   | <----- KV store ---> |  config store  |
-   diagnostic  |     deamon      |     (control path)   |     client     |
+   diagnostic  |     daemon      |     (control path)   |     client     |
                |                 |                      |                |
                |_________________|                      |________________|
                |                 |
@@ -111,7 +111,7 @@
   - if /search -> set search domain on moby host (todo)
   - if /nameserver/xxx -> set DNS servers on moby (todo)
 
-- The privileged system service update configuration files:
+- The privileged system service updates configuration files:
   - /ect/resolv.conf (todo)
 
 #### Calf


### PR DESCRIPTION
Signed-off-by: Mindy Preston <mindy.preston@docker.com>

**- What I did**

Fixed typos

**- How I did it**

Used keyboard

**- How to verify it**

```
4.04.0+afl🐫  (copyedit) mirageos:~/linuxkit/projects/miragesdk$ echo "deamon" | aspell list
deamon
4.04.0+afl🐫  (copyedit) mirageos:~/linuxkit/projects/miragesdk$ echo "daemon" | aspell list
4.04.0+afl🐫  (copyedit) mirageos:~/linuxkit/projects/miragesdk$ 
```

The second change requires a speaker of English conversant in tense agreement.

**- Description for the changelog**

This change does not need to be included in the changelog.  If inclusion is necessary, "fix typos in miragesdk roadmap" is sufficient.

**- A picture of a cute animal (not mandatory but encouraged)**

```
,,,=^.^=,,,~~~
```
