### PR TITLE
cmd: Unify disk command line options for local hypervisors

### DIFF
--- a/docs/external-disk.md
+++ b/docs/external-disk.md
@@ -5,38 +5,18 @@
 2. Mount the disk
 
 ## Make Disk Available
-In order to make the disk available, you need to tell `linuxkit` where the disk file or block device is. This depends on your run method.
+In order to make the disk available, you need to tell `linuxkit` where the disk file or block device is.
 
-**Note:** With all of the options below, *always* give disk options before the _prefix_.
+All local `linuxkit run` methods (currently `hyperkit`, `qemu`, and `vmware`) take two arguments:
 
-### Mac HyperKit
-`linuxkit run hyperkit -disk <path_to_disk> -disk-size <size> <prefix>`
-
-* `-disk-size <size>`: size of disk in MB, e.g. `-disk-size 4096` will provide a 4GB disk.
+* `-disk-size <size>`: size of disk. The default is in MB but a `G` can be appended to specify the size in GB, e.g. `-disk-size 4096` or `disk-size 4G` will provide a 4GB disk.
 * `-disk <path>`: use the disk at location _path_, e.g. `-disk foo.img` will use the disk at `$PWD/foo.img`
 
-Several important points to note:
+If you do not provide `-disk `_path_, `linuxkit` assumes a default, which is _prefix_`-state/disk.img` for `hyperkit` and `vmware` and _prefix_`-disk.img` for `qemu`. 
 
-1. if you do not provide `-disk `_path_, `linuxkit` assumes the default to be `$PWD/`_prefix_`-disk.img`.
-2. If the disk at `<path>`, or the default if `-disk` option is not provided, does not exist, `linuxkit` will create one of size `<size>`.
+If the disk at `<path>`, or the default if `-disk` option is not provided, does not exist, `linuxkit` will create one of size `<size>`.
 
-### QEMU
-`linuxkit run qemu -disk <path_to_disk> -disk-size <size> <prefix>`
-
-* `-disk-size <size>`: size of disk in MB, e.g. `-disk-size 4096` will provide a 4GB disk.
-* `-disk <path>`: use the disk at location _path_, e.g. `-disk foo.img` will use the disk at `$PWD/foo.img`
-
-Several important points to note:
-
-1. if you do not provide `-disk `_path_, `linuxkit` assumes the default to be `$PWD/`_prefix_`-disk.img`.
-2. If the disk at `<path>`, or the default if `-disk` option is not provided, does not exist, `linuxkit` will create one of size `<size>`.
-
-### vmware
-`linuxkit run vmware -disk <path_to_disk> <prefix>`
-
-* `-disk <path>`: use the disk at location _path_, e.g. `-disk foo.img` will use the disk at `$PWD/foo.img`
-
-Unlike with qemu and hyperkit, `linuxkit run vmware` _currently_ will not create the disk for you if it does not exist. We intend to align the functionality in the near future. 
+**TODO:** GCP
 
 ## Mount the Disk
 A disk created or used via `hyperkit run` will be available inside the image at `/dev/vda` with the first partition at `/dev/vda1`.

--- a/src/cmd/linuxkit/util.go
+++ b/src/cmd/linuxkit/util.go
@@ -97,3 +97,24 @@ func stringToIntArray(l string, sep string) ([]int, error) {
 	}
 	return i, nil
 }
+
+// Parse a string which is either a number in MB, or a number with
+// either M (for Megabytes) or G (for GigaBytes) as a suffix and
+// returns the number in MB. Return 0 if string is empty.
+func getDiskSizeMB(s string) (int, error) {
+	if s == "" {
+		return 0, nil
+	}
+	sz := len(s)
+	if strings.HasSuffix(s, "G") {
+		i, err := strconv.Atoi(s[:sz-1])
+		if err != nil {
+			return 0, err
+		}
+		return i * 1024, nil
+	}
+	if strings.HasSuffix(s, "M") {
+		s = s[:sz-1]
+	}
+	return strconv.Atoi(s)
+}


### PR DESCRIPTION
- '-disk-size' is now always in MB
- The disk will be created if it doesn't exist (didn't happen in qemu)

Update the documentation.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

resolves: #1886

![image](https://cloud.githubusercontent.com/assets/3338098/26400614/b6c22596-4079-11e7-9c8c-986f9fd184f4.png)
