### PR TITLE
Add /pkg/vsudd

### DIFF
--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -1,0 +1,22 @@
+kernel:
+  image: "linuxkit/kernel:4.9.x"
+  cmdline: "console=ttyS0 page_poison=1"
+init:
+  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:deaf5bf838bf7f131c2287ecff3ed9835b0497e2
+onboot:
+  - name: dhcpcd
+    image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+services:
+  - name: vsudd
+    image: "linuxkit/vsudd:a66df914201aac784195d5b78262f622fe7f910c"
+    binds:
+        - /run/containerd/containerd.sock:/run/containerd/containerd.sock
+    command: ["/vsudd", 
+        "-inport", "2374:unix:/run/containerd/containerd.sock"]
+
+trust:
+  org:
+    - linuxkit

--- a/pkg/vsudd/Dockerfile
+++ b/pkg/vsudd/Dockerfile
@@ -1,0 +1,14 @@
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+
+RUN apk add --no-cache go musl-dev git build-base
+ENV GOPATH=/go PATH=$PATH:/go/bin 
+ENV VIRTSOCK_COMMIT=a381dcc5bcddf1d7f449495c373dbf70f8e501c0
+
+RUN git clone https://github.com/linuxkit/virtsock.git /go/src/github.com/linuxkit/virtsock && \
+    cd /go/src/github.com/linuxkit/virtsock && \
+    git checkout $VIRTSOCK_COMMIT && \
+    make vsudd
+
+FROM scratch
+COPY --from=mirror /go/src/github.com/linuxkit/virtsock/build/vsudd.linux /vsudd
+ENTRYPOINT ["/vsudd"]

--- a/pkg/vsudd/Makefile
+++ b/pkg/vsudd/Makefile
@@ -1,0 +1,15 @@
+default: push
+
+ORG?=linuxkit
+IMAGE=vsudd
+DEPS=$(wildcard *.go) Makefile Dockerfile
+
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
+
+tag: $(DEPS)
+	docker build --squash --no-cache -t $(ORG)/$(IMAGE):$(HASH) .
+
+push: tag
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+

--- a/pkg/vsudd/README.md
+++ b/pkg/vsudd/README.md
@@ -1,0 +1,23 @@
+#### Vsudd
+
+Vsudd is a daemon that forwards unix domain socket traffic from the host to the
+guest VM via VSOCK. It can be used to control other daemons, like `containerd`
+and `dockerd`, from the host.  An example configuration file is available in
+[examples/vsudd.yml](/examples/vsudd.yml).
+
+After building the example, run the example with `linuxkit run hyperkit
+-vsock-ports 2374 vsudd`. This will create a unix domain socket in the state
+directory that map to the `containerd` control socket. The socket is called
+`guest.00000946`.
+
+If you install the `ctr` tool on the host you should be able to access the
+`containerd` running in the VM:
+
+```
+$ go get -u -ldflags -s github.com/containerd/containerd/cmd/ctr
+...
+$ ctr -a vsudd-state/guest.00000946 list
+ID        IMAGE     PID       STATUS
+vsudd               466       RUNNING
+```
+


### PR DESCRIPTION
Adds new package`vsudd` that clones and builds `linuxkit/virtsock/cmd/vsudd`. This is #1947 with the vsudd code removed.

I've added a minimal example and a README.md for controlling containerd from the host with ctr.

Pushed to a temporary hub user for now so the example works.