### PR TITLE
Remove all getty from init

### DIFF
--- a/pkg/init/etc/init.d/000-issue
+++ b/pkg/init/etc/init.d/000-issue
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ -f /etc/issue ]; then
+	for opt in $(cat /proc/cmdline); do
+		case "$opt" in
+		console=*)
+			fulltty=${opt#console=}
+			tty=${fulltty%,*}
+			cat /etc/issue >> /dev/$tty
+		esac
+	done
+fi

--- a/pkg/init/init
+++ b/pkg/init/init
@@ -1,45 +1,9 @@
 #!/bin/sh
 
-setup_console() {
-	tty=${1%,*}
-	speed=${1#*,}
-	inittab="$2"
-	securetty="$3"
-	line=
-	term="linux"
-	[ "$speed" = "$1" ] && speed=115200
-
-	case "$tty" in
-	ttyS*|ttyAMA*|ttyUSB*|ttyMFD*)
-		line="-L"
-		term="vt100"
-		;;
-	tty?)
-		line=""
-		speed="38400"
-		term=""
-		;;
-	esac
-	# skip consoles already in inittab
-	grep -q "^$tty:" "$inittab" && return
-
-	echo "$tty::once:cat /etc/issue" >> "$inittab"
-	echo "$tty::respawn:/sbin/getty -n -l /bin/sh $line $speed $tty $term" >> "$inittab"
-	if ! grep -q -w "$tty" "$securetty"; then
-		echo "$tty" >> "$securetty"
-	fi
-}
-
 /bin/mount -t tmpfs tmpfs /mnt
 
 /bin/cp -a / /mnt 2>/dev/null
 
 /bin/mount -t proc -o noexec,nosuid,nodev proc /proc
-for opt in $(cat /proc/cmdline); do
-	case "$opt" in
-	console=*)
-		setup_console ${opt#console=} /mnt/etc/inittab /mnt/etc/securetty;;
-	esac
-done
 
 exec /bin/busybox switch_root /mnt /sbin/init


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Removed the `getty` functionality from `linuxkit/init`. The only tty-related code left is to `cat /etc/issue` to the given tty, and even that probably could be removed or replaced.

**- How I did it**

Remove most of the code from `setup_console()` in `pkg/init/init`

**- How to verify it**

1. Build the container image
2. Build a linuxkit image using this new `init` image instead of the original one
3. See that no getty is started: you cannot login on console, nor do you get a shell

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Remove getty functionality from init in favour of `linuxkit/getty`


**- A picture of a cute animal (not mandatory but encouraged)**

Another croc, because that is what I did for the getty PR:

![croc](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Crocodile_de_Morelet.jpeg/1200px-Crocodile_de_Morelet.jpeg)



Some important points:

1. This should be merged in only *after* the PR #1977 creating the `linuxkit/getty` image is in place (and pushed out to docker hub).
2. After both of these are merged in (and pushed out to docker hub), a separate PR should update all of the examples.
3. After both are in place, we might want to think of a "merged" login container that can be configured for sshd, getty, or both. But I think we want each working well independently before going there.