### PR TITLE
The `-drive` parameter for qemu run requires more flags

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -238,7 +238,7 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 	}
 
 	if config.DiskPath != "" {
-		qemuArgs = append(qemuArgs, "-drive", "file="+config.DiskPath+",format=qcow2")
+		qemuArgs = append(qemuArgs, "-drive", "file="+config.DiskPath+",format=qcow2,index=0,media=disk")
 	}
 
 	// Check flags for iso/uefi boot and if so disable kernel boot


### PR DESCRIPTION
To use `-drive` as an analog for `-hda` or `-hdb`, etc. the qemu
docs note that "media" and "index" are required flags. Local
testing shows that drive shows up properly as `/dev/sda` after
this change.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>