### PR TITLE
Update containerd

### DIFF
--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -20,4 +20,4 @@ RUN cp bin/containerd bin/ctr bin/containerd-shim bin/dist /usr/bin/
 WORKDIR /
 COPY . .
 RUN printf "FROM scratch\nCOPY /usr/bin/* /usr/bin/\nCOPY /etc/containerd/config.toml /etc/containerd/\n" > Dockerfile
-CMD ["tar", "cf", "-", "Dockerfile", "usr/bin/containerd", "usr/bin/ctr", "usr/bin/containerd-shim", "usr/bin/dist", "etc/containerd/config.toml"]
+CMD ["tar", "cf", "-", "Dockerfile", "usr/bin/containerd", "usr/bin/ctr", "usr/bin/containerd-shim", "etc/containerd/config.toml"]

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -9,10 +9,10 @@ RUN \
   linux-headers \
   make \
   && true
-ENV CONTAINERD_COMMIT=ffe684b017252262431e157741406d4e1fb22831
+ENV CONTAINERD_COMMIT=25a161bf5d4483bd0bea9e38b0e8fe3ecb17b53e
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
-  git clone https://github.com/justincormack/containerd.git
+  git clone https://github.com/containerd/containerd.git
 WORKDIR $GOPATH/src/github.com/containerd/containerd
 RUN git checkout $CONTAINERD_COMMIT
 RUN make binaries GO_GCFLAGS="-buildmode pie --ldflags '-extldflags \"-fno-PIC -static\"'"


### PR DESCRIPTION
My patch was upstreamed so update, even though we won't need it soon.

Remove `dist` from bundle as we don't need it.

Not going to update anything that uses it as needs shifting to new Alpine package anyway (needs Go added still, will do this).
