### PR TITLE
Remove outputs from the yaml files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 PREFIX?=/usr/local/
 
-MOBY_COMMIT=b47f3dec4a8357bc3ee4da878c402700d3fed62e
+MOBY_COMMIT=1cb9fab3e13c8d3931c6f989c5d36087382e8710
 bin/moby: | bin
 	docker run --rm --log-driver=none $(CROSS) $(GO_COMPILE) --clone-path github.com/moby/tool --clone https://github.com/moby/tool.git --commit $(MOBY_COMMIT) --package github.com/moby/tool/cmd/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
 	tar xf tmp_moby_bin.tar > $@

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ rtf -x run linuxkit.examples
 To customise, copy or modify the [`linuxkit.yml`](linuxkit.yml) to your own `file.yml` or use one of the [examples](examples/) and then run `moby build file.yml` to
 generate its specified output. You can run the output with `linuxkit run file`.
 
-The yaml file specifies a kernel and base init system, a set of containers that are built into the generated image and started at boot time. It also specifies what
-formats to output, such as bootable ISOs and images for various platforms.
+The yaml file specifies a kernel and base init system, a set of containers that are built into the generated image and started at boot time. You can specify the type
+of artifact to build with the `moby` tool eg `moby build -output vhd linuxkit.yml`.
 
 ### Yaml Specification
 
@@ -89,7 +89,6 @@ The yaml format specifies the image to be built:
 - `onboot` are the system containers, executed sequentially in order. They should terminate quickly when done.
 - `services` is the system services, which normally run for the whole time the system is up
 - `files` are additional files to add to the image
-- `outputs` are descriptions of what to build, such as ISOs.
 
 For a more detailed overview of the options see [yaml documentation](docs/yaml.md).
 

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -47,25 +47,6 @@ integrity, and freshness guarantees for the components it verifies.  The LinuxKi
 The image name may include tag or digest, but the matching also succeeds if the base image name is the same.
 - `org` lists which organizations for which Docker Content Trust is to be enforced across all images (ex: `mobylinux` is the org for `mobylinux/kernel`)
 
-## `output`
-
-This section specifies the output formats that are created. Files are created with the base name of
-the config file, eg `moby` for `moby.yml` or the name specified with `moby build --name ...`. Then
-they will have a suffix related to the file type created, such as `moby-bzImage` or `moby.img.tar.gz`.
-The generated names are output by the command for reference or scripting.
-
-- `kernel+initrd` outputs the raw kernel (`bzImage`), the init ramdisk, and a file with the specified
-  command line. This is used for example by the hyperkit driver.
-- `iso-bios` outputs a CD image that is bootable via a traditional BIOS. Can also be used with Qemu.
-- `iso-efi` outputs a CD image that can be used by an EFI BIOS, as required by Hyper-V and newer hardware.
-- `gcp-img` outputs a compressed tarred filesystem image as used on Google Cloud Platform.
-- `gcp-storage` stores the `gcp-img` in a GCP bucket. `bucket` and `project` must be specified.
-- `gcp` stores the `gcp-img` as a bootable machine image, after uploading to the bucket. `bucket` and `project`
-  must be specified. Use `replace: true` to replace any existing image. You can specify an image `family`.
-- `qcow` or `qcow2` creates a `qcow2` image for Qemu and similar systems
-- `vhd` creates a VHD image.
-- `vmdk` creates a VMDK image, suitable for use with VMWare.
-
 ## Image specification
 
 For each image in the `system` and `daemon` sections you can specify the OCI options that are passed to

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -62,5 +62,3 @@ trust:
     - linuxkit/kernel
     - linuxkit/binfmt
     - linuxkit/rngd
-outputs:
-  - format: kernel+initrd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -46,6 +46,3 @@ trust:
   image:
     - linuxkit/kernel
     - linuxkit/rngd
-outputs:
-  - format: kernel+initrd
-  - format: gcp-img

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -12,5 +12,3 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
-outputs:
-  - format: kernel+initrd

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -24,5 +24,3 @@ trust:
   image:
     - linuxkit/kernel
     - linuxkit/rngd
-outputs:
-  - format: kernel+initrd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -30,5 +30,3 @@ trust:
 files:
   - path: root/.ssh/authorized_keys
     contents: '#your ssh key here'
-outputs:
-  - format: kernel+initrd

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -21,5 +21,3 @@ services:
      - CAP_SETGID
      - CAP_DAC_OVERRIDE
     net: host
-outputs:
-  - format: kernel+initrd

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -30,7 +30,3 @@ trust:
 files:
   - path: root/.ssh/authorized_keys
     contents: '#your ssh key here'
-outputs:
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -59,7 +59,3 @@ services:
 trust:
   image:
     - linuxkit/kernel
-outputs:
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -27,5 +27,3 @@ trust:
   image:
     - linuxkit/kernel
     - linuxkit/rngd
-outputs:
-  - format: vmdk

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -34,7 +34,3 @@ trust:
     - linuxkit/kernel
     - linuxkit/binfmt
     - linuxkit/rngd
-outputs:
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -22,5 +22,3 @@ services:
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'
-outputs:
-  - format: kernel+initrd

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -72,11 +72,3 @@ services:
     binds:
      - /var/lib/etcd:/var/lib/etcd
      - /var/config/etcd:/etc/etcd
-
-outputs:
-  - format: kernel+initrd
-  - format: gcp
-    project: docker4x
-    bucket: rolf
-    family: moby-demo
-    replace: true

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -35,10 +35,3 @@ services:
 trust:
   image:
     - mobylinux/kernel
-outputs:
-  - format: kernel+initrd
-  - format: gcp
-    project: docker4x
-    bucket: rolf
-    family: moby-demo
-    replace: true

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -50,5 +50,3 @@ trust:
     - linuxkit/kernel
     - linuxkit/binfmt
     - linuxkit/rngd
-outputs:
-  - format: kernel+initrd

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -97,5 +97,3 @@ files:
     contents: '# Your ssh key goes here'
   - {path: etc/cni, directory: true}
   - {path: opt/cni, directory: true}
-outputs:
-  - format: kernel+initrd

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -93,5 +93,3 @@ files:
     contents: '# Your ssh key goes here'
   - {path: etc/cni, directory: true}
   - {path: opt/cni, directory: true}
-outputs:
-  - format: kernel+initrd

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -22,7 +22,3 @@ services:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
-outputs:
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -33,7 +33,3 @@ files:
 trust:
   image:
     - mobylinux/kernel
-outputs:
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -38,7 +38,3 @@ services:
 files:
   - path: /var/run/dhcp-client/README
     contents: 'data for dhcp-client'
-outputs:
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -26,7 +26,3 @@ services:
 files:
   - path: root/.ssh/authorized_keys
     contents: '#your ssh key here'
-outputs:
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi

--- a/projects/selinux/selinux.yml
+++ b/projects/selinux/selinux.yml
@@ -19,7 +19,3 @@ services:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
-outputs:
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -74,7 +74,3 @@ services:
       - /var/lib/containerd:/var/lib/containerd
       - /var/lib/swarmd:/var/lib/swarmd
       - /etc/resolv.conf:/etc/resolv.conf
-outputs:
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi

--- a/projects/wireguard/examples/wireguard.yml
+++ b/projects/wireguard/examples/wireguard.yml
@@ -19,7 +19,3 @@ services:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800
     readonly: true
-outputs:
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi

--- a/test/Makefile
+++ b/test/Makefile
@@ -31,7 +31,7 @@ gcp-hack: ../artifacts/test.img.tar.gz
 ../artifacts/test.img.tar.gz:
 	rm -rf ../artifacts
 	mkdir -p ../artifacts
-	$(MOBY) build --pull -name ../artifacts/test hack/test.yml
+	$(MOBY) build -output gcp-img -pull -name ../artifacts/test hack/test.yml
 
 define check_test_log
 	@cat $1 |grep -q 'test suite PASSED'
@@ -40,7 +40,7 @@ endef
 .PHONY: ltp
 ltp: export CLOUDSDK_IMAGE_NAME?=test-ltp
 ltp: $(LINUXKIT) test-ltp.img.tar.gz
-	$(MOBY) build --pull hack/test-ltp.yml
+	$(MOBY) build -output gcp-img -pull hack/test-ltp.yml
 	$(LINUXKIT) push gcp test-ltp.img.tar.gz
 	$(LINUXKIT) run gcp -skip-cleanup -machine n1-highcpu-4 $(CLOUDSDK_IMAGE_NAME) | tee test-ltp.log
 	$(call check_test_log, test-ltp.log)

--- a/test/cases/000_build/000_outputs/test.sh
+++ b/test/cases/000_build/000_outputs/test.sh
@@ -17,8 +17,7 @@ clean_up() {
 
 trap clean_up EXIT
 
-moby build -name "${NAME}" test.yml
-
+moby build -output tar,kernel+initrd,iso-bios,iso-efi,img-gz,qcow2,vmdk -name "${NAME}" test.yml
 [ -f "${NAME}.tar" ] || exit 1
 [ -f "${NAME}-kernel" ] || exit 1
 [ -f "${NAME}-initrd.img" ] || exit 1

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -12,14 +12,3 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
-outputs:
-  - format: tar
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi
-  - format: img-gz
-  - format: gcp-img
-  - format: qcow2
-# Disable VHD for now. It requires a lot of memory, which our CI instance currently doesn't have
-#  - format: vhd
-  - format: vmdk

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.sh
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 
 trap clean_up EXIT
 
-moby build -name "${NAME}" test.yml
+moby build -output kernel+initrd -name "${NAME}" test.yml
 [ -f "${NAME}-kernel" ] || exit 1
 [ -f "${NAME}-initrd.img" ] || exit 1
 [ -f "${NAME}-cmdline" ]|| exit 1

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -12,5 +12,3 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
-outputs:
-  - format: kernel+initrd

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.sh
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.sh
@@ -16,7 +16,7 @@ clean_up() {
 
 trap clean_up EXIT
 
-moby build -name "${NAME}" test.yml
+moby build -output iso-bios -name "${NAME}" test.yml
 [ -f "${NAME}.iso" ] || exit 1
 linuxkit run qemu -iso "${NAME}.iso" | grep -q "Welcome to LinuxKit"
 exit 0

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -12,5 +12,3 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
-outputs:
-  - format: iso-bios

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.sh
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.sh
@@ -23,7 +23,7 @@ if command -v qemu-system-x86_64; then
 	fi
 fi
 
-moby build -name "${NAME}" test.yml
+moby build -output iso-efi -name "${NAME}" test.yml
 [ -f "${NAME}-efi.iso" ] || exit 1
 linuxkit run qemu -iso -uefi "${NAME}-efi.iso" | grep -q "Welcome to LinuxKit"
 exit 0

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -12,5 +12,3 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
-outputs:
-  - format: iso-efi

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.sh
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 
 trap clean_up EXIT
 
-moby build -name "${NAME}" test.yml
+moby build -output qcow2 -name "${NAME}" test.yml
 [ -f "${NAME}.qcow2" ] || exit 1
 linuxkit run qemu -disk-format qcow2 "${NAME}.qcow2" | grep -q "Welcome to LinuxKit"
 exit 0

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -12,5 +12,3 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
-outputs:
-  - format: qcow2

--- a/test/cases/010_platforms/000_qemu/100_container/test.sh
+++ b/test/cases/010_platforms/000_qemu/100_container/test.sh
@@ -26,7 +26,7 @@ if [ -z "${QEMU}" ]; then
     exit $RT_CANCEL
 fi
 
-moby build -name "${NAME}" test.yml
+moby build -output kernel+initrd -name "${NAME}" test.yml
 [ -f "${NAME}-kernel" ] || exit 1
 [ -f "${NAME}-initrd.img" ] || exit 1
 [ -f "${NAME}-cmdline" ]|| exit 1

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -12,5 +12,3 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
-outputs:
-  - format: kernel+initrd

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.sh
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.sh
@@ -18,7 +18,7 @@ clean_up() {
 }
 trap clean_up EXIT
 
-moby build -name "${NAME}" test.yml
+moby build -output kernel+initrd -name "${NAME}" test.yml
 [ -f "${NAME}-kernel" ] || exit 1
 [ -f "${NAME}-initrd.img" ] || exit 1
 [ -f "${NAME}-cmdline" ]|| exit 1

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -12,5 +12,3 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
-outputs:
-  - format: kernel+initrd

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -12,5 +12,3 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
-outputs:
-  - format: kernel+initrd

--- a/test/cases/020_kernel/000_config_4.4.x/test.sh
+++ b/test/cases/020_kernel/000_config_4.4.x/test.sh
@@ -15,7 +15,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build test-kernel-config
+moby build -output kernel+initrd test-kernel-config
 RESULT="$(linuxkit run qemu -kernel test-kernel-config)"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -12,5 +12,3 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
-outputs:
-  - format: kernel+initrd

--- a/test/cases/020_kernel/001_config_4.9.x/test.sh
+++ b/test/cases/020_kernel/001_config_4.9.x/test.sh
@@ -15,7 +15,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build test-kernel-config
+moby build -output kernel+initrd test-kernel-config
 RESULT="$(linuxkit run qemu test-kernel-config)"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/020_kernel/002_config_4.10.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/002_config_4.10.x/test-kernel-config.yml
@@ -12,5 +12,3 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
-outputs:
-  - format: kernel+initrd

--- a/test/cases/020_kernel/002_config_4.10.x/test.sh
+++ b/test/cases/020_kernel/002_config_4.10.x/test.sh
@@ -15,7 +15,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build test-kernel-config
+moby build -output kernel+initrd test-kernel-config
 RESULT="$(linuxkit run qemu test-kernel-config)"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -12,5 +12,3 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
-outputs:
-  - format: kernel+initrd

--- a/test/cases/020_kernel/003_config_4.11.x/test.sh
+++ b/test/cases/020_kernel/003_config_4.11.x/test.sh
@@ -15,7 +15,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build test-kernel-config
+moby build -output kernel+initrd test-kernel-config
 RESULT="$(linuxkit run qemu test-kernel-config)"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -16,5 +16,3 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
-outputs:
-  - format: kernel+initrd

--- a/test/cases/020_kernel/010_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.9.x/test.sh
@@ -22,6 +22,6 @@ docker pull linuxkit/kernel:4.9.x
 # Build a package
 docker build -t ${IMAGE_NAME} .
 # Build a LinuxKit image with kernel module (and test script)
-moby build kmod
+moby build -output kernel+initrd kmod
 # Run it
 linuxkit run qemu kmod | grep -q "Hello LinuxKit"

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -60,5 +60,3 @@ trust:
     - linuxkit/kernel
     - linuxkit/binfmt
     - linuxkit/rngd
-outputs:
-  - format: kernel+initrd

--- a/test/cases/040_packages/000_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/000_sysctl/test-sysctl.yml
@@ -18,5 +18,3 @@ trust:
     - linuxkit/kernel
     - linuxkit/binfmt
     - linuxkit/rngd
-outputs:
-  - format: kernel+initrd

--- a/test/cases/040_packages/000_sysctl/test.sh
+++ b/test/cases/040_packages/000_sysctl/test.sh
@@ -15,7 +15,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build test-sysctl
+moby build -output kernel+initrd test-sysctl
 RESULT="$(linuxkit run qemu -kernel test-sysctl)"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/001_mkimage/mkimage.yml
+++ b/test/cases/040_packages/001_mkimage/mkimage.yml
@@ -22,5 +22,3 @@ trust:
     - linuxkit/kernel
     - linuxkit/binfmt
     - linuxkit/rngd
-outputs:
-  - format: kernel+initrd

--- a/test/cases/040_packages/001_mkimage/run.yml
+++ b/test/cases/040_packages/001_mkimage/run.yml
@@ -14,5 +14,3 @@ trust:
     - linuxkit/kernel
     - linuxkit/binfmt
     - linuxkit/rngd
-outputs:
-  - format: kernel+initrd

--- a/test/cases/040_packages/001_mkimage/test.sh
+++ b/test/cases/040_packages/001_mkimage/test.sh
@@ -17,8 +17,8 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build run.yml
-moby build mkimage.yml
+moby build -output kernel+initrd run.yml
+moby build -output kernel+initrd mkimage.yml
 linuxkit run qemu -disk-size 200 -disk-format qcow2 -disk disk.qcow2 -kernel mkimage
 linuxkit run qemu disk.qcow2
 

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -20,5 +20,3 @@ onboot:
 files:
   - path: /etc/ltp/baseline
     contents: "100"
-outputs:
-  - format: gcp-img

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -18,5 +18,3 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
-outputs:
-    - format: gcp-img


### PR DESCRIPTION
The latest version of the `moby` tool now requires that the output formats
be specified in the CLI not in the yaml file.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![nest](https://cloud.githubusercontent.com/assets/482364/26494815/786dee74-4218-11e7-9857-b7d4b41e3186.jpg)
