### PR TITLE
Add security SIG info and notes

### DIFF
--- a/reports/sig-security/2017-05-24.md
+++ b/reports/sig-security/2017-05-24.md
@@ -1,0 +1,17 @@
+# 2017-05-24
+Video link: https://docker.zoom.us/j/779801882
+
+## Agenda
+- Introductions
+- Discuss goals of SIG
+- Updates on security `/projects`:
+  - clear-containers
+  - kernel-config
+  - kspp
+  - landlock
+  - miragesdk
+  - okernel
+  - wireguard
+- `hardened` channel proposal: combining multiple security `/projects` into one yml
+
+## Meeting Notes

--- a/sigs/README.md
+++ b/sigs/README.md
@@ -1,0 +1,8 @@
+# SIGs
+
+This directory will contain the descriptions for LinuxKit special interest groups (SIGs).
+
+The community is welcome to participate in any special interest groups they would like - these meetings are completely
+open to the public. Moreover, it is encouraged that participants suggest meeting agenda points via pull-requests.
+
+Meeting notes will be posted promptly after each SIG meeting in the appropriate subdirectory.

--- a/sigs/security/README.md
+++ b/sigs/security/README.md
@@ -1,0 +1,15 @@
+# LinuxKit Security SIG
+
+## Join us!
+- The LinuxKit Security SIG is open to the public and recurs every other Wednesday at 9AM PT: https://docker.zoom.us/j/779801882
+- Moby project forum topic: https://forums.mobyproject.org/c/sig/linuxkit-security
+- #linuxkit channel on [Docker Community Slack](https://dockercommunity.slack.com/messages/C50QFMRC2/) (sign up [here](https://community.docker.com/registrations/groups/4316))
+
+## Goals:
+- Collaborate on security efforts already incubating in the `/projects` subdirectory such as WireGuard, Landlock, and okernel
+- Discuss upstream Linux security
+- Re-implement system daemons in type-safe languages, such as Rust and OCaml
+
+## Meeting Info:
+- Meeting notes and agendas for upcoming meetings are kept in the [/reports/sigs/security directory](../../reports/sigs/security)
+


### PR DESCRIPTION
Following up on https://github.com/moby/mobywebsite/pull/11, adding more info and agenda/notes to the linuxkit repo under a `sigs` top level dir.  I've setup the zoom meeting and forum topic as well.  Aiming for May 24th as the first meeting, though this is flexible (intro email coming soon)

I'll update the mobywebsite repo once this is merged

cc @chanezon 

<img src="https://zellox.com/wp-content/uploads/2016/02/chameleon.jpg" width="400"></img>

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>