### PR TITLE
Update Hyper-V patches for 4.11 and add Hub org override for kernel builds

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -10,7 +10,8 @@
 
 # Git tree hash of this directory. Override to force build
 HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-# Name on Hub
+# Name and Org on Hub
+ORG?=linuxkit
 IMAGE:=kernel
 
 .PHONY: check tag push sign
@@ -34,24 +35,24 @@ sign:
 # build_4.9.x_dbg and adds "_dbg" to the hub image name.
 define kernel
 build_$(2)$(3): Dockerfile Makefile $(wildcard patches-$(2)/*) kernel_config-$(2) kernel_config.debug
-	docker pull linuxkit/$(IMAGE):$(1)$(3)-$(HASH) || \
+	docker pull $(ORG)/$(IMAGE):$(1)$(3)-$(HASH) || \
 		docker build \
 			--build-arg KERNEL_VERSION=$(1) \
 			--build-arg KERNEL_SERIES=$(2) \
 			--build-arg DEBUG=$(3) \
-			--no-cache -t linuxkit/$(IMAGE):$(1)$(3)-$(HASH) .
+			--no-cache -t $(ORG)/$(IMAGE):$(1)$(3)-$(HASH) .
 
 push_$(2)$(3): build_$(2)$(3)
-	docker pull linuxkit/$(IMAGE):$(1)$(3)-$(HASH) || \
-		(docker push linuxkit/$(IMAGE):$(1)$(3)-$(HASH) && \
-		 docker tag linuxkit/$(IMAGE):$(1)$(3)-$(HASH) linuxkit/$(IMAGE):$(2)$(3) && \
-		 docker push linuxkit/$(IMAGE):$(2)$(3))
+	docker pull $(ORG)/$(IMAGE):$(1)$(3)-$(HASH) || \
+		(docker push $(ORG)/$(IMAGE):$(1)$(3)-$(HASH) && \
+		 docker tag $(ORG)/$(IMAGE):$(1)$(3)-$(HASH) $(ORG)/$(IMAGE):$(2)$(3) && \
+		 docker push $(ORG)/$(IMAGE):$(2)$(3))
 
 sign_$(2)$(3): build_$(2)$(3)
-	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(1)$(3)-$(HASH) || \
-		(DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(1)$(3)-$(HASH) && \
-		 docker tag linuxkit/$(IMAGE):$(1)$(3)-$(HASH) linuxkit/$(IMAGE):$(2)$(3) && \
-		 DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(2)$(3))
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(1)$(3)-$(HASH) || \
+		(DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(1)$(3)-$(HASH) && \
+		 docker tag $(ORG)/$(IMAGE):$(1)$(3)-$(HASH) $(ORG)/$(IMAGE):$(2)$(3) && \
+		 DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(2)$(3))
 
 build: build_$(2)$(3)
 push: push_$(2)$(3)

--- a/kernel/patches-4.11.x/0001-vmbus-introduce-in-place-packet-iterator.patch
+++ b/kernel/patches-4.11.x/0001-vmbus-introduce-in-place-packet-iterator.patch
@@ -1,7 +1,7 @@
 From a1b252ef7f38e04a2f5c8218adab6c1689fc3418 Mon Sep 17 00:00:00 2001
 From: stephen hemminger <stephen@networkplumber.org>
 Date: Mon, 27 Feb 2017 10:26:48 -0800
-Subject: [PATCH 1/8] vmbus: introduce in-place packet iterator
+Subject: [PATCH 1/9] vmbus: introduce in-place packet iterator
 
 This is mostly just a refactoring of previous functions
 (get_pkt_next_raw, put_pkt_raw and commit_rd_index) to make it easier

--- a/kernel/patches-4.11.x/0002-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
+++ b/kernel/patches-4.11.x/0002-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
@@ -1,7 +1,7 @@
-From 4a3e506dd01faf30ba830ba553c25ec4af287d65 Mon Sep 17 00:00:00 2001
+From 0cf4173a76cf771d4d4406f48c59fcb85b5a5400 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:12 -0600
-Subject: [PATCH 2/8] vmbus: vmbus_open(): reset onchannel_callback on error
+Subject: [PATCH 2/9] vmbus: vmbus_open(): reset onchannel_callback on error
 
 No real issue is observed without the patch, but let's add this
 just in case.
@@ -10,8 +10,8 @@ Signed-off-by: Dexuan Cui <decui@microsoft.com>
 Cc: K. Y. Srinivasan <kys@microsoft.com>
 Cc: Haiyang Zhang <haiyangz@microsoft.com>
 Cc: Stephen Hemminger <sthemmin@microsoft.com>
-Origin: git@github.com:dcui/linux.git
-(cherry picked from commit d66cd1ea748e2e3250aeb58b35f9ad665e310db9)
+Origin: https://github.com/dcui/linux/commits/decui/hv_sock/v4.11/20170511
+(cherry picked from commit c248b14174e1337c1461f9b13a573ad90a136e1c)
 ---
  drivers/hv/channel.c | 2 ++
  1 file changed, 2 insertions(+)

--- a/kernel/patches-4.11.x/0003-vmbus-add-the-matching-tasklet_enable-in-vmbus_close.patch
+++ b/kernel/patches-4.11.x/0003-vmbus-add-the-matching-tasklet_enable-in-vmbus_close.patch
@@ -1,7 +1,7 @@
-From e0ea4ac1148a83e19426015b1ab790e53d2ac87b Mon Sep 17 00:00:00 2001
+From d1d1e90f2106c7048feab6a6da955fc2ed521896 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:15 -0600
-Subject: [PATCH 3/8] vmbus: add the matching tasklet_enable() in
+Subject: [PATCH 3/9] vmbus: add the matching tasklet_enable() in
  vmbus_close_internal()
 
 If we disable a tasklet that is scheduled but hasn't started to run,
@@ -19,8 +19,8 @@ Signed-off-by: Dexuan Cui <decui@microsoft.com>
 Cc: K. Y. Srinivasan <kys@microsoft.com>
 Cc: Haiyang Zhang <haiyangz@microsoft.com>
 Cc: Stephen Hemminger <sthemmin@microsoft.com>
-Origin: git@github.com:dcui/linux.git
-(cherry picked from commit 2e653533181f0c70db04d2ca13a4ae60251d1a93)
+Origin: https://github.com/dcui/linux/commits/decui/hv_sock/v4.11/20170511
+(cherry picked from commit 008d8d8bc0c86473a8549a365bee9a479243e412)
 ---
  drivers/hv/channel.c | 1 +
  1 file changed, 1 insertion(+)

--- a/kernel/patches-4.11.x/0004-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.11.x/0004-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,7 +1,7 @@
-From 9317ce0dfdd69ea4df992743779e16c180c5c5ea Mon Sep 17 00:00:00 2001
+From 3fe617c0af23272071c320b295fb987f69f0ac77 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:20 -0600
-Subject: [PATCH 4/8] vmbus: remove "goto error_clean_msglist" in vmbus_open()
+Subject: [PATCH 4/9] vmbus: remove "goto error_clean_msglist" in vmbus_open()
 
 This is just a cleanup patch to simplify the code a little.
 No semantic change.
@@ -10,8 +10,8 @@ Signed-off-by: Dexuan Cui <decui@microsoft.com>
 Cc: K. Y. Srinivasan <kys@microsoft.com>
 Cc: Haiyang Zhang <haiyangz@microsoft.com>
 Cc: Stephen Hemminger <sthemmin@microsoft.com>
-Origin: git@github.com:dcui/linux.git
-(cherry picked from commit 2deba76a449075c5a05bd572bfdee660f710b207)
+Origin: https://github.com/dcui/linux/commits/decui/hv_sock/v4.11/20170511
+(cherry picked from commit 4713066c11b2396eafd2873cbed7bdd72d1571eb)
 ---
  drivers/hv/channel.c | 18 +++++++-----------
  1 file changed, 7 insertions(+), 11 deletions(-)

--- a/kernel/patches-4.11.x/0005-vmbus-dynamically-enqueue-dequeue-a-channel-on-vmbus.patch
+++ b/kernel/patches-4.11.x/0005-vmbus-dynamically-enqueue-dequeue-a-channel-on-vmbus.patch
@@ -1,7 +1,7 @@
-From 07c35ba69ab292b925a08c2ac21d255f0b93a15b Mon Sep 17 00:00:00 2001
+From 3809a76e095d648d7d99cb1822ce17844a22ad2a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:23 -0600
-Subject: [PATCH 5/8] vmbus: dynamically enqueue/dequeue a channel on
+Subject: [PATCH 5/9] vmbus: dynamically enqueue/dequeue a channel on
  vmbus_open/close
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -22,8 +22,8 @@ Tested-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
 Cc: K. Y. Srinivasan <kys@microsoft.com>
 Cc: Haiyang Zhang <haiyangz@microsoft.com>
 Cc: Stephen Hemminger <sthemmin@microsoft.com>
-Origin: git@github.com:dcui/linux.git
-(cherry picked from commit fed51f8f6068cb953be480c6b6322a3a6e97745d)
+Origin: https://github.com/dcui/linux/commits/decui/hv_sock/v4.11/20170511
+(cherry picked from commit 1df677b35ff010d0def33f5420773015815cf843)
 ---
  drivers/hv/channel.c      | 12 +++++++++---
  drivers/hv/channel_mgmt.c | 50 +++++++++++++++++++++--------------------------

--- a/kernel/patches-4.11.x/0006-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
+++ b/kernel/patches-4.11.x/0006-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
@@ -1,7 +1,7 @@
-From eb5f0c02850dfeef78da421871e51c753711bd64 Mon Sep 17 00:00:00 2001
+From 189479e4a60fcdb92439aebd7a116f4ba0eede0d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:26 -0600
-Subject: [PATCH 6/8] hv_sock: implements Hyper-V transport for Virtual Sockets
+Subject: [PATCH 6/9] hv_sock: implements Hyper-V transport for Virtual Sockets
  (AF_VSOCK)
 
 Hyper-V Sockets (hv_sock) supplies a byte-stream based communication
@@ -34,8 +34,8 @@ Cc: Stefan Hajnoczi <stefanha@redhat.com>
 Cc: Vitaly Kuznetsov <vkuznets@redhat.com>
 Cc: Cathy Avery <cavery@redhat.com>
 Cc: Rolf Neugebauer <rolf.neugebauer@docker.com>
-Origin: git@github.com:dcui/linux.git
-(cherry picked from commit 691aff936c0fa6fc24e2662c0e8cc6ab65509600)
+Origin: https://github.com/dcui/linux/commits/decui/hv_sock/v4.11/20170511
+(cherry picked from commit 3476be340d2ff777609fca3e763da0292acbfc45)
 ---
  MAINTAINERS                      |   1 +
  net/vmw_vsock/Kconfig            |  12 +

--- a/kernel/patches-4.11.x/0007-VMCI-only-try-to-load-on-VMware-hypervisor.patch
+++ b/kernel/patches-4.11.x/0007-VMCI-only-try-to-load-on-VMware-hypervisor.patch
@@ -1,7 +1,7 @@
-From 3693f434f0c7b78611cb9bb3dd32737bb5e9fd85 Mon Sep 17 00:00:00 2001
+From f467ed8a4c51eed215f9f8db32cad8f240a59a2e Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:29 -0600
-Subject: [PATCH 7/8] VMCI: only try to load on VMware hypervisor
+Subject: [PATCH 7/9] VMCI: only try to load on VMware hypervisor
 
 Without the patch, vmw_vsock_vmci_transport.ko and vmw_vmci.ko can
 automatically load when an application creates an AF_VSOCK socket.
@@ -27,8 +27,8 @@ Cc: Jorgen Hansen <jhansen@vmware.com>
 Cc: K. Y. Srinivasan <kys@microsoft.com>
 Cc: Haiyang Zhang <haiyangz@microsoft.com>
 Cc: Stephen Hemminger <sthemmin@microsoft.com>
-Origin: git@github.com:dcui/linux.git
-(cherry picked from commit d643b934352ffea88cd9ce50a709667574523a8d)
+Origin: https://github.com/dcui/linux/commits/decui/hv_sock/v4.11/20170511
+(cherry picked from commit b5566b1b6e5cb19b381590587f841f950caabe4d)
 ---
  drivers/misc/vmw_vmci/vmci_driver.c | 8 ++++++++
  1 file changed, 8 insertions(+)

--- a/kernel/patches-4.11.x/0008-hv_sock-add-the-support-of-auto-loading.patch
+++ b/kernel/patches-4.11.x/0008-hv_sock-add-the-support-of-auto-loading.patch
@@ -1,7 +1,7 @@
-From 91a309bb9dc27b60329a769e322a6e20f79858ce Mon Sep 17 00:00:00 2001
+From 1ee84d4b4cceac4c7f42573476c1253b06e8cdaf Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:35 -0600
-Subject: [PATCH 8/8] hv_sock: add the support of auto-loading
+Subject: [PATCH 8/9] hv_sock: add the support of auto-loading
 
 After we disable VMWare virtual sockets driver's auto-loading on Hyper-V,
 we can enable hv_sock's auto-loading now.
@@ -10,8 +10,8 @@ Signed-off-by: Dexuan Cui <decui@microsoft.com>
 Cc: K. Y. Srinivasan <kys@microsoft.com>
 Cc: Haiyang Zhang <haiyangz@microsoft.com>
 Cc: Stephen Hemminger <sthemmin@microsoft.com>
-Origin: git@github.com:dcui/linux.git
-(cherry picked from commit d02cd7376ce780f3d46b72a2f553f266ad558cd4)
+Origin: https://github.com/dcui/linux/commits/decui/hv_sock/v4.11/20170511
+(cherry picked from commit 6f1aa69011356ff95ed6c57400095e5f2d9eb900)
 ---
  net/vmw_vsock/hyperv_transport.c | 1 +
  1 file changed, 1 insertion(+)

--- a/kernel/patches-4.11.x/0009-hvsock-fix-a-race-in-hvs_stream_dequeue.patch
+++ b/kernel/patches-4.11.x/0009-hvsock-fix-a-race-in-hvs_stream_dequeue.patch
@@ -1,0 +1,113 @@
+From d0e6020dd2b25f8880b8d25305c356cf4a22f12d Mon Sep 17 00:00:00 2001
+From: Dexuan Cui <decui@microsoft.com>
+Date: Tue, 16 May 2017 22:14:03 +0800
+Subject: [PATCH 9/9] hvsock: fix a race in hvs_stream_dequeue()
+
+If hv_pkt_iter_next() returns a non-NULL pointer, we must update
+the recv_data_len/data_off info, otherwise the received data will
+be silently dropped, and let's fix hvs_stream_has_data() accordingly.
+
+Thank Rolf for finding this!
+
+Reported-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
+Signed-off-by: Dexuan Cui <decui@microsoft.com>
+Origin: https://github.com/dcui/linux/commits/decui/hv_sock/v4.11/20170511
+(cherry picked from commit 83c8635b893bbc0b5b329c632cea0382d5479763)
+---
+ net/vmw_vsock/hyperv_transport.c | 50 +++++++++++++++++++++++++++++-----------
+ 1 file changed, 36 insertions(+), 14 deletions(-)
+
+diff --git a/net/vmw_vsock/hyperv_transport.c b/net/vmw_vsock/hyperv_transport.c
+index f465b0b662df..30154836acd0 100644
+--- a/net/vmw_vsock/hyperv_transport.c
++++ b/net/vmw_vsock/hyperv_transport.c
+@@ -476,13 +476,33 @@ static bool hvs_dgram_allow(u32 cid, u32 port)
+ 	return false;
+ }
+ 
++static int hvs_update_recv_data(struct hvsock *hvs)
++{
++	struct hvs_recv_buf *recv_buf;
++	u32 payload_len;
++
++	recv_buf = (struct hvs_recv_buf *)(hvs->recv_desc + 1);
++	payload_len = recv_buf->hdr.data_size;
++
++	if (payload_len > HVS_MTU_SIZE)
++		return -EIO;
++
++	if (payload_len == 0)
++		hvs->vsk->peer_shutdown |= SEND_SHUTDOWN;
++
++	hvs->recv_data_len = payload_len;
++	hvs->recv_data_off = 0;
++
++	return 0;
++}
++
+ static ssize_t hvs_stream_dequeue(struct vsock_sock *vsk, struct msghdr *msg,
+ 				  size_t len, int flags)
+ {
+ 	struct hvsock *hvs = vsk->trans;
+ 	bool need_refill = !hvs->recv_desc;
+ 	struct hvs_recv_buf *recv_buf;
+-	u32 payload_len, to_read;
++	u32 to_read;
+ 	int ret;
+ 
+ 	if (flags & MSG_PEEK)
+@@ -490,29 +510,28 @@ static ssize_t hvs_stream_dequeue(struct vsock_sock *vsk, struct msghdr *msg,
+ 
+ 	if (need_refill) {
+ 		hvs->recv_desc = hv_pkt_iter_first(hvs->chan);
+-		recv_buf = (struct hvs_recv_buf *)(hvs->recv_desc + 1);
+-
+-		payload_len = recv_buf->hdr.data_size;
+-		if (payload_len == 0 || payload_len > HVS_MTU_SIZE)
+-			return -EIO;
+-
+-		hvs->recv_data_len = payload_len;
+-		hvs->recv_data_off = 0;
+-	} else {
+-		recv_buf = (struct hvs_recv_buf *)(hvs->recv_desc + 1);
++		ret = hvs_update_recv_data(hvs);
++		if (ret)
++			return ret;
+ 	}
+ 
++	recv_buf = (struct hvs_recv_buf *)(hvs->recv_desc + 1);
+ 	to_read = min_t(u32, len, hvs->recv_data_len);
+ 	ret = memcpy_to_msg(msg, recv_buf->data + hvs->recv_data_off, to_read);
+ 	if (ret != 0)
+ 		return ret;
+ 
+ 	hvs->recv_data_len -= to_read;
+-
+-	if (hvs->recv_data_len == 0)
++	if (hvs->recv_data_len == 0) {
+ 		hvs->recv_desc = hv_pkt_iter_next(hvs->chan, hvs->recv_desc);
+-	else
++		if (hvs->recv_desc) {
++			ret = hvs_update_recv_data(hvs);
++			if (ret)
++				return ret;
++		}
++	} else {
+ 		hvs->recv_data_off += to_read;
++	}
+ 
+ 	return to_read;
+ }
+@@ -554,6 +573,9 @@ static s64 hvs_stream_has_data(struct vsock_sock *vsk)
+ 	struct hvsock *hvs = vsk->trans;
+ 	s64 ret;
+ 
++	if (hvs->recv_data_len > 0)
++		return 1;
++
+ 	switch (hvs_channel_readable_payload(hvs->chan)) {
+ 	case 1:
+ 		ret = 1;
+-- 
+2.12.2
+


### PR DESCRIPTION
While testing the new support for Hyper-V sockets in 4.11 we discovered some issues. The updated patches from Microsoft in this PR address this issue. I have run some light stress tests and they passed (after failing previously). I will run more tests over night but this is a definite improvement over the previous patches.

While at it, also make the Hub org configurable during build, ie:
```
make push_4.11.x ORG=rneugeba
```
pushes the image to my Hub account for testing (wip #1824)