### PR TITLE
Convert remaining packages to multi-stage, git tree hash, and Alpine base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: default
 VERSION="0.0" # dummy for now
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:3ba94f14de51b73551417e769d122815ec917ee7
+GO_COMPILE=linuxkit/go-compile:6579a00b44686d0e504d513fc4860094769fe7df
 
 MOBY?=bin/moby
 LINUXKIT?=bin/linuxkit

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -22,7 +22,7 @@ docker run -it --rm \
 -v $(PWD):/go/src/github.com/docker/moby \
 -w /go/src/github.com/docker/moby \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:90607983001c2789911afabf420394d51f78ced8
+linuxkit/go-compile:6579a00b44686d0e504d513fc4860094769fe7df
 ```
 
 To update a single dependency:
@@ -32,7 +32,7 @@ docker run -it --rm \
 -v $(PWD):/go/src/github.com/docker/moby \
 -w /go/src/github.com/docker/moby \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:90607983001c2789911afabf420394d51f78ced8 \
+linuxkit/go-compile:6579a00b44686d0e504d513fc4860094769fe7df \
 github.com/docker/docker
 ```
 

--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -15,7 +15,7 @@ import (
 )
 
 // QemuImg is the version of qemu container
-const QemuImg = "linuxkit/qemu:17f052263d63c8a2b641ad91c589edcbb8a18c82"
+const QemuImg = "linuxkit/qemu:c9691f5c50dd191e62b77eaa2f3dfd05ed2ed77c"
 
 // QemuConfig contains the config for Qemu
 type QemuConfig struct {

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -10,7 +10,7 @@ onboot:
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"
     readonly: true
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -10,7 +10,7 @@ onboot:
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"
     readonly: true
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -10,7 +10,7 @@ onboot:
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"
     readonly: true
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -14,7 +14,7 @@ onboot:
     capabilities:
      - all
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -36,7 +36,7 @@ services:
      - /lib/modules:/lib/modules
      - /run:/var/run
   - name: test-docker-bench
-    image: "linuxkit/test-docker-bench:2f941429d874c5dcf05e38005affb4f10192e1a8"
+    image: "linuxkit/test-docker-bench:5264fdfd098d2bfbacd88159e92bc59a9d2be6cc"
     ipc: host
     pid: host
     net: host

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -16,7 +16,7 @@ onboot:
       - /proc/sys/fs/binfmt_misc:/binfmt_misc
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -15,7 +15,7 @@ onboot:
       - /etc:/host-etc
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -17,7 +17,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -9,7 +9,7 @@ onboot:
   - name: mkimage
     image: "linuxkit/mkimage:a3fd615543b84733ac8ba6f7e1927727665ef404"
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
 files:
   - path: data/kernel
     source: run-kernel

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -11,7 +11,7 @@ onboot:
     binds:
      - /etc/ltp/baseline:/etc/ltp/baseline
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
 files:
   - path: /etc/ltp/baseline
     contents: "100"

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -7,13 +7,9 @@ init:
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
 onboot:
   - name: ltp
-    image: "linuxkit/test-ltp:20170116"
-    net: host
-    pid: host
+    image: "linuxkit/test-ltp:6df23ac196332cafb9c0f8e32f328e22d612267d"
     binds:
      - /etc/ltp/baseline:/etc/ltp/baseline
-    capabilities:
-     - all
   - name: poweroff
     image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
 files:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -15,7 +15,7 @@ onboot:
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"
     readonly: true
   - name: poweroff
-    image: "linuxkit/poweroff:a8f1e4ad8d459f1fdaad9e4b007512cb3b504ae8"
+    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   image:

--- a/test/pkg/docker-bench/Dockerfile
+++ b/test/pkg/docker-bench/Dockerfile
@@ -1,22 +1,31 @@
-FROM alpine:3.5
-RUN apk update && apk upgrade && apk add --no-cache bash curl
-ADD . ./
+FROM linuxkit/alpine:451603daf499e3a40308dbf5571dcffed2343ffa AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    busybox \
+    bash \
+    curl
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-# Also add docker
+FROM scratch
+WORKDIR /
+COPY --from=mirror /out/ /
+
+# Add docker
 ENV DOCKER_BUCKET get.docker.com
-ENV DOCKER_VERSION 17.04.0-ce
-ENV DOCKER_SHA256 c52cff62c4368a978b52e3d03819054d87bcd00d15514934ce2e0e09b99dd100
+ENV DOCKER_VERSION 17.05.0-ce
+ENV DOCKER_SHA256 340e0b5a009ba70e1b644136b94d13824db0aeb52e09071410f35a95d94316d9
 
-# Downloads docker but only installs the client
+# Install just the client
 RUN set -x \
-	&& curl -fSL "https://${DOCKER_BUCKET}/builds/$(uname -s)/$(uname -m)/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
-	&& echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
-	&& tar -xzvf docker.tgz \
-	&& mv docker/docker /usr/bin/ \
-	&& rm -rf docker \
-	&& rm docker.tgz \
-	&& docker -v
+        && curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+        && echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
+        && tar -xzvf docker.tgz \
+        && mv docker/docker /usr/bin/ \
+        && rm -rf docker \
+        && rm docker.tgz \
+        && docker -v
 
-COPY . ./
+COPY bench_runner.sh ./bench_runner.sh
 
 ENTRYPOINT ["/bin/sh", "/bench_runner.sh"]

--- a/test/pkg/docker-bench/Makefile
+++ b/test/pkg/docker-bench/Makefile
@@ -1,29 +1,15 @@
 .PHONY: tag push
-
-BASE=alpine:3.5
-IMAGE=test-docker-bench
-
 default: push
 
-hash: Dockerfile bench_runner.sh
-	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
-	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
-	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c "cat $^ /lib/apk/db/installed | sha1sum" | sed 's/ .*//' > hash
+ORG?=linuxkit
+IMAGE=test-docker-bench
+DEPS=Dockerfile Makefile bench_runner.sh
 
-push: hash
-	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
-		 DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash))
-	docker rmi $(IMAGE):build
-	rm -f hash
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 
-tag: hash
-	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash)
-	docker rmi $(IMAGE):build
-	rm -f hash
+tag: $(DEPS)
+	docker build --squash --no-cache -t $(ORG)/$(IMAGE):$(HASH) .
 
-clean:
-	rm -f hash
-
-.DELETE_ON_ERROR:
+push: tag
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/test/pkg/ltp/Dockerfile
+++ b/test/pkg/ltp/Dockerfile
@@ -1,7 +1,6 @@
-FROM debian:jessie
+FROM debian:jessie@sha256:476959f29a17423a24a17716e058352ff6fbf13d8389e4a561c8ccc758245937 AS build
 
-ARG LTP_VERSION
-
+ENV LTP_VERSION=20170116
 ENV LTP_SOURCE=https://github.com/linux-test-project/ltp/releases/download/${LTP_VERSION}/ltp-full-${LTP_VERSION}.tar.xz
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -17,3 +16,10 @@ RUN cd /ltp \
     && ./configure \
     && make -j "$(getconf _NPROCESSORS_ONLN)" all \
     && make install
+
+FROM debian:jessie-slim@sha256:12d31a3d5a1f7cb272708be35031ba068dec46fa84af6aeb38aef5c8a83e8974
+COPY --from=build /opt/ltp/ /opt/ltp/
+ADD check.sh ./check.sh
+WORKDIR /opt/ltp
+ENTRYPOINT ["/bin/sh", "/check.sh"]
+LABEL org.mobyproject.config='{"pid": "host", "capabilities": ["all"]}'

--- a/test/pkg/ltp/Dockerfile.pkg
+++ b/test/pkg/ltp/Dockerfile.pkg
@@ -1,4 +1,0 @@
-FROM debian:jessie-slim@sha256:fb22c1cef74071a6cd0145c1f91ca85ba9bd3f8b4d6db8560fe69eb36a175ca3
-ADD . /
-WORKDIR /opt/ltp
-ENTRYPOINT ["/bin/sh", "/check.sh"]

--- a/test/pkg/ltp/Makefile
+++ b/test/pkg/ltp/Makefile
@@ -1,44 +1,15 @@
-LTP_VERSION=20170116
+.PHONY: tag push
+default: push
 
-all: ltp.tar push
-
-# Build LTP and get the result as a tarball
-DEPS=Dockerfile.build Makefile
-ltp.tag: $(DEPS)
-	BUILD=$$(docker build -f $< -q . --build-arg LTP_VERSION=$(LTP_VERSION)) && [ -n "$$BUILD" ] && echo "Built $$BUILD" && echo "$$BUILD" > $@
-
-ltp.tar: ltp.tag
-	docker run --rm --net=none --log-driver=none $(shell cat ltp.tag) tar cf - opt/ltp  > $@
-
-SHASUM=alpine:3.5
+ORG?=linuxkit
 IMAGE=test-ltp
+DEPS=Dockerfile Makefile check.sh
 
-# Note: We do not compute the hash from all the dependencies here
-# because the ltp binaries will change everytime we build. Ideally, we
-# would calculate the hash from the source and the apt-get cache, but
-# it's not that critical.
-hash: Dockerfile.pkg ltp.tar check.sh $(DEPS)
-	tar xf ltp.tar
-	tar cf - Dockerfile.pkg opt check.sh | docker build --no-cache -t $(IMAGE):build -f Dockerfile.pkg -
-	cat Dockerfile.pkg check.sh $(DEPS) | DOCKER_CONTENT_TRUST=1 docker run --rm -i $(SHASUM) sha1sum | sed 's/ .*//' > $@
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 
-push: hash
-	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
-		 docker tag $(IMAGE):build linuxkit/$(IMAGE):$(LTP_VERSION) && \
-		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash) && \
-		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(LTP_VERSION))
-	docker rmi $(IMAGE):build
-	rm -f hash
+tag: $(DEPS)
+	docker build --no-cache -t $(ORG)/$(IMAGE):$(HASH) .
 
-tag: hash
-	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash)
-	docker rmi $(IMAGE):build
-	rm -f hash
-
-.PHONY: clean
-clean:
-	rm -rf opt ltp.tar ltp.tag hash
-
-.DELETE_ON_ERROR:
+push: tag
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/test/pkg/poweroff/Dockerfile
+++ b/test/pkg/poweroff/Dockerfile
@@ -1,4 +1,12 @@
-FROM alpine:3.5
-ADD . ./
+FROM linuxkit/alpine:451603daf499e3a40308dbf5571dcffed2343ffa AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+FROM scratch
+CMD []
+WORKDIR /
+COPY --from=mirror /out/ /
+COPY /poweroff.sh /poweroff.sh
 ENTRYPOINT ["/bin/sh", "/poweroff.sh"]
 LABEL org.mobyproject.config='{"pid": "host", "readonly": true, "capabilities": ["CAP_SYS_BOOT"]}'

--- a/test/pkg/poweroff/Makefile
+++ b/test/pkg/poweroff/Makefile
@@ -1,29 +1,15 @@
 .PHONY: tag push
-
-BASE=alpine:3.5
-IMAGE=poweroff
-
 default: push
 
-hash: Dockerfile poweroff.sh
-	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
-	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
-	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c "cat $^ /lib/apk/db/installed | sha1sum" | sed 's/ .*//' > hash
+ORG?=linuxkit
+IMAGE=poweroff
+DEPS=Dockerfile Makefile poweroff.sh
 
-push: hash
-	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
-		 DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash))
-	docker rmi $(IMAGE):build
-	rm -f hash
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 
-tag: hash
-	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash)
-	docker rmi $(IMAGE):build
-	rm -f hash
+tag: $(DEPS)
+	docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
-clean:
-	rm -f hash
-
-.DELETE_ON_ERROR:
+push: tag
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -24,6 +24,9 @@ RUN apk index --rewrite-arch $(uname -m) -o /mirror/$(uname -m)/APKINDEX.unsigne
 RUN cp /mirror/$(uname -m)/APKINDEX.unsigned.tar.gz /mirror/$(uname -m)/APKINDEX.tar.gz
 RUN abuild-sign /mirror/$(uname -m)/APKINDEX.tar.gz
 
+# fetch OVMF for qemu EFI boot (this is not added as a package)
+RUN apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/community ovmf
+
 # set this as our repo
 RUN echo "/mirror" > /etc/apk/repositories && apk update
 
@@ -44,6 +47,7 @@ COPY --from=mirror /etc/apk/repositories /etc/apk/repositories
 COPY --from=mirror /etc/apk/keys /etc/apk/keys/
 COPY --from=mirror /mirror /mirror/
 COPY --from=mirror /go/bin /go/bin/
+COPY --from=mirror /usr/share/ovmf/bios.bin /usr/share/ovmf/bios.bin
 COPY --from=mirror /Dockerfile /Dockerfile
 
 COPY --from=shellcheck /usr/local/bin/shellcheck /usr/local/bin/shellcheck

--- a/tools/go-compile/Dockerfile
+++ b/tools/go-compile/Dockerfile
@@ -1,10 +1,16 @@
-FROM alpine:3.5
-RUN apk update && apk add --no-cache build-base git go
+FROM linuxkit/alpine:451603daf499e3a40308dbf5571dcffed2343ffa AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    busybox \
+    git \
+    go \
+    musl-dev
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+FROM scratch
 ENV GOPATH=/go PATH=$PATH:/go/bin
-RUN go get -u github.com/golang/lint/golint && \
-    go get -u github.com/gordonklaus/ineffassign && \
-    go get -u github.com/LK4D4/vndr
-
-COPY . ./
-
+COPY --from=mirror /out/ /
+COPY --from=mirror /go/bin/ /go/bin/
+COPY /compile.sh /compile.sh
 ENTRYPOINT ["/compile.sh"]

--- a/tools/go-compile/Makefile
+++ b/tools/go-compile/Makefile
@@ -1,41 +1,15 @@
 .PHONY: tag push
-
-BASE=alpine:3.5
-IMAGE=go-compile
-
 default: push
 
-hash: Dockerfile compile.sh
-	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
-	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
-	docker run --rm --entrypoint=/bin/sh $(IMAGE):build -c "cat $^ /lib/apk/db/installed /go/bin/golint | sha1sum" | sed 's/ .*//' > hash
+ORG?=linuxkit
+IMAGE=go-compile
+DEPS=Dockerfile Makefile compile.sh
 
-push: hash
-	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
-		 docker push linuxkit/$(IMAGE):$(shell cat hash))
-	docker rmi $(IMAGE):build
-	rm -f hash
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 
-tag: hash
-	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash)
-	docker rmi $(IMAGE):build
-	rm -f hash
+tag: $(DEPS)
+	docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
-signed-tag: hash
-	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		(DOCKER_CONTENT_TRUST=1 docker pull $(BASE) && \
-		 docker build --no-cache -t $(IMAGE):build . && \
-		 docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash))
-
-sign: signed-tag
-	DOCKER_CONTENT_TRUST=1 docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		DOCKER_CONTENT_TRUST=1 docker push linuxkit/$(IMAGE):$(shell cat hash)
-	rm -f hash
-	docker rmi $(IMAGE):build || true
-
-clean:
-	rm -f hash
-
-.DELETE_ON_ERROR:
+push: tag
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/tools/qemu/Dockerfile
+++ b/tools/qemu/Dockerfile
@@ -1,15 +1,19 @@
-FROM alpine:edge
+FROM linuxkit/alpine:5240cbd9cf371c8211c8f1968e57c51a32098c8f AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    busybox \
+    libarchive-tools \
+    qemu-img \
+    qemu-system-x86_64
 
-COPY repositories /etc/apk/
+RUN mkdir -p /out/usr/share/ovmf \
+    && cp /usr/share/ovmf/bios.bin /out/usr/share/ovmf/bios.bin
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-RUN \
-  apk update && apk upgrade && \
-  apk add --no-cache \
-  libarchive-tools \
-  qemu-img \
-  qemu-system-arm \
-  qemu-system-x86_64 \
-  ovmf@testing \
-  && true
+FROM scratch
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=mirror /out/ /
 
-COPY . .

--- a/tools/qemu/Makefile
+++ b/tools/qemu/Makefile
@@ -1,29 +1,15 @@
 .PHONY: tag push
-
-BASE=alpine:3.5
-IMAGE=qemu
-
 default: push
 
-hash: Dockerfile repositories
-	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
-	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
-	docker run --rm --entrypoint /bin/sh $(IMAGE):build -c 'cat Dockerfile /lib/apk/db/installed | sha1sum' | sed 's/ .*//' > $@
+ORG?=linuxkit
+IMAGE=qemu
+DEPS=Dockerfile Makefile
 
-push: hash
-	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
-		 docker push linuxkit/$(IMAGE):$(shell cat hash))
-	docker rmi $(IMAGE):build
-	rm -f hash
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 
-tag: hash
-	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
-		docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash)
-	docker rmi $(IMAGE):build
-	rm -f hash
+tag: $(DEPS)
+	DOCKER_CONTENT_TRUST=1 docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
 
-clean:
-	rm -f hash
-
-.DELETE_ON_ERROR:
+push: tag
+	docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	docker push $(ORG)/$(IMAGE):$(HASH)

--- a/tools/qemu/repositories
+++ b/tools/qemu/repositories
@@ -1,2 +1,0 @@
-http://dl-cdn.alpinelinux.org/alpine/edge/main
-@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing


### PR DESCRIPTION
These are the remaining packages/tools which were not using multi-stage builds and/or git tree hashes and/or Alpine base.


This resolves #1921, though I didn't convert the `guestfs`/`mkimage-*` tools as they should go away. I also didn't change the `perf` package as this needs to be fixed properly first (see #1613)
