### PR TITLE
Add support for building mainline, Ubuntu and Debian kernel packages

### DIFF
--- a/scripts/kernels/Dockerfile.deb
+++ b/scripts/kernels/Dockerfile.deb
@@ -1,0 +1,24 @@
+FROM alpine:3.5 AS extract
+
+ARG DEB_URLS
+
+RUN apk add --no-cache curl dpkg tar && true
+WORKDIR /deb
+RUN mkdir extract
+RUN for url in ${DEB_URLS}; do \
+        echo "Extracting: $url"; \
+        curl -fsSL -o dl.deb $url && \
+        dpkg-deb -x dl.deb . ;\
+    done
+
+RUN mkdir /out
+RUN cp -a boot/vmlinuz-* /out/kernel
+RUN cp -a boot/config-* /out/kernel_config
+RUN tar cf /out/kernel.tar lib
+RUN tar cf /out/kernel-dev.tar usr
+
+FROM linuxkit/toybox-media:d7e82a7d19ccc84c9071fa7a88ecaa58ae958f7c@sha256:4c7d25f2be2429cd08417c36e04161cb924e46f3e419ee33a0aa9ff3a0942e02
+WORKDIR /
+ENTRYPOINT []
+CMD []
+COPY --from=extract /out/* /

--- a/scripts/kernels/debian.sh
+++ b/scripts/kernels/debian.sh
@@ -1,0 +1,25 @@
+#! /bin/sh
+
+REPO="linuxkit/kernel-debian"
+BASE_URL=http://mirrors.kernel.org/debian/pool/main/l/linux/
+
+ARCH=amd64
+LINKS=$(curl -s ${BASE_URL}/ | sed -n 's/.*href="\([^"]*\).*/\1/p')
+# Just get names for 4.x kernels
+KERNELS=$(echo $LINKS | \
+    grep -o "linux-image-4\.[0-9]\+\.[0-9]\+-[0-9]\+-${ARCH}[^ ]\+_${ARCH}\.deb")
+
+for KERN_DEB in $KERNELS; do
+    VERSION=$(echo $KERN_DEB | \
+        grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+-[0-9]\+" | head -1)
+
+    echo "$VERSION -> $KERN_DEB"
+    DOCKER_CONTENT_TRUST=1 docker pull ${REPO}:${VERSION} && continue
+
+    URLS="${BASE_URL}/${KERN_DEB}"
+
+    # Doesn't exist build and push
+    docker build -t ${REPO}:${VERSION} -f Dockerfile.deb --no-cache \
+           --build-arg DEB_URLS="${URLS}" . &&
+        DOCKER_CONTENT_TRUST=1 docker push ${REPO}:${VERSION})
+done

--- a/scripts/kernels/mainline.sh
+++ b/scripts/kernels/mainline.sh
@@ -1,0 +1,49 @@
+#! /bin/sh
+
+REPO="linuxkit/kernel-mainline"
+BASE_URL=http://kernel.ubuntu.com/~kernel-ppa/mainline
+
+build_image() {
+    VERSION=$1
+    KDIR=$2
+    ARCH=amd64
+
+    LINKS=$(curl -s ${BASE_URL}/${KDIR}/ | \
+                sed -n 's/.*href="\([^"]*\).*/\1/p')
+
+    IMAGE=$(echo $LINKS | \
+            grep -o "linux-image[^ ]\+-generic[^ ]\+${ARCH}.deb" | head -1)
+    [ -z "${IMAGE}" ] && return 1
+    HDR_GEN=$(echo $LINKS | grep -o "linux-headers[^ ]\+_all.deb" | head -1)
+    [ -z "${HDR_GEN}" ] && return 1
+    HDR_ARCH=$(echo $LINKS | \
+               grep -o "linux-headers[^ ]\+-generic[^ ]\+${ARCH}.deb" | head -1)
+    [ -z "${HDR_ARCH}" ] && return 1
+
+    DEB_URL=${BASE_URL}/${KDIR}/${IMAGE}
+    HDR_GEN_URL=${BASE_URL}/${KDIR}/${HDR_GEN}
+    HDR_ARCH_URL=${BASE_URL}/${KDIR}/${HDR_ARCH}
+    echo "Trying to fetch ${VERSION} from ${DEB_URL}"
+
+    docker build -t ${REPO}:${VERSION} -f Dockerfile.deb --no-cache \
+           --build-arg DEB_URLS="${DEB_URL} ${HDR_GEN_URL} ${HDR_ARCH_URL}" .
+}
+
+LINKS=$(curl -s ${BASE_URL}/ | sed -n 's/.*href="\([^"]*\).*/\1/p')
+# Extract all kernel versions (drop RCs, ckt(?) and other links)
+VERSIONS=$(echo $LINKS | grep -o "v[0-9]\+\.[0-9]\+\.[0-9]\+[^ ]*" | \
+           grep -ve '-rc' | grep -ve '-ckt' | uniq)
+
+# Extract 3.16.x and 4.x.x
+THREES=$(echo $VERSIONS | grep -o "v3\.16\.[0-9]\+[^ ]*")
+FOURS=$(echo $VERSIONS | grep -o "v4\.[0-9]\+\.[0-9]\+[^ ]*")
+KDIRS="${THREES} ${FOURS}"
+
+for KDIR in $KDIRS; do
+    # Strip the Ubuntu release name for the tag and also the 'v' like with
+    # the other kernel packages
+    VERSION=$(echo $KDIR | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+")
+    DOCKER_CONTENT_TRUST=1 docker pull ${REPO}:${VERSION} && continue
+    build_image ${VERSION} ${KDIR} && \
+        DOCKER_CONTENT_TRUST=1 docker push ${REPO}:${VERSION}
+done

--- a/scripts/kernels/ubuntu.sh
+++ b/scripts/kernels/ubuntu.sh
@@ -1,0 +1,34 @@
+#! /bin/sh
+
+REPO="linuxkit/kernel-ubuntu"
+BASE_URL=http://mirrors.kernel.org/ubuntu/pool/main/l/linux/
+
+ARCH=amd64
+LINKS=$(curl -s ${BASE_URL}/ | sed -n 's/.*href="\([^"]*\).*/\1/p')
+# Just get names for 4.x kernels
+KERNELS=$(echo $LINKS | \
+    grep -o "linux-image-4\.[0-9]\+\.[0-9]\+-[0-9]\+-generic_[^ ]\+${ARCH}\.deb")
+
+for KERN_DEB in $KERNELS; do
+    VERSION=$(echo $KERN_DEB | \
+        grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+-[0-9]\+" | head -1)
+
+    echo "$VERSION -> $KERN_DEB"
+    DOCKER_CONTENT_TRUST=1 docker pull ${REPO}:${VERSION} && continue
+
+    EXTRA_DEB=$(echo $LINKS | \
+        grep -o "linux-image-extra-${VERSION}-generic_[^ ]\+${ARCH}\.deb")
+
+    # Don't pull in the headers. This is mostly for testing
+    # HDR_DEB=$(echo $LINKS | \
+    #     grep -o "linux-headers-${VERSION}_[^ ]\+_all\.deb")
+    # HDR_ARCH_DEB=$(echo $LINKS | \
+    #     grep -o "linux-headers-${VERSION}-generic_[^ ]\+_${ARCH}\.deb")
+
+    URLS="${BASE_URL}/${KERN_DEB} ${BASE_URL}/${EXTRA_DEB} ${BASE_URL}/${HDR_DEB} ${BASE_URL}/${HDR_ARCH_DEB}"
+
+    # Doesn't exist build and push
+    docker build -t ${REPO}:${VERSION} -f Dockerfile.deb --no-cache \
+           --build-arg DEB_URLS="${URLS}" . &&
+        DOCKER_CONTENT_TRUST=1 docker push ${REPO}:${VERSION})
+done


### PR DESCRIPTION
This PR adds support for repackaging kernel debian packages from the Ubuntu mainline PPA (which tracks kernel.org releases) as well as the main Ubuntu and Debian kernel packages.

The scripts are written in a way that they should be run daily/weekly as they scrape the relevant websites and determine the kernel version. It then compares this with images on Hub before building/signing/pushing.

I have not started the scripts yet, but will when merged.

wip: #1431
closes: #1265