### PR TITLE
Update to containerd bdf9f5f7388e8203e63a74b89800f7f3dd4a7743

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 services:
   - name: rngd
     image: "linuxkit/rngd:1fa4de44c961bb5075647181891a3e7e7ba51c31"

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -6,7 +6,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS qemu
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS qemu
 RUN apk add \
     qemu-aarch64 \
     qemu-arm \

--- a/pkg/ca-certificates/Dockerfile
+++ b/pkg/ca-certificates/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 as alpine
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf as alpine
 
 RUN apk add ca-certificates
 

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   make \
   && true
 ENV GOPATH=/root/go
-ENV CONTAINERD_COMMIT=25cc7614ae1cc2c192f6c9ceca0c1c6fd6b091aa
+ENV CONTAINERD_COMMIT=bdf9f5f7388e8203e63a74b89800f7f3dd4a7743
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git

--- a/pkg/dhcpcd/Dockerfile
+++ b/pkg/dhcpcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/docker-ce/Dockerfile
+++ b/pkg/docker-ce/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 # removed openssl as I do not think server needs it

--- a/pkg/format/Dockerfile
+++ b/pkg/format/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/mkimage/Dockerfile
+++ b/pkg/mkimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/mount/Dockerfile
+++ b/pkg/mount/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/open-vm-tools/Dockerfile
+++ b/pkg/open-vm-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/openntpd/Dockerfile
+++ b/pkg/openntpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/qemu-ga/Dockerfile
+++ b/pkg/qemu-ga/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS build
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS build
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN mkdir -p /out/var/run
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,11 +1,11 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     tini
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 RUN mkdir -p /out/dev /out/proc /out/sys
 
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS build
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS build
 RUN apk add \
     argp-standalone \
     automake \

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 as alpine
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf as alpine
 RUN \
   apk add \
   bash \

--- a/pkg/sshd/Dockerfile
+++ b/pkg/sshd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/swap/Dockerfile
+++ b/pkg/swap/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/sysctl/Dockerfile
+++ b/pkg/sysctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/sysfs/Dockerfile
+++ b/pkg/sysfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/vsudd/Dockerfile
+++ b/pkg/vsudd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037 # with runc, logwrite, startmemlogd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd/Dockerfile
+++ b/projects/swarmd/swarmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS build
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS build
 
 RUN \
   apk update && apk upgrade && \

--- a/projects/wireguard/tools/Dockerfile
+++ b/projects/wireguard/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 as tools
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf as tools
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 RUN \
   apk update && \

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:ecff41279ccbc408079a3996a956432651c6eb9c"

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: check
     image: "kmod-test"

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: binfmt
     image: "linuxkit/binfmt:8ac5535f57f0c6f5fe88317b9d22a7677093c765"

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: test

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: mkimage
     image: "linuxkit/mkimage:f4bf0c24261f7d120c8674892805ab3054eb8ac3"

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: ltp
     image: "linuxkit/test-ltp:6df23ac196332cafb9c0f8e32f328e22d612267d"

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -6,7 +6,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
-  - linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/test/pkg/virtsock/Dockerfile
+++ b/test/pkg/virtsock/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     tini


### PR DESCRIPTION
Note that this is not the latest (which was 95efd45db073 at time of writing)
but the next commit 6428b4bad0c2 merges "Port ctr to use client package" breaks
the use of `ctr run --runtime-config` (by removing that option).

This contains https://github.com/containerd/containerd/pull/954 which was
causing some services to fail to start.

All previous uses of 15541037b9d84352ee4b66d8cd43d2d4a3595d41 are updated to
5749f2e9e65395cc6635229e8da0e0d484320ddf.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

**- What I did**

Updated `pkg/containerd/Dockerfile` to clone bdf9f5f7388e8203e63a74b89800f7f3dd4a7743 and updated yml files to pick up the new result.

**- How I did it**

Emacs and
```
git grep -l linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41 | xargs sed -i -e 's,linuxkit/containerd:15541037b9d84352ee4b66d8cd43d2d4a3595d41,linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf,g'
```
**- How to verify it**

Build and boot on of the images (I used `projects/swarmd/swarmd.yml`), observe that all services are started correctly.

**- Description for the changelog**

Updated to containerd bdf9f5f7388e8203e63a74b89800f7f3dd4a7743

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://upload.wikimedia.org/wikipedia/en/8/8b/Deftones_-_Diamond_Eyes.jpg "Deftones, Diamond Eyes")
