### PR TITLE
Dev image with Docker and SSHD

### DIFF
--- a/examples/dev.yml
+++ b/examples/dev.yml
@@ -77,8 +77,8 @@ services:
      - /var/run/:/var/run/
      - /var/lib/docker:/var/lib/docker
      - /lib/modules:/lib/modules
-  - name: sshd
-    image: "linuxkit/sshd:e108d208adf692c8a0954f602743e0eec445364e"
+  - name: dev
+    image: "linuxkit/dev:8079304d97ae9eb3c0f6240d674407c036ea817e"
     capabilities:
      - all
     net: host

--- a/examples/dev.yml
+++ b/examples/dev.yml
@@ -1,0 +1,101 @@
+kernel:
+  image: "linuxkit/kernel:4.9.x"
+  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+init:
+  - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
+  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
+  - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
+  - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
+onboot:
+  - name: sysctl
+    image: "linuxkit/sysctl:1f5ec5d5e6f7a7a1b3d2ff9dd9e36fd6fb14756a"
+    net: host
+    pid: host
+    ipc: host
+    capabilities:
+     - CAP_SYS_ADMIN
+    readonly: true
+  - name: sysfs
+    image: linuxkit/sysfs:6c1d06f28ddd9681799d3950cddf044b930b221c
+  - name: binfmt
+    image: "linuxkit/binfmt:131026c0cf6084467316395fed3b358f64bda00c"
+    binds:
+     - /proc/sys/fs/binfmt_misc:/binfmt_misc
+    readonly: true
+  - name: format
+    image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
+    binds:
+     - /dev:/dev
+    capabilities:
+     - CAP_SYS_ADMIN
+     - CAP_MKNOD
+  - name: mount
+    image: "linuxkit/mount:fc7164d7c4e1fe5d1da395c7f949fb332cffe752"
+    binds:
+     - /dev:/dev
+     - /var:/var:rshared,rbind
+    capabilities:
+     - CAP_SYS_ADMIN
+    rootfsPropagation: shared
+    command: ["/mount.sh", "/var/lib/docker"]
+services:
+  - name: rngd
+    image: "linuxkit/rngd:61a07ced77a9747708223ca16a4aec621eacf518"
+    capabilities:
+     - CAP_SYS_ADMIN
+    oomScoreAdj: -800
+    readonly: true
+  - name: dhcpcd
+    image: "linuxkit/dhcpcd:2def74ab3f9233b4c09ebb196ba47c27c08b0ed8"
+    binds:
+     - /var:/var
+     - /tmp/etc:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    oomScoreAdj: -800
+  - name: ntpd
+    image: "linuxkit/openntpd:a38eabb308d0405f58894979f8b8031a6c7e1134"
+    capabilities:
+      - CAP_SYS_TIME
+      - CAP_SYS_NICE
+      - CAP_SYS_CHROOT
+      - CAP_SETUID
+      - CAP_SETGID
+    net: host
+  - name: docker
+    image: "linuxkit/docker-ce:050e734489f2d19b42ec818a4242a318ea446bc3"
+    capabilities:
+     - all
+    net: host
+    mounts:
+     - type: cgroup
+       options: ["rw","nosuid","noexec","nodev","relatime"]
+    binds:
+     - /var/run/:/var/run/
+     - /var/lib/docker:/var/lib/docker
+     - /lib/modules:/lib/modules
+  - name: sshd
+    image: "linuxkit/sshd:e108d208adf692c8a0954f602743e0eec445364e"
+    capabilities:
+     - all
+    net: host
+    pid: host
+    binds:
+     - /var/run/:/var/run/
+     - /root/.ssh:/root/.ssh
+     - /etc/resolv.conf:/etc/resolv.conf
+files:
+  - path: root/.ssh/authorized_keys
+    contents: '#your ssh key here'
+  - path: etc/docker/daemon.json
+    contents: '{"debug": true}'
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/binfmt
+    - linuxkit/rngd
+outputs:
+  - format: kernel+initrd

--- a/pkg/dev/Dockerfile
+++ b/pkg/dev/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:edge
+
+ENV DOCKER_BUCKET get.docker.com
+ENV DOCKER_VERSION 17.05.0-ce
+ENV DOCKER_SHA256 340e0b5a009ba70e1b644136b94d13824db0aeb52e09071410f35a95d94316d9
+
+RUN \
+  apk update && apk upgrade && \
+  apk add --no-cache \
+  curl \
+  openssh-server \
+  tini \
+  util-linux \
+  && true
+
+RUN set -x \
+	&& curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+	&& echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
+	&& tar -xzvf docker.tgz \
+	&& mv docker/* /usr/bin/ \
+	&& rmdir docker \
+	&& rm docker.tgz \
+	&& docker -v
+
+COPY . .
+
+RUN mkdir -p /etc/ssh /root/.ssh && chmod 0700 /root/.ssh
+
+CMD ["/sbin/tini", "/usr/bin/ssh.sh"]

--- a/pkg/dev/Dockerfile
+++ b/pkg/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM linuxkit/sshd:e108d208adf692c8a0954f602743e0eec445364e
 
 ENV DOCKER_BUCKET get.docker.com
 ENV DOCKER_VERSION 17.05.0-ce
@@ -8,9 +8,6 @@ RUN \
   apk update && apk upgrade && \
   apk add --no-cache \
   curl \
-  openssh-server \
-  tini \
-  util-linux \
   && true
 
 RUN set -x \
@@ -22,8 +19,5 @@ RUN set -x \
 	&& rm docker.tgz \
 	&& docker -v
 
-COPY . .
-
-RUN mkdir -p /etc/ssh /root/.ssh && chmod 0700 /root/.ssh
 
 CMD ["/sbin/tini", "/usr/bin/ssh.sh"]

--- a/pkg/dev/Makefile
+++ b/pkg/dev/Makefile
@@ -1,0 +1,29 @@
+.PHONY: tag push
+
+BASE=alpine:edge
+IMAGE=dev
+
+default: push
+
+hash: Dockerfile etc/ssh/sshd_config usr/bin/ssh.sh etc/motd
+	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --rm $(IMAGE):build sh -c "cat $^ /lib/apk/db/installed | sha1sum" | sed 's/ .*//' > $@
+
+push: hash
+	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
+		 docker push linuxkit/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/pkg/dev/etc/motd
+++ b/pkg/dev/etc/motd
@@ -1,0 +1,1 @@
+Welcome to LinuxKit 

--- a/pkg/dev/etc/ssh/sshd_config
+++ b/pkg/dev/etc/ssh/sshd_config
@@ -1,0 +1,144 @@
+#	$OpenBSD: sshd_config,v 1.98 2016/02/17 05:29:04 djm Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/bin:/usr/bin:/sbin:/usr/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+# The default requires explicit activation of protocol 1
+#Protocol 2
+
+# HostKey for protocol version 1
+#HostKey /etc/ssh/ssh_host_key
+# HostKeys for protocol version 2
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_dsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Lifetime and size of ephemeral version 1 server key
+#KeyRegenerationInterval 1h
+#ServerKeyBits 1024
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+# obsoletes QuietMode and FascistLogging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#RSAAuthentication yes
+#PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#RhostsRSAAuthentication no
+# similar for protocol version 2
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# RhostsRSAAuthentication and HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication no
+#PermitEmptyPasswords no
+
+# Change to no to disable s/key passwords
+ChallengeResponseAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+#UsePAM no
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+#X11Forwarding no
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#UsePrivilegeSeparation sandbox
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# Default of no subsystems
+#Subsystem	sftp	/usr/lib/ssh/sftp-server
+
+# the following are HPN related configuration options
+# tcp receive buffer polling. disable in non autotuning kernels
+#TcpRcvBufPoll yes
+ 
+# disable hpn performance boosts
+#HPNDisabled no
+
+# buffer size for hpn to non-hpn connections
+#HPNBufferSize 2048
+
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server

--- a/pkg/dev/usr/bin/ssh.sh
+++ b/pkg/dev/usr/bin/ssh.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+KEYS=$(find /etc/ssh -name 'ssh_host_*_key')
+[ -z "$KEYS" ] && ssh-keygen -A >/dev/null 2>/dev/null
+
+exec /usr/sbin/sshd -D -e


### PR DESCRIPTION
**- What I did**
Created a simple `dev.yml` example where you SSH into the machine and you can interact with the Docker service container.

**- How I did it**
Added dev service container based on the SSHD container with the Docker client and mounted the `/var/run` directory from the root to both service containers.

**- How to verify it**
Right now, in `dev.yml`, in the `dev` service container I pointed to `linuxkit/dev:8079304d97ae9eb3c0f6240d674407c036ea817e` which doesn't exist. Once you run `make` in the `pkg/dev` directory and the image above gets pushed:

(In order to verify without actually creating that image: replace the `linuxkit/dev` image with `radumatei/linuxkit-dev:dev`)

```
cd examples
moby build dev.yml
linuxkit run dev
```
This will start the VM. Now test it just like the usual SSHD example, but now you can start/stop Docker containers.

**- Description for the changelog**
<!--
Added dev image with SSHD and Docker
-->
