### PR TITLE
Eliminated the need for users to copy their public key.

### DIFF
--- a/projects/kubernetes/Makefile
+++ b/projects/kubernetes/Makefile
@@ -20,9 +20,13 @@ push-container-images: build-container-images cache-images
 build-vm-images: kube-master-initrd.img kube-node-initrd.img
 
 kube-master-initrd.img: kube-master.yml
+	[ ! -f ~/.ssh/id_rsa.pub ] || echo "The public key was not found at ~/.ssh/id_rsa.pub" || exit 1
+	KEY="$(shell cat ~/.ssh/id_rsa.pub)"; sed -i 's|    contents: .*$$|    contents: '"$$KEY"'|' kube-master.yml
 	../../bin/moby build -name kube-master kube-master.yml
 
 kube-node-initrd.img: kube-node.yml
+	[ ! -f ~/.ssh/sid_rsa.pub ] || echo "The public key found at ~/.ssh/id_rsa.pub" || exit 1
+	KEY="$(shell cat ~/.ssh/id_rsa.pub)"; sed -i 's|    contents: .*$$|    contents: '"$$KEY"'|' kube-node.yml
 	../../bin/moby build -name kube-node kube-node.yml
 
 clean:

--- a/projects/kubernetes/README.md
+++ b/projects/kubernetes/README.md
@@ -2,16 +2,17 @@
 
 This project aims to demonstrate how one can create minimal and immutable Kubernetes OS images with LinuxKit.
 
-Make sure to `cd projects/kubernetes` first.
-
-Edit `kube-master.yml` and add your public SSH key to `files` section.
+Make sure to change directory to `projects/kubernetes` first.
 
 Build OS images:
 ```
 make build-vm-images
 ```
+Please note: The make process copies your public ssh key to the
+`kube-master.yml` and `kube-node.yml` files adding your public key to the
+authorized_key file so you are able to ssh to systems running these images.
 
-Boot Kubernetes master OS image using `hyperkit` on macOS:
+Boot Kubernetes master OS image using the `linuxkit run` command:
 ```
 ./boot-master.sh
 ```


### PR DESCRIPTION
**- What I did**
The Makefile now copies the public key for the user.

**- How I did it**
Edited the Makefile to exit if no public key exists, otherwise uses sed to copy the key to the files.

**- How to verify it**
Run make build-vm-images and check `kube-master.yml` and `kube-node.yml`

**- Description for the changelog**
<!--
Eliminated the need for manual copy of the user's public key to the `kube-master.yml` and `kube-node.yml` files.
-->


**- A picture of a cute animal (not mandatory but encouraged)**
nope