### PR TITLE
logging project: fix example

### DIFF
--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037 # with runc, logwrite, startmemlogd
+  - linuxkit/init:b5c88b78cd9cc73ed83b45f66bc9de618223768a # NOTE: custom init with logwrite ctr/runc, startmemlogd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d


### PR DESCRIPTION
Example had been updated to the standard init that didn't include logging on startup, so no logs were recorded.

To use memlogd you currently need a custom init. It has to start the `memlogd` container before running onboot/service containers and then call `ctr`/`runc` through `logwrite` to capture stderr/stdout.

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>