### PR TITLE
Makefile: gather all build artifacts in one location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Dockerfile.media
 *.qcow2
 *-kernel
 *-cmdline
+artifacts/*

--- a/Makefile
+++ b/Makefile
@@ -74,28 +74,43 @@ test-ltp.img.tar.gz: $(MOBY) test/ltp/test-ltp.yml
 
 .PHONY: test-ltp
 test-ltp: export CLOUDSDK_IMAGE_NAME?=test-ltp
-test-ltp: $(LINUXKIT) test-ltp.img.tar.gz
-	$(LINUXKIT) push gcp test-ltp.img.tar.gz
+test-ltp: $(LINUXKIT) artifacts/test-ltp.img.tar.gz
+	$(LINUXKIT) push gcp artifacts/test-ltp.img.tar.gz
 	$(LINUXKIT) run gcp -skip-cleanup -machine n1-highcpu-4 $(CLOUDSDK_IMAGE_NAME) | tee test-ltp.log
 	$(call check_test_log, test-ltp.log)
+
+artifacts:
+	mkdir -p $@
+
+artifacts/test.img.tar.gz: test.img.tar.gz | artifacts
+	cp test.img.tar.gz artifacts/
+
+artifacts/test-ltp.img.tar.gz: test-ltp.img.tar.gz | artifacts
+	cp test-ltp.img.tar.gz artifacts/
+
+.PHONY: collect-artifacts
+collect-artifacts: artifacts/test.img.tar.gz artifacts/test-ltp.img.tar.gz
 
 .PHONY: ci ci-tag ci-pr
 ci:
 	$(MAKE) clean
 	$(MAKE)
 	$(MAKE) test
+	$(MAKE) collect-artifacts
 	$(MAKE) test-ltp
 
 ci-tag:
 	$(MAKE) clean
 	$(MAKE)
 	$(MAKE) test
+	$(MAKE) collect-artifacts
 	$(MAKE) test-ltp
 
 ci-pr:
 	$(MAKE) clean
 	$(MAKE)
 	$(MAKE) test
+	$(MAKE) artifacts/test.img.tar.gz
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This makes it easier for CI to grab artifacts from the ephemeral build
VMs and provides a stable location so they can be used in subsequent
tests. For example, running the LTP tests.

Signed-off-by: Dave Tucker <dt@docker.com>