### PR TITLE
Fix for old moby reference in linuxkit CLI

### DIFF
--- a/src/cmd/linuxkit/run.go
+++ b/src/cmd/linuxkit/run.go
@@ -21,9 +21,9 @@ func runUsage() {
 	fmt.Printf("  packet\n")
 	fmt.Printf("\n")
 	fmt.Printf("'options' are the backend specific options.\n")
-	fmt.Printf("See 'moby run [backend] --help' for details.\n\n")
+	fmt.Printf("See 'linuxkit run [backend] --help' for details.\n\n")
 	fmt.Printf("'prefix' specifies the path to the VM image.\n")
-	fmt.Printf("It defaults to './moby'.\n")
+	fmt.Printf("It defaults to './image'.\n")
 }
 
 func run(args []string) {


### PR DESCRIPTION
Signed-off-by: Carlton-Semple <carlton.semple@ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I changed the `linuxkit run --help` text to say `See 'linuxkit run [backend] --help' for details.` rather than `See 'moby run [backend] --help' for details.`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://cloud.githubusercontent.com/assets/6462396/25401106/c7e37ba4-29c2-11e7-803a-831175695182.png)

