### PR TITLE
Add option for forwarding vsock ports in linuxrun for hyperkit

### DIFF
--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -32,6 +32,7 @@ func runHyperKit(args []string) {
 	data := flags.String("data", "", "Metadata to pass to VM (either a path to a file or a string)")
 	ipStr := flags.String("ip", "", "IP address for the VM")
 	state := flags.String("state", "", "Path to directory to keep VM state in")
+	vsockports := flags.String("vsock-ports", "", "List of vsock ports to forward from the guest on startup (comma separated). A unix domain socket for each port will be created in the state directory")
 
 	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
@@ -98,6 +99,10 @@ func runHyperKit(args []string) {
 	h, err := hyperkit.New(*hyperkitPath, "auto", *state)
 	if err != nil {
 		log.Fatalln("Error creating hyperkit: ", err)
+	}
+
+	if h.VSockPorts, err = stringToIntArray(*vsockports, ","); err != nil {
+		log.Fatalln("Unable to parse vsock-ports: ", err)
 	}
 
 	h.Kernel = prefix + "-kernel"

--- a/src/cmd/linuxkit/util.go
+++ b/src/cmd/linuxkit/util.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"strconv"
+	"strings"
 )
 
 func getStringValue(envKey string, flagVal string, defaultVal string) string {
@@ -80,4 +81,19 @@ func getBoolValue(envKey string, flagVal bool) bool {
 	}
 
 	return res
+}
+
+func stringToIntArray(l string, sep string) ([]int, error) {
+	var err error
+	if l == "" {
+		return []int{}, err
+	}
+	s := strings.Split(l, sep)
+	i := make([]int, len(s))
+	for idx := range s {
+		if i[idx], err = strconv.Atoi(s[idx]); err != nil {
+			return nil, err
+		}
+	}
+	return i, nil
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -9,7 +9,7 @@ github.com/docker/infrakit cb420e3e50ea60afe58538b1d3cab1cb14059433
 github.com/golang/protobuf c9c7427a2a70d2eb3bafa0ab2dc163e45f143317
 github.com/googleapis/gax-go 8c5154c0fe5bf18cf649634d4c6df50897a32751
 github.com/mitchellh/go-ps 4fdf99ab29366514c69ccccddab5dc58b8d84062
-github.com/moby/hyperkit 9b5f5fd848f0f5aedccb67a5a8cfa6787b8654f9
+github.com/moby/hyperkit fa78d9472a7d98e393233fd61ad5e95adc8c6912
 github.com/opencontainers/runtime-spec d094a5c9c1997ab086197b57e9378fabed394d92
 github.com/pkg/errors ff09b135c25aae272398c51a07235b90a75aa4f0
 github.com/packethost/packngo 91d54000aa56874149d348a884ba083c41d38091

--- a/vendor/github.com/moby/hyperkit/README.md
+++ b/vendor/github.com/moby/hyperkit/README.md
@@ -38,7 +38,7 @@ via `brew` and using `opam` to install the appropriate libraries:
     $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam install uri qcow.0.8.1 mirage-block-unix.2.6.0 conf-libev logs fmt mirage-unix
+    $ opam install uri qcow.0.9.5 mirage-block-unix.2.7.0 conf-libev logs fmt mirage-unix
 
 Notes:
 

--- a/vendor/github.com/moby/hyperkit/src/include/xhyve/firmware/bootrom.h
+++ b/vendor/github.com/moby/hyperkit/src/include/xhyve/firmware/bootrom.h
@@ -3,6 +3,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-void bootrom_init(const char *bootrom_path);
+int bootrom_init(const char *bootrom_path);
 uint64_t bootrom_load(void);
 bool bootrom_contains_gpa(uint64_t gpa);

--- a/vendor/github.com/moby/hyperkit/src/include/xhyve/firmware/fbsd.h
+++ b/vendor/github.com/moby/hyperkit/src/include/xhyve/firmware/fbsd.h
@@ -97,6 +97,6 @@ struct loader_callbacks {
 	const char * (*getenv)(void *arg, int num);
 };
 
-void fbsd_init(char *userboot_path, char *bootvolume_path, char *kernelenv,
+int fbsd_init(char *userboot_path, char *bootvolume_path, char *kernelenv,
 	char *cons);
 uint64_t fbsd_load(void);

--- a/vendor/github.com/moby/hyperkit/src/include/xhyve/firmware/kexec.h
+++ b/vendor/github.com/moby/hyperkit/src/include/xhyve/firmware/kexec.h
@@ -82,5 +82,5 @@ struct zero_page {
 	uint8_t _7[276];
 } __attribute__((packed));
 
-void kexec_init(char *kernel_path, char *initrd_path, char *cmdline);
+int kexec_init(char *kernel_path, char *initrd_path, char *cmdline);
 uint64_t kexec(void);

--- a/vendor/github.com/moby/hyperkit/src/include/xhyve/firmware/multiboot.h
+++ b/vendor/github.com/moby/hyperkit/src/include/xhyve/firmware/multiboot.h
@@ -1,0 +1,4 @@
+#include <stdint.h>
+
+int multiboot_init(char *kernel_path, char *module_spec, char *cmdline);
+uint64_t multiboot(void);

--- a/vendor/github.com/moby/hyperkit/src/lib/pci_virtio_net_vpnkit.c
+++ b/vendor/github.com/moby/hyperkit/src/lib/pci_virtio_net_vpnkit.c
@@ -317,11 +317,6 @@ static int vpnkit_connect(int fd, const char uuid[36], struct vif_info *vif)
 			init_reply.magic[4]);
 		return -1;
 	}
-	if (init_reply.version != 1) {
-		fprintf(stderr, "virtio-net-vpnkit: bad init version %d\n",
-			init_reply.version);
-		return -1;
-	}
 
 	fprintf(stderr, "virtio-net-vpnkit: magic=%c%c%c%c%c version=%d commit=%*s\n",
 		init_reply.magic[0], init_reply.magic[1],


### PR DESCRIPTION
Adds a new option `-vsock-ports` that can be used to make listed vsock ports in the guest available as unix domain sockets in the state-directory.

Also updates the hyperkit version in `/vendor`. 

(Running `vndr` from the root dir removed several of the existing dependencies as they were reported to not be in use, but I didn't include the deleted files in this PR.)

![3675289_orig](https://cloud.githubusercontent.com/assets/1076486/26068003/428b6892-399c-11e7-8e03-3938bf26d111.jpg)