### PR TITLE
hyperkit: Add --networking option

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -5,7 +5,7 @@ github.com/docker/infrakit cb420e3e50ea60afe58538b1d3cab1cb14059433
 github.com/golang/protobuf c9c7427a2a70d2eb3bafa0ab2dc163e45f143317
 github.com/googleapis/gax-go 8c5154c0fe5bf18cf649634d4c6df50897a32751
 github.com/mitchellh/go-ps 4fdf99ab29366514c69ccccddab5dc58b8d84062
-github.com/moby/hyperkit 95a60c3e75ac73a1cfd73bacdb5de94a737b6095
+github.com/moby/hyperkit 70205a6d5143340299a679af259f70dfcd7cf8a4
 github.com/packethost/packngo 91d54000aa56874149d348a884ba083c41d38091
 github.com/rneugeba/iso9660wrap 4606f848a055435cdef85305960b0e1bb788d506
 github.com/satori/go.uuid b061729afc07e77a8aa4fad0a2fd840958f1942a

--- a/vendor/github.com/moby/hyperkit/go/hyperkit.go
+++ b/vendor/github.com/moby/hyperkit/go/hyperkit.go
@@ -553,6 +553,9 @@ func checkVPNKitSock(vpnkitsock string) (string, error) {
 	if vpnkitsock == "auto" {
 		vpnkitsock = filepath.Join(getHome(), defaultVPNKitSock)
 	}
+	if vpnkitsock == "" {
+		return "", nil
+	}
 
 	vpnkitsock = filepath.Clean(vpnkitsock)
 	_, err := os.Stat(vpnkitsock)


### PR DESCRIPTION
Adds a new bool option to disable networking with `linuxkit run hyperkit`.
Networking is enabled by default.

Fixes #1912 

![web_small-animal1](https://cloud.githubusercontent.com/assets/1076486/26547655/6562a0cc-4470-11e7-9dcd-e9586c4a7b00.jpg)
