### PR TITLE
[RFC] Reconfigure the CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,24 +53,29 @@ test:
 .PHONY: collect-artifacts
 collect-artifacts: artifacts/test.img.tar.gz artifacts/test-ltp.img.tar.gz
 
-.PHONY: ci ci-tag ci-pr
+.PHONY: ci ci-tag ci-pr ci-platforms
 ci:
 	$(MAKE) clean
 	$(MAKE)
 	$(MAKE) install
 	$(MAKE) -C test all
+	$(MAKE) -C test platforms
 
 ci-tag:
 	$(MAKE) clean
 	$(MAKE)
 	$(MAKE) install
 	$(MAKE) -C test all
+	$(MAKE) -C test platforms
 
 ci-pr:
 	$(MAKE) clean
 	$(MAKE)
 	$(MAKE) install
 	$(MAKE) -C test pr
+
+ci-platforms:
+	$(MAKE) -C test platforms
 
 .PHONY: clean
 clean:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -67,19 +67,18 @@ The test logs are available via the `Details` link but also via this [website](h
 
 ## PR Testing
 
-Each PR is tested on disposable VM's spawned in Google Cloud Platform
+Each PR is tested on disposable VMs spawned in Google Cloud Platform
 This machine has no privileges or credentials to talk to GCP or other cloud platforms.
 
 TODO: Add instructions on how to build a base image for LinuxKit CI in GCP.
 
 LinuxKit CI runs `make ci-pr` in the VM.
 This target runs the tests using `rtf` and the results directory is `scp`'ed back to the controller.
-The test results will be stored in DataKit for additional access
-Additionally, the `./artifacts` folder is `scp`'ed back to the controller.
+The test results are stored in DataKit.
 
-If the tests passed the next step is to check if the kernel config test image runs on GCP.
-The `./artifacts/test.img.tar.gz` file is used to create a GCP image by the Python scripts
-that are part of LiunxKit CI. It runs this image and greps for the success message in the logs.
+If the tests passed the next step is to run additional platform tests.
+LinxKit CI runs `make ci-platforms` from the controller.
+This will use `rtf` to run tests on all local and/or cloud platforms in the test suite.
 
 ## Branch and Tag testing
 
@@ -87,8 +86,8 @@ Branches and Tags are tested on a dedicated machine that runs in GCP.
 
 LinuxKit CI runs `make ci` or `make ci-tag` in the VM
 This target runs the tests using `rtf` and the results directory is SCP'd back to the controller.
+The labels supplied to `rtf` via the `Makefile` will enable slower tests like the Linux Testing Project tests
+for more thorough test coverage.
 The test results will be stored in DataKit.
 
-If the tests pass, the GCP test is run in the same manner as described for PR tests.
-
-Finally, CI will run `make test-ltp` which will run the Linux Testing Project tests.
+If the tests pass, the platform tests are run in the same manner as described for PR's. 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,9 +1,9 @@
 .PHONY: default pr all
 
-default: check-deps test 
-pr: check-deps test-pr
-# TODO: should have a separate target
-all: check-deps test-pr ltp
+pr: check-deps test
+all: check-deps test-all
+platforms: check-deps test-platforms
+default: pr
 
 MOBY:=$(shell command -v moby 2> /dev/null)
 LINUXKIT:=$(shell command -v linuxkit 2> /dev/null)
@@ -21,33 +21,14 @@ ifndef RTF
 	$(error "rtf is not available. please install it!")
 endif
 
+test: 
+	@rtf -x run
 
-# TODO: Remove this section once we no longer depend on this in CI
-### -------
-# Currently the linuxkit-ci runs GCP tests outside of rtf and expects some
-# files in ../artifacts. This hacky target puts them there until
-# the CI can use rtf for running GCP tests
-gcp-hack: ../artifacts/test.img.tar.gz
-../artifacts/test.img.tar.gz:
-	rm -rf ../artifacts
-	mkdir -p ../artifacts
-	$(MOBY) build -output gcp-img -pull -name ../artifacts/test hack/test.yml
+test-pr:
+	@rtf -x run
 
-define check_test_log
-	@cat $1 |grep -q 'test suite PASSED'
-endef
+test-all:
+	@rtf -l slow,gcp -x run
 
-.PHONY: ltp
-ltp: export CLOUDSDK_IMAGE_NAME?=test-ltp
-ltp: $(LINUXKIT) test-ltp.img.tar.gz
-	$(MOBY) build -output gcp-img -pull hack/test-ltp.yml
-	$(LINUXKIT) push gcp test-ltp.img.tar.gz
-	$(LINUXKIT) run gcp -skip-cleanup -machine n1-highcpu-4 $(CLOUDSDK_IMAGE_NAME) | tee test-ltp.log
-	$(call check_test_log, test-ltp.log)
-### ------
-
-test: gcp-hack
-	@rtf -l build -x run
-
-test-pr: gcp-hack
-	@rtf -l build -x run
+test-platforms:
+	@rtf -l gcp -x run linuxkit.platforms

--- a/test/cases/010_platforms/110_gcp/000_minimal/test.sh
+++ b/test/cases/010_platforms/110_gcp/000_minimal/test.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# SUMMARY: Test that a minimal image boots on GCP
+# LABELS:
+# AUTHOR: Dave Tucker <dt@docker.com>
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+IMAGE_NAME=gcp-minimal
+
+clean_up() {
+	rm -rf ${IMAGE_NAME}*
+}
+
+trap clean_up EXIT
+
+# Test code goes here
+moby build -name ${IMAGE_NAME} test.yml
+linuxkit push gcp ${IMAGE_NAME}.img.tar.gz
+RESULT=$(linuxkit run gcp "${CLOUDSDK_IMAGE_NAME}")
+echo "$RESULT"| grep -q "I Can Haz Linux?"
+exit 0

--- a/test/cases/010_platforms/110_gcp/000_minimal/test.yml
+++ b/test/cases/010_platforms/110_gcp/000_minimal/test.yml
@@ -1,8 +1,6 @@
-# FIXME: This should use the minimal example
-# We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
   image: "linuxkit/kernel:4.9.x"
-  cmdline: "console=ttyS0"
+  cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
@@ -13,6 +11,9 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"
+  - name: whalesay
+    image: "docker/whalesay"
+    command: ["/usr/local/bin/cowsay", "I Can Haz Linux?"]
     readonly: true
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
@@ -24,3 +25,5 @@ trust:
     - linuxkit/runc
     - linuxkit/containerd
     - linuxkit/dhcpcd
+outputs:
+  - format: gcp-img

--- a/test/cases/010_platforms/110_gcp/group.sh
+++ b/test/cases/010_platforms/110_gcp/group.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # SUMMARY: LinuxKit Google Cloud tests
-# LABELS:
+# LABELS: gcp
 # For the top level group.sh also specify a 'NAME:' comment
 
 # Source libraries. Uncomment if needed/defined

--- a/test/cases/020_kernel/020_ltp/test.sh
+++ b/test/cases/020_kernel/020_ltp/test.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# SUMMARY: Run the Linux Testing Project tests
+# LABELS: slow, gcp
+# REPEAT:
+# AUTHOR: Dave Tucker <dt@docker.com>
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+IMAGE_NAME=ltp
+
+clean_up() {
+	rm -rf ${IMAGE_NAME}*
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build --name ${IMAGE_NAME} test.yml
+# NOTE: It's pushed using the CLOUDSDK_IMAGE_NAME
+linuxkit push gcp ${IMAGE_NAME}.img.tar.gz
+RESULT="$(linuxkit run gcp -skip-cleanup -machine n1-highcpu-4 ${CLOUDSDK_IMAGE_NAME})"
+echo "${RESULT}" | grep -q "suite has passed"
+
+exit 0

--- a/test/cases/020_kernel/020_ltp/test.yml
+++ b/test/cases/020_kernel/020_ltp/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
-  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/init:deea956a9ab07bf262083e93a86930bdc610cc2f
+  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
 onboot:
   - name: ltp
     image: "linuxkit/test-ltp:20170116"


### PR DESCRIPTION
This PR is both an RFC and a test case for reconfiguring the CI.

- Remove existing hacks in place to copy artifacts from ephemeral VM to the LinuxKit CI controller
- Control LTP test runs through `rtf` and labels and not through a make target called by CI directly
- Move the GCP test (run via Python scripts in CI) to a `rtf` test case
- Run the `linuxkit.platforms` tests on PR's and Master from *after* the first test run has been completed

This PR makes the necessary changes in LinuxKit and update the documentation.

Once CI has been update and reconfigured this PR should be green and ready for merge.