### PR TITLE
*.yml: move dhcpcd from onboot to services

### DIFF
--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -15,17 +15,6 @@ onboot:
     capabilities:
      - CAP_SYS_ADMIN
     readonly: true
-  - name: dhcpcd
-    image: "linuxkit/dhcpcd:48e249ebef6a521eed886b3bce032db69fbb4afa"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: "linuxkit/metadata:c5567e65e9125f0a4c4b8cb9d56a86377be62652"
     binds:
@@ -42,6 +31,17 @@ services:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
+  - name: dhcpcd
+    image: "linuxkit/dhcpcd:57a8ef29d3a910645b2b24c124f9ce9ef53ce703"
+    binds:
+     - /var:/var
+     - /tmp/etc:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    oomScoreAdj: -800
   - name: sshd
     image: "linuxkit/sshd:e108d208adf692c8a0954f602743e0eec445364e"
     capabilities:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:42fe8cb1508b3afed39eb89821906e3cc7a70551
+  - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - linuxkit/containerd:60e2486a74c665ba4df57e561729aec20758daed
-onboot:
+  - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
+services:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:48e249ebef6a521eed886b3bce032db69fbb4afa"
+    image: "linuxkit/dhcpcd:57a8ef29d3a910645b2b24c124f9ce9ef53ce703"
     binds:
      - /var:/var
      - /tmp/etc:/etc
@@ -16,7 +16,7 @@ onboot:
      - CAP_NET_BIND_SERVICE
      - CAP_NET_RAW
     net: host
-    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+    oomScoreAdj: -800
 trust:
   image:
     - linuxkit/kernel

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:42fe8cb1508b3afed39eb89821906e3cc7a70551
+  - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - linuxkit/containerd:60e2486a74c665ba4df57e561729aec20758daed
+  - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
@@ -20,8 +20,15 @@ onboot:
     binds:
      - /proc/sys/fs/binfmt_misc:/binfmt_misc
     readonly: true
+services:
+  - name: rngd
+    image: "linuxkit/rngd:c42fd499690b2cb6e4e6cb99e41dfafca1cf5b14"
+    capabilities:
+     - CAP_SYS_ADMIN
+    oomScoreAdj: -800
+    readonly: true
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:48e249ebef6a521eed886b3bce032db69fbb4afa"
+    image: "linuxkit/dhcpcd:57a8ef29d3a910645b2b24c124f9ce9ef53ce703"
     binds:
      - /var:/var
      - /tmp/etc:/etc
@@ -30,14 +37,7 @@ onboot:
      - CAP_NET_BIND_SERVICE
      - CAP_NET_RAW
     net: host
-    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
-services:
-  - name: rngd
-    image: "linuxkit/rngd:c42fd499690b2cb6e4e6cb99e41dfafca1cf5b14"
-    capabilities:
-     - CAP_SYS_ADMIN
     oomScoreAdj: -800
-    readonly: true
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/projects/demo/etcd/etcd.yml
+++ b/projects/demo/etcd/etcd.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:42fe8cb1508b3afed39eb89821906e3cc7a70551
+  - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - linuxkit/containerd:fe1b7f438a234cb6481c6538295115eac2a0596d
+  - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
@@ -31,17 +31,6 @@ onboot:
      - CAP_SYS_ADMIN
     rootfsPropagation: shared
     command: ["/mount.sh", "/var/lib/etcd"]
-  - name: dhcpcd
-    image: "linuxkit/dhcpcd:0d4012269cb142972fed8542fbdc3ff5a7b695cd"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: "linuxkit/metadata:c5567e65e9125f0a4c4b8cb9d56a86377be62652"
     binds:
@@ -58,6 +47,17 @@ services:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
+  - name: dhcpcd
+    image: "linuxkit/dhcpcd:57a8ef29d3a910645b2b24c124f9ce9ef53ce703"
+    binds:
+     - /var:/var
+     - /tmp/etc:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    oomScoreAdj: -800
   - name: ntpd
     image: "linuxkit/openntpd:a570316d7fc49ca1daa29bd945499f4963d227af"
     capabilities:

--- a/projects/demo/prom/etcd-prom-us-central1-f.yml
+++ b/projects/demo/prom/etcd-prom-us-central1-f.yml
@@ -15,17 +15,6 @@ onboot:
     capabilities:
      - CAP_SYS_ADMIN
     readonly: true
-  - name: dhcpcd
-    image: "linuxkit/dhcpcd:48e249ebef6a521eed886b3bce032db69fbb4afa"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: "linuxkit/metadata:c5567e65e9125f0a4c4b8cb9d56a86377be62652"
     binds:
@@ -42,6 +31,17 @@ services:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
+  - name: dhcpcd
+    image: "linuxkit/dhcpcd:57a8ef29d3a910645b2b24c124f9ce9ef53ce703"
+    binds:
+     - /var:/var
+     - /tmp/etc:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    oomScoreAdj: -800
   - name: prometheus
     image: "moby/prom-us-central1-f"
     binds:

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -21,8 +21,15 @@ onboot:
     binds:
      - /proc/sys/fs/binfmt_misc:/binfmt_misc
     readonly: true
+services:
+  - name: rngd
+    image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
+    capabilities:
+     - CAP_SYS_ADMIN
+    oomScoreAdj: -800
+    readonly: true
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:48e249ebef6a521eed886b3bce032db69fbb4afa"
+    image: "linuxkit/dhcpcd:57a8ef29d3a910645b2b24c124f9ce9ef53ce703"
     binds:
      - /var:/var
      - /tmp/etc:/etc
@@ -31,14 +38,7 @@ onboot:
      - CAP_NET_BIND_SERVICE
      - CAP_NET_RAW
     net: host
-    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
-services:
-  - name: rngd
-    image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
-    capabilities:
-     - CAP_SYS_ADMIN
     oomScoreAdj: -800
-    readonly: true
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/test/test.yml
+++ b/test/test.yml
@@ -7,23 +7,24 @@ init:
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
-  - name: dhcpcd
-    image: "linuxkit/dhcpcd:48e249ebef6a521eed886b3bce032db69fbb4afa"
-    binds:
-     - /var:/var
-     - /tmp:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check
     image: "linuxkit/check:43c4147dda4e02d066ef158cd81718dbff8c8bd0"
     pid: host
     capabilities:
      - CAP_SYS_BOOT
     readonly: true
+services:
+  - name: dhcpcd
+    image: "linuxkit/dhcpcd:57a8ef29d3a910645b2b24c124f9ce9ef53ce703"
+    binds:
+     - /var:/var
+     - /tmp/etc:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    oomScoreAdj: -800
 outputs:
   - format: kernel+initrd
   - format: iso-bios


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
move dhcpcd from onboot to services, so that the instance can invoke DHCP request on network reconnection and on lease timeout

**- How I did it**
Edit *.yml


**- How to verify it**
```
host$ moby build minimal.yml && linuxkit run minimal
guest$ runc list
ID          PID         STATUS      BUNDLE                        CREATED                          OWNER           
dhcpcd      301         running     /containers/services/dhcpcd   2017-04-25T05:13:03.762592514Z   root
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![penguin](https://upload.wikimedia.org/wikipedia/commons/8/8e/Kaiserpinguinjunges.jpg)


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>