### PR TITLE
Remove remaining uses of tools/go-compile from packages

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -12,7 +12,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:47367d0ef851e8bf2a9e2f80a05392c17f5c2c88
   - name: binfmt
-    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
+    image: "linuxkit/binfmt:3433ade10a9271d4035f9424e8669358e425b6f6"
   - name: format
     image: "linuxkit/format:55afe08816c2a4d8dbae3ee51ef53e0bee422d66"
   - name: mount

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -13,14 +13,7 @@ onboot:
     image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: "linuxkit/metadata:a810b68fec9c9282cf096eed50605ddd6b2f3142"
-    binds:
-     - /dev:/dev
-     - /var:/var
-     - /tmp/etc/resolv.conf:/etc/resolv.conf
-    net: host
-    capabilities:
-     - CAP_SYS_ADMIN
+    image: "linuxkit/metadata:b053fd6a945829bb626bb3546cad69aae0ff7803"
 services:
   - name: rngd
     image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -10,7 +10,7 @@ onboot:
   - name: sysctl
     image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: binfmt
-    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
+    image: "linuxkit/binfmt:3433ade10a9271d4035f9424e8669358e425b6f6"
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -4,18 +4,19 @@ RUN apk add \
     qemu-arm \
     qemu-ppc64le
 
-FROM linuxkit/go-compile:4513068d9a7e919e4ec42e2d7ee879ff5b95b7f5@sha256:bdfadbe3e4ec699ca45b67453662321ec270f2d1a1dbdbf09625776d3ebd68c5 AS build
-COPY main.go main.go
-RUN echo "gofmt..." && test -z $(gofmt -s -l main.go) && \
-    echo "go vet..." && test -z $(GOOS=linux go tool vet -printf=false main.go) && \
-    echo "golint..." && test -z $(golint main.go)
-RUN go build -o usr/bin/binfmt -buildmode pie -ldflags "-s -w -extldflags -static" main.go
+FROM linuxkit/alpine:451603daf499e3a40308dbf5571dcffed2343ffa AS mirror
+
+RUN apk add --no-cache go musl-dev
+ENV GOPATH=/go PATH=$PATH:/go/bin
+
+COPY main.go /go/src/binfmt/
+RUN go-compile.sh /go/src/binfmt
 
 FROM scratch
 ENTRYPOINT []
 WORKDIR /
 COPY --from=qemu usr/bin/qemu-* usr/bin/
-COPY --from=build usr/bin/binfmt usr/bin/binfmt
+COPY --from=mirror /go/bin/binfmt usr/bin/binfmt
 COPY etc/binfmt.d/00_linuxkit.conf etc/binfmt.d/00_linuxkit.conf
 CMD ["/usr/bin/binfmt", "-dir", "/etc/binfmt.d/", "-mount", "/binfmt_misc"]
 LABEL org.mobyproject.config='{"binds": ["/proc/sys/fs/binfmt_misc:/binfmt_misc"], "readonly": true}'

--- a/pkg/metadata/Dockerfile
+++ b/pkg/metadata/Dockerfile
@@ -1,3 +1,15 @@
+FROM linuxkit/alpine:451603daf499e3a40308dbf5571dcffed2343ffa AS mirror
+
+RUN apk add --no-cache go musl-dev
+ENV GOPATH=/go PATH=$PATH:/go/bin
+
+COPY .  /go/src/metadata/
+RUN go-compile.sh /go/src/metadata
+
 FROM scratch
-COPY . ./
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=mirror /go/bin/metadata /usr/bin/metadata
 CMD ["/usr/bin/metadata"]
+LABEL org.mobyproject.config='{"net": "host", "binds": ["/dev:/dev", "/var:/var", "/tmp/etc/resolv.conf:/etc/resolv.conf"], "capabilities": ["CAP_SYS_ADMIN"]}'

--- a/pkg/metadata/Makefile
+++ b/pkg/metadata/Makefile
@@ -1,45 +1,15 @@
-GO_COMPILE=linuxkit/go-compile:4513068d9a7e919e4ec42e2d7ee879ff5b95b7f5@sha256:bdfadbe3e4ec699ca45b67453662321ec270f2d1a1dbdbf09625776d3ebd68c5
-
-SHA_IMAGE=alpine:3.5@sha256:dfbd4a3a8ebca874ebd2474f044a0b33600d4523d03b0df76e5c5986cb02d7e8
-
-METADATA_BINARY=usr/bin/metadata
+.PHONY: tag push
+default: push
 
 ORG?=linuxkit
 IMAGE=metadata
+DEPS=Dockerfile Makefile $(wildcard *.go)
 
-.PHONY: tag push clean container
-default: push
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 
-$(METADATA_BINARY): $(wildcard *.go) Makefile
-	mkdir -p $(dir $@)
-	tar cf - $^ | docker run --rm --net=none --log-driver=none -i $(GO_COMPILE) -o $@ | tar xf -
+tag: $(DEPS)
+	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
-DIRS=dev proc sys
-$(DIRS):
-	mkdir -p $@
-
-DEPS=$(DIRS) $(METADATA_BINARY)
-
-container: Dockerfile $(DEPS)
-	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
-
-hash: Dockerfile $(DEPS)
-	find $^ -type f | xargs cat | docker run --rm -i $(SHA_IMAGE) sha1sum - | sed 's/ .*//' > hash
-
-push: hash container
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
-		(docker tag $(IMAGE):build $(ORG)/$(IMAGE):$(shell cat hash) && \
-		 DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(shell cat hash))
-	docker rmi $(IMAGE):build
-	rm -f hash
-
-tag: hash container
-	docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
-		docker tag $(IMAGE):build $(ORG)/$(IMAGE):$(shell cat hash)
-	docker rmi $(IMAGE):build
-	rm -f hash
-
-clean:
-	rm -rf hash $(DIRS) usr
-
-.DELETE_ON_ERROR:
+push: tag
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -18,14 +18,7 @@ onboot:
     image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: "linuxkit/metadata:a810b68fec9c9282cf096eed50605ddd6b2f3142"
-    binds:
-     - /dev:/dev
-     - /var:/var
-     - /tmp/etc/resolv.conf:/etc/resolv.conf
-    net: host
-    capabilities:
-     - CAP_SYS_ADMIN
+    image: "linuxkit/metadata:b053fd6a945829bb626bb3546cad69aae0ff7803"
 services:
   - name: rngd
     image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"
@@ -47,15 +40,5 @@ services:
      - /var/lib/etcd:/var/lib/etcd
      - /var/config/etcd:/etc/etcd
 trust:
-  - images:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/ca-certificates
-    - linuxkit/sysctl
-    - linuxkit/format
-    - linuxkit/mount
-    - linuxkit/dhcpcd
-    - linuxkit/rngd
-    - linuxkit/openntpd
+  org:
+    - linuxkit

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -13,14 +13,7 @@ onboot:
     image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: "linuxkit/metadata:a810b68fec9c9282cf096eed50605ddd6b2f3142"
-    binds:
-     - /dev:/dev
-     - /var:/var
-     - /tmp/etc/resolv.conf:/etc/resolv.conf
-    net: host
-    capabilities:
-     - CAP_SYS_ADMIN
+    image: "linuxkit/metadata:b053fd6a945829bb626bb3546cad69aae0ff7803"
 services:
   - name: rngd
     image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -11,7 +11,7 @@ onboot:
   - name: sysctl
     image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: binfmt
-    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
+    image: "linuxkit/binfmt:3433ade10a9271d4035f9424e8669358e425b6f6"
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -12,7 +12,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:47367d0ef851e8bf2a9e2f80a05392c17f5c2c88
   - name: binfmt
-    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
+    image: "linuxkit/binfmt:3433ade10a9271d4035f9424e8669358e425b6f6"
   - name: format
     image: "linuxkit/format:55afe08816c2a4d8dbae3ee51ef53e0bee422d66"
   - name: mounts

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -12,7 +12,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:47367d0ef851e8bf2a9e2f80a05392c17f5c2c88
   - name: binfmt
-    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
+    image: "linuxkit/binfmt:3433ade10a9271d4035f9424e8669358e425b6f6"
   - name: format
     image: "linuxkit/format:55afe08816c2a4d8dbae3ee51ef53e0bee422d66"
   - name: mounts

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -11,7 +11,7 @@ onboot:
   - name: sysctl
     image: "linuxkit/sysctl:b16a483897dd5f71be7e0c04cd090b05f52682e1"
   - name: binfmt
-    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
+    image: "linuxkit/binfmt:3433ade10a9271d4035f9424e8669358e425b6f6"
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2f17a0e5d1ef9a75a527821a9ab0d753b22e7e"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -18,14 +18,7 @@ onboot:
     image: "linuxkit/mount:15e20f27abe69d276f796e4026531833ec5ff345"
     command: ["/mount.sh", "/var/lib/swarmd"]
   - name: metadata
-    image: "linuxkit/metadata:a810b68fec9c9282cf096eed50605ddd6b2f3142"
-    binds:
-     - /dev:/dev
-     - /var:/var
-     - /tmp/etc/resolv.conf:/etc/resolv.conf
-    net: host
-    capabilities:
-     - CAP_SYS_ADMIN
+    image: "linuxkit/metadata:b053fd6a945829bb626bb3546cad69aae0ff7803"
 services:
   - name: rngd
     image: "linuxkit/rngd:b67c3151a52b05db50e6207b40876900f2208d14"

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -12,7 +12,7 @@ onboot:
   - name: sysfs
     image: "linuxkit/sysfs:47367d0ef851e8bf2a9e2f80a05392c17f5c2c88"
   - name: binfmt
-    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
+    image: "linuxkit/binfmt:3433ade10a9271d4035f9424e8669358e425b6f6"
   - name: format
     image: "linuxkit/format:55afe08816c2a4d8dbae3ee51ef53e0bee422d66"
   - name: mount

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: binfmt
-    image: "linuxkit/binfmt:eb3977596d5fc9e847eee1d34cb3beb3f574cac9"
+    image: "linuxkit/binfmt:3433ade10a9271d4035f9424e8669358e425b6f6"
   - name: test
     image: "alpine:3.6"
     readonly: true

--- a/test/pkg/virtsock/Dockerfile
+++ b/test/pkg/virtsock/Dockerfile
@@ -4,7 +4,10 @@ RUN apk add --no-cache --initdb -p /out \
     tini
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/go-compile:4513068d9a7e919e4ec42e2d7ee879ff5b95b7f5@sha256:bdfadbe3e4ec699ca45b67453662321ec270f2d1a1dbdbf09625776d3ebd68c5 AS build
+FROM linuxkit/alpine:451603daf499e3a40308dbf5571dcffed2343ffa AS build
+
+RUN apk add --no-cache go musl-dev git make
+ENV GOPATH=/go PATH=$PATH:/go/bin
 
 ENV VIRTSOCK_COMMIT=3bfdf22e3b63a7d130ae5db41c2d76eaffa444d4
 RUN mkdir -p $GOPATH/src/github.com/rneugeba && \
@@ -12,10 +15,11 @@ RUN mkdir -p $GOPATH/src/github.com/rneugeba && \
   git clone https://github.com/rneugeba/virtsock.git
 WORKDIR $GOPATH/src/github.com/rneugeba/virtsock
 RUN git checkout $VIRTSOCK_COMMIT
-RUN make build/virtsock_stress.linux
-RUN cp -a build/virtsock_stress.linux /virtsock_stress
+# Don't use go-compile.sh quite yet as the virtsock package is not yet lint free
+RUN make build/virtsock_stress.linux && \
+    cp -a build/virtsock_stress.linux /virtsock_stress
 
 FROM scratch
 COPY --from=mirror /out/ /
-COPY --from=build virtsock_stress bin/virtsock_stress
-CMD ["/sbin/tini", "/bin/virtsock_stress", "-s", "-v", "1"]
+COPY --from=build virtsock_stress usr/bin/virtsock_stress
+CMD ["/sbin/tini", "/usr/bin/virtsock_stress", "-s", "-v", "1"]


### PR DESCRIPTION
This removes the use of the go-compile package for package builds and converts the metadata package to use a multi-stage build

resolves #1919

![image](https://cloud.githubusercontent.com/assets/3338098/26555996/d8d9815a-448f-11e7-81cd-72cacc56c444.png)
