### PR TITLE
Add buildchain security to agenda, proposed time allocations

### DIFF
--- a/reports/sig-security/2017-06-07.md
+++ b/reports/sig-security/2017-06-07.md
@@ -8,17 +8,17 @@ Announcement: Moby project forum post coming soon!
 Previous meeting notes: [2017-05-24](2017-05-24.md)
 
 ## Agenda
-- Introductions & Administrivia
-- RFC on `"probational"`/`"hardened"`/`"staging"` channel
+- Introductions & Administrivia (5 min)
+- RFC on `"probational"`/`"hardened"`/`"staging"` channel (15 min)
   - proof-of-concept in LinuxKit repo
   - proposed process for promotion to channel, out of channel
-- Overview of LinuxKit and its security initiatives
-- Discuss goals of SIG
-- `miragesdk` deep dive - @avsm @samoht
+- buildchain security: PIE/ASLR for packages @fntlnz (10 min)
+- `miragesdk` deep dive - @avsm @samoht (20 min)
   - What is it?  Why do we care?
   - RFC: which system daemons should we implement?
   - architecture deep dive
   - demo: `dhcp`
+- Project updates (10 min)
 - Next meeting: 2017-06-21
   - landlock demo and deep dive - @l0kod
   - we can propose additional deep dives and discussion topics!


### PR DESCRIPTION
cc @fntlnz for buildchain security discussion topic
cc @avsm @samoht for time-allocation - do you think we need more time for the deep dive?  I can shuffle topics around :)


<img src="https://scopicimpulse.files.wordpress.com/2017/05/1101_comedy-wildlife-frog-1000x623.jpg" width="400"></img>

