### PR TITLE
Update mkimage to use a tarball as source for files

### DIFF
--- a/pkg/mkimage/Dockerfile
+++ b/pkg/mkimage/Dockerfile
@@ -20,4 +20,4 @@ WORKDIR /
 COPY --from=mirror /out/ /
 COPY mkimage.sh /usr/bin/
 CMD ["mkimage.sh"]
-LABEL org.mobyproject.config='{"readonly": true, "capabilities": ["CAP_SYS_ADMIN", "CAP_MKNOD"], "binds": ["/dev:/dev", "/data:/data"]}'
+LABEL org.mobyproject.config='{"readonly": true, "capabilities": ["CAP_SYS_ADMIN", "CAP_MKNOD"], "binds": ["/dev:/dev"]}'

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -7,16 +7,9 @@ init:
   - linuxkit/containerd:deaf5bf838bf7f131c2287ecff3ed9835b0497e2
 onboot:
   - name: mkimage
-    image: "linuxkit/mkimage:a3fd615543b84733ac8ba6f7e1927727665ef404"
+    image: "linuxkit/mkimage:f4bf0c24261f7d120c8674892805ab3054eb8ac3"
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
-files:
-  - path: data/kernel
-    source: run-kernel
-  - path: data/initrd.img
-    source: run-initrd.img
-  - path: data/cmdline
-    source: run-cmdline
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/013_mkimage/test.sh
+++ b/test/cases/040_packages/013_mkimage/test.sh
@@ -12,14 +12,15 @@ set -e
 clean_up() {
 	find . -iname "run*" -not -iname "*.yml" -exec rm -rf {} \;
 	find . -iname "mkimage*" -not -iname "*.yml" -exec rm -rf {} \;
-	rm -f disk.qcow2
+	rm -f disk.qcow2 tarball.img
 }
 trap clean_up EXIT
 
 # Test code goes here
 moby build -output kernel+initrd run.yml
 moby build -output kernel+initrd mkimage.yml
-linuxkit run qemu -disk disk.qcow2,size=200M,format=qcow2 -kernel mkimage
+tar cf tarball.img run-kernel run-initrd.img run-cmdline
+linuxkit run qemu -disk disk.qcow2,size=200M,format=qcow2 -disk tarball.img,format=raw -kernel mkimage
 linuxkit run qemu disk.qcow2
 
 exit 0


### PR DESCRIPTION
This uses the qemu multi disk support for the `mkimage` package - instead of baking in the images into the VM, it passes them as a tarball, disguised as a raw disk. This means you can use the same `mkimage` VM again and again without rebuilding it each time, plus it is faster as the image is smaller. This was nicer than using the network in the end.