### PR TITLE
Code in the initrd generator to split a single tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,5 +65,5 @@ ci-pr:
 
 .PHONY: clean
 clean:
-	rm -rf bin *.log *-kernel *-cmdline *.img *.iso *.tar.gz *.qcow2 *.vhd *.vmx *.vmdk
+	rm -rf bin *.log *-kernel *-cmdline *.img *.iso *.tar.gz *.qcow2 *.vhd *.vmx *.vmdk *.tar
 	$(MAKE) -C test clean


### PR DESCRIPTION
In the WIP code in `moby` we now have a standard base tarball format,
that includes the kernel and cmdline as files in `/boot` so that the
entire output of the yaml file can default to a single tarball. Then
this can be split back up by LinuxKit into initrd, kernel and cmdline
as needed. This will probably become the only output of the `moby build`
stage, with a `moby package` stage dealing with output formats.

We may remove the output format specification from the yaml file as well,
and just have it in the command.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>
