### PR TITLE
Fix typo "ndodev"

### DIFF
--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1c8cd75ec89313f4058b069449e9bac966cd96b1
+  - linuxkit/init:f71c3b30ac1ba4ef16c160c89610fa4976f9752f
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:60e2486a74c665ba4df57e561729aec20758daed
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,8 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:63eed9ca7a09d2ce4c0c5e7238ac005fa44f564b
-  - linuxkit/init:1c8cd75ec89313f4058b069449e9bac966cd96b1
+  - linuxkit/init:f71c3b30ac1ba4ef16c160c89610fa4976f9752f
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:fe1b7f438a234cb6481c6538295115eac2a0596d
 services:

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1c8cd75ec89313f4058b069449e9bac966cd96b1
+  - linuxkit/init:f71c3b30ac1ba4ef16c160c89610fa4976f9752f
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:60e2486a74c665ba4df57e561729aec20758daed
   - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f

--- a/pkg/init/etc/init.d/rcS
+++ b/pkg/init/etc/init.d/rcS
@@ -3,7 +3,7 @@
 # mount filesystems
 mkdir -p -m 0755 /proc /run /tmp /sys /dev
 
-mount -n -t proc proc /proc -o ndodev,nosuid,noexec,relatime
+mount -n -t proc proc /proc -o nodev,nosuid,noexec,relatime
 
 mount -n -t tmpfs tmpfs /run -o nodev,nosuid,noexec,relatime,size=10%,mode=755
 mount -n -t tmpfs tmpfs /tmp -o nodev,nosuid,noexec,relatime,size=10%,mode=1777

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1c8cd75ec89313f4058b069449e9bac966cd96b1
+  - linuxkit/init:f71c3b30ac1ba4ef16c160c89610fa4976f9752f
   - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - linuxkit/containerd:fe1b7f438a234cb6481c6538295115eac2a0596d
   - linuxkit/ca-certificates:e091a05fbf7c5e16f18b23602febd45dd690ba2f

--- a/projects/logging/pkg/init/etc/init.d/rcS
+++ b/projects/logging/pkg/init/etc/init.d/rcS
@@ -3,7 +3,7 @@
 # mount filesystems
 mkdir -p -m 0755 /proc /run /tmp /sys /dev
 
-mount -n -t proc proc /proc -o ndodev,nosuid,noexec,relatime
+mount -n -t proc proc /proc -o nodev,nosuid,noexec,relatime
 
 mount -n -t tmpfs tmpfs /run -o nodev,nosuid,noexec,relatime,size=10%,mode=755
 mount -n -t tmpfs tmpfs /tmp -o nodev,nosuid,noexec,relatime,size=10%,mode=1777

--- a/projects/miragesdk/pkg/init/etc/init.d/rcS
+++ b/projects/miragesdk/pkg/init/etc/init.d/rcS
@@ -3,7 +3,7 @@
 # mount filesystems
 mkdir -p -m 0755 /proc /run /tmp /sys /dev
 
-mount -n -t proc proc /proc -o ndodev,nosuid,noexec,relatime
+mount -n -t proc proc /proc -o nodev,nosuid,noexec,relatime
 
 mount -n -t tmpfs tmpfs /run -o nodev,nosuid,noexec,relatime,size=10%,mode=755
 mount -n -t tmpfs tmpfs /tmp -o nodev,nosuid,noexec,relatime,size=10%,mode=1777

--- a/projects/selinux/init/etc/init.d/rcS
+++ b/projects/selinux/init/etc/init.d/rcS
@@ -3,7 +3,7 @@
 # mount filesystems
 mkdir -p -m 0755 /proc /run /tmp /sys /dev
 
-mount -n -t proc proc /proc -o ndodev,nosuid,noexec,relatime
+mount -n -t proc proc /proc -o nodev,nosuid,noexec,relatime
 
 mount -n -t tmpfs tmpfs /run -o nodev,nosuid,noexec,relatime,size=10%,mode=755
 mount -n -t tmpfs tmpfs /tmp -o nodev,nosuid,noexec,relatime,size=10%,mode=1777

--- a/projects/wireguard/init-wireguard/etc/init.d/rcS
+++ b/projects/wireguard/init-wireguard/etc/init.d/rcS
@@ -3,7 +3,7 @@
 # mount filesystems
 mkdir -p -m 0755 /proc /run /tmp /sys /dev
 
-mount -n -t proc proc /proc -o ndodev,nosuid,noexec,relatime
+mount -n -t proc proc /proc -o nodev,nosuid,noexec,relatime
 
 mount -n -t tmpfs tmpfs /run -o nodev,nosuid,noexec,relatime,size=10%,mode=755
 mount -n -t tmpfs tmpfs /tmp -o nodev,nosuid,noexec,relatime,size=10%,mode=1777


### PR DESCRIPTION
Not sure when this arrived but it was stopping anything running.
Appears not to be in the older test `init` containers.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>
