### PR TITLE
Signing targets for binfmt, rngd, compilers, toybox, tini

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,13 @@ endif
 PREFIX?=/usr/local/
 
 bin/moby: | bin
-	DOCKER_CONTENT_TRUST=1 docker pull $(GO_COMPILE)
-	DOCKER_CONTENT_TRUST=1 docker run --rm --log-driver=none $(CROSS) $(GO_COMPILE) --clone-path github.com/moby/tool --clone https://github.com/moby/tool.git --package github.com/moby/tool/cmd/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
+	docker run --rm --log-driver=none $(CROSS) $(GO_COMPILE) --clone-path github.com/moby/tool --clone https://github.com/moby/tool.git --package github.com/moby/tool/cmd/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
 	tar xf tmp_moby_bin.tar > $@
 	rm tmp_moby_bin.tar
 	touch $@
 
 LINUXKIT_DEPS=$(wildcard src/cmd/linuxkit/*.go) Makefile vendor.conf
 bin/linuxkit: $(LINUXKIT_DEPS) | bin
-	DOCKER_CONTENT_TRUST=1 docker pull $(GO_COMPILE)
 	tar cf - vendor -C src/cmd/linuxkit . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/linuxkit/linuxkit --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_linuxkit_bin.tar
 	tar xf tmp_linuxkit_bin.tar > $@
 	rm tmp_linuxkit_bin.tar

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: default
 VERSION="0.0" # dummy for now
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:5bf17af781df44f07906099402680b9a661f999b@sha256:0bf523bcebb96ccc525f983a118f1fd8cb5e17dbf90e83044ca71bb983000e70
+GO_COMPILE=linuxkit/go-compile:5bf17af781df44f07906099402680b9a661f999b
 
 MOBY?=bin/moby
 LINUXKIT?=bin/linuxkit
@@ -18,14 +18,14 @@ endif
 PREFIX?=/usr/local/
 
 bin/moby: | bin
-	docker run --rm --log-driver=none $(CROSS) $(GO_COMPILE) --clone-path github.com/moby/tool --clone https://github.com/moby/tool.git --package github.com/moby/tool/cmd/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
+	DOCKER_CONTENT_TRUST=1 docker run --rm --log-driver=none $(CROSS) $(GO_COMPILE) --clone-path github.com/moby/tool --clone https://github.com/moby/tool.git --package github.com/moby/tool/cmd/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
 	tar xf tmp_moby_bin.tar > $@
 	rm tmp_moby_bin.tar
 	touch $@
 
 LINUXKIT_DEPS=$(wildcard src/cmd/linuxkit/*.go) Makefile vendor.conf
 bin/linuxkit: $(LINUXKIT_DEPS) | bin
-	tar cf - vendor -C src/cmd/linuxkit . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/linuxkit/linuxkit --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_linuxkit_bin.tar
+	tar cf - vendor -C src/cmd/linuxkit . | DOCKER_CONTENT_TRUST=1 docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/linuxkit/linuxkit --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_linuxkit_bin.tar
 	tar xf tmp_linuxkit_bin.tar > $@
 	rm tmp_linuxkit_bin.tar
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ endif
 PREFIX?=/usr/local/
 
 bin/moby: | bin
+	DOCKER_CONTENT_TRUST=1 docker pull $(GO_COMPILE)
 	DOCKER_CONTENT_TRUST=1 docker run --rm --log-driver=none $(CROSS) $(GO_COMPILE) --clone-path github.com/moby/tool --clone https://github.com/moby/tool.git --package github.com/moby/tool/cmd/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
 	tar xf tmp_moby_bin.tar > $@
 	rm tmp_moby_bin.tar
@@ -25,7 +26,8 @@ bin/moby: | bin
 
 LINUXKIT_DEPS=$(wildcard src/cmd/linuxkit/*.go) Makefile vendor.conf
 bin/linuxkit: $(LINUXKIT_DEPS) | bin
-	tar cf - vendor -C src/cmd/linuxkit . | DOCKER_CONTENT_TRUST=1 docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/linuxkit/linuxkit --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_linuxkit_bin.tar
+	DOCKER_CONTENT_TRUST=1 docker pull $(GO_COMPILE)
+	tar cf - vendor -C src/cmd/linuxkit . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/linuxkit/linuxkit --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_linuxkit_bin.tar
 	tar xf tmp_linuxkit_bin.tar > $@
 	rm tmp_linuxkit_bin.tar
 	touch $@

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -82,5 +82,7 @@ files:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/binfmt
+    - linuxkit/rngd
 outputs:
   - format: kernel+initrd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -63,6 +63,7 @@ services:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/rngd
 outputs:
   - format: kernel+initrd
   - format: gcp-img

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -36,5 +36,6 @@ services:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/rngd
 outputs:
   - format: kernel+initrd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -43,6 +43,7 @@ services:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/rngd
 files:
   - path: root/.ssh/authorized_keys
     contents: '#your ssh key here'

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -43,6 +43,7 @@ services:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/rngd
 files:
   - path: root/.ssh/authorized_keys
     contents: '#your ssh key here'

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -45,5 +45,6 @@ services:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/rngd
 outputs:
   - format: vmdk

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -53,6 +53,8 @@ files:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/binfmt
+    - linuxkit/rngd
 outputs:
   - format: kernel+initrd
   - format: iso-bios

--- a/pkg/binfmt/Makefile
+++ b/pkg/binfmt/Makefile
@@ -25,7 +25,13 @@ push: tag
 	rm -f hash
 	docker rmi $(IMAGE):build || true
 
-sign: tag
+signed-tag: hash
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		(DOCKER_CONTENT_TRUST=1 docker pull $(BASE) && \
+		 docker build --no-cache -t $(IMAGE):build . && \
+		 docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash))
+
+sign: signed-tag
 	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
 		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
 	rm -f hash

--- a/pkg/binfmt/Makefile
+++ b/pkg/binfmt/Makefile
@@ -23,6 +23,12 @@ push: tag
 	rm -f hash
 	docker rmi $(IMAGE):build || true
 
+sign: tag
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
+	rm -f hash
+	docker rmi $(IMAGE):build || true
+
 clean:
 	rm -f hash
 	docker rmi $(IMAGE):build || true

--- a/pkg/binfmt/Makefile
+++ b/pkg/binfmt/Makefile
@@ -2,6 +2,7 @@
 default: push
 
 IMAGE=binfmt
+BASE=alpine:edge
 SHA_IMAGE=alpine:3.5@sha256:dfbd4a3a8ebca874ebd2474f044a0b33600d4523d03b0df76e5c5986cb02d7e8
 DEPS=Dockerfile Makefile main.go $(wildcard etc/binmft.d/*)
 
@@ -14,7 +15,8 @@ hash: $(DEPS)
 
 tag: hash
 	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		(docker build --no-cache -t $(IMAGE):build . && \
+		(DOCKER_CONTENT_TRUST=1 docker pull $(BASE) && \
+		 docker build --no-cache -t $(IMAGE):build . && \
 		 docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash))
 
 push: tag

--- a/pkg/init/Makefile
+++ b/pkg/init/Makefile
@@ -1,11 +1,11 @@
-C_COMPILE=linuxkit/c-compile:63b085bbaec1aa7c42a7bd22a4b1c350d900617d@sha256:286e3a729c7a0b1a605ae150235416190f9f430c29b00e65fa50ff73158998e5
+C_COMPILE=linuxkit/c-compile:63b085bbaec1aa7c42a7bd22a4b1c350d900617d
 START_STOP_DAEMON=sbin/start-stop-daemon
 
 default: push
 
 $(START_STOP_DAEMON): start-stop-daemon.c
 	mkdir -p $(dir $@)
-	tar cf - $^ | docker run --rm --net=none --log-driver=none -i $(C_COMPILE) -o $@ | tar xf -
+	tar cf - $^ | DOCKER_CONTENT_TRUST=1 docker run --rm --net=none --log-driver=none -i $(C_COMPILE) -o $@ | tar xf -
 
 .PHONY: tag push
 

--- a/pkg/init/Makefile
+++ b/pkg/init/Makefile
@@ -5,6 +5,7 @@ default: push
 
 $(START_STOP_DAEMON): start-stop-daemon.c
 	mkdir -p $(dir $@)
+	DOCKER_CONTENT_TRUST=1 docker pull $(C_COMPILE)
 	tar cf - $^ | DOCKER_CONTENT_TRUST=1 docker run --rm --net=none --log-driver=none -i $(C_COMPILE) -o $@ | tar xf -
 
 .PHONY: tag push

--- a/pkg/rngd/Makefile
+++ b/pkg/rngd/Makefile
@@ -22,7 +22,13 @@ push: tag
 	rm -f hash
 	docker rmi $(IMAGE):build || true
 
-sign: tag
+signed-tag: hash
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		(DOCKER_CONTENT_TRUST=1 docker pull $(BASE) && \
+		 docker build --no-cache -t $(IMAGE):build . && \
+		 docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash))
+
+sign: signed-tag
 	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
 		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
 	rm -f hash

--- a/pkg/rngd/Makefile
+++ b/pkg/rngd/Makefile
@@ -19,6 +19,12 @@ push: tag
 	rm -f hash
 	docker rmi $(IMAGE):build || true
 
+sign: tag
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
+	rm -f hash
+	docker rmi $(IMAGE):build || true
+
 clean:
 	rm -f hash
 	docker rmi $(IMAGE):build || true

--- a/pkg/rngd/Makefile
+++ b/pkg/rngd/Makefile
@@ -2,6 +2,7 @@
 default: push
 
 IMAGE=rngd
+BASE=linuxkit/c-compile:f52f485825c890d581e82a62af6906c1d33d8e5d
 SHA_IMAGE=alpine:3.5@sha256:dfbd4a3a8ebca874ebd2474f044a0b33600d4523d03b0df76e5c5986cb02d7e8
 DEPS=Dockerfile Makefile
 
@@ -9,8 +10,10 @@ hash: $(DEPS)
 	find $^ -type f | xargs cat | docker run --rm -i $(SHA_IMAGE) sha1sum - | sed 's/ .*//' > hash
 
 tag: hash
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		(docker build --no-cache -t $(IMAGE):build . && \
+		(DOCKER_CONTENT_TRUST=1 docker pull $(BASE) && \
+		 docker build --no-cache -t $(IMAGE):build . && \
 		 docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash))
 
 push: tag

--- a/test/docker-bench/test-docker-bench.yml
+++ b/test/docker-bench/test-docker-bench.yml
@@ -80,5 +80,7 @@ services:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/binfmt
+    - linuxkit/rngd
 outputs:
   - format: kernel+initrd

--- a/test/virtsock/test-virtsock-server.yml
+++ b/test/virtsock/test-virtsock-server.yml
@@ -43,6 +43,7 @@ services:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/rngd
 outputs:
   - format: kernel+initrd
   - format: iso-bios

--- a/tools/c-compile/Makefile
+++ b/tools/c-compile/Makefile
@@ -23,7 +23,13 @@ tag: hash
 	docker rmi $(IMAGE):build
 	rm -f hash
 
-sign: tag
+signed-tag: hash
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		(DOCKER_CONTENT_TRUST=1 docker pull $(BASE) && \
+		 docker build --no-cache -t $(IMAGE):build . && \
+		 docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash))
+
+sign: signed-tag
 	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
 		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
 	rm -f hash

--- a/tools/c-compile/Makefile
+++ b/tools/c-compile/Makefile
@@ -23,6 +23,12 @@ tag: hash
 	docker rmi $(IMAGE):build
 	rm -f hash
 
+sign: tag
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
+	rm -f hash
+	docker rmi $(IMAGE):build || true
+
 clean:
 	rm -f hash
 

--- a/tools/go-compile/Makefile
+++ b/tools/go-compile/Makefile
@@ -23,7 +23,13 @@ tag: hash
 	docker rmi $(IMAGE):build
 	rm -f hash
 
-sign: tag
+signed-tag: hash
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		(DOCKER_CONTENT_TRUST=1 docker pull $(BASE) && \
+		 docker build --no-cache -t $(IMAGE):build . && \
+		 docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash))
+
+sign: signed-tag
 	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
 		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
 	rm -f hash

--- a/tools/go-compile/Makefile
+++ b/tools/go-compile/Makefile
@@ -23,6 +23,12 @@ tag: hash
 	docker rmi $(IMAGE):build
 	rm -f hash
 
+sign: tag
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
+	rm -f hash
+	docker rmi $(IMAGE):build || true
+
 clean:
 	rm -f hash
 

--- a/tools/tini/Makefile
+++ b/tools/tini/Makefile
@@ -2,10 +2,12 @@
 default: push
 
 IMAGE=tini
+BASE=linuxkit/c-compile:f52f485825c890d581e82a62af6906c1d33d8e5d
 SHA_IMAGE=alpine:3.5@sha256:dfbd4a3a8ebca874ebd2474f044a0b33600d4523d03b0df76e5c5986cb02d7e8
 DEPS=Dockerfile Makefile
 
 hash: $(DEPS)
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	find $^ -type f | xargs cat | docker run --rm -i $(SHA_IMAGE) sha1sum - | sed 's/ .*//' > hash
 
 tag: hash

--- a/tools/tini/Makefile
+++ b/tools/tini/Makefile
@@ -19,6 +19,12 @@ push: tag
 	rm -f hash
 	docker rmi $(IMAGE):build || true
 
+sign: tag
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
+	rm -f hash
+	docker rmi $(IMAGE):build || true
+
 clean:
 	rm -f hash
 	docker rmi $(IMAGE):build || true

--- a/tools/tini/Makefile
+++ b/tools/tini/Makefile
@@ -21,7 +21,13 @@ push: tag
 	rm -f hash
 	docker rmi $(IMAGE):build || true
 
-sign: tag
+signed-tag: hash
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		(DOCKER_CONTENT_TRUST=1 docker pull $(BASE) && \
+		 docker build --no-cache -t $(IMAGE):build . && \
+		 docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash))
+
+sign: signed-tag
 	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
 		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
 	rm -f hash

--- a/tools/toybox-media/Makefile
+++ b/tools/toybox-media/Makefile
@@ -19,6 +19,12 @@ push: tag
 	rm -f hash
 	docker rmi $(IMAGE):build || true
 
+sign: tag
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
+	rm -f hash
+	docker rmi $(IMAGE):build || true
+
 clean:
 	rm -f hash
 	docker rmi $(IMAGE):build || true

--- a/tools/toybox-media/Makefile
+++ b/tools/toybox-media/Makefile
@@ -21,7 +21,13 @@ push: tag
 	rm -f hash
 	docker rmi $(IMAGE):build || true
 
-sign: tag
+signed-tag: hash
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		(DOCKER_CONTENT_TRUST=1 docker pull $(BASE) && \
+		 docker build --no-cache -t $(IMAGE):build . && \
+		 docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash))
+
+sign: signed-tag
 	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
 		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
 	rm -f hash

--- a/tools/toybox-media/Makefile
+++ b/tools/toybox-media/Makefile
@@ -2,10 +2,12 @@
 default: push
 
 IMAGE=toybox-media
+BASE=linuxkit/c-compile:f52f485825c890d581e82a62af6906c1d33d8e5d
 SHA_IMAGE=alpine:3.5@sha256:dfbd4a3a8ebca874ebd2474f044a0b33600d4523d03b0df76e5c5986cb02d7e8
 DEPS=Dockerfile Makefile
 
 hash: $(DEPS)
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	find $^ -type f | xargs cat | docker run --rm -i $(SHA_IMAGE) sha1sum - | sed 's/ .*//' > hash
 
 tag: hash


### PR DESCRIPTION
Set up notary delegations and Makefile `sign` targets for:
```
docker.io/linuxkit/binfmt
docker.io/linuxkit/rngd
docker.io/linuxkit/go-compile
docker.io/linuxkit/c-compile
docker.io/linuxkit/toybox-media
docker.io/linuxkit/tini
```

Also updated yml files and Makefiles to verify signatures where appropriate.

<img src="http://media.indiatimes.in/media/content/2015/Nov/animal-beg_3447494k_1447323007.jpg" width="400"/>