### PR TITLE
kernel: Update to 4.4.66/4.9.26/4.10.14

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -62,8 +62,8 @@ endef
 # Build Targets
 # Debug targets only for latest stable and LTS stable
 #
-$(eval $(call kernel,4.10.13,4.10.x))
-$(eval $(call kernel,4.10.13,4.10.x,_dbg))
-$(eval $(call kernel,4.9.25,4.9.x))
-$(eval $(call kernel,4.9.25,4.9.x,_dbg))
-$(eval $(call kernel,4.4.65,4.4.x))
+$(eval $(call kernel,4.10.14,4.10.x))
+$(eval $(call kernel,4.10.14,4.10.x,_dbg))
+$(eval $(call kernel,4.9.26,4.9.x))
+$(eval $(call kernel,4.9.26,4.9.x,_dbg))
+$(eval $(call kernel,4.4.66,4.4.x))

--- a/kernel/kernel_config-4.10.x
+++ b/kernel/kernel_config-4.10.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.10.10 Kernel Configuration
+# Linux/x86 4.10.14 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/kernel_config-4.4.x
+++ b/kernel/kernel_config-4.4.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.61 Kernel Configuration
+# Linux/x86 4.4.66 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/kernel_config-4.9.x
+++ b/kernel/kernel_config-4.9.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.22 Kernel Configuration
+# Linux/x86 4.9.26 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.10.x/0001-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.10.x/0001-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,7 +1,7 @@
-From 619e73aadf2a24f58cbc5aed2622d35ac4cf5182 Mon Sep 17 00:00:00 2001
+From dd08e20ca2c64c1d4d6ee282e949eb5e89f77512 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Thu, 21 Jul 2016 16:04:38 -0600
-Subject: [PATCH 1/6] hv_sock: introduce Hyper-V Sockets
+Subject: [PATCH 1/7] hv_sock: introduce Hyper-V Sockets
 
 Hyper-V Sockets (hv_sock) supplies a byte-stream based communication
 mechanism between the host and the guest. It's somewhat like TCP over
@@ -1787,5 +1787,5 @@ index 000000000000..331d3759f5cb
 +MODULE_DESCRIPTION("Hyper-V Sockets");
 +MODULE_LICENSE("Dual BSD/GPL");
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.10.x/0002-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.10.x/0002-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,7 +1,7 @@
-From 9ab0abb7cbbfd39bae399909d6e7e08284f58090 Mon Sep 17 00:00:00 2001
+From 6d21f35a580779c88a2f251395097b082574f4cc Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
-Subject: [PATCH 2/6] Drivers: hv: vmbus: Use all supported IC versions to
+Subject: [PATCH 2/7] Drivers: hv: vmbus: Use all supported IC versions to
  negotiate
 
 Previously, we were assuming that each IC protocol version was tied to a
@@ -488,5 +488,5 @@ index ca26335de49a..41e5ed87f833 100644
  void hv_event_tasklet_disable(struct vmbus_channel *channel);
  void hv_event_tasklet_enable(struct vmbus_channel *channel);
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.10.x/0003-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.10.x/0003-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,7 +1,7 @@
-From 207cbe08e87497d5b405892d6879808600103e52 Mon Sep 17 00:00:00 2001
+From fbdcc24ca6ecc490da8254110a85aa33325137b9 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
-Subject: [PATCH 3/6] Drivers: hv: Log the negotiated IC versions.
+Subject: [PATCH 3/7] Drivers: hv: Log the negotiated IC versions.
 
 Log the negotiated IC versions.
 
@@ -114,5 +114,5 @@ index f3797c07be10..89440c2eb346 100644
  					hb_srv_version & 0xFFFF);
  			}
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.10.x/0004-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.10.x/0004-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,7 +1,7 @@
-From 81e07cf983050fdbf27115f757a337c29fe8e3b4 Mon Sep 17 00:00:00 2001
+From 64b212adc820690cb54855b79e30e23329aecc5a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
-Subject: [PATCH 4/6] vmbus: fix missed ring events on boot
+Subject: [PATCH 4/7] vmbus: fix missed ring events on boot
 
 During initialization, the channel initialization code schedules the
 tasklet to scan the VMBUS receive event page (i.e. simulates an
@@ -52,5 +52,5 @@ index feca5d2e7b25..3fda63bf60ab 100644
  
  void hv_process_channel_removal(struct vmbus_channel *channel, u32 relid)
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.10.x/0005-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.10.x/0005-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,7 +1,7 @@
-From 849282cf210be7d3aa84725857e08e62238e4473 Mon Sep 17 00:00:00 2001
+From 0c089ad42dfc3a845ce6a21a1f78dd1704cbbaed Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
-Subject: [PATCH 5/6] vmbus: remove "goto error_clean_msglist" in vmbus_open()
+Subject: [PATCH 5/7] vmbus: remove "goto error_clean_msglist" in vmbus_open()
 
 This is just a cleanup patch to simplify the code a little.
 No semantic change.
@@ -55,5 +55,5 @@ index 1606e7f08f4b..1caed01954f6 100644
  	vmbus_teardown_gpadl(newchannel, newchannel->ringbuffer_gpadlhandle);
  	kfree(open_info);
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.10.x/0006-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.10.x/0006-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,7 +1,7 @@
-From b3f63e4dfcc3aa79c7d4e4d966505ff3fd697211 Mon Sep 17 00:00:00 2001
+From 67f5a959cea3dea2f5773cf7b690337dde421f9b Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
-Subject: [PATCH 6/6] vmbus: dynamically enqueue/dequeue the channel on
+Subject: [PATCH 6/7] vmbus: dynamically enqueue/dequeue the channel on
  vmbus_open/close
 
 Signed-off-by: Dexuan Cui <decui@microsoft.com>
@@ -173,5 +173,5 @@ index 41e5ed87f833..0792d16f4b3e 100644
  
  void vmbus_setevent(struct vmbus_channel *channel);
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.10.x/0007-scsi-storvsc-Workaround-for-virtual-DVD-SCSI-version.patch
+++ b/kernel/patches-4.10.x/0007-scsi-storvsc-Workaround-for-virtual-DVD-SCSI-version.patch
@@ -1,0 +1,94 @@
+From 6064d8207f1a62352f2476d09b8d6c6fba572359 Mon Sep 17 00:00:00 2001
+From: Stephen Hemminger <stephen@networkplumber.org>
+Date: Tue, 7 Mar 2017 09:15:53 -0800
+Subject: [PATCH 7/7] scsi: storvsc: Workaround for virtual DVD SCSI version
+
+Hyper-V host emulation of SCSI for virtual DVD device reports SCSI
+version 0 (UNKNOWN) but is still capable of supporting REPORTLUN.
+
+Without this patch, a GEN2 Linux guest on Hyper-V will not boot 4.11
+successfully with virtual DVD ROM device. What happens is that the SCSI
+scan process falls back to doing sequential probing by INQUIRY.  But the
+storvsc driver has a previous workaround that masks/blocks all errors
+reports from INQUIRY (or MODE_SENSE) commands.  This workaround causes
+the scan to then populate a full set of bogus LUN's on the target and
+then sends kernel spinning off into a death spiral doing block reads on
+the non-existent LUNs.
+
+By setting the correct blacklist flags, the target with the DVD device
+is scanned with REPORTLUN and that works correctly.
+
+Patch needs to go in current 4.11, it is safe but not necessary in older
+kernels.
+
+Signed-off-by: Stephen Hemminger <sthemmin@microsoft.com>
+Reviewed-by: K. Y. Srinivasan <kys@microsoft.com>
+Reviewed-by: Christoph Hellwig <hch@lst.de>
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+(cherry picked from commit f1c635b439a5c01776fe3a25b1e2dc546ea82e6f)
+---
+ drivers/scsi/storvsc_drv.c | 27 +++++++++++++++++----------
+ 1 file changed, 17 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/scsi/storvsc_drv.c b/drivers/scsi/storvsc_drv.c
+index 7be04fc0d0e7..6f5d173ea9ff 100644
+--- a/drivers/scsi/storvsc_drv.c
++++ b/drivers/scsi/storvsc_drv.c
+@@ -400,8 +400,6 @@ MODULE_PARM_DESC(storvsc_vcpus_per_sub_channel, "Ratio of VCPUs to subchannels")
+  */
+ static int storvsc_timeout = 180;
+ 
+-static int msft_blist_flags = BLIST_TRY_VPD_PAGES;
+-
+ #if IS_ENABLED(CONFIG_SCSI_FC_ATTRS)
+ static struct scsi_transport_template *fc_transport_template;
+ #endif
+@@ -1283,6 +1281,22 @@ static int storvsc_do_io(struct hv_device *device,
+ 	return ret;
+ }
+ 
++static int storvsc_device_alloc(struct scsi_device *sdevice)
++{
++	/*
++	 * Set blist flag to permit the reading of the VPD pages even when
++	 * the target may claim SPC-2 compliance. MSFT targets currently
++	 * claim SPC-2 compliance while they implement post SPC-2 features.
++	 * With this flag we can correctly handle WRITE_SAME_16 issues.
++	 *
++	 * Hypervisor reports SCSI_UNKNOWN type for DVD ROM device but
++	 * still supports REPORT LUN.
++	 */
++	sdevice->sdev_bflags = BLIST_REPORTLUN2 | BLIST_TRY_VPD_PAGES;
++
++	return 0;
++}
++
+ static int storvsc_device_configure(struct scsi_device *sdevice)
+ {
+ 
+@@ -1298,14 +1312,6 @@ static int storvsc_device_configure(struct scsi_device *sdevice)
+ 	sdevice->no_write_same = 1;
+ 
+ 	/*
+-	 * Add blist flags to permit the reading of the VPD pages even when
+-	 * the target may claim SPC-2 compliance. MSFT targets currently
+-	 * claim SPC-2 compliance while they implement post SPC-2 features.
+-	 * With this patch we can correctly handle WRITE_SAME_16 issues.
+-	 */
+-	sdevice->sdev_bflags |= msft_blist_flags;
+-
+-	/*
+ 	 * If the host is WIN8 or WIN8 R2, claim conformance to SPC-3
+ 	 * if the device is a MSFT virtual device.  If the host is
+ 	 * WIN10 or newer, allow write_same.
+@@ -1569,6 +1575,7 @@ static struct scsi_host_template scsi_driver = {
+ 	.eh_host_reset_handler =	storvsc_host_reset_handler,
+ 	.proc_name =		"storvsc_host",
+ 	.eh_timed_out =		storvsc_eh_timed_out,
++	.slave_alloc =		storvsc_device_alloc,
+ 	.slave_configure =	storvsc_device_configure,
+ 	.cmd_per_lun =		255,
+ 	.this_id =		-1,
+-- 
+2.11.0
+

--- a/kernel/patches-4.4.x/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
+++ b/kernel/patches-4.4.x/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
@@ -1,4 +1,4 @@
-From 88a161fda95c9975f0a6ac2d6a8cc97759f67ae8 Mon Sep 17 00:00:00 2001
+From c0450d109cf66e876b94dbea237ef151dc2e1daf Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 17 Dec 2015 16:53:43 +0800
 Subject: [PATCH 01/44] virtio: make find_vqs() checkpatch.pl-friendly

--- a/kernel/patches-4.4.x/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
+++ b/kernel/patches-4.4.x/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
@@ -1,4 +1,4 @@
-From ad858ab88426a3ae49116568557634a6d6f666e9 Mon Sep 17 00:00:00 2001
+From 8e44803a51f4758fb556f1b0ef504facd23bd259 Mon Sep 17 00:00:00 2001
 From: Julia Lawall <julia.lawall@lip6.fr>
 Date: Sat, 21 Nov 2015 18:39:17 +0100
 Subject: [PATCH 02/44] VSOCK: constify vmci_transport_notify_ops structures

--- a/kernel/patches-4.4.x/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
+++ b/kernel/patches-4.4.x/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
@@ -1,4 +1,4 @@
-From da72343ac89415a3649e5af2635827a0728372ca Mon Sep 17 00:00:00 2001
+From 33f5155a5923bbe591393c5012d5b58d53257629 Mon Sep 17 00:00:00 2001
 From: Claudio Imbrenda <imbrenda@linux.vnet.ibm.com>
 Date: Tue, 22 Mar 2016 17:05:52 +0100
 Subject: [PATCH 03/44] AF_VSOCK: Shrink the area influenced by prepare_to_wait

--- a/kernel/patches-4.4.x/0004-vsock-make-listener-child-lock-ordering-explicit.patch
+++ b/kernel/patches-4.4.x/0004-vsock-make-listener-child-lock-ordering-explicit.patch
@@ -1,4 +1,4 @@
-From c4666b9d4c62d2df51b544aab50cdd21126dc816 Mon Sep 17 00:00:00 2001
+From d257ca48b7d08a0f0380cc3dd9202a8d0f8d569d Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 23 Jun 2016 16:28:58 +0100
 Subject: [PATCH 04/44] vsock: make listener child lock ordering explicit

--- a/kernel/patches-4.4.x/0005-VSOCK-transport-specific-vsock_transport-functions.patch
+++ b/kernel/patches-4.4.x/0005-VSOCK-transport-specific-vsock_transport-functions.patch
@@ -1,4 +1,4 @@
-From effa9e0c7cd09f2d5f2329954abbcfa8f42ececd Mon Sep 17 00:00:00 2001
+From ab128bd9c0f78eb513b57c704b68c2392c46e0d5 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:30 +0100
 Subject: [PATCH 05/44] VSOCK: transport-specific vsock_transport functions

--- a/kernel/patches-4.4.x/0006-VSOCK-defer-sock-removal-to-transports.patch
+++ b/kernel/patches-4.4.x/0006-VSOCK-defer-sock-removal-to-transports.patch
@@ -1,4 +1,4 @@
-From 98b869d29f5dae8c5ce907f9f20a0f4f4f5e1a65 Mon Sep 17 00:00:00 2001
+From d17744910502eb2ce946a116bb46f1ab6d094e05 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:31 +0100
 Subject: [PATCH 06/44] VSOCK: defer sock removal to transports

--- a/kernel/patches-4.4.x/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
+++ b/kernel/patches-4.4.x/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
@@ -1,4 +1,4 @@
-From bcb6718c392d78e26717c9153dc7259d4480fbcf Mon Sep 17 00:00:00 2001
+From f085865016733189a0e3c246e78f97ad03d90020 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:32 +0100
 Subject: [PATCH 07/44] VSOCK: Introduce virtio_vsock_common.ko

--- a/kernel/patches-4.4.x/0008-VSOCK-Introduce-virtio_transport.ko.patch
+++ b/kernel/patches-4.4.x/0008-VSOCK-Introduce-virtio_transport.ko.patch
@@ -1,4 +1,4 @@
-From 1ca60a870f53031a10d909f8704eec45485c145b Mon Sep 17 00:00:00 2001
+From e68cc033460e45b09a0c62883bede33ef8e7d7a7 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:33 +0100
 Subject: [PATCH 08/44] VSOCK: Introduce virtio_transport.ko

--- a/kernel/patches-4.4.x/0009-VSOCK-Introduce-vhost_vsock.ko.patch
+++ b/kernel/patches-4.4.x/0009-VSOCK-Introduce-vhost_vsock.ko.patch
@@ -1,4 +1,4 @@
-From 046aef3c4e52984035fa8c6245eea03daf4bb6fc Mon Sep 17 00:00:00 2001
+From 6e741b0543a2ef3ab5aba9077e6c3df70c9c9f81 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:34 +0100
 Subject: [PATCH 09/44] VSOCK: Introduce vhost_vsock.ko

--- a/kernel/patches-4.4.x/0010-VSOCK-Add-Makefile-and-Kconfig.patch
+++ b/kernel/patches-4.4.x/0010-VSOCK-Add-Makefile-and-Kconfig.patch
@@ -1,4 +1,4 @@
-From 24c1d6a5fc6075538591045899ceddc985b2d913 Mon Sep 17 00:00:00 2001
+From a22b78482a982556b1f160f8bcb49f26f6d3eb12 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:35 +0100
 Subject: [PATCH 10/44] VSOCK: Add Makefile and Kconfig

--- a/kernel/patches-4.4.x/0011-VSOCK-Use-kvfree.patch
+++ b/kernel/patches-4.4.x/0011-VSOCK-Use-kvfree.patch
@@ -1,4 +1,4 @@
-From acbb8fad5d2d446be198806be3a638e2fc47842f Mon Sep 17 00:00:00 2001
+From ddae8d61bc30e6adacc046a5f71c94e17c3f5913 Mon Sep 17 00:00:00 2001
 From: Wei Yongjun <weiyj.lk@gmail.com>
 Date: Tue, 2 Aug 2016 13:50:42 +0000
 Subject: [PATCH 11/44] VSOCK: Use kvfree()

--- a/kernel/patches-4.4.x/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
+++ b/kernel/patches-4.4.x/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
@@ -1,4 +1,4 @@
-From 6f18c754865212144f1473f8a30c2eaee99cf486 Mon Sep 17 00:00:00 2001
+From b6f92aa8c9ecd6b079f4fb4a60bcbf5d1d12cdb7 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 4 Aug 2016 14:52:53 +0100
 Subject: [PATCH 12/44] vhost/vsock: fix vhost virtio_vsock_pkt use-after-free

--- a/kernel/patches-4.4.x/0013-virtio-vsock-fix-include-guard-typo.patch
+++ b/kernel/patches-4.4.x/0013-virtio-vsock-fix-include-guard-typo.patch
@@ -1,4 +1,4 @@
-From 8b28af425ab7d1a989b605bd5f7c7c077928ad1d Mon Sep 17 00:00:00 2001
+From 9647e75a3b13fd4624fc5d27715e303d60ff195f Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Fri, 5 Aug 2016 13:52:09 +0100
 Subject: [PATCH 13/44] virtio-vsock: fix include guard typo

--- a/kernel/patches-4.4.x/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
+++ b/kernel/patches-4.4.x/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
@@ -1,4 +1,4 @@
-From 4af002eb78275dc2c489f4b6a7ea89cb8d2f0bca Mon Sep 17 00:00:00 2001
+From d58af1f7b4746bc72b7c3fcc472afc1a52d8d703 Mon Sep 17 00:00:00 2001
 From: Gerard Garcia <ggarcia@deic.uab.cat>
 Date: Wed, 10 Aug 2016 17:24:34 +0200
 Subject: [PATCH 14/44] vhost/vsock: drop space available check for TX vq

--- a/kernel/patches-4.4.x/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/kernel/patches-4.4.x/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,4 +1,4 @@
-From f1f59f16e41c6980daae15dc8afb7256ba97593b Mon Sep 17 00:00:00 2001
+From 9235762644913c58ab1bf0fb5c30c5d758609e85 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
 Subject: [PATCH 15/44] VSOCK: Only allow host network namespace to use

--- a/kernel/patches-4.4.x/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
+++ b/kernel/patches-4.4.x/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
@@ -1,4 +1,4 @@
-From 9c0ba54d98d8aac25bd16cff53145a20f25e24b7 Mon Sep 17 00:00:00 2001
+From eda06ba5ccd4612fdd8cd1052c5c16c110578ad0 Mon Sep 17 00:00:00 2001
 From: Jake Oshins <jakeo@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:41 -0800
 Subject: [PATCH 16/44] drivers:hv: Define the channel type for Hyper-V PCI

--- a/kernel/patches-4.4.x/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
+++ b/kernel/patches-4.4.x/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
@@ -1,4 +1,4 @@
-From 01c8ecad0d1157f3aea0f81597178662a39f48d6 Mon Sep 17 00:00:00 2001
+From 1d9663f5a2796b309b27160f0af4e5c4c0f18c83 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:43 -0800
 Subject: [PATCH 17/44] Drivers: hv: vmbus: Use uuid_le type consistently

--- a/kernel/patches-4.4.x/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
+++ b/kernel/patches-4.4.x/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
@@ -1,4 +1,4 @@
-From 022d71456eaf782543a64626e0b5c7caed71ef74 Mon Sep 17 00:00:00 2001
+From 3a8878f2643a9c283b61fea32055a5518225ff45 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:44 -0800
 Subject: [PATCH 18/44] Drivers: hv: vmbus: Use uuid_le_cmp() for comparing

--- a/kernel/patches-4.4.x/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
+++ b/kernel/patches-4.4.x/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
@@ -1,4 +1,4 @@
-From b12496b9356c8672186e1fc1410c3371ee6e3c2e Mon Sep 17 00:00:00 2001
+From a8ae4adc714d2f48b1cf5d6aeccc8c82e5d70286 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:48 -0800
 Subject: [PATCH 19/44] Drivers: hv: vmbus: do sanity check of channel state in

--- a/kernel/patches-4.4.x/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
+++ b/kernel/patches-4.4.x/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
@@ -1,4 +1,4 @@
-From 883c61ea4027d65921195e4ad08b3438c50b7da5 Mon Sep 17 00:00:00 2001
+From ed9bb4b2f7531355f35f73caef1de8ced325582f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:50 -0800
 Subject: [PATCH 20/44] Drivers: hv: vmbus: release relid on error in

--- a/kernel/patches-4.4.x/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
+++ b/kernel/patches-4.4.x/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
@@ -1,4 +1,4 @@
-From d65102ce43264db3d7022c5d901af0274ea36b1d Mon Sep 17 00:00:00 2001
+From 6078a1469613cd8ae73d701f0b75296b53645992 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:51 -0800
 Subject: [PATCH 21/44] Drivers: hv: vmbus: channge

--- a/kernel/patches-4.4.x/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
+++ b/kernel/patches-4.4.x/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
@@ -1,4 +1,4 @@
-From e779fd49a0004c2f87fac6fb090042ac073296b7 Mon Sep 17 00:00:00 2001
+From 1a4fcd51c1303c01488a792792b5dca837de3b41 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Mon, 14 Dec 2015 19:02:00 -0800
 Subject: [PATCH 22/44] Drivers: hv: remove code duplication between

--- a/kernel/patches-4.4.x/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
+++ b/kernel/patches-4.4.x/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
@@ -1,4 +1,4 @@
-From d3c59e89fb179b54e06c9ed2b54ff0837b9252e1 Mon Sep 17 00:00:00 2001
+From 27f8ff7c68cae02679c069b2c7b23e14abb46827 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Dec 2015 12:21:22 -0800
 Subject: [PATCH 23/44] Drivers: hv: vmbus: fix the building warning with

--- a/kernel/patches-4.4.x/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
+++ b/kernel/patches-4.4.x/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
@@ -1,4 +1,4 @@
-From 56db61ebf00e0da299cdf1024feb47bbad13fe18 Mon Sep 17 00:00:00 2001
+From 668161423bf5234ba5bfeb14c8e7e66bbce69cc7 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Tue, 15 Dec 2015 16:27:27 -0800
 Subject: [PATCH 24/44] Drivers: hv: vmbus: Treat Fibre Channel devices as

--- a/kernel/patches-4.4.x/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
+++ b/kernel/patches-4.4.x/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
@@ -1,4 +1,4 @@
-From 45c2b88e86b7c8e664cb8a8abbf7419b6409e7a2 Mon Sep 17 00:00:00 2001
+From 16e0a94e99ad3442a9379c7468df57f4ce8c670c Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Fri, 25 Dec 2015 20:00:30 -0800
 Subject: [PATCH 25/44] Drivers: hv: vmbus: Add vendor and device atttributes

--- a/kernel/patches-4.4.x/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
+++ b/kernel/patches-4.4.x/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
@@ -1,4 +1,4 @@
-From dd5942a9a75947e5e06e527f674600e67b392ae5 Mon Sep 17 00:00:00 2001
+From d3389a4bb44b67606dbd2a52443e6dee1f41903c Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:37 -0800
 Subject: [PATCH 26/44] Drivers: hv: vmbus: add a helper function to set a

--- a/kernel/patches-4.4.x/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
+++ b/kernel/patches-4.4.x/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
@@ -1,4 +1,4 @@
-From 1fa6ff43be2b82f661fa66e8669603e1caa8e5cb Mon Sep 17 00:00:00 2001
+From a4833dbcff7f2afd1ade9037b694c96ef2c55e9a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:38 -0800
 Subject: [PATCH 27/44] Drivers: hv: vmbus: define the new offer type for

--- a/kernel/patches-4.4.x/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
+++ b/kernel/patches-4.4.x/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
@@ -1,4 +1,4 @@
-From 6f516da849cad2eb753fe35e08a3353f8cfa1cde Mon Sep 17 00:00:00 2001
+From 40e732755e1420f4af2708b6507db8f468eed6e6 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:39 -0800
 Subject: [PATCH 28/44] Drivers: hv: vmbus: vmbus_sendpacket_ctl: hvsock: avoid

--- a/kernel/patches-4.4.x/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
+++ b/kernel/patches-4.4.x/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
@@ -1,4 +1,4 @@
-From dce0e762bdec2bc4919b5994169a538c0149ad11 Mon Sep 17 00:00:00 2001
+From e47b702fac77aca41a609d215fe2edcd6ba0ca8a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:40 -0800
 Subject: [PATCH 29/44] Drivers: hv: vmbus: define a new VMBus message type for

--- a/kernel/patches-4.4.x/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
+++ b/kernel/patches-4.4.x/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
@@ -1,4 +1,4 @@
-From 266eef3467b88025089ebd3f1996ef4e381a0306 Mon Sep 17 00:00:00 2001
+From c46c619d2fed44189a7aee83b80b7377c4d629d5 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:41 -0800
 Subject: [PATCH 30/44] Drivers: hv: vmbus: add a hvsock flag in struct

--- a/kernel/patches-4.4.x/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
+++ b/kernel/patches-4.4.x/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
@@ -1,4 +1,4 @@
-From f54c86bc24273b8c8687ce0e0e8e7fb0f63f5a17 Mon Sep 17 00:00:00 2001
+From 882ffbba712762a42f99b2b5c0f8faaeb304af5d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:42 -0800
 Subject: [PATCH 31/44] Drivers: hv: vmbus: add a per-channel rescind callback

--- a/kernel/patches-4.4.x/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
+++ b/kernel/patches-4.4.x/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
@@ -1,4 +1,4 @@
-From dec0462e4468a82204567297e23860ef7345fe8a Mon Sep 17 00:00:00 2001
+From 2a62dd8f306cbfe472da7c4f101392d39d0c9016 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:43 -0800
 Subject: [PATCH 32/44] Drivers: hv: vmbus: add an API

--- a/kernel/patches-4.4.x/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
+++ b/kernel/patches-4.4.x/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
@@ -1,4 +1,4 @@
-From 6013a0ecabce5d1373b5c505c23707164e31bf58 Mon Sep 17 00:00:00 2001
+From 7252800fbb2a5139ba09890fd6e0661bae81da94 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:45 -0800
 Subject: [PATCH 33/44] Drivers: hv: vmbus: Give control over how the ring

--- a/kernel/patches-4.4.x/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
+++ b/kernel/patches-4.4.x/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
@@ -1,4 +1,4 @@
-From f4c5342d4a7fe9e68e2595ad7922f608ade7aa90 Mon Sep 17 00:00:00 2001
+From e44228c16f9762cb41d72e43be893b495dd16b6a Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:16 -0800
 Subject: [PATCH 34/44] Drivers: hv: vmbus: avoid wait_for_completion() on

--- a/kernel/patches-4.4.x/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
+++ b/kernel/patches-4.4.x/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
@@ -1,4 +1,4 @@
-From 32c9f4b3fd836edd97455d1069b806f6284d4768 Mon Sep 17 00:00:00 2001
+From c12bf6dd35af915ea91a2b77c30ac6af6c1d0bb2 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:18 -0800
 Subject: [PATCH 35/44] Drivers: hv: vmbus: avoid unneeded compiler

--- a/kernel/patches-4.4.x/0036-kcm-Kernel-Connection-Multiplexor-module.patch
+++ b/kernel/patches-4.4.x/0036-kcm-Kernel-Connection-Multiplexor-module.patch
@@ -1,4 +1,4 @@
-From 2e116844edadec3cd662a0e233069dc62aa94943 Mon Sep 17 00:00:00 2001
+From 2f2c721a585f51ca062ef5c01e8c8c8fae9b08a4 Mon Sep 17 00:00:00 2001
 From: Tom Herbert <tom@herbertland.com>
 Date: Mon, 7 Mar 2016 14:11:06 -0800
 Subject: [PATCH 36/44] kcm: Kernel Connection Multiplexor module

--- a/kernel/patches-4.4.x/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4.x/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From 03424c40d68ba5a1a12463515540b382b3868baf Mon Sep 17 00:00:00 2001
+From df6f53e7e114aff82892cb7c7ba545f9cc53a05d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:51:09 -0700
 Subject: [PATCH 37/44] net: add the AF_KCM entries to family name tables

--- a/kernel/patches-4.4.x/0038-net-Add-Qualcomm-IPC-router.patch
+++ b/kernel/patches-4.4.x/0038-net-Add-Qualcomm-IPC-router.patch
@@ -1,4 +1,4 @@
-From 017ff57203c40c88b8689d4aaf369df953fa1d06 Mon Sep 17 00:00:00 2001
+From 3f2fbebff8f29b780fe49c360f5f4bfd9e245244 Mon Sep 17 00:00:00 2001
 From: Courtney Cavin <courtney.cavin@sonymobile.com>
 Date: Wed, 27 Apr 2016 12:13:03 -0700
 Subject: [PATCH 38/44] net: Add Qualcomm IPC router

--- a/kernel/patches-4.4.x/0039-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.4.x/0039-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From dc7c1989d8bc702dd71d0749226e233df27a14cc Mon Sep 17 00:00:00 2001
+From 74b1beed224843379bf096722504c0d9f2be5290 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 15 May 2016 09:53:11 -0700
 Subject: [PATCH 39/44] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.4.x/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4.x/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From 8e15a498069bdc1aaedb19460d7f3ca706fa466b Mon Sep 17 00:00:00 2001
+From 58de1ac0776e5b11824cc1a6040e04a2f41d011f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:53:08 -0700
 Subject: [PATCH 40/44] net: add the AF_HYPERV entries to family name tables

--- a/kernel/patches-4.4.x/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
+++ b/kernel/patches-4.4.x/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
@@ -1,4 +1,4 @@
-From 739524bb420ceda3d25d8aa60ce60bd954226a56 Mon Sep 17 00:00:00 2001
+From 228576533966d8649f77cb3a24db2a8cd885e69c Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 21 May 2016 16:55:50 +0800
 Subject: [PATCH 41/44] Drivers: hv: vmbus: fix the race when querying &

--- a/kernel/patches-4.4.x/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.4.x/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From e8e35e54e02c041e3f5ad823defd9474e9a8e5d1 Mon Sep 17 00:00:00 2001
+From ea2c749b3b5e3377c282c875198d9603e5fc6290 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 42/44] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.4.x/0043-fs-add-filp_clone_open-API.patch
+++ b/kernel/patches-4.4.x/0043-fs-add-filp_clone_open-API.patch
@@ -1,4 +1,4 @@
-From b0b62e16c8d8a8b6e60cec10acfb4d7bad58318c Mon Sep 17 00:00:00 2001
+From 1975a6b966000e16517637c5c3e50f063d126133 Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:49:38 -0800
 Subject: [PATCH 43/44] fs: add filp_clone_open API

--- a/kernel/patches-4.4.x/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
+++ b/kernel/patches-4.4.x/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
@@ -1,4 +1,4 @@
-From 730d3bfe1aa62085de6d997fc90c9d4756ed89d2 Mon Sep 17 00:00:00 2001
+From 46e13af65a8647ca3d7b905e114b3b08cb1baa52 Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:51:16 -0800
 Subject: [PATCH 44/44] binfmt_misc: add persistent opened binary handler for

--- a/kernel/patches-4.9.x/0001-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0001-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,7 +1,7 @@
-From bebcadfcf570ed3339f40cebeff53c79e1e6edb6 Mon Sep 17 00:00:00 2001
+From 03346ab53ed7b8630f0beb9f485c594893fea0b7 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
-Subject: [PATCH 01/10] hv_sock: introduce Hyper-V Sockets
+Subject: [PATCH 01/11] hv_sock: introduce Hyper-V Sockets
 
 Hyper-V Sockets (hv_sock) supplies a byte-stream based communication
 mechanism between the host and the guest. It's somewhat like TCP over
@@ -1787,5 +1787,5 @@ index 000000000000..331d3759f5cb
 +MODULE_DESCRIPTION("Hyper-V Sockets");
 +MODULE_LICENSE("Dual BSD/GPL");
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.9.x/0002-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0002-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,7 +1,7 @@
-From 22e169b0a7a89a4185fa24b616e8f2c8176b00bc Mon Sep 17 00:00:00 2001
+From 8c9e43ab0c900ec022e5ead9da3ae0f6c3550d1a Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
-Subject: [PATCH 02/10] vmbus: Don't spam the logs with unknown GUIDs
+Subject: [PATCH 02/11] vmbus: Don't spam the logs with unknown GUIDs
 
 With Hyper-V sockets device types are introduced on the fly. The pr_info()
 then prints a message on every connection, which is way too verbose.  Since
@@ -26,5 +26,5 @@ index d8bc4b910192..8df02f3ca0b2 100644
  }
  
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.9.x/0003-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0003-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,7 +1,7 @@
-From b1469b9da1d5cc11b859c68150b86fe63fd2fb63 Mon Sep 17 00:00:00 2001
+From 9a9e0018b0792a5d90a55f9f9884ca00b055570a Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
-Subject: [PATCH 03/10] Drivers: hv: utils: Fix the mapping between host
+Subject: [PATCH 03/11] Drivers: hv: utils: Fix the mapping between host
  version and protocol to use
 
 We should intentionally declare the protocols to use for every known host
@@ -44,5 +44,5 @@ index bcd06306f3e8..e7707747f56d 100644
  	}
  
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.9.x/0004-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0004-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,7 +1,7 @@
-From 42b0b930525dd64fa971301202a0e258de87c852 Mon Sep 17 00:00:00 2001
+From 5dee12c0277b5ab5f0565e3b398878558aef8f5f Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
-Subject: [PATCH 04/10] Drivers: hv: vss: Improve log messages.
+Subject: [PATCH 04/11] Drivers: hv: vss: Improve log messages.
 
 Adding log messages to help troubleshoot error cases and transaction
 handling.
@@ -101,5 +101,5 @@ index a76e3db0d01f..b1446d51ef45 100644
  	return 0;
  }
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.9.x/0005-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,7 +1,7 @@
-From 07edc21bf8fd9935767548acb8053c20bf94122e Mon Sep 17 00:00:00 2001
+From f13e08ae1e622240939ca89de246df4f2c7548e1 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
-Subject: [PATCH 05/10] Drivers: hv: vss: Operation timeouts should match host
+Subject: [PATCH 05/11] Drivers: hv: vss: Operation timeouts should match host
  expectation
 
 Increase the timeout of backup operations. When system is under I/O load,
@@ -44,5 +44,5 @@ index b1446d51ef45..4e543dbb731a 100644
  	rc = hvutil_transport_send(hvt, vss_msg, sizeof(*vss_msg), NULL);
  	if (rc) {
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,7 +1,7 @@
-From 4de61bfff1dad61236e61206b0da9b310e5cff3f Mon Sep 17 00:00:00 2001
+From df244245d15f278d893b35a2f89f1eb16aa056c7 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
-Subject: [PATCH 06/10] Drivers: hv: vmbus: Use all supported IC versions to
+Subject: [PATCH 06/11] Drivers: hv: vmbus: Use all supported IC versions to
  negotiate
 
 Previously, we were assuming that each IC protocol version was tied to a
@@ -488,5 +488,5 @@ index 489ad74c1e6e..956acfc93487 100644
  void hv_event_tasklet_disable(struct vmbus_channel *channel);
  void hv_event_tasklet_enable(struct vmbus_channel *channel);
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.9.x/0007-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,7 +1,7 @@
-From 4af1b7aeac8800fd387e05b808b850a80ba81800 Mon Sep 17 00:00:00 2001
+From 2aa2225bcfc4aecae9bc96eb2ed77d89bc0ea31a Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
-Subject: [PATCH 07/10] Drivers: hv: Log the negotiated IC versions.
+Subject: [PATCH 07/11] Drivers: hv: Log the negotiated IC versions.
 
 Log the negotiated IC versions.
 
@@ -114,5 +114,5 @@ index f3797c07be10..89440c2eb346 100644
  					hb_srv_version & 0xFFFF);
  			}
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.9.x/0008-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0008-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,7 +1,7 @@
-From 39a8a807834cbacf175f0a4d8f934918aa96b652 Mon Sep 17 00:00:00 2001
+From a0550b2fcf751edd0ad064a7f2b6a5073266379e Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
-Subject: [PATCH 08/10] vmbus: fix missed ring events on boot
+Subject: [PATCH 08/11] vmbus: fix missed ring events on boot
 
 During initialization, the channel initialization code schedules the
 tasklet to scan the VMBUS receive event page (i.e. simulates an
@@ -52,5 +52,5 @@ index e7949b64bfbc..2fe024e86209 100644
  
  void hv_process_channel_removal(struct vmbus_channel *channel, u32 relid)
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.9.x/0009-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0009-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,7 +1,7 @@
-From 6103845814b39c73c1745898e9bb785c0b40b81d Mon Sep 17 00:00:00 2001
+From 7775a44dbae9741449f73361124c5357a56b46c3 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
-Subject: [PATCH 09/10] vmbus: remove "goto error_clean_msglist" in
+Subject: [PATCH 09/11] vmbus: remove "goto error_clean_msglist" in
  vmbus_open()
 
 This is just a cleanup patch to simplify the code a little.
@@ -56,5 +56,5 @@ index 1606e7f08f4b..1caed01954f6 100644
  	vmbus_teardown_gpadl(newchannel, newchannel->ringbuffer_gpadlhandle);
  	kfree(open_info);
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.9.x/0010-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,7 +1,7 @@
-From b6c139b4368a30b22fae95abff5233e3c8cec10c Mon Sep 17 00:00:00 2001
+From 71b4ddd8f0e46a27e8c6d7f121b2b00e99275b13 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
-Subject: [PATCH 10/10] vmbus: dynamically enqueue/dequeue the channel on
+Subject: [PATCH 10/11] vmbus: dynamically enqueue/dequeue the channel on
  vmbus_open/close
 
 Signed-off-by: Dexuan Cui <decui@microsoft.com>
@@ -173,5 +173,5 @@ index 956acfc93487..9ee292b28e41 100644
  
  void vmbus_setevent(struct vmbus_channel *channel);
 -- 
-2.11.1
+2.11.0
 

--- a/kernel/patches-4.9.x/0011-scsi-storvsc-Workaround-for-virtual-DVD-SCSI-version.patch
+++ b/kernel/patches-4.9.x/0011-scsi-storvsc-Workaround-for-virtual-DVD-SCSI-version.patch
@@ -1,0 +1,94 @@
+From 4addded16fd89ad950103cca7af3dfea1f644cea Mon Sep 17 00:00:00 2001
+From: Stephen Hemminger <stephen@networkplumber.org>
+Date: Tue, 7 Mar 2017 09:15:53 -0800
+Subject: [PATCH 11/11] scsi: storvsc: Workaround for virtual DVD SCSI version
+
+Hyper-V host emulation of SCSI for virtual DVD device reports SCSI
+version 0 (UNKNOWN) but is still capable of supporting REPORTLUN.
+
+Without this patch, a GEN2 Linux guest on Hyper-V will not boot 4.11
+successfully with virtual DVD ROM device. What happens is that the SCSI
+scan process falls back to doing sequential probing by INQUIRY.  But the
+storvsc driver has a previous workaround that masks/blocks all errors
+reports from INQUIRY (or MODE_SENSE) commands.  This workaround causes
+the scan to then populate a full set of bogus LUN's on the target and
+then sends kernel spinning off into a death spiral doing block reads on
+the non-existent LUNs.
+
+By setting the correct blacklist flags, the target with the DVD device
+is scanned with REPORTLUN and that works correctly.
+
+Patch needs to go in current 4.11, it is safe but not necessary in older
+kernels.
+
+Signed-off-by: Stephen Hemminger <sthemmin@microsoft.com>
+Reviewed-by: K. Y. Srinivasan <kys@microsoft.com>
+Reviewed-by: Christoph Hellwig <hch@lst.de>
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+(cherry picked from commit f1c635b439a5c01776fe3a25b1e2dc546ea82e6f)
+---
+ drivers/scsi/storvsc_drv.c | 27 +++++++++++++++++----------
+ 1 file changed, 17 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/scsi/storvsc_drv.c b/drivers/scsi/storvsc_drv.c
+index 3f218f5cf29b..c5ab1b0037fc 100644
+--- a/drivers/scsi/storvsc_drv.c
++++ b/drivers/scsi/storvsc_drv.c
+@@ -400,8 +400,6 @@ MODULE_PARM_DESC(storvsc_vcpus_per_sub_channel, "Ratio of VCPUs to subchannels")
+  */
+ static int storvsc_timeout = 180;
+ 
+-static int msft_blist_flags = BLIST_TRY_VPD_PAGES;
+-
+ #if IS_ENABLED(CONFIG_SCSI_FC_ATTRS)
+ static struct scsi_transport_template *fc_transport_template;
+ #endif
+@@ -1283,6 +1281,22 @@ static int storvsc_do_io(struct hv_device *device,
+ 	return ret;
+ }
+ 
++static int storvsc_device_alloc(struct scsi_device *sdevice)
++{
++	/*
++	 * Set blist flag to permit the reading of the VPD pages even when
++	 * the target may claim SPC-2 compliance. MSFT targets currently
++	 * claim SPC-2 compliance while they implement post SPC-2 features.
++	 * With this flag we can correctly handle WRITE_SAME_16 issues.
++	 *
++	 * Hypervisor reports SCSI_UNKNOWN type for DVD ROM device but
++	 * still supports REPORT LUN.
++	 */
++	sdevice->sdev_bflags = BLIST_REPORTLUN2 | BLIST_TRY_VPD_PAGES;
++
++	return 0;
++}
++
+ static int storvsc_device_configure(struct scsi_device *sdevice)
+ {
+ 
+@@ -1298,14 +1312,6 @@ static int storvsc_device_configure(struct scsi_device *sdevice)
+ 	sdevice->no_write_same = 1;
+ 
+ 	/*
+-	 * Add blist flags to permit the reading of the VPD pages even when
+-	 * the target may claim SPC-2 compliance. MSFT targets currently
+-	 * claim SPC-2 compliance while they implement post SPC-2 features.
+-	 * With this patch we can correctly handle WRITE_SAME_16 issues.
+-	 */
+-	sdevice->sdev_bflags |= msft_blist_flags;
+-
+-	/*
+ 	 * If the host is WIN8 or WIN8 R2, claim conformance to SPC-3
+ 	 * if the device is a MSFT virtual device.  If the host is
+ 	 * WIN10 or newer, allow write_same.
+@@ -1569,6 +1575,7 @@ static struct scsi_host_template scsi_driver = {
+ 	.eh_host_reset_handler =	storvsc_host_reset_handler,
+ 	.proc_name =		"storvsc_host",
+ 	.eh_timed_out =		storvsc_eh_timed_out,
++	.slave_alloc =		storvsc_device_alloc,
+ 	.slave_configure =	storvsc_device_configure,
+ 	.cmd_per_lun =		255,
+ 	.this_id =		-1,
+-- 
+2.11.0
+


### PR DESCRIPTION
This also adds the cherry-picked commit f1c635b439a5c017 ("scsi: storvsc: Workaround
for virtual DVD SCSI version") from 4.11 for the 4.9 and 4.10 kernels. This commit
fixes a crash/memory leak on Hyper-V when no disk drives are attached and if one
boots of a CD-ROM drive.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

resolves #1659