### PR TITLE
Fix typo in docs/kernels.md

### DIFF
--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -144,4 +144,4 @@ rm $KITSRC/kernel/patches-4.9.x/*
 git format-patch -o $KITSRC/kernel/patches-4.9.x v4.9.15..HEAD
 ```
 
-The, create a PR for LinuxKit.
+Then, create a PR for LinuxKit.


### PR DESCRIPTION
Hey,
i think there is a typo at the end of `docs/kernels.md`.  

