### PR TITLE
Adding Dynamic VHD mkimage package

### DIFF
--- a/tools/mkimage-dynamic-vhd/Dockerfile
+++ b/tools/mkimage-dynamic-vhd/Dockerfile
@@ -1,0 +1,5 @@
+FROM linuxkit/guestfs:2657580764d5791e103647237dac5a0276533e2e@sha256:8f99eba6720df17bce8893052d7ca9a07cdc9cd09b335a5a9c57ebd5a44934be
+
+COPY . .
+
+ENTRYPOINT [ "/make-dynamic-vhd" ]

--- a/tools/mkimage-dynamic-vhd/Makefile
+++ b/tools/mkimage-dynamic-vhd/Makefile
@@ -1,0 +1,27 @@
+.PHONY: tag push
+
+IMAGE=mkimage-dynamic-vhd
+
+default: push
+
+hash: Dockerfile make-dynamic-vhd
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --entrypoint sh --rm $(IMAGE):build -c "(cat $^; apt list --installed 2>/dev/null) | sha1sum" | sed 's/ .*//' > hash
+
+push: hash
+	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
+		 docker push linuxkit/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/tools/mkimage-dynamic-vhd/make-dynamic-vhd
+++ b/tools/mkimage-dynamic-vhd/make-dynamic-vhd
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+set -e
+
+mkdir -p /tmp/image
+cd /tmp/image
+
+# input is a tarball of kernel and initrd.img on stdin
+# output is a vmdk on stdout
+
+mkdir -p files
+
+cd files
+
+# extract. As guestfs base is currently Debian, no compression support
+# only if stdin is a tty, if so need files volume mounted...
+[ -t 0 ] || tar xf -
+
+INITRD="$(find . -name '*.img')"
+KERNEL="$(find . -name kernel -or -name '*bzImage')"
+CMDLINE="$*"
+
+[ "$KERNEL" = "./kernel" ] || mv "$KERNEL" vmlinuz64
+[ "$INITRD" = "./initrd.img" ] || mv "$INITRD" initrd.img
+
+# clean up subdirectories
+find . -mindepth 1 -maxdepth 1 -type d | xargs rm -rf
+
+CFG="DEFAULT linux
+LABEL linux
+    KERNEL /kernel
+    INITRD /initrd.img
+    APPEND ${CMDLINE}
+"
+
+printf "$CFG" > syslinux.cfg
+
+cd ..
+
+tar cf files.tar -C files .
+
+# Disk is created in qcow format.
+virt-make-fs --size=25G --type=ext4 --partition files.tar --format=qcow2 disk.qcow
+
+guestfish -a disk.qcow -m /dev/sda1 <<EOF
+  upload /usr/lib/SYSLINUX/mbr.bin /mbr.bin
+  copy-file-to-device /mbr.bin /dev/sda size:440
+  rm /mbr.bin
+  extlinux /
+  part-set-bootable /dev/sda 1 true
+EOF
+
+# Can't convert directly to VHD, as it's not supported by qemu-img. First, compress qcow image to vmdk format.
+qemu-img convert -f qcow2 -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 -c disk.qcow disk.vmdk 1>&2
+
+# Then create dynamic VHD
+qemu-img convert -f vmdk -O vpc -o subformat=dynamic disk.vmdk disk.vhd 1>&2
+
+cat disk.vhd


### PR DESCRIPTION
Adding a mkimage package to create dynamic VHD images (static/fixed VHD images are already supported by LinuxKit). Dynamic VHD files are smaller in size, making them much easier to upload to our cloud.

Signed-off-by: Dave Freitag <dcfreita@us.ibm.com>

**- What I did**
Created a mkimage package to support the creation of dynamic VHD images. 

**- How I did it**
I based the new files off of the existing vhd and vmdk mkimage filesets.

**- How to verify it**
Once built into the moby tool as an output format, it can be verified. I can submit a PR to the moby tool for that, but will need assistance getting the tagged 'linuxkit/mkimage-dynamic-vhd:<hash>' image built and pushed first.

**- Description for the changelog**
Added a mkimage package to support the dynamic VHD output format
