### PR TITLE
Allow forcing qemu backend to use container via command line

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -63,6 +63,9 @@ func runQemu(args []string) {
 	cpus := flags.String("cpus", "1", "Number of CPUs")
 	mem := flags.String("mem", "1024", "Amount of memory in MB")
 
+	// Backend configuration
+	qemuContainerized := flags.Bool("containerized", false, "Run qemu in a container")
+
 	publishFlags := multipleFlag{}
 	flags.Var(&publishFlags, "publish", "Publish a vm's port(s) to the host (default [])")
 
@@ -95,6 +98,7 @@ func runQemu(args []string) {
 		Arch:           *arch,
 		CPUs:           *cpus,
 		Memory:         *mem,
+		Containerized:  *qemuContainerized,
 		PublishedPorts: publishFlags,
 	}
 


### PR DESCRIPTION
`linuxkit run --containerized foo`

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added `--containerized` option to the Qemu runner, to aid in reproducing https://github.com/linuxkit/linuxkit/issues/1828.

**- How I did it**

Typing.

**- How to verify it**

`linuxkit run qemu --containerized` will run in a container 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
`linuxkit run qemu --containerized` can now be used to force the use of the Qemu container rather than host Qemu.

**- A picture of a cute animal (not mandatory but encouraged)**

![](http://blowthescene.com/wp-content/uploads/2012/06/primate-draw-back-a-stump.jpg "Primate, Draw Back A Stump")
