### PR TITLE
docs: add a blurb about CVE-2017-1000363

### DIFF
--- a/docs/security-events.md
+++ b/docs/security-events.md
@@ -5,6 +5,8 @@ The incomplete list below is an assessment of some CVEs, and LinuxKit's resilien
 
 ### Bugs mitigated:
 
+* [CVE-2017-1000363](http://www.openwall.com/lists/oss-security/2017/05/23/16):
+  This CVE requires `CONFIG_PRINTER=y`, so we are not vulnerable.
 * [CVE-2017-2636](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-2636)
   ([exploit post](https://a13xp0p0v.github.io/2017/03/24/CVE-2017-2636.html)):
   This CVE requires `CONFIG_N_HDLC={y|m}`, which LinuxKit does not specify, and so


### PR DESCRIPTION
As of the time of this patch, the CVE was not available yet in the mitre
db.

Signed-off-by: Tycho Andersen <tycho@docker.com>