### PR TITLE
Add a simple qemu guest agent package

### DIFF
--- a/pkg/qemu-ga/Dockerfile
+++ b/pkg/qemu-ga/Dockerfile
@@ -1,0 +1,12 @@
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS build
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN mkdir -p /out/var/run
+RUN apk add --no-cache --initdb -p /out \
+    qemu-guest-agent \
+    musl
+FROM scratch
+WORKDIR /
+ENTRYPOINT []
+COPY --from=build /out /
+CMD ["/usr/bin/qemu-ga", "-p", "/dev/vport0p1"]
+LABEL org.mobyproject.config='{"net": "host"}'

--- a/pkg/qemu-ga/Makefile
+++ b/pkg/qemu-ga/Makefile
@@ -1,0 +1,14 @@
+.PHONY: tag push
+
+ORG?=linuxkit
+IMAGE=qemu-ga
+
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
+
+default: push
+
+tag: Dockerfile
+	docker build --network=none -t $(ORG)/$(IMAGE):$(HASH) .
+
+push: tag
+	docker pull $(ORG)/$(IMAGE):$(HASH) || docker push $(ORG)/$(IMAGE):$(HASH)

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -20,6 +20,10 @@ onboot:
   - name: metadata
     image: "linuxkit/metadata:b053fd6a945829bb626bb3546cad69aae0ff7803"
 services:
+  - name: qemu-ga
+    image: "linuxkit/qemu-ga:e5fbcf55926f6e1a96b3e49a392e547e8be1022c"
+    binds:
+      - /dev/vport0p1:/dev/vport0p1
   - name: rngd
     image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: ntpd


### PR DESCRIPTION
We don't actually build it here, we just use the alpine package.

Can be instantiated with a service stanza such as:
```
  - name: qemu_ga
    image: "linuxkit/qemu_ga:ffc2c35a1126aeab5a324254ce83c4b302eeaf04"
    binds:
      - /dev/vport1p1:/dev/vport1p1
    command: ["/usr/bin/qemu-ga", "-p", "/dev/vport1p1"]
    net: host
```

Note that `net: host` is required since one function (and the only one I've
tested) is to report IP addresses to the host (e.g. via `virsh domifaddr`).

The mdev tool appears to not create the symlinks which udev would provide
`/dev/virtio-ports/org.qemu.guest_agent.0` hence the need to hardcode the
potentially unstable `/dev/vportNp1`, `N` seems to depend on the number and
order of virtio devices in use. I don't know if it is possible to get mdev to
create these links. For reference the udev rule is:

    SUBSYSTEM=="virtio-ports", KERNEL=="vport*", ATTR{name}=="?*", SYMLINK+="virtio-ports/$attr{name}"

See https://wiki.libvirt.org/page/Qemu_guest_agent for more info on the guest
agent.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a new pkg containing the qemu guest agent

**- How I did it**

**- How to verify it**

Configure a VM with the appropriate channel. I used the following in a libvirt domain's `channels` list:

```
<channel type='unix'>
   <target type='virtio' name='org.qemu.guest_agent.0'/>
</channel>
```

With this commands such as `virsh domifaddr --source agent <domain>` ought to work, you may need to adjust the `/dev/vportNp1` to match your VM (I'm not 100% sure how `N` is arrived at, although it appears to be somewhat stable for a given VM configuration).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added a Qemu Guest Agent package.

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://upload.wikimedia.org/wikipedia/en/6/63/Planes_Mistaken_for_Stars_-_Prey.jpg "Planes Mistaken For Stars, Prey")
