### PR TITLE
Use linuxkit on boot scripts instead of moby

### DIFF
--- a/projects/kubernetes/boot-master.sh
+++ b/projects/kubernetes/boot-master.sh
@@ -2,4 +2,4 @@
 disk="kube-master-disk.img"
 set -x
 rm -f "${disk}"
-../../bin/moby run hyperkit -cpus 2 -mem 4096 -disk-size 4096 kube-master
+../../bin/linuxkit run hyperkit -cpus 2 -mem 4096 -disk-size 4096 kube-master

--- a/projects/kubernetes/boot-node.sh
+++ b/projects/kubernetes/boot-node.sh
@@ -5,4 +5,4 @@ shift
 disk="kube-${name}-disk.img"
 set -x
 rm -f "${disk}"
-../../bin/moby run hyperkit -cpus 2 -mem 4096 -disk-size 4096 -disk "${disk}" -data "${*}" kube-node
+../../bin/linuxkit run hyperkit -cpus 2 -mem 4096 -disk-size 4096 -disk "${disk}" -data "${*}" kube-node


### PR DESCRIPTION
Fixes #1711

Signed-off-by: Tiago Pires <tandrepires@gmail.com>

**- What I did**
Updated the `boot-master` and `boot-node` scripts.

**- Description for the changelog**
Fixed kubernetes boot scripts.