### PR TITLE
kernel: Add vmlinux to debug builds

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -33,7 +33,8 @@ RUN make defconfig && \
     make oldconfig && \
     make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
     cp arch/x86_64/boot/bzImage /out/kernel && \
-    cp System.map /out
+    cp System.map /out && \
+    ([ -n "${DEBUG}" ] && cp vmlinux /out || true)
 
 # Modules
 RUN make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install && \


### PR DESCRIPTION
The vmlinux image is the un-stripped kernel image containing
full debug information which is useful for kernel debugging.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>