### PR TITLE
Add moby config label to common packages

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -12,10 +12,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:1cde5876d44117af61dfea629ad922defcd48808
   - name: binfmt
-    image: "linuxkit/binfmt:548f7f044f5411a8938913527c5ce55d9876bb07"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
+    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
   - name: format
     image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
     binds:
@@ -34,22 +31,9 @@ onboot:
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:c97ef16be340884a985d8b025983505a9bcc51f0"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
+    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    oomScoreAdj: -800
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
   - name: ntpd
     image: "linuxkit/openntpd:ad834449a7eaf10dc022b3d8d2ed9faf7ec99d37"
     capabilities:

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -10,15 +10,7 @@ onboot:
   - name: sysctl
     image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: "linuxkit/metadata:a810b68fec9c9282cf096eed50605ddd6b2f3142"
@@ -31,11 +23,7 @@ onboot:
      - CAP_SYS_ADMIN
 services:
   - name: rngd
-    image: "linuxkit/rngd:c97ef16be340884a985d8b025983505a9bcc51f0"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
+    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
   - name: sshd
     image: "linuxkit/sshd:1613253e5def414e0dfd261acd0e191eadb5fedf"
     capabilities:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -7,15 +7,7 @@ init:
   - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 trust:
   image:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -7,21 +7,9 @@ init:
   - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
 services:
   - name: rngd
-    image: "linuxkit/rngd:c97ef16be340884a985d8b025983505a9bcc51f0"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
+    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    oomScoreAdj: -800
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
   - name: node_exporter
     image: "linuxkit/node_exporter:bdb20b41855d0e2b4edeec44ef569d030ea3cc47"
     capabilities:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -11,21 +11,9 @@ onboot:
     image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
 services:
   - name: rngd
-    image: "linuxkit/rngd:c97ef16be340884a985d8b025983505a9bcc51f0"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
+    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    oomScoreAdj: -800
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
   - name: sshd
     image: "linuxkit/sshd:1613253e5def414e0dfd261acd0e191eadb5fedf"
     capabilities:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -9,15 +9,7 @@ init:
   - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: redis

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -11,21 +11,9 @@ onboot:
     image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
 services:
   - name: rngd
-    image: "linuxkit/rngd:c97ef16be340884a985d8b025983505a9bcc51f0"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
+    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    oomScoreAdj: -800
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
   - name: sshd
     image: "linuxkit/sshd:1613253e5def414e0dfd261acd0e191eadb5fedf"
     capabilities:

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -10,20 +10,9 @@ onboot:
   - name: sysctl
     image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
   - name: binfmt
-    image: "linuxkit/binfmt:548f7f044f5411a8938913527c5ce55d9876bb07"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
+    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
     image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
@@ -58,10 +47,6 @@ onboot:
 services:
   - name: rngd
     image: "linuxkit/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -11,22 +11,9 @@ onboot:
     image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
 services:
   - name: rngd
-    image: "linuxkit/rngd:c97ef16be340884a985d8b025983505a9bcc51f0"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
+    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    oomScoreAdj: -800
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -10,28 +10,13 @@ onboot:
   - name: sysctl
     image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
   - name: binfmt
-    image: "linuxkit/binfmt:548f7f044f5411a8938913527c5ce55d9876bb07"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
+    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:c97ef16be340884a985d8b025983505a9bcc51f0"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
+    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e AS qemu
+FROM linuxkit/alpine:5f6db26ab7bf6a9c452a612e236cc7495408132b@sha256:d009afc85d0b005daf51c8f3026aa552ab997dc47cab43915e9dc761accae086 AS qemu
 RUN apk add \
     qemu-aarch64 \
     qemu-arm \
@@ -18,3 +18,4 @@ COPY --from=qemu usr/bin/qemu-* usr/bin/
 COPY --from=build usr/bin/binfmt usr/bin/binfmt
 COPY etc/binfmt.d/00_linuxkit.conf etc/binfmt.d/00_linuxkit.conf
 CMD ["/usr/bin/binfmt", "-dir", "/etc/binfmt.d/", "-mount", "/binfmt_misc"]
+LABEL org.mobyproject.config='{"binds": ["/proc/sys/fs/binfmt_misc:/binfmt_misc"], "readonly": true}'

--- a/pkg/dhcpcd/Dockerfile
+++ b/pkg/dhcpcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e AS mirror
+FROM linuxkit/alpine:5f6db26ab7bf6a9c452a612e236cc7495408132b@sha256:d009afc85d0b005daf51c8f3026aa552ab997dc47cab43915e9dc761accae086 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
@@ -16,3 +16,4 @@ WORKDIR /
 COPY --from=mirror /out/ /
 COPY /dhcpcd.conf /usr/ /
 CMD ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf"]
+LABEL org.mobyproject.config='{"binds": ["/var:/var", "/tmp/etc:/etc"], "net": "host", "capabilities": ["CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE", "CAP_NET_RAW"]}'

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:dae8bcbc6e2cec0a1cc1958dddbc5d6bd3ccf9a0@sha256:02c251d54c4083a596ead8cae92144306b385db0ff961c95a3a620a4c69961ed AS mirror
+FROM linuxkit/alpine:5f6db26ab7bf6a9c452a612e236cc7495408132b@sha256:d009afc85d0b005daf51c8f3026aa552ab997dc47cab43915e9dc761accae086 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     tini
@@ -42,3 +42,4 @@ WORKDIR /
 COPY --from=mirror /out/ /
 COPY --from=build usr/sbin/rngd usr/sbin/rngd
 CMD ["/sbin/tini", "/usr/sbin/rngd", "-f"]
+LABEL org.mobyproject.config='{"capabilities": ["CAP_SYS_ADMIN"], "oomScoreAdj": -800, "readonly": true}'

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -26,15 +26,7 @@ onboot:
     rootfsPropagation: shared
     command: ["/mount.sh", "/var/lib/etcd"]
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: "linuxkit/metadata:a810b68fec9c9282cf096eed50605ddd6b2f3142"
@@ -48,10 +40,6 @@ onboot:
 services:
   - name: rngd
     image: "linuxkit/rngd:f5e5be43e730ea819c3293d5c6dcbfa7f4c5c314"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
   - name: ntpd
     image: "linuxkit/openntpd:ad834449a7eaf10dc022b3d8d2ed9faf7ec99d37"
     capabilities:

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -10,15 +10,7 @@ onboot:
   - name: sysctl
     image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: "linuxkit/metadata:a810b68fec9c9282cf096eed50605ddd6b2f3142"
@@ -32,10 +24,6 @@ onboot:
 services:
   - name: rngd
     image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
   - name: prometheus
     image: "moby/prom-us-central1-f"
     binds:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -12,10 +12,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:1cde5876d44117af61dfea629ad922defcd48808
   - name: binfmt
-    image: "linuxkit/binfmt:548f7f044f5411a8938913527c5ce55d9876bb07"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
+    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
   - name: format
     image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
     binds:
@@ -35,21 +32,8 @@ onboot:
 services:
   - name: rngd
     image: "linuxkit/rngd:f5e5be43e730ea819c3293d5c6dcbfa7f4c5c314"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    oomScoreAdj: -800
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
   - name: ntpd
     image: "linuxkit/openntpd:ad834449a7eaf10dc022b3d8d2ed9faf7ec99d37"
     capabilities:

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -12,10 +12,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:1cde5876d44117af61dfea629ad922defcd48808
   - name: binfmt
-    image: "linuxkit/binfmt:548f7f044f5411a8938913527c5ce55d9876bb07"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
+    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
   - name: format
     image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
     binds:
@@ -35,21 +32,8 @@ onboot:
 services:
   - name: rngd
     image: "linuxkit/rngd:f5e5be43e730ea819c3293d5c6dcbfa7f4c5c314"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    oomScoreAdj: -800
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
   - name: ntpd
     image: "linuxkit/openntpd:ad834449a7eaf10dc022b3d8d2ed9faf7ec99d37"
     capabilities:

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -11,28 +11,13 @@ onboot:
   - name: sysctl
     image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
   - name: binfmt
-    image: "linuxkit/binfmt:548f7f044f5411a8938913527c5ce55d9876bb07"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
+    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:c97ef16be340884a985d8b025983505a9bcc51f0"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
+    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -10,10 +10,6 @@ onboot:
   - name: sysctl
     image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
   - name: binfmt
-    image: linuxkit/binfmt:548f7f044f5411a8938913527c5ce55d9876bb07
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
 services:
   - name: rngd
     image: mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -12,20 +12,8 @@ onboot:
 services:
   - name: rngd
     image: "linuxkit/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    oomScoreAdj: -800
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
   - name: sshd
     image: "linuxkit/sshd:1613253e5def414e0dfd261acd0e191eadb5fedf"
     capabilities:

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -10,15 +10,7 @@ onboot:
   - name: sysctl
     image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
     image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
@@ -47,11 +39,7 @@ onboot:
      - CAP_SYS_ADMIN
 services:
   - name: rngd
-    image: "linuxkit/rngd:c97ef16be340884a985d8b025983505a9bcc51f0"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
+    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
   - name: ntpd
     image: "linuxkit/openntpd:ad834449a7eaf10dc022b3d8d2ed9faf7ec99d37"
     capabilities:

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -7,15 +7,7 @@ init:
   - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 trust:
   image:

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -12,10 +12,7 @@ onboot:
   - name: sysfs
     image: "linuxkit/sysfs:1cde5876d44117af61dfea629ad922defcd48808"
   - name: binfmt
-    image: "linuxkit/binfmt:548f7f044f5411a8938913527c5ce55d9876bb07"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
+    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
   - name: format
     image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
     binds:
@@ -34,22 +31,9 @@ onboot:
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:c97ef16be340884a985d8b025983505a9bcc51f0"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
+    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
-    oomScoreAdj: -800
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
   - name: docker
     image: "linuxkit/docker-ce:261f93927d85001c65e5ce0f421eb6062f09c0a5"
     capabilities:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -10,15 +10,7 @@ init:
   - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:cb96c09a33c166eca6530f166f0f79927c3e83b0"
-    binds:
-     - /var:/var
-     - /tmp:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
+    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"


### PR DESCRIPTION
This adds the config label to the `binfmt`, `dhcpcd`, and `rngd` packages and updates the YAML files to remove the now unnecessary additional container configs. `dhcpcd` and `rngd` are easily the most commonly used packages.

While at it, I also update the packages to use the latest Alpine base

![image](https://cloud.githubusercontent.com/assets/3338098/26360674/9b9cb7da-3fd0-11e7-9979-0f4d27d9c775.png)
