### PR TITLE
Metadata fix + a simpler file content option

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -29,10 +29,7 @@ For example, the following userdata file:
         }
     },
     "foo" : {
-        "bar" : {
-            "perm": "0644",
-            "content": "foobar"
-        },
+        "bar" : "foobar",
         "baz" : {
             "perm": "0600",
             "content": "bar"
@@ -46,6 +43,16 @@ will generate the following files:
 /var/config/foo/bar
 /var/config/foo/baz
 ```
+
+Each file can either be:
+
+- a simple string (as for `foo/bar` above) in which case the file will
+  be created with the given contents and read/write (but not execute)
+  permissions for user and read permissions for group and everyone else (in octal format `0644`).
+- a map (as for `ssh/sshd_config` and `foo/baz` above) with the
+  following mandatory keys:
+  - `content`: the contents of the file.
+  - `perm`: the permissions to create the file with.
 
 This hierarchy can then be used by individual containers, who can bind
 mount the config sub-directory into their namespace where it is

--- a/pkg/metadata/main.go
+++ b/pkg/metadata/main.go
@@ -167,25 +167,31 @@ func processUserData(data []byte) error {
 			continue
 		}
 		for f, i := range files {
-			fi, ok := i.(map[string]interface{})
-			if !ok {
+			p := uint64(0644)
+			var c string
+
+			switch fi := i.(type) {
+			case map[string]interface{}:
+				if _, ok := fi["perm"]; !ok {
+					log.Printf("No permission provided %s:%s", f, fi)
+					continue
+				}
+				if _, ok := fi["content"]; !ok {
+					log.Printf("No content provided %s:%s", f, fi)
+					continue
+				}
+				c = fi["content"].(string)
+				if p, err = strconv.ParseUint(fi["perm"].(string), 8, 32); err != nil {
+					log.Printf("Failed to parse permission %s: %s", fi, err)
+					continue
+				}
+			case string:
+				c = fi
+			default:
 				log.Printf("Couldn't convert JSON for items: %s", i)
 				continue
 			}
-			if _, ok := fi["perm"]; !ok {
-				log.Printf("No permission provided %s:%s", f, fi)
-				continue
-			}
-			if _, ok := fi["content"]; !ok {
-				log.Printf("No content provided %s:%s", f, fi)
-				continue
-			}
-			c := fi["content"].(string)
-			p, err := strconv.ParseUint(fi["perm"].(string), 8, 32)
-			if err != nil {
-				log.Printf("Failed to parse permission %s: %s", fi, err)
-				continue
-			}
+
 			if err := ioutil.WriteFile(path.Join(dir, f), []byte(c), os.FileMode(p)); err != nil {
 				log.Printf("Failed to write %s/%s: %s", dir, f, err)
 				continue

--- a/pkg/metadata/main.go
+++ b/pkg/metadata/main.go
@@ -167,9 +167,9 @@ func processUserData(data []byte) error {
 			continue
 		}
 		for f, i := range files {
-			fi := i.(map[string]interface{})
+			fi, ok := i.(map[string]interface{})
 			if !ok {
-				log.Printf("Could convert JSON for items: %s", i)
+				log.Printf("Couldn't convert JSON for items: %s", i)
 				continue
 			}
 			if _, ok := fi["perm"]; !ok {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed a bug in parsing the input JSON and added a less verbose mechanism to populate a data (i.e. not executable) file 

**- How I did it**

If a file key corresponds to a string rather than a map take that to be the desired file contents and write it with the default rw permissions (moduo `umask`). If the key corresponds to a map then the existing scheme (with separate `content` and `perm` keys) is maintained.

**- How to verify it**

Provide e.g. `{ "foo": { "bar": "some contents" } }` and observe that `/var/config/foo/bar` contains `some contents`.

**- Description for the changelog**
Metadata JSON can now contain a simple string which will be written to the file

**- A picture of a cute animal (not mandatory but encouraged)**
![Faith No More, Angel Dust](https://upload.wikimedia.org/wikipedia/en/2/24/Faith_no_more_angel_dust.jpg)
