### PR TITLE
Add support for encrypted swap

### DIFF
--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -48,16 +48,19 @@ onboot:
     rootfsPropagation: shared
     command: ["/mount.sh", "/var/external"]
   - name: swap
-    image: "linuxkit/swap:d089b31acad8a5f6a5f1c368ddd1dfe1d049b100"
+    image: "linuxkit/swap:a881d50445ea27624be67dcda39313e7a2051982"
     net: host
     pid: host
     capabilities:
      - CAP_SYS_ADMIN
+     - CAP_MKNOD
     readonly: true
     binds:
      - /var:/var
      - /dev:/dev
-    command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G"]
+    # to use unencrypted swap, use:
+    # command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G"]
+    command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: rngd
     image: "linuxkit/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"

--- a/pkg/swap/Dockerfile
+++ b/pkg/swap/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:3.5
 
 # swap command - only minimal Alpine install
 
-# use util-linux to get swapfile utils
-#   at some point, hopefully use our own mkswap and swapon
-RUN apk add --update util-linux
+# use util-linux to get swapfile utils, cryptsetup
+#   at some point, hopefully use our own mkswap and swapon, as well as cryptsetup
+RUN apk add --update util-linux cryptsetup
 
 # add the entrypoint and make it executable
 COPY . ./

--- a/pkg/swap/README.md
+++ b/pkg/swap/README.md
@@ -8,11 +8,12 @@ Normally, unless you are running explicitly in a desktop version, LinuxKit image
 ```
 onboot:
   - name: swap
-    image: "linuxkit/swap:1.0.0"
-    net: none
+    image: "linuxkit/swap:a881d50445ea27624be67dcda39313e7a2051982"
+    net: host
     pid: host
     capabilities:
      - CAP_SYS_ADMIN
+     - CAP_MKNOD
     readonly: true
     binds:
      - /dev:/dev
@@ -34,7 +35,8 @@ Options are passed to it via command-line options. The following are the options
 |`--path`|Path to file as seen in the underlying OS||**Yes**||
 |`--size`|Target swapfile size||**Yes**||
 |`--condition`|_condition_||No|Condition that must be met to create a swapfile|
-|`--debug`||No|Turns on verbose output from the command making the swap|
+|`--debug`|||No|Turns on verbose output from the command making the swap|
+|`--encrypt`|||No|Encrypts swapfile|
 
 
 #### File
@@ -48,6 +50,11 @@ You **always** should put the swap file somewhere under `/var`, since that is wh
 `--size <size>` indicates the desired swapfile size, e.g. `2G` `100M` `5670K` `8765432`. There is no default. Acceptable size units are `G`, `M`, `K` and bytes of no unit provided.
 
 If disk space on the requested partition is insufficient to create the swapfile, the container exits with an error.
+
+#### Encryption
+If you want the swapfile to be encrypted, pass the `--encrypt` option. It will create an encrypted swapfile at the path you provide to `--path`, using devicemapper to map the clear device to `/dev/mapper/swapfile`.
+
+Encryption is performed using `cryptsetup` with `plain` encryption, using `/dev/urandom` to generate a random keyfile, key size of `256`, and cipher `aes-cbc-essiv:sha256`.
 
 #### Conditions
 You may want to create a swapfile only if certain conditions are met. Supported conditions are:

--- a/pkg/swap/swap.sh
+++ b/pkg/swap/swap.sh
@@ -126,7 +126,7 @@ if [ "$ENCRYPT" == "true" ]; then
 	#loop=$(losetup -f)
 	#losetup ${loop} ${path}
 
-	cryptsetup open --type plain --key-file /dev/urandom --key-size=256 --hash=sha256 --cipher=aes-cbc-essiv --offset=0  ${path} swapfile
+	cryptsetup open --type plain --key-file /dev/urandom --key-size=256 --cipher=aes-cbc-essiv:sha256 --offset=0  ${path} swapfile
 	SWAPDEV=/dev/mapper/swapfile
 else
 	SWAPDEV=$path


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

* Added support for encrypted swap
* Added encrypted-swap.yml example

**- How I did it**

1. Add `cryptsetup` to `linuxkit/swap` image
2. Add `--encrypt` option
3. When `--encrypt` is provided, use `cryptsetup` to set up encrypted swap

**- How to verify it**
Run it with `--encrypt`. When successful (takes a few seconds), the swapfile should be `/dev/mapper/swap` (check in `/proc/swaps`), which is devicemapped via plain encryption to `/var/external/swap` (or whatever is in the `.yml` file)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add support for encrypted swap as an `onboot` option, along with example `.yml` file.


**- A picture of a cute animal (not mandatory but encouraged)**

![cockatiel](https://i.ytimg.com/vi/28Fn1FGntck/maxresdefault.jpg)
