### PR TITLE
Add image builder for compressed disk image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ Dockerfile.media
 *.iso
 *.vhd
 *.tar
-*.tar.gz
+*.gz
 *.vhdx
 *.efi
 *.qcow2

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 PREFIX?=/usr/local/
 
-MOBY_COMMIT=1135cdddcc31ab010ae4dc69a86d56a7182ce607
+MOBY_COMMIT=a9a00fae6204a89baeed6903c7e2901412c1ede0
 bin/moby: | bin
 	docker run --rm --log-driver=none $(CROSS) $(GO_COMPILE) --clone-path github.com/moby/tool --clone https://github.com/moby/tool.git --commit $(MOBY_COMMIT) --package github.com/moby/tool/cmd/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
 	tar xf tmp_moby_bin.tar > $@
@@ -65,5 +65,5 @@ ci-pr:
 
 .PHONY: clean
 clean:
-	rm -rf bin *.log *-kernel *-cmdline *.img *.iso *.tar.gz *.qcow2 *.vhd *.vmx *.vmdk *.tar
+	rm -rf bin *.log *-kernel *-cmdline *.img *.iso *.gz *.qcow2 *.vhd *.vmx *.vmdk *.tar
 	$(MAKE) -C test clean

--- a/tools/mkimage-img-gz/Dockerfile
+++ b/tools/mkimage-img-gz/Dockerfile
@@ -1,0 +1,5 @@
+FROM linuxkit/guestfs:2657580764d5791e103647237dac5a0276533e2e@sha256:8f99eba6720df17bce8893052d7ca9a07cdc9cd09b335a5a9c57ebd5a44934be
+
+COPY . .
+
+ENTRYPOINT [ "/make-img-gz" ]

--- a/tools/mkimage-img-gz/Makefile
+++ b/tools/mkimage-img-gz/Makefile
@@ -1,0 +1,27 @@
+.PHONY: tag push
+
+IMAGE=mkimage-img-gz
+
+default: push
+
+hash: Dockerfile make-img-gz
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --entrypoint sh --rm $(IMAGE):build -c "(cat $^; apt list --installed 2>/dev/null) | sha1sum" | sed 's/ .*//' > hash
+
+push: hash
+	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
+		 docker push linuxkit/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/tools/mkimage-img-gz/make-img-gz
+++ b/tools/mkimage-img-gz/make-img-gz
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+set -e
+
+SIZE="$1"
+[ -z "$SIZE" ] && SIZE=1G
+
+mkdir -p /tmp/image
+cd /tmp/image
+
+# input is a tarball of kernel and initrd.img on stdin
+# output is a compressed raw disk image on stdout
+
+mkdir -p files
+
+cd files
+
+# extract. As guestfs base is currently Debian, no compression support
+# only if stdin is a tty, if so need files volume mounted...
+[ -t 0 ] || tar xf -
+
+INITRD="$(find . -name '*.img')"
+KERNEL="$(find . -name kernel -or -name bzImage)"
+CMDLINE_FILE="$(find . -name cmdline)"
+CMDLINE="$(cat $CMDLINE_FILE)"
+
+[ "$KERNEL" = "./kernel" ] || mv "$KERNEL" kernel
+[ "$INITRD" = "./initrd.img" ] || mv "$INITRD" initrd.img
+
+# clean up subdirectories
+find . -mindepth 1 -maxdepth 1 -type d | xargs rm -rf
+
+CFG="DEFAULT linux
+LABEL linux
+    KERNEL /kernel
+    INITRD /initrd.img
+    APPEND ${CMDLINE}
+"
+
+printf "$CFG" > syslinux.cfg
+
+cd ..
+
+tar cf files.tar -C files .
+
+virt-make-fs --size=${SIZE} --type=ext4 --partition files.tar disk.raw
+
+guestfish -a disk.raw -m /dev/sda1 <<EOF
+  upload /usr/lib/SYSLINUX/mbr.bin /mbr.bin
+  copy-file-to-device /mbr.bin /dev/sda size:440
+  rm /mbr.bin
+  extlinux /
+  part-set-bootable /dev/sda 1 true
+EOF
+
+cat disk.raw | gzip -9


### PR DESCRIPTION
This is a fairly generic bootable disk with syslinux. Should
work if you `dd` it onto a USB stick, and should also work for AWS.

You need to uncompress it of course! Default size is 1G.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

`moby` PR coming shortly.

![hedgehogs](https://cloud.githubusercontent.com/assets/482364/26000042/4cf39248-371f-11e7-9709-932c4bc240d6.jpg)
