### PR TITLE
Add rm flag to projects/kubernetes ssh script

### DIFF
--- a/projects/kubernetes/ssh.sh
+++ b/projects/kubernetes/ssh.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -eux
 docker run \
+  --rm \
   -ti \
   -v ~/.ssh/:/root/.ssh \
     jdeathe/centos-ssh \


### PR DESCRIPTION
Signed-off-by: Jesse Adametz <jesseadametz@gmail.com>

Fixes #1814 

**- What I did**

Added the `--rm` flag to the `docker run` command inside of `projects/kubernetes/ssh.sh`