### PR TITLE
Fix empty AWS default image name

### DIFF
--- a/src/cmd/linuxkit/push_aws.go
+++ b/src/cmd/linuxkit/push_aws.go
@@ -65,7 +65,7 @@ func pushAWS(args []string) {
 	defer f.Close()
 
 	if name == "" {
-		name = strings.TrimSuffix(name, filepath.Ext(src))
+		name = strings.TrimSuffix(src, filepath.Ext(src))
 	}
 
 	content, err := ioutil.ReadAll(f)


### PR DESCRIPTION
Signed-off-by: Dieter Reuter <dieter.reuter@me.com>

**- What I did**
Fix coding error, so the default `-img-name` will now be set correctly to the basename of the provided image file.

**- How I did it**
Use filename from variable `src` as the default for `-img-name`.

**- How to verify it**
Before the fix, the used image name was empty, so you'll see `Key: ".img"` in the debug log and the import/register as AMI raises an error.
```
$ linuxkit -v push aws -bucket <BUCKET_NAME> aws.img
DEBU[0000] PutObject:
{
  Body: buffer(0xc42000c0e0),
  Bucket: "<BUCKET_NAME>",
  ContentLength: 209715200,
  ContentType: "application/octet-stream",
  Key: ".img"
}
```
With the fix, it'll work correctly with `Key: "aws.img"` and the correct AMI name `aws` will be used.

**- Description for the changelog**
Fix setting the default `-img-name` to the basename of the provided image file

