### PR TITLE
sdk: update the tests to use mtime 1.0 and logs.fmt

### DIFF
--- a/projects/miragesdk/src/test/jbuild
+++ b/projects/miragesdk/src/test/jbuild
@@ -2,7 +2,8 @@
 
 (executables
   ((names (test))
-   (libraries (sdk alcotest astring mtime mtime.clock.os mirage-flow-lwt))))
+   (libraries (sdk alcotest astring mtime mtime.clock.os mirage-flow-lwt
+               logs.fmt))))
 
 (alias
  ((name    runtest)

--- a/projects/miragesdk/src/test/jbuild
+++ b/projects/miragesdk/src/test/jbuild
@@ -2,7 +2,7 @@
 
 (executables
   ((names (test))
-   (libraries (sdk alcotest astring mtime.os mirage-flow-lwt))))
+   (libraries (sdk alcotest astring mtime mtime.clock.os mirage-flow-lwt))))
 
 (alias
  ((name    runtest)

--- a/projects/miragesdk/src/test/test.ml
+++ b/projects/miragesdk/src/test/test.ml
@@ -283,7 +283,7 @@ let reporter ?(prefix="") () =
     let k _ = over (); k () in
     let ppf = match level with Logs.App -> Fmt.stdout | _ -> Fmt.stderr in
     let with_stamp h _tags k fmt =
-      let dt = Mtime.to_us (Mtime.elapsed ()) in
+      let dt = Mtime.Span.to_us (Mtime_clock.elapsed ()) in
       Fmt.kpf k ppf ("%s%+04.0fus %a %a @[" ^^ fmt ^^ "@]@.")
         prefix
         dt


### PR DESCRIPTION
This fixes basic build issues.


![](https://s-media-cache-ak0.pinimg.com/736x/9d/6d/9b/9d6d9b7a445e659035f36eb61814893b.jpg)
