### PR TITLE
projects/miragesdk: add a frontend yaml format for dhcp-client

### DIFF
--- a/projects/miragesdk/yaml/dhcp-client.yml
+++ b/projects/miragesdk/yaml/dhcp-client.yml
@@ -1,0 +1,47 @@
+# There are three processes running in the DHCP daemon:
+# - dhcp-network: handles L2 network traffic
+# - dhcp-engine: protocol state machine
+# - dhcp-actuator: sets interface state
+# And a dhcp-client which starts the three above and exits.
+#
+# dhcp-actuator: can be written in Rust and only contain
+#   minimal support for setting syscalls.
+# dhcp-engine: requires no system access beyond the input
+#   from `dhcp-network` and output to `dhcp-actuator`.
+# dhcp-network: requires L2 network access and then only
+#   outputs to dhcp-engine.  It may transmit via responses
+#   from dhcp-engine.
+- name: dhcp-client
+  image: <image>
+  net: host
+  capabilities:
+   - CAP_SYS_ADMIN # for runc (unshare)
+   - CAP_SETGID    # for runc (setns)
+  mounts: # for runc
+   - type: cgroup
+     options: ["rw","nosuid","noexec","nodev","relatime"]
+  binds:
+    - /var/run/dhcp-client:/data
+    - /usr/bin/runc:/usr/bin/runc # for runc
+    - /run/runc:/run/runc         # for runc
+- name: dhcp-network
+  capabilities:
+   - CAP_NET_ADMIN # to bring eth0 up
+   - CAP_NET_RAW   # to read /dev/eth0
+- name: dhcp-engine
+  image: <image>
+  rpc:
+   - dhcp-network
+   - dhcp-actuator
+- name: dhcp-actuator
+  image: <image>
+  capabilities:
+    - CAP_NET_ADMIN # for syscall, needs to be ebpf
+  binds:
+    - /state # needs to write resolv.conf file
+    - /sbin:/sbin   # for ifconfig
+    - /bin:/bin     # for ifconfig
+    - /lib:/lib     # for ifconfig
+files:
+  - path: /var/run/dhcp-client/README
+    contents: 'data for dhcp-client'

--- a/projects/miragesdk/yaml/dhcp.capnp
+++ b/projects/miragesdk/yaml/dhcp.capnp
@@ -1,0 +1,35 @@
+@0xb224be3ea8450819;
+
+struct DhcpNetworkRequest {
+  id   @0 :Int32;
+  path @1 :List(Text);
+  union {
+    write  @2 :Data;
+    read   @3 :Void;
+    delete @4 :Void;
+  }
+}
+
+struct DhcpNetworkResponse {
+  id   @0: Int32;
+  union {
+    ok    @1 :Data;
+    error @2 :Data;
+  }
+}
+
+struct DhcpActuatorRequest {
+  id   @0 :Int32;
+  interface @1 :Text;
+  ipv4Addr @2 :List(Text);
+  resolvConf @3 :List(Text);
+}
+
+struct DhcpActuatorResponse {
+  id   @0: Int32;
+  union {
+    ok    @1 :Data;
+    error @2 :Data;
+  }
+}
+


### PR DESCRIPTION
The intention with the yaml fragment is that it specifies the
set of processes that form the daemon, with minimal privileges
for each component and each running inside a separate container.

In addition to the normal container capabilities, there is also
a new field which lets a startup process establish an RPC channel,
based on a Capnp specification. This allows for extremely
unprivileged components to be started, such as the `dhcp-engine`
in this example which can only communicate with the outside world
via the `dhcp-network` (to transmit) or `dhcp-actuator` (to alter
the state of the local Linux distribution).

This is a first cut at the yaml interface and the capnp, with the
intention to refine it as we combine it with the rest of the existing
prototype (which currently doesnt have an RPC layer).  Expect
more changes...

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
