### PR TITLE
Change to use kernel not bzImage everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ Dockerfile.media
 *.vhdx
 *.efi
 *.qcow2
-*-bzImage
+*-kernel
 *-cmdline

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 PREFIX?=/usr/local/
 
-MOBY_COMMIT=3375f32d51dcf1a043b79a4d6f4a9cc696a8b19e
+MOBY_COMMIT=d504afe4795528920ef06af611efd27b74098d5e
 bin/moby: | bin
 	docker run --rm --log-driver=none $(CROSS) $(GO_COMPILE) --clone-path github.com/moby/tool --clone https://github.com/moby/tool.git --commit $(MOBY_COMMIT) --package github.com/moby/tool/cmd/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
 	tar xf tmp_moby_bin.tar > $@

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -58,7 +58,7 @@ FROM linuxkit/toybox-media:eee3dd4d72cd784801e95b1781e6c4f9d8a5e5eb@sha256:7f940
 ENTRYPOINT []
 CMD []
 WORKDIR /
-COPY --from=kernel-build bzImage /
+COPY --from=kernel-build bzImage /kernel
 COPY --from=kernel-build kernel-headers.tar /
 COPY --from=kernel-build kernel-modules.tar /kernel.tar
 COPY --from=kernel-build kernel-dev.tar /

--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -101,7 +101,7 @@ func runHyperKit(args []string) {
 		log.Fatalln("Error creating hyperkit: ", err)
 	}
 
-	h.Kernel = prefix + "-bzImage"
+	h.Kernel = prefix + "-kernel"
 	h.Initrd = prefix + "-initrd.img"
 	h.VPNKitKey = vpnKitKey
 	h.UUID = vmUUID

--- a/src/cmd/linuxkit/run_packet.go
+++ b/src/cmd/linuxkit/run_packet.go
@@ -66,7 +66,7 @@ func runPacket(args []string) {
 
 	url := getStringValue(packetBaseURL, *baseURLFlag, "")
 	if url == "" {
-		log.Fatal("Need to specify a value for --base-url where the images are hosted. This URL should contain <url>/%s-bzImage and <url>/%s-initrd.img")
+		log.Fatal("Need to specify a value for --base-url where the images are hosted. This URL should contain <url>/%s-kernel and <url>/%s-initrd.img")
 	}
 	facility := getStringValue(packetZoneVar, *zoneFlag, "")
 	plan := getStringValue(packetMachineVar, *machineFlag, defaultMachine)
@@ -82,10 +82,10 @@ func runPacket(args []string) {
 	name := getStringValue(packetNameVar, *nameFlag, prefix)
 	osType := "custom_ipxe"
 	billing := "hourly"
-	userData := fmt.Sprintf("#!ipxe\n\ndhcp\nset base-url %s\nset kernel-params ip=dhcp nomodeset ro serial console=ttyS1,115200\nkernel ${base-url}/%s-bzImage ${kernel-params}\ninitrd ${base-url}/%s-initrd.img\nboot", url, name, name)
+	userData := fmt.Sprintf("#!ipxe\n\ndhcp\nset base-url %s\nset kernel-params ip=dhcp nomodeset ro serial console=ttyS1,115200\nkernel ${base-url}/%s-kernel ${kernel-params}\ninitrd ${base-url}/%s-initrd.img\nboot", url, name, name)
 	log.Debugf("Using userData of:\n%s\n", userData)
 	initrdURL := fmt.Sprintf("%s/%s-initrd.img", url, name)
-	kernelURL := fmt.Sprintf("%s/%s-bzImage", url, name)
+	kernelURL := fmt.Sprintf("%s/%s-kernel", url, name)
 	ValidateHTTPURL(kernelURL)
 	ValidateHTTPURL(initrdURL)
 	client := packngo.NewClient("", apiKey, nil)

--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -48,7 +48,7 @@ func runQemu(args []string) {
 	qemuGUI := qemuFlags.Bool("gui", false, "Set qemu to use video output instead of stdio")
 	qemuUEFI := qemuFlags.Bool("uefi", false, "Set UEFI boot from 'prefix'-efi.iso")
 	qemuIso := qemuFlags.Bool("iso", false, "Set Legacy BIOS boot from 'prefix'.iso")
-	qemuKernel := qemuFlags.Bool("kernel", true, "Set boot using 'prefix'-bzImage/-initrd/-cmdline")
+	qemuKernel := qemuFlags.Bool("kernel", true, "Set boot using 'prefix'-kernel/-initrd/-cmdline")
 
 	// Paths and settings for Disks and UEFI firware
 	qemuDiskPath := qemuFlags.String("diskpath", "", "Path to disk image to use")
@@ -256,9 +256,9 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 		qemuArgs = append(qemuArgs, "-boot", "d")
 	}
 
-	// build kernel boot config from bzImage/initrd/cmdline
+	// build kernel boot config from kernel/initrd/cmdline
 	if config.Kernel {
-		qemuKernelPath := buildPath(config.Prefix, "-bzImage")
+		qemuKernelPath := buildPath(config.Prefix, "-kernel")
 		qemuInitrdPath := buildPath(config.Prefix, "-initrd.img")
 		qemuArgs = append(qemuArgs, "-kernel", qemuKernelPath)
 		qemuArgs = append(qemuArgs, "-initrd", qemuInitrdPath)

--- a/tools/mkimage-gcp/make-gcp
+++ b/tools/mkimage-gcp/make-gcp
@@ -5,7 +5,7 @@ set -e
 mkdir -p /tmp/image
 cd /tmp/image
 
-# input is a tarball of vmlinuz64 and initrd.img on stdin
+# input is a tarball of kernel and initrd.img on stdin
 # output is a compressed tarball of a raw disk image on stdout
 
 mkdir -p files
@@ -17,10 +17,10 @@ cd files
 [ -t 0 ] || tar xf -
 
 INITRD="$(find . -name '*.img')"
-KERNEL="$(find . -name vmlinuz64 -or -name bzImage)"
+KERNEL="$(find . -name kernel -or -name bzImage)"
 CMDLINE="$*"
 
-[ "$KERNEL" = "./vmlinuz64" ] || mv "$KERNEL" vmlinuz64
+[ "$KERNEL" = "./kernel" ] || mv "$KERNEL" kernel
 [ "$INITRD" = "./initrd.img" ] || mv "$INITRD" initrd.img
 
 # clean up subdirectories
@@ -31,7 +31,7 @@ GCP_CONFIG="earlyprintk=ttyS0,115200 console=ttyS0,115200 vsyscall=emulate page_
 
 CFG="DEFAULT linux
 LABEL linux
-    KERNEL /vmlinuz64
+    KERNEL /kernel
     INITRD /initrd.img
     APPEND ${CMDLINE}
 "

--- a/tools/mkimage-iso-bios/make-iso
+++ b/tools/mkimage-iso-bios/make-iso
@@ -5,7 +5,7 @@ set -e
 mkdir -p /tmp/iso
 cd /tmp/iso
 
-# input is a tarball of vmlinuz64 and initrd.img on stdin
+# input is a tarball of kernel and initrd.img on stdin
 # output is an iso on stdout
 
 # extract. BSD tar auto recognises compression, unlike GNU tar
@@ -13,10 +13,10 @@ cd /tmp/iso
 [ -t 0 ] || bsdtar xzf -
 
 INITRD="$(find . -name '*.img')"
-KERNEL="$(find . -name vmlinuz64 -or -name bzImage)"
+KERNEL="$(find . -name kernel -or -name '*bzImage')"
 CMDLINE="$*"
 
-[ "$KERNEL" = "vmlinuz64" ] || mv "$KERNEL" vmlinuz64
+[ "$KERNEL" = "kernel" ] || mv "$KERNEL" kernel
 [ "$INITRD" = "initrd.img" ] || mv "$INITRD" initrd.img
 
 # clean up subdirectories
@@ -28,7 +28,7 @@ cp /usr/share/syslinux/ldlinux.c32 ./isolinux/
 
 CFG="DEFAULT linux
 LABEL linux
-    KERNEL /vmlinuz64
+    KERNEL /kernel
     INITRD /initrd.img
     APPEND ${CMDLINE}
 "

--- a/tools/mkimage-iso-efi/make-efi
+++ b/tools/mkimage-iso-efi/make-efi
@@ -5,7 +5,7 @@ set -e
 mkdir -p /tmp/efi
 cd /tmp/efi
 
-# input is a tarball of vmlinuz64 and initrd.img on stdin
+# input is a tarball of kernel and initrd.img on stdin
 # output is an iso on stdout
 
 # extract. BSD tar auto recognises compression, unlike GNU tar
@@ -13,11 +13,11 @@ cd /tmp/efi
 [ -t 0 ] || bsdtar xzf -
 
 INITRD="$(find . -name '*.img')"
-KERNEL="$(find . -name vmlinuz64 -or -name bzImage)"
+KERNEL="$(find . -name kernel -or -name bzImage)"
 CMDLINE="$*"
 
-[ "$KERNEL" = "vmlinuz64" ] || mv "$KERNEL" vmlinuz64
-[ "$INITRD" = "initrd.img" ] || mv "$INITRD" initrd.img
+[ "$KERNEL" = "./kernel" ] || mv "$KERNEL" kernel
+[ "$INITRD" = "./initrd.img" ] || mv "$INITRD" initrd.img
 
 # clean up subdirectories
 find . -mindepth 1 -maxdepth 1 -type d | xargs rm -rf
@@ -30,8 +30,8 @@ echo "${CMDLINE} rootdelay=300 noautodetect" > cmdline.txt
 objcopy \
 	--add-section .osrel=/etc/os-release --change-section-vma .osrel=0x20000 \
 	--add-section .cmdline=./cmdline.txt --change-section-vma .cmdline=0x30000 \
-	--add-section .linux=./vmlinuz64 --change-section-vma .linux=0x40000 \
-	--add-section .initrd=initrd.img --change-section-vma .initrd=0x3000000 \
+	--add-section .linux=./kernel --change-section-vma .linux=0x40000 \
+	--add-section .initrd=./initrd.img --change-section-vma .initrd=0x3000000 \
 	./linuxx64.efi.stub \
 	linuxkit.efi
 

--- a/tools/mkimage-qcow/make-qcow
+++ b/tools/mkimage-qcow/make-qcow
@@ -5,7 +5,7 @@ set -e
 mkdir -p /tmp/image
 cd /tmp/image
 
-# input is a tarball of vmlinuz64 and initrd.img on stdin
+# input is a tarball of kernel and initrd.img on stdin
 # output is a qcow2 on stdout
 
 mkdir -p files
@@ -17,10 +17,10 @@ cd files
 [ -t 0 ] || tar xf -
 
 INITRD="$(find . -name '*.img')"
-KERNEL="$(find . -name vmlinuz64 -or -name '*bzImage')"
+KERNEL="$(find . -name kernel -or -name '*bzImage')"
 CMDLINE="$*"
 
-[ "$KERNEL" = "./vmlinuz64" ] || mv "$KERNEL" vmlinuz64
+[ "$KERNEL" = "./kernel" ] || mv "$KERNEL" kernel
 [ "$INITRD" = "./initrd.img" ] || mv "$INITRD" initrd.img
 
 # clean up subdirectories
@@ -28,7 +28,7 @@ find . -mindepth 1 -maxdepth 1 -type d | xargs rm -rf
 
 CFG="DEFAULT linux
 LABEL linux
-    KERNEL /vmlinuz64
+    KERNEL /kernel
     INITRD /initrd.img
     APPEND ${CMDLINE}
 "

--- a/tools/mkimage-vhd/make-vhd
+++ b/tools/mkimage-vhd/make-vhd
@@ -5,7 +5,7 @@ set -e
 mkdir -p /tmp/image
 cd /tmp/image
 
-# input is a tarball of vmlinuz64 and initrd.img on stdin
+# input is a tarball of kernel and initrd.img on stdin
 # output is a vhd on stdout
 
 mkdir -p files
@@ -17,10 +17,10 @@ cd files
 [ -t 0 ] || tar xf -
 
 INITRD="$(find . -name '*.img')"
-KERNEL="$(find . -name vmlinuz64 -or -name '*bzImage')"
+KERNEL="$(find . -name kernel -or -name '*bzImage')"
 CMDLINE="$*"
 
-[ "$KERNEL" = "./vmlinuz64" ] || mv "$KERNEL" vmlinuz64
+[ "$KERNEL" = "./kernel" ] || mv "$KERNEL" vmlinuz64
 [ "$INITRD" = "./initrd.img" ] || mv "$INITRD" initrd.img
 
 # clean up subdirectories
@@ -28,7 +28,7 @@ find . -mindepth 1 -maxdepth 1 -type d | xargs rm -rf
 
 CFG="DEFAULT linux
 LABEL linux
-    KERNEL /vmlinuz64
+    KERNEL /kernel
     INITRD /initrd.img
     APPEND ${CMDLINE}
 "

--- a/tools/mkimage-vmdk/make-vmdk
+++ b/tools/mkimage-vmdk/make-vmdk
@@ -5,7 +5,7 @@ set -e
 mkdir -p /tmp/image
 cd /tmp/image
 
-# input is a tarball of vmlinuz64 and initrd.img on stdin
+# input is a tarball of kernel and initrd.img on stdin
 # output is a vmdk on stdout
 
 mkdir -p files
@@ -17,10 +17,10 @@ cd files
 [ -t 0 ] || tar xf -
 
 INITRD="$(find . -name '*.img')"
-KERNEL="$(find . -name vmlinuz64 -or -name '*bzImage')"
+KERNEL="$(find . -name kernel -or -name '*bzImage')"
 CMDLINE="$*"
 
-[ "$KERNEL" = "./vmlinuz64" ] || mv "$KERNEL" vmlinuz64
+[ "$KERNEL" = "./kernel" ] || mv "$KERNEL" vmlinuz64
 [ "$INITRD" = "./initrd.img" ] || mv "$INITRD" initrd.img
 
 # clean up subdirectories
@@ -28,7 +28,7 @@ find . -mindepth 1 -maxdepth 1 -type d | xargs rm -rf
 
 CFG="DEFAULT linux
 LABEL linux
-    KERNEL /vmlinuz64
+    KERNEL /kernel
     INITRD /initrd.img
     APPEND ${CMDLINE}
 "


### PR DESCRIPTION
Previously we hardcoded `bzImage` which is not used for all
use cases or architectures.

fix #1630

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

~~Requires https://github.com/moby/tool/pull/8 to be merged~~