### PR TITLE
More signing!

### DIFF
--- a/docs/signing/notary.md
+++ b/docs/signing/notary.md
@@ -1,0 +1,49 @@
+# Signing LinuxKit Hub Images
+
+We sign and verify LinuxKit component images, such as `linuxkit/kernel`, using [Notary](https://github.com/docker/notary).
+
+This document details the process for setting this up, intended for maintainers.
+
+## Initialize a New Repository
+
+Let's say we're publishing a new `linuxkit/foo` image that we want to sign and verify in LinuxKit.
+We first need to initialize the Notary repository:
+
+```apple js
+notary -s https://notary.docker.io -d ~/.docker/trust init -p docker.io/linuxkit/foo
+```
+
+This command will generate some private keys in `~/.docker/trust` and ask you for passphrases such that they are encrypted at rest.
+All linuxkit repositories are currently using the same root key so we can pin trust on key ID `1908a0cf4f55710138e63f65ab2a97e8fa3948e5ca3b8857a29f235a3b61ea1b`.
+
+We'll also let the notary server take control of the snapshot key, for easier delegation collaboration:
+```apple js
+notary -s https://notary.docker.io -d ~/.docker/trust key rotate docker.io/linuxkit/foo snapshot -r
+```
+
+## Add maintainers to delegation roles:
+
+Maintainers are to sign with `delegation` keys, which are adminstered by a non-root key.
+Thusly, they are easily rotated without having to bring the root key online.
+Additionally, maintainers can be added to separate roles for auditing purposes: the current setup is to add maintainers to both the `targets/releases` role that is intended
+for release consumption, as well as an individual `targets/<maintainer_name>` role for auditing.
+Docker will automatically sign into both roles when pushing with Docker Content Trust.
+
+Here's what the command looks like to add all maintainers to the `targets/releases` role:
+```apple js
+notary -s https://notary.docker.io -d ~/.docker/trust delegation add -p docker.io/linuxkit/foo targets/releases alice.crt bob.crt charlie.crt --all-paths
+```
+
+Here's what the commands look like to add all maintainers to their individually named roles:
+```apple js
+notary -s https://notary.docker.io -d ~/.docker/trust delegation add -p docker.io/linuxkit/foo targets/alice alice.crt --all-paths
+notary -s https://notary.docker.io -d ~/.docker/trust delegation add -p docker.io/linuxkit/foo targets/bob bob.crt --all-paths
+notary -s https://notary.docker.io -d ~/.docker/trust delegation add -p docker.io/linuxkit/foo targets/charlie charlie.crt --all-paths
+```
+
+## Maintainers import their private keys
+
+It's important that each maintainer imports their private key into Docker's key storage, so Docker can use it to sign:
+```apple js
+notary -d ~/.docker/trust key import alice.key -r user
+```

--- a/pkg/ca-certificates/Makefile
+++ b/pkg/ca-certificates/Makefile
@@ -11,4 +11,5 @@ tag: Dockerfile
 	docker build --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -11,4 +11,5 @@ tag: Dockerfile
 	docker build -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/dhcpcd/Makefile
+++ b/pkg/dhcpcd/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/format/Makefile
+++ b/pkg/format/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/init/Makefile
+++ b/pkg/init/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/metadata/Makefile
+++ b/pkg/metadata/Makefile
@@ -27,9 +27,9 @@ hash: Dockerfile $(DEPS)
 	find $^ -type f | xargs cat | docker run --rm -i $(SHA_IMAGE) sha1sum - | sed 's/ .*//' > hash
 
 push: hash container
-	docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(IMAGE):build $(ORG)/$(IMAGE):$(shell cat hash) && \
-		 docker push $(ORG)/$(IMAGE):$(shell cat hash))
+		 DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(shell cat hash))
 	docker rmi $(IMAGE):build
 	rm -f hash
 

--- a/pkg/mount/Makefile
+++ b/pkg/mount/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/openntpd/Makefile
+++ b/pkg/openntpd/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/runc/Makefile
+++ b/pkg/runc/Makefile
@@ -11,4 +11,5 @@ tag: Dockerfile
 	docker build -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/sshd/Makefile
+++ b/pkg/sshd/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/sysctl/Makefile
+++ b/pkg/sysctl/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/sysfs/Makefile
+++ b/pkg/sysfs/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -12,9 +12,9 @@ hash:
 	docker run --rm $(IMAGE):build sh -c 'echo /lib/apk/db/installed $$(find /mirror -name '*.apk' -type f) $$(find /go/bin -type f) | xargs cat | sha1sum' | sed 's/ .*//' > $@
 
 push: hash
-	docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(IMAGE):build $(ORG)/$(IMAGE):$(shell cat hash) && \
-		 docker push $(ORG)/$(IMAGE):$(shell cat hash))
+		 DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(shell cat hash))
 	docker run --rm $(IMAGE):build find /mirror -name '*.apk' -exec basename '{}' .apk \; | sort | (echo '# automatically generated list of installed packages'; cat -) > versions
 	docker rmi $(IMAGE):build
 	rm -f hash


### PR DESCRIPTION
I've setup signing for more repos, notably:
```
docker.io/linuxkit/alpine
docker.io/linuxkit/sysctl
docker.io/linuxkit/sysfs
docker.io/linuxkit/dhcpcd
docker.io/linuxkit/init
docker.io/linuxkit/metadata
docker.io/linuxkit/mount
docker.io/linuxkit/format
docker.io/linuxkit/openntpd
docker.io/linuxkit/sshd
docker.io/linuxkit/runc
docker.io/linuxkit/containerd
docker.io/linuxkit/ca-certificates
```

NOTE: I haven't gone through and repushed all of those repos with content trust yet - once I do that I'll also update the appropriate yml files to require trust for these repos.

I've also added a brief primer doc on setting up the signing process - it relies on keys that I maintain/safely store.  @justincormack @rneugeba @ijc25 as maintainers we can figure out the best way to securely share them (I have some ideas, we can discuss offline).

I also have a script that I've been using to help set things up, I'm cleaning that up and determining the best way to share that in the repo.

<img src="https://scopicimpulse.files.wordpress.com/2017/05/comedy-wildlife-photo-awards-shortlist-57fb45e4e42fa__880.jpg" width="400"></img>