### PR TITLE
projects/kubernetes: Fixup boot-*.sh

### DIFF
--- a/projects/kubernetes/boot-master.sh
+++ b/projects/kubernetes/boot-master.sh
@@ -2,4 +2,4 @@
 disk="kube-master-disk.img"
 set -x
 rm -f "${disk}"
-../../bin/linuxkit run hyperkit -cpus 2 -mem 4096 -disk-size 4096 kube-master
+../../bin/linuxkit run -cpus 2 -mem 4096 -disk-size 4096 kube-master

--- a/projects/kubernetes/boot-node.sh
+++ b/projects/kubernetes/boot-node.sh
@@ -5,4 +5,4 @@ shift
 disk="kube-${name}-disk.img"
 set -x
 rm -f "${disk}"
-../../bin/linuxkit run hyperkit -cpus 2 -mem 4096 -disk-size 4096 -disk "${disk}" -data "${*}" kube-node
+../../bin/linuxkit run -cpus 2 -mem 4096 -disk-size 4096 -disk "${disk}" -data "${*}" kube-node


### PR DESCRIPTION
It seems that `-disk-size` is now `-disksize`.

Also, drop `hyperkit` from the `linuxkit run` invocation, thus causing the
linuxkit tool to pick the platform's default backend (which is qemu on my Linux
system, which works better than hyperkit in this environment).

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

(full disclosure: I've booted master, booting node seems to require me to read more of the README, but I propagated the same changes blindly nonetheless)
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Updated `projects/kubernetes/boot-*.sh`

**- How I did it**

emacs

**- How to verify it**

Run the `boot-master.sh` script.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![Mastodon, Leviathan](https://upload.wikimedia.org/wikipedia/en/thumb/d/d8/Mastodonleviathan.jpg/220px-Mastodonleviathan.jpg)
