### PR TITLE
Clean up of Qemu run

### DIFF
--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.sh
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.sh
@@ -20,5 +20,5 @@ trap clean_up EXIT
 
 moby build -name "${NAME}" test.yml
 [ -f "${NAME}.iso" ] || exit 1
-linuxkit run qemu -iso "${NAME}" | grep -q "Welcome to LinuxKit"
+linuxkit run qemu -iso "${NAME}.iso" | grep -q "Welcome to LinuxKit"
 exit 0

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.sh
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.sh
@@ -27,5 +27,5 @@ fi
 
 moby build -name "${NAME}" test.yml
 [ -f "${NAME}-efi.iso" ] || exit 1
-linuxkit run qemu -uefi "${NAME}" | grep -q "Welcome to LinuxKit"
+linuxkit run qemu -iso -uefi "${NAME}-efi.iso" | grep -q "Welcome to LinuxKit"
 exit 0

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.sh
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-# SUMMARY: Check that the kernel+initrd image boots in qemu
+# SUMMARY: Check that qcow2 image boots in qemu
 # LABELS:
 # AUTHOR: Dave Tucker <dt@docker.com>
-# AUTHOR: Rolf Neugebauer <rolf.neugebauer@docker.com>
+# AUTHOR: Justin Cormack <justin.cormack@docker.com>
 
 set -e
 
@@ -10,7 +10,7 @@ set -e
 #. "${RT_LIB}"
 . "${RT_PROJECT_ROOT}/_lib/lib.sh"
 
-NAME=qemu-kernel
+NAME=qemu-qcow2
 
 clean_up() {
 	# remove any files, containers, images etc
@@ -20,8 +20,6 @@ clean_up() {
 trap clean_up EXIT
 
 moby build -name "${NAME}" test.yml
-[ -f "${NAME}-kernel" ] || exit 1
-[ -f "${NAME}-initrd.img" ] || exit 1
-[ -f "${NAME}-cmdline" ]|| exit 1
-linuxkit run qemu -kernel "${NAME}" | grep -q "Welcome to LinuxKit"
+[ -f "${NAME}.qcow2" ] || exit 1
+linuxkit run qemu -disk-format qcow2 "${NAME}.qcow2" | grep -q "Welcome to LinuxKit"
 exit 0

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -1,0 +1,16 @@
+kernel:
+  image: "linuxkit/kernel:4.9.x"
+  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+init:
+  - linuxkit/init:f71c3b30ac1ba4ef16c160c89610fa4976f9752f
+  - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
+  - linuxkit/containerd:60e2486a74c665ba4df57e561729aec20758daed
+onboot:
+  - name: poweroff
+    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    command: ["/bin/sh", "/poweroff.sh", "10"]
+trust:
+  image:
+    - linuxkit/kernel
+outputs:
+  - format: qcow2

--- a/test/cases/020_kernel/000_config_4.4.x/test.sh
+++ b/test/cases/020_kernel/000_config_4.4.x/test.sh
@@ -17,7 +17,7 @@ trap clean_up EXIT
 
 # Test code goes here
 moby build test-kernel-config
-RESULT="$(linuxkit run qemu test-kernel-config)"
+RESULT="$(linuxkit run qemu -kernel test-kernel-config)"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/040_packages/000_sysctl/test.sh
+++ b/test/cases/040_packages/000_sysctl/test.sh
@@ -17,7 +17,7 @@ trap clean_up EXIT
 
 # Test code goes here
 moby build test-sysctl
-RESULT="$(linuxkit run qemu test-sysctl)"
+RESULT="$(linuxkit run qemu -kernel test-sysctl)"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0


### PR DESCRIPTION
For all output formats except kernel+initrd, recommend that people just
add the full path of the file they want to run. If you do this, generally
make the options automatic.

Split the uefi option to mean "use uefi firmware" not be ISO specific.

Allow specifying a bootable disk image, so we can test disk image output
formats with qemu too.

Specifying a prefix for anything other than kernel+initrd is deprecated
and will be removed at some point.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![top-10-dirty-animals-covered-in-mud-l-cbxk4f](https://cloud.githubusercontent.com/assets/482364/26319498/2d8b7024-3f17-11e7-8eaa-f240f26543ba.jpeg)
