### PR TITLE
Adjust docker-ce package

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -66,7 +66,7 @@ services:
       - CAP_SETGID
     net: host
   - name: docker
-    image: "linuxkit/docker-ce:741bf21513328f674e0cdcaa55492b0b75974e08"
+    image: "linuxkit/docker-ce:a82b61b151f6d6a3606e66f284c927b4c83b50f5"
     capabilities:
      - all
     net: host

--- a/pkg/docker-ce/Dockerfile
+++ b/pkg/docker-ce/Dockerfile
@@ -12,17 +12,16 @@ RUN set -x \
 	&& echo 'dockremap:165536:65536' >> /etc/subgid
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
-# sfdisk and jq used by disk mounting code at present
+# removed openssl as I do not think server needs it
 RUN apk add --no-cache \
+	btrfs-progs \
 	ca-certificates \
 	curl \
+	e2fsprogs \
+	e2fsprogs-extra \
 	iptables \
-	xz \
-	sfdisk \
-	jq
-
-# removed xfsprogs e2fs btrfs as we do not support dm or btrfs yet
-# removed openssl as I do not think server needs it
+	xfsprogs \
+	xz
 
 ENV DOCKER_BUCKET get.docker.com
 ENV DOCKER_VERSION 17.04.0-ce


### PR DESCRIPTION
Bring it into line with official images: remove `jq`, `sfdisk` which
are not needed; we used them for disk mounting but this is down standalone.
Add the tools for other filesystems, which are needed for `dm`, `btrfs`.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

cc @cpuguy83 

We should move this to `moby` soon.