### PR TITLE
pkg/runc: WORKDIR as first item in second stage

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
 onboot:
   - name: dhcpcd

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:fe1b7f438a234cb6481c6538295115eac2a0596d
 services:
   - name: rngd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS1 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -5,7 +5,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
 services:
   - name: dhcpcd

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:42fe8cb1508b3afed39eb89821906e3cc7a70551
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -22,6 +22,6 @@ RUN make static BUILDTAGS="seccomp"
 RUN cp runc /usr/bin/
 
 FROM scratch
-ENTRYPOINT []
 WORKDIR /
+ENTRYPOINT []
 COPY --from=alpine /usr/bin/runc /usr/bin/

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:fe1b7f438a234cb6481c6538295115eac2a0596d
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:062e57b1d1e017e44c6339fc2b4cd41f3f10b2a9 # with runc, logwrite, startmemlogd
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/test/cases/test-docker-bench.yml
+++ b/test/cases/test-docker-bench.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/test/cases/test-kernel-config.yml
+++ b/test/cases/test-kernel-config.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/test/cases/test-ltp.yml
+++ b/test/cases/test-ltp.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/test/cases/test-virtsock-server.yml
+++ b/test/cases/test-virtsock-server.yml
@@ -7,7 +7,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
   - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
 onboot:

--- a/test/kmod/kmod.yml
+++ b/test/kmod/kmod.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
   - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
 onboot:
   - name: check


### PR DESCRIPTION
Works around https://github.com/moby/moby/issues/33176 and fixes #1807.

Updated al users of linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38 to
this new build.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Removed unexpected `/root/go/src/github.com/opencontainers/runc` from runc image.

**- How I did it**

Moving the `WORKDIR` immediately after the `FROM scratch` to workaround https://github.com/moby/moby/issues/33176

**- How to verify it**

Use `docker save` to inspect the image (as shown in #1807) or boot a LinuxKit image and check for `/root/go`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Removed stray `/root/go/src/github.com/opencontainers/runc` from runc image.

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://upload.wikimedia.org/wikipedia/en/f/f9/PearlJam-Vs.jpg "Pearl Jam, Vs")
