### PR TITLE
Specified platform for hyperkit and qemu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-bzImage: test-initrd.img
 
 .PHONY: test-qemu-efi
 test-qemu-efi: $(LINUXKIT) test-efi.iso
-	$(LINUXKIT) run $^ | tee test-efi.log
+	$(LINUXKIT) run qemu test | tee test-efi.log
 	$(call check_test_log, test-efi.log)
 
 bin:
@@ -53,7 +53,7 @@ endef
 .PHONY: test-hyperkit
 test-hyperkit: $(LINUXKIT) test-initrd.img test-bzImage test-cmdline
 	rm -f disk.img
-	$(LINUXKIT) run test | tee test.log
+	$(LINUXKIT) run hyperkit test | tee test.log
 	$(call check_test_log, test.log)
 
 .PHONY: test-gcp


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>


**- What I did**
Just fixed the platform for `test-hyperkit` and `test-qemu-efi` so that they work only under the right circumstances 

**- How to verify it**

**qemu**
```
make test-qemu-efi
```

Now only runs using qemu and not the default platform.

**hyperkit**
```bash
make test-hyperkit
```
Now runs only on applicable platforms (Mac)

```zsh
➜  linuxkit git:(fix/makefile-test-targets) make test-hyperkit
rm -f disk.img
bin/linuxkit run hyperkit test | tee test.log
FATA[0000] Error creating hyperkit:  Could not find hyperkit executable 
Makefile:55: recipe for target 'test-hyperkit' failed
make: *** [test-hyperkit] Error 1
```



**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://cloud.githubusercontent.com/assets/3083633/25459616/5f80b6f8-2adf-11e7-84ef-61f9cd560a72.png)

