### PR TITLE
Update ca-certificates to be based on Alpine and use nested build

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:1f5ec5d5e6f7a7a1b3d2ff9dd9e36fd6fb14756a"

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:1f5ec5d5e6f7a7a1b3d2ff9dd9e36fd6fb14756a"

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:e10e2efc1b78ef41d196175cbc07e069391f406e
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:1f5ec5d5e6f7a7a1b3d2ff9dd9e36fd6fb14756a"

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:1c8cd75ec89313f4058b069449e9bac966cd96b1
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:60e2486a74c665ba4df57e561729aec20758daed
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/pkg/ca-certificates/Dockerfile
+++ b/pkg/ca-certificates/Dockerfile
@@ -1,7 +1,8 @@
-FROM debian:testing
+FROM alpine:3.5 as alpine
 
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get -yq upgrade && apt-get install -yq ca-certificates
+RUN apk update && apk upgrade -a && apk add --no-cache ca-certificates
 
-RUN printf "FROM scratch\nCOPY /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/\n" > Dockerfile
-CMD ["tar", "cf", "-", "Dockerfile", "etc/ssl/certs/ca-certificates.crt"]
+FROM scratch
+ENTRYPOINT []
+WORKDIR /
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/pkg/ca-certificates/Makefile
+++ b/pkg/ca-certificates/Makefile
@@ -1,16 +1,19 @@
 .PHONY: tag push
 
-BASE=debian:testing
+BASE=alpine:3.5
 IMAGE=ca-certificates
+
+SHA_IMAGE=alpine:3.5@sha256:dfbd4a3a8ebca874ebd2474f044a0b33600d4523d03b0df76e5c5986cb02d7e8
 
 default: push
 
 hash: Dockerfile
 	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
-	tar cf - $^ | docker build --no-cache -t $(IMAGE):build0 -
-	docker run --rm $(IMAGE):build0 | docker build --no-cache -t $(IMAGE):build -
-	docker run --rm -i $(IMAGE):build0 sh -c "cat /etc/ssl/certs/ca-certificates.crt /etc/debian_version | sha1sum - | sed 's/ .*//'" > $@
-	docker rmi $(IMAGE):build0
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	CONTAINER=$$(docker create $(IMAGE):build /dev/null); \
+		mkdir tmp && docker export $${CONTAINER} | tar xf - -C tmp && \
+		cat tmp/etc/ssl/certs/ca-certificates.crt | docker run --rm -i $(SHA_IMAGE) sha1sum - | sed 's/ .*//' > $@ && \
+		rm -rf tmp && docker rm $${CONTAINER}
 
 push: hash
 	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
@@ -26,6 +29,6 @@ tag: hash
 	rm -f hash
 
 clean:
-	rm -f hash
+	rm -f hash tmp
 
 .DELETE_ON_ERROR:

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:1c8cd75ec89313f4058b069449e9bac966cd96b1
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:fe1b7f438a234cb6481c6538295115eac2a0596d
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:1f5ec5d5e6f7a7a1b3d2ff9dd9e36fd6fb14756a"

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:1f5ec5d5e6f7a7a1b3d2ff9dd9e36fd6fb14756a"

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:1f5ec5d5e6f7a7a1b3d2ff9dd9e36fd6fb14756a"

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/test/docker-bench/test-docker-bench.yml
+++ b/test/docker-bench/test-docker-bench.yml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:1f5ec5d5e6f7a7a1b3d2ff9dd9e36fd6fb14756a"

--- a/test/ltp/test-ltp.yml
+++ b/test/ltp/test-ltp.yml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: ltp
     image: "linuxkit/test-ltp-20170116:81229df2d25065b06f0a3071faaace8d66c87e67"

--- a/test/test.yml
+++ b/test/test.yml
@@ -5,7 +5,7 @@ init:
   - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:48e249ebef6a521eed886b3bce032db69fbb4afa"

--- a/test/virtsock/test-virtsock-server.yml
+++ b/test/virtsock/test-virtsock-server.yml
@@ -9,7 +9,7 @@ init:
   - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
-  - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
+  - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:1f5ec5d5e6f7a7a1b3d2ff9dd9e36fd6fb14756a"


### PR DESCRIPTION
We were using Debian but Alpine more consistent. Use nested build.

Currently extract the hash in a nasty way but this can be fixed later
when we switch over hashing method.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![lambpiglet](https://cloud.githubusercontent.com/assets/482364/25439581/bb27e288-2a94-11e7-9bf8-ffc9d8c0f6a2.jpg)
