### PR TITLE
Update Alpine base, add config labels, and trust

### DIFF
--- a/docs/external-disk.md
+++ b/docs/external-disk.md
@@ -39,20 +39,9 @@ To simplify the process, two `onboot` images are available for you to use:
 ```yml
 onboot:
   - name: format
-    image: "linuxkit/format:fdbfda789fe30a97ff194a06ac51ee0ff6b3ccf4"
-    binds:
-     - /dev:/dev
-    capabilities:
-     - CAP_SYS_ADMIN
-     - CAP_MKNOD
+    image: "linuxkit/format:55afe08816c2a4d8dbae3ee51ef53e0bee422d66"
   - name: mount
-    image: "linuxkit/mount:ad138d252798d9d0d6779f7f4d35b7fbcbbeefb9"
-    binds:
-     - /dev:/dev
-     - /var:/var:rshared,rbind
-    capabilities:
-     - CAP_SYS_ADMIN
-    rootfsPropagation: shared
+    image: "linuxkit/mount:15e20f27abe69d276f796e4026531833ec5ff345"
     command: ["/mount.sh", "/var/external"]
 ```
 
@@ -62,10 +51,12 @@ Notice several key points:
     * The format container needs to have bind mounts for `/dev`
     * The format container needs `CAP_SYS_ADMIN` and `CAP_MKNOD` capabilities
     * The format container only needs to run **once**, not matter how many external disks or partitions are provided. It finds all block devices under `/dev` and processes them.
+    * The default container config should be sufficient
 2. mount container
     * The mount container `command` is `mount.sh` followed by the desired mount point. Remember that nearly everything in a linuxkit image is read-only except under `/var`, so mount it there.
     * The mount container needs to have bind mounts for `/dev` and `/var`
     * The mount container needs `CAP_SYS_ADMIN` capabilities
     * The mount container needs `rootfsPropagation: shared`
+    * The default container config should be sufficient, though the `mount.sh` command needs to be specified
 
 With the above in place, if run with the current disk options, the image will make the external disk available as `/dev/vda1` and mount it at `/var/external`.

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -50,8 +50,7 @@ The image name may include tag or digest, but the matching also succeeds if the 
 ## Image specification
 
 For each image in the `system` and `daemon` sections you can specify the OCI options that are passed to
-`runc`, so you can specify what capabilities are needed and so on. Generally there are few defaults.
-For more details see the [OCI specification](https://github.com/opencontainers/runtime-spec/blob/master/spec.md).
+`runc`, so you can specify what capabilities are needed and so on. Most LinuxKit packages now define defaults in the `org.mobyproject.config` image label. For more details see the [OCI specification](https://github.com/opencontainers/runtime-spec/blob/master/spec.md).
 
 - `name` a unique name for the program being executed, used as the `containerd` id.
 - `image` the Docker image to use for the root filesystem. The default command, path and environment are

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,49 +2,31 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: sysfs
-    image: linuxkit/sysfs:1cde5876d44117af61dfea629ad922defcd48808
+    image: linuxkit/sysfs:47367d0ef851e8bf2a9e2f80a05392c17f5c2c88
   - name: binfmt
-    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
+    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
   - name: format
-    image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
-    binds:
-     - /dev:/dev
-    capabilities:
-     - CAP_SYS_ADMIN
-     - CAP_MKNOD
+    image: "linuxkit/format:55afe08816c2a4d8dbae3ee51ef53e0bee422d66"
   - name: mount
-    image: "linuxkit/mount:fc7164d7c4e1fe5d1da395c7f949fb332cffe752"
-    binds:
-     - /dev:/dev
-     - /var:/var:rshared,rbind
-    capabilities:
-     - CAP_SYS_ADMIN
-    rootfsPropagation: shared
+    image: "linuxkit/mount:15e20f27abe69d276f796e4026531833ec5ff345"
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
   - name: ntpd
     image: "linuxkit/openntpd:ad834449a7eaf10dc022b3d8d2ed9faf7ec99d37"
-    capabilities:
-      - CAP_SYS_TIME
-      - CAP_SYS_NICE
-      - CAP_SYS_CHROOT
-      - CAP_SETUID
-      - CAP_SETGID
-    net: host
   - name: docker
-    image: "linuxkit/docker-ce:261f93927d85001c65e5ce0f421eb6062f09c0a5"
+    image: "linuxkit/docker-ce:668d62da6e3da081a8f8aca7db3e2a98adf5da59"
     capabilities:
      - all
     net: host
@@ -60,5 +42,15 @@ files:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/ca-certificates
+    - linuxkit/sysctl
+    - linuxkit/sysfs
     - linuxkit/binfmt
+    - linuxkit/format
+    - linuxkit/mount
     - linuxkit/rngd
+    - linuxkit/dhcpcd
+    - linuxkit/openntpd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,15 +2,15 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: "linuxkit/metadata:a810b68fec9c9282cf096eed50605ddd6b2f3142"
@@ -23,14 +23,9 @@ onboot:
      - CAP_SYS_ADMIN
 services:
   - name: rngd
-    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: sshd
-    image: "linuxkit/sshd:1613253e5def414e0dfd261acd0e191eadb5fedf"
-    capabilities:
-     - all
-    net: host
-    pid: host
-    binds:
+    image: "linuxkit/sshd:ddce15b9fbde068941e31294acdcd22befa4fc20"
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
      - /tmp/etc/resolv.conf:/etc/resolv.conf
   - name: nginx
@@ -45,4 +40,10 @@ services:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/ca-certificates
+    - linuxkit/sysctl
+    - linuxkit/dhcpcd
     - linuxkit/rngd

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,13 +2,17 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/dhcpcd

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,25 +2,21 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 services:
   - name: rngd
-    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
   - name: node_exporter
-    image: "linuxkit/node_exporter:bdb20b41855d0e2b4edeec44ef569d030ea3cc47"
-    capabilities:
-     - all
-    net: host
-    pid: host
-    binds:
-     - /proc:/host/proc
-     - /sys:/host/sys
-     - /:/rootfs
+    image: "linuxkit/node_exporter:29a85e9c5de1a1bd470a963878194303f6a7bd8c"
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
     - linuxkit/rngd
+    - linuxkit/dhcpcd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,31 +2,32 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS1 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
 services:
   - name: rngd
-    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
   - name: sshd
-    image: "linuxkit/sshd:1613253e5def414e0dfd261acd0e191eadb5fedf"
-    capabilities:
-     - all
-    net: host
-    pid: host
-    binds:
-     - /root/.ssh:/root/.ssh
-     - /etc/resolv.conf:/etc/resolv.conf
-trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/rngd
+    image: "linuxkit/sshd:ddce15b9fbde068941e31294acdcd22befa4fc20"
 files:
   - path: root/.ssh/authorized_keys
     contents: '#your ssh key here'
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/ca-certificates
+    - linuxkit/sysctl
+    - linuxkit/rngd
+    - linuxkit/dhcpcd
+    - linuxkit/openntpd
+    - linuxkit/sshd

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,12 +4,12 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: redis
@@ -21,3 +21,10 @@ services:
      - CAP_SETGID
      - CAP_DAC_OVERRIDE
     net: host
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/dhcpcd

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,31 +2,31 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
 services:
   - name: rngd
-    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
   - name: sshd
-    image: "linuxkit/sshd:1613253e5def414e0dfd261acd0e191eadb5fedf"
-    capabilities:
-     - all
-    net: host
-    pid: host
-    binds:
-     - /root/.ssh:/root/.ssh
-     - /etc/resolv.conf:/etc/resolv.conf
-trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/rngd
+    image: "linuxkit/sshd:ddce15b9fbde068941e31294acdcd22befa4fc20"
 files:
   - path: root/.ssh/authorized_keys
     contents: '#your ssh key here'
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/ca-certificates
+    - linuxkit/sysctl
+    - linuxkit/rngd
+    - linuxkit/dhcpcd
+    - linuxkit/sshd

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,51 +2,29 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:42fe8cb1508b3afed39eb89821906e3cc7a70551
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
-  - name: binfmt
-    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
-    binds:
-     - /dev:/dev
-    capabilities:
-     - CAP_SYS_ADMIN
-     - CAP_MKNOD
+    image: "linuxkit/format:55afe08816c2a4d8dbae3ee51ef53e0bee422d66"
   - name: mount
-    image: "linuxkit/mount:fc7164d7c4e1fe5d1da395c7f949fb332cffe752"
-    binds:
-     - /dev:/dev
-     - /var:/var:rshared,rbind
-    capabilities:
-     - CAP_SYS_ADMIN
-    rootfsPropagation: shared
+    image: "linuxkit/mount:15e20f27abe69d276f796e4026531833ec5ff345"
     command: ["/mount.sh", "/var/external"]
   - name: swap
-    image: "linuxkit/swap:c4c723a3d6678dc49770181bbb231ec99b271c75"
-    net: host
-    pid: host
-    capabilities:
-     - CAP_SYS_ADMIN
-     - CAP_MKNOD
-    readonly: true
-    binds:
-     - /var:/var
-     - /dev:/dev
+    image: "linuxkit/swap:085f0088dd1ef2f994e707e438218ea4d41bad13"
     # to use unencrypted swap, use:
     # command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G"]
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: nginx
     image: "nginx:alpine"
     capabilities:
@@ -59,3 +37,12 @@ services:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/ca-certificates
+    - linuxkit/sysctl
+    - linuxkit/dhcpcd
+    - linuxkit/format
+    - linuxkit/mount
+    - linuxkit/rngd

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,18 +2,18 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
 services:
   - name: rngd
-    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
   - name: nginx
     image: "nginx:alpine"
     capabilities:
@@ -26,4 +26,10 @@ services:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/ca-certificates
+    - linuxkit/sysctl
     - linuxkit/rngd
+    - linuxkit/dhcpcd

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,21 +2,21 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: binfmt
-    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
+    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: nginx
     image: "nginx:alpine"
     capabilities:
@@ -32,5 +32,11 @@ files:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/ca-certificates
+    - linuxkit/sysctl
     - linuxkit/binfmt
+    - linuxkit/dhcpcd
     - linuxkit/rngd

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:5f6db26ab7bf6a9c452a612e236cc7495408132b@sha256:d009afc85d0b005daf51c8f3026aa552ab997dc47cab43915e9dc761accae086 AS qemu
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS qemu
 RUN apk add \
     qemu-aarch64 \
     qemu-arm \

--- a/pkg/ca-certificates/Dockerfile
+++ b/pkg/ca-certificates/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e as alpine
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 as alpine
 
 RUN apk add ca-certificates
 

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e as alpine
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 as alpine
 RUN \
   apk add \
   btrfs-progs-dev \

--- a/pkg/dhcpcd/Dockerfile
+++ b/pkg/dhcpcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:5f6db26ab7bf6a9c452a612e236cc7495408132b@sha256:d009afc85d0b005daf51c8f3026aa552ab997dc47cab43915e9dc761accae086 AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/docker-ce/Dockerfile
+++ b/pkg/docker-ce/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 # removed openssl as I do not think server needs it

--- a/pkg/format/Dockerfile
+++ b/pkg/format/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -19,3 +19,4 @@ WORKDIR /
 COPY --from=mirror /out/ /
 COPY format.sh /
 CMD ["/bin/sh", "/format.sh"]
+LABEL org.mobyproject.config='{"binds": ["/dev:/dev"], "capabilities": ["CAP_SYS_ADMIN", "CAP_MKNOD"]}'

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/mkimage/Dockerfile
+++ b/pkg/mkimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/mount/Dockerfile
+++ b/pkg/mount/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -17,3 +17,4 @@ WORKDIR /
 COPY --from=mirror /out/ /
 COPY mount.sh /
 CMD ["/bin/sh", "/mount.sh"]
+LABEL org.mobyproject.config='{"binds": ["/dev:/dev", "/var:/var:rshared,rbind"], "capabilities": ["CAP_SYS_ADMIN"], "rootfsPropagation": "shared"}'

--- a/pkg/node_exporter/Dockerfile
+++ b/pkg/node_exporter/Dockerfile
@@ -4,3 +4,4 @@ ENTRYPOINT ["/bin/node_exporter", "-collector.procfs",  "/host/proc", \
             "-collector.sysfs",  "/host/sys", \
             "-collector.filesystem.ignored-mount-points", \
             "^/(sys|proc|dev|host|etc)($|/)"]
+LABEL org.mobyproject.config='{"net": "host", "pid": "host", "binds": ["/proc:/host/proc", "/sys:/host/sys", "/:/rootfs"], "capabilities": ["all"]}'

--- a/pkg/open-vm-tools/Dockerfile
+++ b/pkg/open-vm-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:dc7d4cdb5932f3e6ff62172c05627816c0d412fa@sha256:0239e6984a9932bfe1b44dc9be6f8e4c29dd7bdb431ba0b040b6d027b1091f08 AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/openntpd/Dockerfile
+++ b/pkg/openntpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -16,3 +16,4 @@ WORKDIR /
 COPY --from=mirror /out/ /
 COPY etc/ /etc/
 CMD ["/usr/sbin/ntpd", "-d", "-s"]
+LABEL org.mobyproject.config='{"net": "host", "capabilities": ["CAP_SYS_TIME", "CAP_SYS_NICE", "CAP_SYS_CHROOT", "CAP_SETUID", "CAP_SETGID"]}'

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,11 +1,11 @@
-FROM linuxkit/alpine:5f6db26ab7bf6a9c452a612e236cc7495408132b@sha256:d009afc85d0b005daf51c8f3026aa552ab997dc47cab43915e9dc761accae086 AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     tini
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 RUN mkdir -p /out/dev /out/proc /out/sys
 
-FROM linuxkit/alpine:dae8bcbc6e2cec0a1cc1958dddbc5d6bd3ccf9a0@sha256:02c251d54c4083a596ead8cae92144306b385db0ff961c95a3a620a4c69961ed AS build
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS build
 RUN apk add \
     argp-standalone \
     automake \

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e as alpine
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 as alpine
 RUN \
   apk add \
   bash \

--- a/pkg/sshd/Dockerfile
+++ b/pkg/sshd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -19,3 +19,4 @@ COPY etc/ /etc/
 COPY usr/ /usr/
 RUN mkdir -p /etc/ssh /root/.ssh && chmod 0700 /root/.ssh
 CMD ["/sbin/tini", "/usr/bin/ssh.sh"]
+LABEL org.mobyproject.config='{"net": "host", "pid": "host", "binds": ["/root/.ssh:/root/.ssh", "/etc/resolv.conf:/etc/resolv.conf"], "capabilities": ["all"]}'

--- a/pkg/swap/Dockerfile
+++ b/pkg/swap/Dockerfile
@@ -1,4 +1,5 @@
-FROM linuxkit/alpine:6336329f15b4166514782eaa555cf0ffd35c519c@sha256:f6c2ce92910b1d6e4e5557850a554f4a3ae9f66c1e89ad86a24d6c6e550f165e AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
@@ -15,3 +16,4 @@ WORKDIR /
 COPY --from=mirror /out/ /
 COPY /swap.sh .
 ENTRYPOINT ["swap.sh"]
+LABEL org.mobyproject.config='{"binds": ["/dev:/dev", "/var:/var"], "capabilities": ["CAP_SYS_ADMIN", "CAP_MKNOD"]}'

--- a/pkg/swap/README.md
+++ b/pkg/swap/README.md
@@ -8,16 +8,7 @@ Normally, unless you are running explicitly in a desktop version, LinuxKit image
 ```
 onboot:
   - name: swap
-    image: "linuxkit/swap:c4c723a3d6678dc49770181bbb231ec99b271c75"
-    net: host
-    pid: host
-    capabilities:
-     - CAP_SYS_ADMIN
-     - CAP_MKNOD
-    readonly: true
-    binds:
-     - /dev:/dev
-     - /var:/var
+    image: "linuxkit/swap:085f0088dd1ef2f994e707e438218ea4d41bad13"
     command: ["swap.sh","--path","/var/external/swap","--size","2G"]
 ```
 

--- a/pkg/sysctl/Dockerfile
+++ b/pkg/sysctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:5f6db26ab7bf6a9c452a612e236cc7495408132b@sha256:d009afc85d0b005daf51c8f3026aa552ab997dc47cab43915e9dc761accae086 AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/sysfs/Dockerfile
+++ b/pkg/sysfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:5f6db26ab7bf6a9c452a612e236cc7495408132b@sha256:d009afc85d0b005daf51c8f3026aa552ab997dc47cab43915e9dc761accae086 AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,23 +2,12 @@ kernel:
   image: "linuxkit/kernel-clear-containers:4.9.x"
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
 onboot:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
-    net: host
-    pid: host
-    ipc: host
-    capabilities:
-     - CAP_SYS_ADMIN
-    readonly: true
 services:
   - name: rngd
-    image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -2,31 +2,20 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: format
-    image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
-    binds:
-     - /dev:/dev
-    capabilities:
-     - CAP_SYS_ADMIN
-     - CAP_MKNOD
+    image: "linuxkit/format:55afe08816c2a4d8dbae3ee51ef53e0bee422d66"
   - name: mount
-    image: "linuxkit/mount:fc7164d7c4e1fe5d1da395c7f949fb332cffe752"
-    binds:
-     - /dev:/dev
-     - /var:/var:rshared,rbind
-    capabilities:
-     - CAP_SYS_ADMIN
-    rootfsPropagation: shared
+    image: "linuxkit/mount:15e20f27abe69d276f796e4026531833ec5ff345"
     command: ["/mount.sh", "/var/lib/etcd"]
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: "linuxkit/metadata:a810b68fec9c9282cf096eed50605ddd6b2f3142"
@@ -39,26 +28,11 @@ onboot:
      - CAP_SYS_ADMIN
 services:
   - name: rngd
-    image: "linuxkit/rngd:f5e5be43e730ea819c3293d5c6dcbfa7f4c5c314"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: ntpd
     image: "linuxkit/openntpd:ad834449a7eaf10dc022b3d8d2ed9faf7ec99d37"
-    capabilities:
-      - CAP_SYS_TIME
-      - CAP_SYS_NICE
-      - CAP_SYS_CHROOT
-      - CAP_SETUID
-      - CAP_SETGID
-    net: host
   - name: node_exporter
-    image: "linuxkit/node_exporter:bdb20b41855d0e2b4edeec44ef569d030ea3cc47"
-    capabilities:
-     - all
-    net: host
-    pid: host
-    binds:
-     - /proc:/host/proc
-     - /sys:/host/sys
-     - /:/rootfs
+    image: "linuxkit/node_exporter:29a85e9c5de1a1bd470a963878194303f6a7bd8c"
   - name: etcd
     image: "moby/etcd"
     capabilities:
@@ -72,3 +46,16 @@ services:
     binds:
      - /var/lib/etcd:/var/lib/etcd
      - /var/config/etcd:/etc/etcd
+trust:
+  - images:
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/ca-certificates
+    - linuxkit/sysctl
+    - linuxkit/format
+    - linuxkit/mount
+    - linuxkit/dhcpcd
+    - linuxkit/rngd
+    - linuxkit/openntpd

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -2,15 +2,15 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: "linuxkit/metadata:a810b68fec9c9282cf096eed50605ddd6b2f3142"

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -3,36 +3,21 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:47b1c38d63468c0f3078f8b1b055d07965a1895d
-  - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
-  - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
   - linuxkit/ima-utils:fe119c7dac08884f4144cd106dc279ddd8b37517
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: binfmt
-    image: "linuxkit/binfmt:131026c0cf6084467316395fed3b358f64bda00c"
-    binds:
-     - /proc/sys/fs/binfmt_misc:/binfmt_misc
-    readonly: true
+    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:2def74ab3f9233b4c09ebb196ba47c27c08b0ed8"
-    binds:
-     - /var:/var
-     - /tmp/etc:/etc
-    capabilities:
-     - CAP_NET_ADMIN
-     - CAP_NET_BIND_SERVICE
-     - CAP_NET_RAW
-    net: host
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:61a07ced77a9747708223ca16a4aec621eacf518"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: nginx
     image: "nginx:alpine"
     capabilities:
@@ -48,5 +33,11 @@ files:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/ca-certificates
+    - linuxkit/sysctl
     - linuxkit/binfmt
+    - linuxkit/dhcpcd
     - linuxkit/rngd

--- a/projects/kubernetes/image-cache/Dockerfile
+++ b/projects/kubernetes/image-cache/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/docker-ce:261f93927d85001c65e5ce0f421eb6062f09c0a5
+FROM linuxkit/docker-ce:668d62da6e3da081a8f8aca7db3e2a98adf5da59
 ADD . /images
 ENTRYPOINT [ "/bin/sh", "-c" ]
 CMD [ "for image in /images/*.tar ; do docker image load -i $image && rm -f $image ; done" ]

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,24 +2,19 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: sysfs
-    image: linuxkit/sysfs:1cde5876d44117af61dfea629ad922defcd48808
+    image: linuxkit/sysfs:47367d0ef851e8bf2a9e2f80a05392c17f5c2c88
   - name: binfmt
-    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
+    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
   - name: format
-    image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
-    binds:
-     - /dev:/dev
-    capabilities:
-     - CAP_SYS_ADMIN
-     - CAP_MKNOD
+    image: "linuxkit/format:55afe08816c2a4d8dbae3ee51ef53e0bee422d66"
   - name: mounts
     image: "linuxkit/kubernetes:latest-mounts"
     capabilities:
@@ -31,28 +26,15 @@ onboot:
      - /var:/var:rshared,rbind
 services:
   - name: rngd
-    image: "linuxkit/rngd:f5e5be43e730ea819c3293d5c6dcbfa7f4c5c314"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
   - name: ntpd
     image: "linuxkit/openntpd:ad834449a7eaf10dc022b3d8d2ed9faf7ec99d37"
-    capabilities:
-      - CAP_SYS_TIME
-      - CAP_SYS_NICE
-      - CAP_SYS_CHROOT
-      - CAP_SETUID
-      - CAP_SETGID
-    net: host
   - name: sshd
-    image: "linuxkit/sshd:1613253e5def414e0dfd261acd0e191eadb5fedf"
-    capabilities:
-     - all
-    net: host
-    pid: host
-    binds:
-     - /root/.ssh:/root/.ssh
+    image: "linuxkit/sshd:ddce15b9fbde068941e31294acdcd22befa4fc20"
   - name: docker
-    image: "linuxkit/docker-ce:261f93927d85001c65e5ce0f421eb6062f09c0a5"
+    image: "linuxkit/docker-ce:668d62da6e3da081a8f8aca7db3e2a98adf5da59"
     capabilities:
      - all
     net: host

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,24 +2,19 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: sysfs
-    image: linuxkit/sysfs:1cde5876d44117af61dfea629ad922defcd48808
+    image: linuxkit/sysfs:47367d0ef851e8bf2a9e2f80a05392c17f5c2c88
   - name: binfmt
-    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
+    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
   - name: format
-    image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
-    binds:
-     - /dev:/dev
-    capabilities:
-     - CAP_SYS_ADMIN
-     - CAP_MKNOD
+    image: "linuxkit/format:55afe08816c2a4d8dbae3ee51ef53e0bee422d66"
   - name: mounts
     image: "linuxkit/kubernetes:latest-mounts"
     capabilities:
@@ -31,28 +26,15 @@ onboot:
      - /var:/var:rshared,rbind
 services:
   - name: rngd
-    image: "linuxkit/rngd:f5e5be43e730ea819c3293d5c6dcbfa7f4c5c314"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
   - name: ntpd
     image: "linuxkit/openntpd:ad834449a7eaf10dc022b3d8d2ed9faf7ec99d37"
-    capabilities:
-      - CAP_SYS_TIME
-      - CAP_SYS_NICE
-      - CAP_SYS_CHROOT
-      - CAP_SETUID
-      - CAP_SETGID
-    net: host
   - name: sshd
-    image: "linuxkit/sshd:1613253e5def414e0dfd261acd0e191eadb5fedf"
-    capabilities:
-     - all
-    net: host
-    pid: host
-    binds:
-     - /root/.ssh:/root/.ssh
+    image: "linuxkit/sshd:ddce15b9fbde068941e31294acdcd22befa4fc20"
   - name: docker
-    image: "linuxkit/docker-ce:261f93927d85001c65e5ce0f421eb6062f09c0a5"
+    image: "linuxkit/docker-ce:668d62da6e3da081a8f8aca7db3e2a98adf5da59"
     capabilities:
      - all
     net: host

--- a/projects/kubernetes/mounts.rb
+++ b/projects/kubernetes/mounts.rb
@@ -1,6 +1,6 @@
 import 'common.rb'
 
-from "linuxkit/mount:fc7164d7c4e1fe5d1da395c7f949fb332cffe752"
+from "linuxkit/mount:15e20f27abe69d276f796e4026531833ec5ff345"
 
 script = [
   mount_bind_hostns_self("/etc/cni"), mount_make_hostns_rshared("/etc/cni"),

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,23 +2,22 @@ kernel:
   image: "mobylinux/kernel-landlock:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
-    net: host
-    pid: host
-    ipc: host
-    capabilities:
-     - CAP_SYS_ADMIN
-    readonly: true
 services:
   - name: rngd
     image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/ca-certificates
+    - linuxkit/sysctl
+    - linuxkit/rngd

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,22 +2,22 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:062e57b1d1e017e44c6339fc2b4cd41f3f10b2a9 # with runc, logwrite, startmemlogd
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480 # with runc, logwrite, startmemlogd
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: binfmt
-    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
+    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: nginx
     image: "nginx:alpine"
     capabilities:
@@ -32,4 +32,12 @@ files:
     contents: '{"debug": true}'
 trust:
   image:
-    - mobylinux/kernel
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/ca-certificates
+    - linuxkit/sysctl
+    - linuxkit/binfmt
+    - linuxkit/dhcpcd
+    - linuxkit/rngd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -8,15 +8,10 @@ init:
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
-  - name: binfmt
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
 services:
   - name: rngd
     image: mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9
-    capabilities:
-     - CAP_SYS_ADMIN
-    oomScoreAdj: -800
-    readonly: true
   - name: dhcp-client
     image: mobylinux/dhcp-client:a7a6b49b0ff51ffa2f44ac848cd649e29f946e0c
     net: host

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,27 +2,20 @@ kernel:
   image: "linuxkit/okernel:latest"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
 services:
   - name: rngd
-    image: "linuxkit/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
   - name: sshd
-    image: "linuxkit/sshd:1613253e5def414e0dfd261acd0e191eadb5fedf"
-    capabilities:
-     - all
-    net: host
-    pid: host
-    binds:
-     - /root/.ssh:/root/.ssh
-     - /etc/resolv.conf:/etc/resolv.conf
+    image: "linuxkit/sshd:ddce15b9fbde068941e31294acdcd22befa4fc20"
 files:
   - path: root/.ssh/authorized_keys
     contents: '#your ssh key here'

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,31 +2,20 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
   - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
-    binds:
-     - /dev:/dev
-    capabilities:
-     - CAP_SYS_ADMIN
-     - CAP_MKNOD
+    image: "linuxkit/format:55afe08816c2a4d8dbae3ee51ef53e0bee422d66"
   - name: mount
-    image: "linuxkit/mount:fc7164d7c4e1fe5d1da395c7f949fb332cffe752"
-    binds:
-     - /dev:/dev
-     - /var:/var:rshared,rbind
-    capabilities:
-     - CAP_SYS_ADMIN
-    rootfsPropagation: shared
+    image: "linuxkit/mount:15e20f27abe69d276f796e4026531833ec5ff345"
     command: ["/mount.sh", "/var/lib/swarmd"]
   - name: metadata
     image: "linuxkit/metadata:a810b68fec9c9282cf096eed50605ddd6b2f3142"
@@ -39,16 +28,9 @@ onboot:
      - CAP_SYS_ADMIN
 services:
   - name: rngd
-    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: ntpd
     image: "linuxkit/openntpd:ad834449a7eaf10dc022b3d8d2ed9faf7ec99d37"
-    capabilities:
-     - CAP_SYS_TIME
-     - CAP_SYS_NICE
-     - CAP_SYS_CHROOT
-     - CAP_SETUID
-     - CAP_SETGID
-    net: host
   - name: swarmd
     image: "linuxkit/swarmd:a2f57f14f07fb6d7cded7832b2dabe878b28554e"
     command: ["/usr/bin/swarmd", "--containerd-addr=/run/containerd/containerd.sock", "--log-level=debug", "--state-dir=/var/lib/swarmd"]

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,13 +2,17 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:f71c3b30ac1ba4ef16c160c89610fa4976f9752f
-  - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - linuxkit/containerd:60e2486a74c665ba4df57e561729aec20758daed
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
@@ -12,3 +12,7 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:f71c3b30ac1ba4ef16c160c89610fa4976f9752f
-  - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - linuxkit/containerd:60e2486a74c665ba4df57e561729aec20758daed
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
@@ -12,3 +12,7 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:f71c3b30ac1ba4ef16c160c89610fa4976f9752f
-  - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - linuxkit/containerd:60e2486a74c665ba4df57e561729aec20758daed
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
@@ -12,3 +12,6 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:f71c3b30ac1ba4ef16c160c89610fa4976f9752f
-  - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - linuxkit/containerd:60e2486a74c665ba4df57e561729aec20758daed
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
@@ -12,3 +12,6 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
@@ -12,3 +12,6 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:f71c3b30ac1ba4ef16c160c89610fa4976f9752f
-  - linuxkit/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
-  - linuxkit/containerd:60e2486a74c665ba4df57e561729aec20758daed
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
@@ -12,3 +12,6 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.4.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"
@@ -12,3 +12,9 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"
@@ -12,3 +12,9 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd

--- a/test/cases/020_kernel/002_config_4.10.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/002_config_4.10.x/test-kernel-config.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.10.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"
@@ -12,3 +12,9 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.11.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"
@@ -12,3 +12,9 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: check
     image: "kmod-test"
@@ -16,3 +16,9 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,40 +2,29 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: sysfs
-    image: "linuxkit/sysfs:1cde5876d44117af61dfea629ad922defcd48808"
+    image: "linuxkit/sysfs:47367d0ef851e8bf2a9e2f80a05392c17f5c2c88"
   - name: binfmt
-    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
+    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
   - name: format
-    image: "linuxkit/format:d78093e943f9c88386e30c00353f9476d34fb551"
-    binds:
-     - /dev:/dev
-    capabilities:
-     - CAP_SYS_ADMIN
-     - CAP_MKNOD
+    image: "linuxkit/format:55afe08816c2a4d8dbae3ee51ef53e0bee422d66"
   - name: mount
-    image: "linuxkit/mount:fc7164d7c4e1fe5d1da395c7f949fb332cffe752"
-    binds:
-     - /dev:/dev
-     - /var:/var:rshared,rbind
-    capabilities:
-     - CAP_SYS_ADMIN
-    rootfsPropagation: shared
+    image: "linuxkit/mount:15e20f27abe69d276f796e4026531833ec5ff345"
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
+    image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
   - name: docker
-    image: "linuxkit/docker-ce:261f93927d85001c65e5ce0f421eb6062f09c0a5"
+    image: "linuxkit/docker-ce:668d62da6e3da081a8f8aca7db3e2a98adf5da59"
     capabilities:
      - all
     net: host
@@ -58,5 +47,14 @@ services:
 trust:
   image:
     - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/ca-certificates
+    - linuxkit/sysctl
+    - linuxkit/sysfs
     - linuxkit/binfmt
+    - linuxkit/format
+    - linuxkit/mount
     - linuxkit/rngd
+    - linuxkit/dhcpcd

--- a/test/cases/040_packages/000_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/000_sysctl/test-sysctl.yml
@@ -2,13 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:1c71f95fa36040ea7e987deb98a7a2a363853f01
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: test
     image: "linuxkit/test-sysctl:c4df4c4d692904d6245dcdef1f4a79389bd3d894"
   - name: poweroff
@@ -16,5 +15,7 @@ onboot:
 trust:
   image:
     - linuxkit/kernel
-    - linuxkit/binfmt
-    - linuxkit/rngd
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/sysctl

--- a/test/cases/040_packages/001_mkimage/mkimage.yml
+++ b/test/cases/040_packages/001_mkimage/mkimage.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: mkimage
-    image: "linuxkit/mkimage:8bb18fe306afaca9ba50fe3148ec12570586c2a6"
+    image: "linuxkit/mkimage:a3fd615543b84733ac8ba6f7e1927727665ef404"
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
 files:
@@ -20,5 +20,6 @@ files:
 trust:
   image:
     - linuxkit/kernel
-    - linuxkit/binfmt
-    - linuxkit/rngd
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd

--- a/test/cases/040_packages/001_mkimage/run.yml
+++ b/test/cases/040_packages/001_mkimage/run.yml
@@ -2,15 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:1c71f95fa36040ea7e987deb98a7a2a363853f01
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
 trust:
   image:
     - linuxkit/kernel
-    - linuxkit/binfmt
-    - linuxkit/rngd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,10 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: ltp
     image: "linuxkit/test-ltp-20170116:81229df2d25065b06f0a3071faaace8d66c87e67"
@@ -20,3 +19,9 @@ onboot:
 files:
   - path: /etc/ltp/baseline
     contents: "100"
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,13 +4,12 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:deea956a9ab07bf262083e93a86930bdc610cc2f
+  - linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
   - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
-  - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
+  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:ae03169274d19fe8841314fa5a6fea3c61adbf4e"
+    image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"
@@ -18,3 +17,10 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/init
+    - linuxkit/runc
+    - linuxkit/containerd
+    - linuxkit/dhcpcd

--- a/test/pkg/virtsock/Dockerfile
+++ b/test/pkg/virtsock/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:dae8bcbc6e2cec0a1cc1958dddbc5d6bd3ccf9a0@sha256:02c251d54c4083a596ead8cae92144306b385db0ff961c95a3a620a4c69961ed AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     tini

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -3,6 +3,8 @@ FROM alpine:3.6 AS mirror
 # update base image
 RUN apk update && apk upgrade -a
 
+# Copy Dockerfile so we can include it in the hash
+COPY Dockerfile /Dockerfile
 COPY packages /tmp/
 
 # mirror packages
@@ -42,6 +44,7 @@ COPY --from=mirror /etc/apk/repositories /etc/apk/repositories
 COPY --from=mirror /etc/apk/keys /etc/apk/keys/
 COPY --from=mirror /mirror /mirror/
 COPY --from=mirror /go/bin /go/bin/
+COPY --from=mirror /Dockerfile /Dockerfile
 
 COPY --from=shellcheck /usr/local/bin/shellcheck /usr/local/bin/shellcheck
 COPY --from=shellcheck /usr/local/lib/ /usr/local/lib/

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge AS mirror
+FROM alpine:3.6 AS mirror
 
 # update base image
 RUN apk update && apk upgrade -a
@@ -33,7 +33,7 @@ RUN go get -u github.com/golang/lint/golint
 RUN go get -u github.com/gordonklaus/ineffassign
 RUN go get -u github.com/LK4D4/vndr
 
-FROM alpine:edge
+FROM alpine:3.6
 
 COPY --from=mirror /etc/apk/repositories /etc/apk/repositories
 COPY --from=mirror /etc/apk/keys /etc/apk/keys/

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -33,11 +33,17 @@ RUN go get -u github.com/golang/lint/golint
 RUN go get -u github.com/gordonklaus/ineffassign
 RUN go get -u github.com/LK4D4/vndr
 
+FROM koalaman/shellcheck:v0.4.6@sha256:191b61e5f436fc51f22faaf2f4e0f77799f75977c7210377dd73a1a0f99ef8bd AS shellcheck
+
+
 FROM alpine:3.6
 
 COPY --from=mirror /etc/apk/repositories /etc/apk/repositories
 COPY --from=mirror /etc/apk/keys /etc/apk/keys/
 COPY --from=mirror /mirror /mirror/
 COPY --from=mirror /go/bin /go/bin/
+
+COPY --from=shellcheck /usr/local/bin/shellcheck /usr/local/bin/shellcheck
+COPY --from=shellcheck /usr/local/lib/ /usr/local/lib/
 
 RUN apk update && apk upgrade -a

--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -6,10 +6,10 @@ BASE=alpine:3.6
 
 default: push
 
-hash:
+hash: Dockerfile Makefile packages
 	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	docker build --no-cache -t $(IMAGE):build .
-	docker run --rm $(IMAGE):build sh -c 'echo /lib/apk/db/installed $$(find /mirror -name '*.apk' -type f) $$(find /go/bin -type f) | xargs cat | sha1sum' | sed 's/ .*//' > $@
+	docker run --rm $(IMAGE):build sh -c 'echo Dockerfile /lib/apk/db/installed $$(find /mirror -name '*.apk' -type f) $$(find /go/bin -type f) | xargs cat | sha1sum' | sed 's/ .*//' > $@
 
 push: hash
 	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \

--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -2,7 +2,7 @@
 
 ORG?=linuxkit
 IMAGE=alpine
-BASE=alpine:edge
+BASE=alpine:3.6
 
 default: push
 

--- a/tools/alpine/versions
+++ b/tools/alpine/versions
@@ -108,7 +108,7 @@ libseccomp-dev-2.3.2-r0
 libsmartcols-2.28.2-r2
 libssh2-1.8.0-r1
 libstdc++-6.3.0-r4
-libtasn1-4.10-r0
+libtasn1-4.10-r1
 libtirpc-1.0.1-r1
 libunistring-0.9.7-r0
 libusb-1.0.21-r0


### PR DESCRIPTION
- Switch Alpine base to 3.6
- Add shellcheck to Alpine base (see also #1897)
- Update most packages to use the config label
- Update YAML files to use:
  - New package versions
  - Remove config info now supplied by the config label
  - Add more images to the trust section

Also:
- Update documentation
- Fix Alpine base image hash calculation

resolves: #1901

![image](https://cloud.githubusercontent.com/assets/3338098/26499465/a9a69556-422a-11e7-8ddd-51f0676c7428.png)
