### PR TITLE
Fix Github language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+vendor/* linguist-vendored
+kernel/*.x linguist-language=text


### PR DESCRIPTION
Ignore go files in `vendor`
Kernel config files are text and not Logos

Signed-off-by: Dave Tucker <dt@docker.com>