### PR TITLE
Support multiple disks in qemu

### DIFF
--- a/docs/external-disk.md
+++ b/docs/external-disk.md
@@ -7,14 +7,15 @@
 ## Make Disk Available
 In order to make the disk available, you need to tell `linuxkit` where the disk file or block device is.
 
-All local `linuxkit run` methods (currently `hyperkit`, `qemu`, and `vmware`) take two arguments:
+All local `linuxkit run` methods (currently `hyperkit`, `qemu`, and `vmware`) take a `-disk` argument:
 
-* `-disk-size <size>`: size of disk. The default is in MB but a `G` can be appended to specify the size in GB, e.g. `-disk-size 4096` or `disk-size 4G` will provide a 4GB disk.
-* `-disk <path>`: use the disk at location _path_, e.g. `-disk foo.img` will use the disk at `$PWD/foo.img`
+* `-disk path,size=100M,format=qcow2`. For size the default is in MB but `G` can be aspecified for GB. The format can be omitted for the platform default, and is only useful on `qemu` at present.
 
-If you do not provide `-disk `_path_, `linuxkit` assumes a default, which is _prefix_`-state/disk.img` for `hyperkit` and `vmware` and _prefix_`-disk.img` for `qemu`. 
+If the _path` is specified it will use the disk at location _path_, if you do not provide `-disk `_path_, `linuxkit` assumes a default, which is _prefix_`-state/disk.img` for `hyperkit` and `vmware` and _prefix_`-disk.img` for `qemu`. 
 
-If the disk at `<path>`, or the default if `-disk` option is not provided, does not exist, `linuxkit` will create one of size `<size>`.
+If the disk at the specified or default `<path>` does not exist, `linuxkit` will create one of size `<size>`.
+
+The `-disk` specification may be repeated for multiple disks, although a limited number may be supported, and some platforms currently only support a single disk.
 
 **TODO:** GCP
 

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.sh
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.sh
@@ -19,5 +19,5 @@ trap clean_up EXIT
 
 moby build -output qcow2 -name "${NAME}" test.yml
 [ -f "${NAME}.qcow2" ] || exit 1
-linuxkit run qemu -disk-format qcow2 "${NAME}.qcow2" | grep -q "Welcome to LinuxKit"
+linuxkit run qemu "${NAME}.qcow2" | grep -q "Welcome to LinuxKit"
 exit 0

--- a/test/cases/040_packages/013_mkimage/test.sh
+++ b/test/cases/040_packages/013_mkimage/test.sh
@@ -19,7 +19,7 @@ trap clean_up EXIT
 # Test code goes here
 moby build -output kernel+initrd run.yml
 moby build -output kernel+initrd mkimage.yml
-linuxkit run qemu -disk-size 200 -disk-format qcow2 -disk disk.qcow2 -kernel mkimage
+linuxkit run qemu -disk disk.qcow2,size=200M,format=qcow2 -kernel mkimage
 linuxkit run qemu disk.qcow2
 
 exit 0


### PR DESCRIPTION
I needed multiple disks for `mkimage` to make it easier to pass data in and out as using the network under `qemu` was a pain. Still need to change the other backends to use the same CLI syntax, just seeing if any objections...

This changes the CLI specification for disks, as it needs to be able to
be repeated.

```
linuxkit run qemu -disk name,size=1G,format=qcow2 ...
```

Options may be omitted.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>
