### PR TITLE
trust: use org key in yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 PREFIX?=/usr/local/
 
-MOBY_COMMIT=1cb9fab3e13c8d3931c6f989c5d36087382e8710
+MOBY_COMMIT=101fa30ef335b2fa70ef4fc322821a12bd368c26
 bin/moby: Makefile | bin
 	docker run --rm --log-driver=none $(CROSS) $(GO_COMPILE) --clone-path github.com/moby/tool --clone https://github.com/moby/tool.git --commit $(MOBY_COMMIT) --package github.com/moby/tool/cmd/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
 	tar xf tmp_moby_bin.tar > $@

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -40,17 +40,5 @@ files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/ca-certificates
-    - linuxkit/sysctl
-    - linuxkit/sysfs
-    - linuxkit/binfmt
-    - linuxkit/format
-    - linuxkit/mount
-    - linuxkit/rngd
-    - linuxkit/dhcpcd
-    - linuxkit/openntpd
+  org:
+    - linuxkit

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -38,12 +38,7 @@ services:
      - CAP_DAC_OVERRIDE
     net: host
 trust:
+  org:
+    - linuxkit
   image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/ca-certificates
-    - linuxkit/sysctl
-    - linuxkit/dhcpcd
-    - linuxkit/rngd
+    - nginx:alpine

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -10,9 +10,5 @@ onboot:
     image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/dhcpcd
+  org:
+    - linuxkit

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -13,10 +13,5 @@ services:
   - name: node_exporter
     image: "linuxkit/node_exporter:29a85e9c5de1a1bd470a963878194303f6a7bd8c"
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/rngd
-    - linuxkit/dhcpcd
+  org:
+    - linuxkit

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -20,14 +20,5 @@ files:
   - path: root/.ssh/authorized_keys
     contents: '#your ssh key here'
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/ca-certificates
-    - linuxkit/sysctl
-    - linuxkit/rngd
-    - linuxkit/dhcpcd
-    - linuxkit/openntpd
-    - linuxkit/sshd
+  org:
+    - linuxkit

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -22,9 +22,7 @@ services:
      - CAP_DAC_OVERRIDE
     net: host
 trust:
+  org:
+    - linuxkit
   image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/dhcpcd
+    - redis:3.0.7-alpine

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -20,13 +20,5 @@ files:
   - path: root/.ssh/authorized_keys
     contents: '#your ssh key here'
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/ca-certificates
-    - linuxkit/sysctl
-    - linuxkit/rngd
-    - linuxkit/dhcpcd
-    - linuxkit/sshd
+  org:
+    - linuxkit

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -35,14 +35,5 @@ services:
      - CAP_DAC_OVERRIDE
     net: host
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/ca-certificates
-    - linuxkit/sysctl
-    - linuxkit/dhcpcd
-    - linuxkit/format
-    - linuxkit/mount
-    - linuxkit/rngd
+  org:
+    - linuxkit

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -24,12 +24,7 @@ services:
      - CAP_DAC_OVERRIDE
     net: host
 trust:
+  org:
+    - linuxkit
   image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/ca-certificates
-    - linuxkit/sysctl
-    - linuxkit/rngd
-    - linuxkit/dhcpcd
+    - nginx:alpine

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -30,13 +30,7 @@ files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'
 trust:
+  org:
+    - linuxkit
   image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/ca-certificates
-    - linuxkit/sysctl
-    - linuxkit/binfmt
-    - linuxkit/dhcpcd
-    - linuxkit/rngd
+    - nginx:alpine

--- a/pkg/docker-ce/Makefile
+++ b/pkg/docker-ce/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --squash --no-cache -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/mkimage/Makefile
+++ b/pkg/mkimage/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/node_exporter/Makefile
+++ b/pkg/node_exporter/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/open-vm-tools/Makefile
+++ b/pkg/open-vm-tools/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/swap/Makefile
+++ b/pkg/swap/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -10,9 +10,5 @@ onboot:
     image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/dhcpcd
+  org:
+    - linuxkit

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -10,9 +10,5 @@ onboot:
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-
+  org:
+    - linuxkit

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -10,9 +10,6 @@ onboot:
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
+  org:
+    - linuxkit
 

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -10,8 +10,5 @@ onboot:
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
+  org:
+    - linuxkit

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -10,8 +10,5 @@ onboot:
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
+  org:
+    - linuxkit

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -10,8 +10,5 @@ onboot:
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
+  org:
+    - linuxkit

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -10,8 +10,5 @@ onboot:
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -13,8 +13,5 @@ onboot:
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -13,8 +13,5 @@ onboot:
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/002_config_4.10.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/002_config_4.10.x/test-kernel-config.yml
@@ -13,8 +13,5 @@ onboot:
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -13,8 +13,5 @@ onboot:
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -17,8 +17,5 @@ onboot:
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
+  org:
+    - linuxkit

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -45,16 +45,5 @@ services:
     capabilities:
      - all
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/ca-certificates
-    - linuxkit/sysctl
-    - linuxkit/sysfs
-    - linuxkit/binfmt
-    - linuxkit/format
-    - linuxkit/mount
-    - linuxkit/rngd
-    - linuxkit/dhcpcd
+  org:
+    - linuxkit

--- a/test/cases/040_packages/000_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/000_sysctl/test-sysctl.yml
@@ -13,9 +13,5 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/sysctl
+  org:
+    - linuxkit

--- a/test/cases/040_packages/001_mkimage/mkimage.yml
+++ b/test/cases/040_packages/001_mkimage/mkimage.yml
@@ -18,8 +18,5 @@ files:
   - path: data/cmdline
     source: run-cmdline
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
+  org:
+    - linuxkit

--- a/test/cases/040_packages/001_mkimage/run.yml
+++ b/test/cases/040_packages/001_mkimage/run.yml
@@ -9,5 +9,5 @@ onboot:
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
 trust:
-  image:
-    - linuxkit/kernel
+  org:
+    - linuxkit

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: ltp
-    image: "linuxkit/test-ltp-20170116:81229df2d25065b06f0a3071faaace8d66c87e67"
+    image: "linuxkit/test-ltp:20170116"
     net: host
     pid: host
     binds:

--- a/test/pkg/docker-bench/Makefile
+++ b/test/pkg/docker-bench/Makefile
@@ -11,9 +11,9 @@ hash: Dockerfile bench_runner.sh
 	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c "cat $^ /lib/apk/db/installed | sha1sum" | sed 's/ .*//' > hash
 
 push: hash
-	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
-		 docker push linuxkit/$(IMAGE):$(shell cat hash))
+		 DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash))
 	docker rmi $(IMAGE):build
 	rm -f hash
 

--- a/test/pkg/kernel-config/Makefile
+++ b/test/pkg/kernel-config/Makefile
@@ -11,9 +11,9 @@ hash: Dockerfile check.sh check-kernel-config.sh etc/linuxkit
 	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c "cat $^ /lib/apk/db/installed | sha1sum" | sed 's/ .*//' > hash
 
 push: hash
-	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
-		 docker push linuxkit/$(IMAGE):$(shell cat hash))
+		 DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash))
 	docker rmi $(IMAGE):build
 	rm -f hash
 

--- a/test/pkg/ltp/Makefile
+++ b/test/pkg/ltp/Makefile
@@ -23,9 +23,9 @@ hash: Dockerfile.pkg ltp.tar check.sh $(DEPS)
 	cat Dockerfile.pkg check.sh $(DEPS) | DOCKER_CONTENT_TRUST=1 docker run --rm -i $(SHASUM) sha1sum | sed 's/ .*//' > $@
 
 push: hash
-	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
-		docker push linuxkit/$(IMAGE):$(shell cat hash))
+		 DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash))
 	docker rmi $(IMAGE):build
 	rm -f hash
 

--- a/test/pkg/ltp/Makefile
+++ b/test/pkg/ltp/Makefile
@@ -11,7 +11,7 @@ ltp.tar: ltp.tag
 	docker run --rm --net=none --log-driver=none $(shell cat ltp.tag) tar cf - opt/ltp  > $@
 
 SHASUM=alpine:3.5
-IMAGE=test-ltp-$(LTP_VERSION)
+IMAGE=test-ltp
 
 # Note: We do not compute the hash from all the dependencies here
 # because the ltp binaries will change everytime we build. Ideally, we
@@ -25,7 +25,9 @@ hash: Dockerfile.pkg ltp.tar check.sh $(DEPS)
 push: hash
 	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
-		 DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash))
+		 docker tag $(IMAGE):build linuxkit/$(IMAGE):$(LTP_VERSION) && \
+		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash) && \
+		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(LTP_VERSION))
 	docker rmi $(IMAGE):build
 	rm -f hash
 

--- a/test/pkg/poweroff/Makefile
+++ b/test/pkg/poweroff/Makefile
@@ -11,9 +11,9 @@ hash: Dockerfile poweroff.sh
 	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c "cat $^ /lib/apk/db/installed | sha1sum" | sed 's/ .*//' > hash
 
 push: hash
-	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
-		 docker push linuxkit/$(IMAGE):$(shell cat hash))
+		 DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash))
 	docker rmi $(IMAGE):build
 	rm -f hash
 

--- a/test/pkg/sysctl/Makefile
+++ b/test/pkg/sysctl/Makefile
@@ -11,9 +11,9 @@ hash: Dockerfile check.sh
 	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c "cat $^ /lib/apk/db/installed | sha1sum" | sed 's/ .*//' > hash
 
 push: hash
-	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
-		 docker push linuxkit/$(IMAGE):$(shell cat hash))
+		 DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash))
 	docker rmi $(IMAGE):build
 	rm -f hash
 

--- a/test/pkg/virtsock/Makefile
+++ b/test/pkg/virtsock/Makefile
@@ -11,5 +11,5 @@ tag: $(DEPS)
 	docker build --squash --no-cache -t $(ORG)/$(IMAGE):$(HASH) .
 
 push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)


### PR DESCRIPTION
Enforce content trust across the `linuxkit` hub org instead of enumerating individual images where we can, since many more packages are signed.  Also enforce our official images are signed.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>

<img src="https://scopicimpulse.files.wordpress.com/2017/05/comedy-wildlife_06.jpg" width="400"></img>