### PR TITLE
examples: switch dhcpd to onboot in redis-os example

### DIFF
--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
   - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
   - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-services:
+onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
     binds:
@@ -18,6 +18,8 @@ services:
      - CAP_NET_BIND_SERVICE
      - CAP_NET_RAW
     net: host
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+services:
   - name: redis
     image: "redis:3.0.7-alpine"
     capabilities:


### PR DESCRIPTION
Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
