### PR TITLE
update gcp docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ See `linuxkit run --help`.
 
 `make test` or `make test-hyperkit` will run the test suite
 
-There are also docs for booting on [Google Cloud](docs/gcp.md); `linuxkit push gcp <name> && linuxkit run gcp <name>.yml` should
-work if you specified a GCP image to be built in the config.
+There are also docs for booting on [Google Cloud](docs/gcp.md).
 
 More detailed docs will be available shortly, for running both single hosts and clusters.
 

--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -50,16 +50,19 @@ Make sure to download the credentials in JSON format and store them somewhere sa
 
 ## Build an image
 
-Add a `gcp-img` output line to your yaml config, see the example in `examples/gcp.yml`.
+Add a `gcp-img` output line to your yaml config, see the example in [`examples/gcp.yml`](../example/gcp.yml).
 
-Then do `moby build myfile.yml`
+Then do `moby build myprefix.yml`
 
-This will create a local `myfile.img.tar.gz` compressed image file.
+This will create a local `myprefix.img.tar.gz` compressed image file.
 
 ## Push image
 
-Do `moby push gcp -project myproject-1234 -bucket bucketname myfile.img.tar.gz` to upload it to the
+Do `linuxkit push gcp -project myproject-1234 -bucket bucketname myprefix.img.tar.gz` to upload it to the
 specified bucket, and create a bootable image from the stored image.
+
+Alternatively, you can set the project name and the bucket name using environment variables, `CLOUDSDK_CORE_PROJECT` and `CLOUDSDK_IMAGE_BUCKET`.
+See the constant values defined in [`src/cmd/linuxkit/run_gcp.go`](../src/cmd/linuxkit/run_gcp.go) for the complete list of the supported environment variables.
 
 ## Create an instance and connect to it
 
@@ -67,5 +70,5 @@ With the image created, we can now create an instance and connect to
 the serial port.
 
 ```
-moby run gcp -project myproject-1234 myfile
+linuxkit run gcp -project myproject-1234 myprefix
 ```


### PR DESCRIPTION
* removed incomplete command from README.md; it does not work without specifying GCP project and bucket
* `moby <push|run>` -> `linuxkit ...`
* `myfile` -> `myprefix`, because there is no file named `myfile`

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>