### PR TITLE
tools: Add strace to the Alpine base

### DIFF
--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -57,6 +57,7 @@ qemu-system-x86_64
 sed
 sfdisk
 squashfs-tools
+strace
 syslinux
 tar
 tini

--- a/tools/alpine/versions
+++ b/tools/alpine/versions
@@ -2,7 +2,7 @@
 alpine-baselayout-3.0.4-r0
 alpine-keys-2.1-r1
 alsa-lib-1.1.3-r0
-apk-tools-2.7.1-r0
+apk-tools-2.7.1-r1
 argp-standalone-1.3-r2
 automake-1.15-r0
 bash-4.3.48-r1
@@ -163,6 +163,7 @@ sfdisk-2.28.2-r2
 snappy-1.1.4-r1
 spice-server-0.13.3-r1
 squashfs-tools-4.3-r3
+strace-4.16-r1
 syslinux-6.04_pre1-r1
 tar-1.29-r1
 tini-0.14.0-r0


### PR DESCRIPTION
While not used anywhere, adding it to the based makes it easy
to add temporarily add it to init (or elsewhere) for debugging.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

New hash is: linuxkit/alpine:451603daf499e3a40308dbf5571dcffed2343ffa