### PR TITLE
Update top-level linuxkit.yml with images from linuxkit org

### DIFF
--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,14 +1,14 @@
 kernel:
-  image: "mobylinux/kernel:4.9.x"
+  image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:42fe8cb1508b3afed39eb89821906e3cc7a70551
-  - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
+  - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:60e2486a74c665ba4df57e561729aec20758daed
-  - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
-    image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
+    image: "linuxkit/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
     net: host
     pid: host
     ipc: host
@@ -33,7 +33,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
+    image: "linuxkit/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
     capabilities:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
@@ -52,7 +52,7 @@ files:
     contents: '{"debug": true}'
 trust:
   image:
-    - mobylinux/kernel
+    - linuxkit/kernel
 outputs:
   - format: kernel+initrd
   - format: iso-bios


### PR DESCRIPTION
Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>

Update the top-level `linuxkit.yml` example assembly with the `linuxkit` hub repo images, following conversation from: https://github.com/linuxkit/linuxkit/pull/1673#discussion_r112793578

Tested with a successful `moby build`/`moby run` locally.

**- A picture of a cute animal (not mandatory but encouraged)**
<img src="http://cdn.images.express.co.uk/img/dynamic/128/590x/killer-whale-600319.jpg" width=400 />
