### PR TITLE
Add `linuxkit metadata create` command

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -51,6 +51,15 @@ This hierarchy can then be used by individual containers, who can bind
 mount the config sub-directory into their namespace where it is
 needed.
 
+# Metadata image creation
+
+Run `linuxkit run` backends accept a `--data=STRING` option which will
+cause the given string to be passed to the VM in a platform specific
+manner to be picked up by the `pkg/metadata` component.
+
+Alternatively `linuxkit metadata create meta.iso STRING` will produce
+a correctly formatted ISO image which can be passed to a VM as a CDROM
+device for consumption by the `pkg/metadata` component.
 
 # Providers
 

--- a/src/cmd/linuxkit/main.go
+++ b/src/cmd/linuxkit/main.go
@@ -41,6 +41,7 @@ func main() {
 	flag.Usage = func() {
 		fmt.Printf("USAGE: %s [options] COMMAND\n\n", filepath.Base(os.Args[0]))
 		fmt.Printf("Commands:\n")
+		fmt.Printf("  metadata    Metadata utilities\n")
 		fmt.Printf("  push        Push a VM image to a cloud or image store\n")
 		fmt.Printf("  run         Run a VM image on a local hypervisor or remote cloud\n")
 		fmt.Printf("  version     Print version information\n")
@@ -79,6 +80,8 @@ func main() {
 	}
 
 	switch args[0] {
+	case "metadata":
+		metadata(args[1:])
 	case "push":
 		push(args[1:])
 	case "run":

--- a/src/cmd/linuxkit/metadata.go
+++ b/src/cmd/linuxkit/metadata.go
@@ -9,6 +9,17 @@ import (
 	"github.com/rneugeba/iso9660wrap"
 )
 
+// WriteMetadataISO writes a metadata ISO file in a format usable by pkg/metadata
+func WriteMetadataISO(path string, content []byte) error {
+	outfh, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer outfh.Close()
+
+	return iso9660wrap.WriteBuffer(outfh, content, "config")
+}
+
 func metadataCreateUsage() {
 	invoked := filepath.Base(os.Args[0])
 	fmt.Printf("USAGE: %s metadata create [file.iso] [metadata]\n\n", invoked)
@@ -32,15 +43,8 @@ func metadataCreate(args []string) {
 	isoImage := args[0]
 	metadata := args[1]
 
-	outfh, err := os.OpenFile(isoImage, os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		log.Fatal("Cannot create user data ISOs", "err", err)
-	}
-	defer outfh.Close()
-
-	err = iso9660wrap.WriteBuffer(outfh, []byte(metadata), "config")
-	if err != nil {
-		log.Fatal("Cannot write user data ISO", "err", err)
+	if err := WriteMetadataISO(isoImage, []byte(metadata)); err != nil {
+		log.Fatal("Failed to write user data ISO: ", err)
 	}
 }
 

--- a/src/cmd/linuxkit/metadata.go
+++ b/src/cmd/linuxkit/metadata.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/rneugeba/iso9660wrap"
+)
+
+func metadataCreateUsage() {
+	invoked := filepath.Base(os.Args[0])
+	fmt.Printf("USAGE: %s metadata create [file.iso] [metadata]\n\n", invoked)
+
+	fmt.Printf("'file.iso' is the file to create.\n")
+	fmt.Printf("'metadata' will be written to '/config' in the ISO.\n")
+	fmt.Printf("This is compatible with the linuxkit/metadata package\n")
+}
+
+func metadataCreate(args []string) {
+	if len(args) != 2 {
+		metadataCreateUsage()
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "help", "-h", "-help", "--help":
+		metadataCreateUsage()
+		os.Exit(0)
+	}
+
+	isoImage := args[0]
+	metadata := args[1]
+
+	outfh, err := os.OpenFile(isoImage, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatal("Cannot create user data ISOs", "err", err)
+	}
+	defer outfh.Close()
+
+	err = iso9660wrap.WriteBuffer(outfh, []byte(metadata), "config")
+	if err != nil {
+		log.Fatal("Cannot write user data ISO", "err", err)
+	}
+}
+
+func metadataUsage() {
+	invoked := filepath.Base(os.Args[0])
+	fmt.Printf("USAGE: %s metadata COMMAND [options]\n\n", invoked)
+	fmt.Printf("Commands:\n")
+	fmt.Printf("  create      Create a metadata ISO\n")
+}
+
+func metadata(args []string) {
+	if len(args) < 1 {
+		metadataUsage()
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "help", "-h", "-help", "--help":
+		metadataUsage()
+		os.Exit(0)
+	}
+
+	switch args[0] {
+	case "create":
+		metadataCreate(args[1:])
+	default:
+		fmt.Printf("%q is not a valid metadata command.\n\n", args[0])
+		metadataUsage()
+		os.Exit(1)
+	}
+}

--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -10,7 +10,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/moby/hyperkit/go"
-	"github.com/rneugeba/iso9660wrap"
 	"github.com/satori/go.uuid"
 )
 
@@ -56,16 +55,8 @@ func runHyperKit(args []string) {
 			}
 		}
 		isoPath = prefix + "-data.iso"
-		outfh, err := os.OpenFile(isoPath, os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			log.Fatalf("Cannot create user data ISO: %v", err)
-		}
-		err = iso9660wrap.WriteBuffer(outfh, d, "config")
-		if err != nil {
-			log.Fatalf("Cannot write user data ISO: %v", err)
-		}
-		if err = outfh.Close(); err != nil {
-			log.Fatalf("Cannot close output ISO: %v", err)
+		if err := WriteMetadataISO(isoPath, d); err != nil {
+			log.Fatalf("Cannot write user data ISO: %s", err)
 		}
 	}
 


### PR DESCRIPTION
This is a thin wrapper to create an iso file in the format expected by
`pkg/metadata`.

Currently very basic and just takes the content on the command line but could
be extended to read from a file etc.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a new `linuxkit` subcommand to create a metadata iso

**- How I did it**

Emacs

**- How to verify it**

Run `linuxkit mkmetadata meta.iso '{ "foo": { "bar": "some contents" } }'` and boot an image (with #1802 merged) using that ISO. Observe that `/var/config/foo/bar` contains `some contents`

**- Description for the changelog**
Added new `mkmetadata` subcommand to `linuxkit`

**- A picture of a cute animal (not mandatory but encouraged)**
![Satyricon, Volcano](https://upload.wikimedia.org/wikipedia/en/7/77/Volcano_-_satyricon.jpg)