### PR TITLE
cmd: Enable virtio sockets for HyperKit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Dockerfile.media
 *.vhdx
 *.efi
 *.qcow2
-*-kernel$
+*-kernel
 *-cmdline
+*-hyperkit
 artifacts/*

--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -87,7 +87,9 @@ func runHyperKit(args []string) {
 		*disk = prefix + "-disk.img"
 	}
 
-	h, err := hyperkit.New(*hyperkitPath, "auto", "")
+	stateDir := prefix + "-hyperkit"
+
+	h, err := hyperkit.New(*hyperkitPath, "auto", stateDir)
 	if err != nil {
 		log.Fatalln("Error creating hyperkit: ", err)
 	}
@@ -98,6 +100,7 @@ func runHyperKit(args []string) {
 	h.UUID = vmUUID
 	h.DiskImage = *disk
 	h.ISOImage = isoPath
+	h.VSock = true
 	h.CPUs = *cpus
 	h.Memory = *mem
 	h.DiskSize = *diskSz


### PR DESCRIPTION
HyperKit optionally exposes virtio sockets via a named pipes
in a directory. This patch passes a state directory and sets
the VSock flag to enable this feature.

Note, this will create a directory called 'prefix'-hyperkit
on every execution of 'linuxkit run hyperkit'.

While at it, also fix the .gitignore settings for kernels.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

![image](https://cloud.githubusercontent.com/assets/3338098/26032388/5fa4503c-388a-11e7-8c8e-6453fda5a1b8.png)
