### PR TITLE
Specifies root user in projects/kubernetes ssh_into_kubelet script

### DIFF
--- a/projects/kubernetes/ssh_into_kubelet.sh
+++ b/projects/kubernetes/ssh_into_kubelet.sh
@@ -1,2 +1,2 @@
 #!/bin/bash -eux
-./ssh.sh -t "$1" nsenter --mount --target 1 runc exec --tty kubelet ash -l
+./ssh.sh -t root@"$1" nsenter --mount --target 1 runc exec --tty kubelet ash -l


### PR DESCRIPTION
Signed-off-by: Jesse Adametz <jesseadametz@gmail.com>

Fixes #1817 

**- What I did**

Specified `root@` before the interpreted IP address within the `projects/kubernetes/ssh_into_kubelet.sh` script.

**- How to verify it**

Follow the `projects/kubernetes/README.md` instructions and successfully SSH into a running kubelet without having to manually specify the user.