### PR TITLE
use updated kernel and correct path in examples/swap.yml

### DIFF
--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -48,7 +48,7 @@ onboot:
     rootfsPropagation: shared
     command: ["/mount.sh", "/var/external"]
   - name: swap
-    image: "linuxkit/swap:edd74ce7ced2b97dba5075012f497570c5490299"
+    image: "linuxkit/swap:d089b31acad8a5f6a5f1c368ddd1dfe1d049b100"
     net: host
     pid: host
     capabilities:
@@ -57,7 +57,7 @@ onboot:
     binds:
      - /var:/var
      - /dev:/dev
-    command: ["swap.sh", "--path", "/var/external/swap", "--size","1G"]
+    command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G"]
 services:
   - name: rngd
     image: "linuxkit/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"

--- a/pkg/swap/swap.sh
+++ b/pkg/swap/swap.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-while [ $# -gt 1 ]; do
+while [ $# -ge 1 ]; do
 	key="$1"
 
 	case $key in
@@ -74,7 +74,9 @@ fi
 ## check each of our conditions
 for cond in $CONDITIONS; do
 	# split the condition parts
-	IFS=: read condtype arg1 arg2 arg3 arg4 <<< "$cond"
+	IFS=: read condtype arg1 arg2 arg3 arg4 <<EOF
+$cond
+EOF
 	case $condtype in
 		part)
 			partition=$arg1


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix `examples/swap.yml` to:

1. Use correct path for `swap.sh`
2. Updated to a more recent kernel version

**- How I did it**

**- How to verify it**

Run.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update kernel in swap.yml example and use correct path to script for onboot container

**- A picture of a cute animal (not mandatory but encouraged)**
![koala](https://upload.wikimedia.org/wikipedia/commons/4/49/Koala_climbing_tree.jpg)