### PR TITLE
Use a "state" directory for linuxkit run state and enable virtio sockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Dockerfile.media
 *.vhdx
 *.efi
 *.qcow2
-*-kernel$
+*-kernel
 *-cmdline
+*-state
 artifacts/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ Dockerfile.media
 *.tag
 *.iso
 *.vhd
+*.vmdk
+*.vmdk.lck
 *.tar
 *.gz
 *.vhdx

--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,4 @@ ci-pr:
 
 .PHONY: clean
 clean:
-	rm -rf bin *.log *-kernel *-cmdline *.img *.iso *.gz *.qcow2 *.vhd *.vmx *.vmdk *.tar
+	rm -rf bin *.log *-kernel *-cmdline *-state *.img *.iso *.gz *.qcow2 *.vhd *.vmx *.vmdk *.tar 

--- a/src/cmd/linuxkit/run_gcp.go
+++ b/src/cmd/linuxkit/run_gcp.go
@@ -27,31 +27,31 @@ const (
 
 // Process the run arguments and execute run
 func runGcp(args []string) {
-	gcpCmd := flag.NewFlagSet("gcp", flag.ExitOnError)
+	flags := flag.NewFlagSet("gcp", flag.ExitOnError)
 	invoked := filepath.Base(os.Args[0])
-	gcpCmd.Usage = func() {
+	flags.Usage = func() {
 		fmt.Printf("USAGE: %s run gcp [options] [name]\n\n", invoked)
 		fmt.Printf("'name' specifies either the name of an already uploaded\n")
 		fmt.Printf("GCP image or the full path to a image file which will be\n")
 		fmt.Printf("uploaded before it is run.\n\n")
 		fmt.Printf("Options:\n\n")
-		gcpCmd.PrintDefaults()
+		flags.PrintDefaults()
 	}
-	zoneFlag := gcpCmd.String("zone", defaultZone, "GCP Zone")
-	machineFlag := gcpCmd.String("machine", defaultMachine, "GCP Machine Type")
-	keysFlag := gcpCmd.String("keys", "", "Path to Service Account JSON key file")
-	projectFlag := gcpCmd.String("project", "", "GCP Project Name")
-	diskSizeFlag := gcpCmd.Int("disk-size", 0, "Size of system disk in GB")
-	skipCleanup := gcpCmd.Bool("skip-cleanup", false, "Don't remove images or VMs")
+	zoneFlag := flags.String("zone", defaultZone, "GCP Zone")
+	machineFlag := flags.String("machine", defaultMachine, "GCP Machine Type")
+	keysFlag := flags.String("keys", "", "Path to Service Account JSON key file")
+	projectFlag := flags.String("project", "", "GCP Project Name")
+	diskSizeFlag := flags.Int("disk-size", 0, "Size of system disk in GB")
+	skipCleanup := flags.Bool("skip-cleanup", false, "Don't remove images or VMs")
 
-	if err := gcpCmd.Parse(args); err != nil {
+	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
 	}
 
-	remArgs := gcpCmd.Args()
+	remArgs := flags.Args()
 	if len(remArgs) == 0 {
 		fmt.Printf("Please specify the name of the image to boot\n")
-		gcpCmd.Usage()
+		flags.Usage()
 		os.Exit(1)
 	}
 	name := remArgs[0]

--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -15,31 +15,31 @@ import (
 
 // Process the run arguments and execute run
 func runHyperKit(args []string) {
-	hyperkitCmd := flag.NewFlagSet("hyperkit", flag.ExitOnError)
+	flags := flag.NewFlagSet("hyperkit", flag.ExitOnError)
 	invoked := filepath.Base(os.Args[0])
-	hyperkitCmd.Usage = func() {
+	flags.Usage = func() {
 		fmt.Printf("USAGE: %s run hyperkit [options] prefix\n\n", invoked)
 		fmt.Printf("'prefix' specifies the path to the VM image.\n")
 		fmt.Printf("\n")
 		fmt.Printf("Options:\n")
-		hyperkitCmd.PrintDefaults()
+		flags.PrintDefaults()
 	}
-	hyperkitPath := hyperkitCmd.String("hyperkit", "", "Path to hyperkit binary (if not in default location)")
-	cpus := hyperkitCmd.Int("cpus", 1, "Number of CPUs")
-	mem := hyperkitCmd.Int("mem", 1024, "Amount of memory in MB")
-	diskSz := hyperkitCmd.Int("disk-size", 0, "Size of Disk in MB")
-	disk := hyperkitCmd.String("disk", "", "Path to disk image to used")
-	data := hyperkitCmd.String("data", "", "Metadata to pass to VM (either a path to a file or a string)")
-	ipStr := hyperkitCmd.String("ip", "", "IP address for the VM")
-	state := hyperkitCmd.String("state", "", "Path to directory to keep VM state in")
+	hyperkitPath := flags.String("hyperkit", "", "Path to hyperkit binary (if not in default location)")
+	cpus := flags.Int("cpus", 1, "Number of CPUs")
+	mem := flags.Int("mem", 1024, "Amount of memory in MB")
+	diskSz := flags.Int("disk-size", 0, "Size of Disk in MB")
+	disk := flags.String("disk", "", "Path to disk image to used")
+	data := flags.String("data", "", "Metadata to pass to VM (either a path to a file or a string)")
+	ipStr := flags.String("ip", "", "IP address for the VM")
+	state := flags.String("state", "", "Path to directory to keep VM state in")
 
-	if err := hyperkitCmd.Parse(args); err != nil {
+	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
 	}
-	remArgs := hyperkitCmd.Args()
+	remArgs := flags.Args()
 	if len(remArgs) == 0 {
 		fmt.Println("Please specify the prefix to the image to boot\n")
-		hyperkitCmd.Usage()
+		flags.Usage()
 		os.Exit(1)
 	}
 	prefix := remArgs[0]

--- a/src/cmd/linuxkit/run_packet.go
+++ b/src/cmd/linuxkit/run_packet.go
@@ -40,25 +40,25 @@ func ValidateHTTPURL(url string) {
 
 // Process the run arguments and execute run
 func runPacket(args []string) {
-	packetCmd := flag.NewFlagSet("packet", flag.ExitOnError)
+	flags := flag.NewFlagSet("packet", flag.ExitOnError)
 	invoked := filepath.Base(os.Args[0])
-	packetCmd.Usage = func() {
+	flags.Usage = func() {
 		fmt.Printf("USAGE: %s run packet [options] [name]\n\n", invoked)
 		fmt.Printf("Options:\n\n")
-		packetCmd.PrintDefaults()
+		flags.PrintDefaults()
 	}
-	baseURLFlag := packetCmd.String("base-url", "", "Base URL that the kernel and initrd are served from.")
-	zoneFlag := packetCmd.String("zone", packetDefaultZone, "Packet Zone")
-	machineFlag := packetCmd.String("machine", packetDefaultMachine, "Packet Machine Type")
-	apiKeyFlag := packetCmd.String("api-key", "", "Packet API key")
-	projectFlag := packetCmd.String("project-id", "", "Packet Project ID")
-	hostNameFlag := packetCmd.String("hostname", packetDefaultHostname, "Hostname of new instance")
-	nameFlag := packetCmd.String("img-name", "", "Overrides the prefix used to identify the files. Defaults to [name]")
-	if err := packetCmd.Parse(args); err != nil {
+	baseURLFlag := flags.String("base-url", "", "Base URL that the kernel and initrd are served from.")
+	zoneFlag := flags.String("zone", packetDefaultZone, "Packet Zone")
+	machineFlag := flags.String("machine", packetDefaultMachine, "Packet Machine Type")
+	apiKeyFlag := flags.String("api-key", "", "Packet API key")
+	projectFlag := flags.String("project-id", "", "Packet Project ID")
+	hostNameFlag := flags.String("hostname", packetDefaultHostname, "Hostname of new instance")
+	nameFlag := flags.String("img-name", "", "Overrides the prefix used to identify the files. Defaults to [name]")
+	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
 	}
 
-	remArgs := packetCmd.Args()
+	remArgs := flags.Args()
 	prefix := "packet"
 	if len(remArgs) > 0 {
 		prefix = remArgs[0]

--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -38,63 +38,63 @@ type QemuConfig struct {
 
 func runQemu(args []string) {
 	invoked := filepath.Base(os.Args[0])
-	qemuFlags := flag.NewFlagSet("qemu", flag.ExitOnError)
-	qemuFlags.Usage = func() {
+	flags := flag.NewFlagSet("qemu", flag.ExitOnError)
+	flags.Usage = func() {
 		fmt.Printf("USAGE: %s run qemu [options] prefix\n\n", invoked)
 		fmt.Printf("'prefix' specifies the path to the VM image.\n")
 		fmt.Printf("\n")
 		fmt.Printf("Options:\n")
-		qemuFlags.PrintDefaults()
+		flags.PrintDefaults()
 	}
 
 	// Determine Flags
-	qemuGUI := qemuFlags.Bool("gui", false, "Set qemu to use video output instead of stdio")
-	qemuUEFI := qemuFlags.Bool("uefi", false, "Set UEFI boot from 'prefix'-efi.iso")
-	qemuIso := qemuFlags.Bool("iso", false, "Set Legacy BIOS boot from 'prefix'.iso")
-	qemuKernel := qemuFlags.Bool("kernel", true, "Set boot using 'prefix'-kernel/-initrd/-cmdline")
+	enableGUI := flags.Bool("gui", false, "Set qemu to use video output instead of stdio")
+	uefiBoot := flags.Bool("uefi", false, "Set UEFI boot from 'prefix'-efi.iso")
+	isoBoot := flags.Bool("iso", false, "Set Legacy BIOS boot from 'prefix'.iso")
+	kernelBoot := flags.Bool("kernel", true, "Set boot using 'prefix'-kernel/-initrd/-cmdline")
 
 	// Paths and settings for Disks and UEFI firware
-	qemuDiskPath := qemuFlags.String("disk", "", "Path to disk image to use")
-	qemuDiskSize := qemuFlags.String("disk-size", "", "Size of disk to create, only created if it doesn't exist")
-	qemuFWPath := qemuFlags.String("fw", "/usr/share/ovmf/bios.bin", "Path to OVMF firmware for UEFI boot")
+	disk := flags.String("disk", "", "Path to disk image to use")
+	diskSz := flags.String("disk-size", "", "Size of disk to create, only created if it doesn't exist")
+	fw := flags.String("fw", "/usr/share/ovmf/bios.bin", "Path to OVMF firmware for UEFI boot")
 
 	// VM configuration
-	qemuArch := qemuFlags.String("arch", "x86_64", "Type of architecture to use, e.g. x86_64, aarch64")
-	qemuCPUs := qemuFlags.String("cpus", "1", "Number of CPUs")
-	qemuMem := qemuFlags.String("mem", "1024", "Amount of memory in MB")
+	arch := flags.String("arch", "x86_64", "Type of architecture to use, e.g. x86_64, aarch64")
+	cpus := flags.String("cpus", "1", "Number of CPUs")
+	mem := flags.String("mem", "1024", "Amount of memory in MB")
 
 	publishFlags := multipleFlag{}
-	qemuFlags.Var(&publishFlags, "publish", "Publish a vm's port(s) to the host (default [])")
+	flags.Var(&publishFlags, "publish", "Publish a vm's port(s) to the host (default [])")
 
-	if err := qemuFlags.Parse(args); err != nil {
+	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
 	}
-	remArgs := qemuFlags.Args()
+	remArgs := flags.Args()
 
 	if len(remArgs) == 0 {
 		fmt.Println("Please specify the prefix to the image to boot")
-		qemuFlags.Usage()
+		flags.Usage()
 		os.Exit(1)
 	}
 	prefix := remArgs[0]
 
 	// Print warning if conflicting UEFI and ISO flags are set
-	if *qemuUEFI && *qemuIso {
+	if *uefiBoot && *isoBoot {
 		log.Warnf("Both -iso and -uefi have been used")
 	}
 
 	config := QemuConfig{
 		Prefix:         prefix,
-		ISO:            *qemuIso,
-		UEFI:           *qemuUEFI,
-		Kernel:         *qemuKernel,
-		GUI:            *qemuGUI,
-		DiskPath:       *qemuDiskPath,
-		DiskSize:       *qemuDiskSize,
-		FWPath:         *qemuFWPath,
-		Arch:           *qemuArch,
-		CPUs:           *qemuCPUs,
-		Memory:         *qemuMem,
+		ISO:            *isoBoot,
+		UEFI:           *uefiBoot,
+		Kernel:         *kernelBoot,
+		GUI:            *enableGUI,
+		DiskPath:       *disk,
+		DiskSize:       *diskSz,
+		FWPath:         *fw,
+		Arch:           *arch,
+		CPUs:           *cpus,
+		Memory:         *mem,
 		PublishedPorts: publishFlags,
 	}
 


### PR DESCRIPTION
Some runners require state to be kept somewhere while they are executing. Examples are the virtio socket unix domain socket for HyperKit and various log and config files for the VMware runner. This patch set introduces a new `-state` argument to the HyperKit and VMware runners. These are the only ones which require such state (the qemu backend ony optionally creates a userdata disk). The state directory defaults to `<prefix>-state\` but can be overwritten.

Having a state directory allows us to enable the virtio socket interface for the HyperKit runner.

While at it, also clean up the backend code somewhat. The different runners were written by different people and the variables and other implementation details were inconsistent.

