### PR TITLE
Convert some tests to run on hyperkit when run on OSX

### DIFF
--- a/test/cases/020_kernel/000_config_4.4.x/test.sh
+++ b/test/cases/020_kernel/000_config_4.4.x/test.sh
@@ -10,13 +10,13 @@ set -e
 . "${RT_PROJECT_ROOT}/_lib/lib.sh"
 
 clean_up() {
-	find . -iname "test-kernel-config*" -not -iname "*.yml" -exec rm -rf {} \;
+	find . -iname "test-kernel-config*" -not -iname "*.yml" -exec rm -rf {} \; || true
 }
 trap clean_up EXIT
 
 # Test code goes here
 moby build -output kernel+initrd test-kernel-config.yml
-RESULT="$(linuxkit run qemu -kernel test-kernel-config)"
+RESULT="$(linuxkit run test-kernel-config)"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/001_config_4.9.x/test.sh
+++ b/test/cases/020_kernel/001_config_4.9.x/test.sh
@@ -10,13 +10,13 @@ set -e
 . "${RT_PROJECT_ROOT}/_lib/lib.sh"
 
 clean_up() {
-	find . -iname "test-kernel-config*" -not -iname "*.yml" -exec rm -rf {} \;
+	find . -iname "test-kernel-config*" -not -iname "*.yml" -exec rm -rf {} \; || true
 }
 trap clean_up EXIT
 
 # Test code goes here
 moby build -output kernel+initrd test-kernel-config.yml
-RESULT="$(linuxkit run qemu test-kernel-config)"
+RESULT="$(linuxkit run test-kernel-config)"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/003_config_4.11.x/test.sh
+++ b/test/cases/020_kernel/003_config_4.11.x/test.sh
@@ -10,13 +10,13 @@ set -e
 . "${RT_PROJECT_ROOT}/_lib/lib.sh"
 
 clean_up() {
-	find . -iname "test-kernel-config*" -not -iname "*.yml" -exec rm -rf {} \;
+	find . -iname "test-kernel-config*" -not -iname "*.yml" -exec rm -rf {} \; || true
 }
 trap clean_up EXIT
 
 # Test code goes here
 moby build -output kernel+initrd test-kernel-config.yml
-RESULT="$(linuxkit run qemu test-kernel-config)"
+RESULT="$(linuxkit run test-kernel-config)"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/010_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.9.x/test.sh
@@ -13,7 +13,7 @@ IMAGE_NAME="kmod-test"
 
 clean_up() {
 	docker rmi ${IMAGE_NAME} || true
-	find . -iname "kmod*" -not -iname "*.yml" -exec rm -rf {} \;
+	find . -iname "kmod*" -not -iname "*.yml" -exec rm -rf {} \; || true
 }
 trap clean_up EXIT
 
@@ -21,7 +21,10 @@ trap clean_up EXIT
 docker pull linuxkit/kernel:4.9.x
 # Build a package
 docker build -t ${IMAGE_NAME} .
-# Build a LinuxKit image with kernel module (and test script)
+
+# Build and run a LinuxKit image with kernel module (and test script)
 moby build -output kernel+initrd kmod.yml
-# Run it
-linuxkit run qemu kmod | grep -q "Hello LinuxKit"
+RESULT="$(linuxkit run kmod)"
+echo "${RESULT}" | grep -q "Hello LinuxKit"
+
+exit 0

--- a/test/cases/040_packages/002_binfmt/test.sh
+++ b/test/cases/040_packages/002_binfmt/test.sh
@@ -4,20 +4,19 @@
 # REPEAT:
 
 set -e
-set -v
 
 # Source libraries. Uncomment if needed/defined
 #. "${RT_LIB}"
 . "${RT_PROJECT_ROOT}/_lib/lib.sh"
 
 clean_up() {
-	find . -iname "test-binfmt*" -not -iname "*.yml" -exec rm -rf {} \;
+	find . -iname "test-binfmt*" -not -iname "*.yml" -exec rm -rf {} \; || true
 }
 trap clean_up EXIT
 
 # Test code goes here
 moby build -output kernel+initrd test-binfmt.yml
-RESULT="$(linuxkit run qemu -kernel test-binfmt)"
+RESULT="$(linuxkit run test-binfmt)"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/003_ca-certificates/test.sh
+++ b/test/cases/040_packages/003_ca-certificates/test.sh
@@ -4,20 +4,19 @@
 # REPEAT:
 
 set -e
-set -v
 
 # Source libraries. Uncomment if needed/defined
 #. "${RT_LIB}"
 . "${RT_PROJECT_ROOT}/_lib/lib.sh"
 
 clean_up() {
-	find . -iname "test-ca-certificates*" -not -iname "*.yml" -exec rm -rf {} \;
+	find . -iname "test-ca-certificates*" -not -iname "*.yml" -exec rm -rf {} \; || true
 }
 trap clean_up EXIT
 
 # Test code goes here
 moby build -output kernel+initrd test-ca-certificates.yml
-RESULT="$(linuxkit run qemu -kernel test-ca-certificates)"
+RESULT="$(linuxkit run test-ca-certificates)"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/004_dhcpcd/test.sh
+++ b/test/cases/040_packages/004_dhcpcd/test.sh
@@ -4,20 +4,19 @@
 # REPEAT:
 
 set -e
-set -v
 
 # Source libraries. Uncomment if needed/defined
 #. "${RT_LIB}"
 . "${RT_PROJECT_ROOT}/_lib/lib.sh"
 
 clean_up() {
-	find . -iname "test-dhcpcd*" -not -iname "*.yml" -exec rm -rf {} \;
+	find . -iname "test-dhcpcd*" -not -iname "*.yml" -exec rm -rf {} \; || true
 }
 trap clean_up EXIT
 
 # Test code goes here
 moby build -output kernel+initrd test-dhcpcd.yml
-RESULT="$(linuxkit run qemu -kernel test-dhcpcd)"
+RESULT="$(linuxkit run test-dhcpcd)"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/019_sysctl/test.sh
+++ b/test/cases/040_packages/019_sysctl/test.sh
@@ -4,20 +4,19 @@
 # REPEAT:
 
 set -e
-set -v
 
 # Source libraries. Uncomment if needed/defined
 #. "${RT_LIB}"
 . "${RT_PROJECT_ROOT}/_lib/lib.sh"
 
 clean_up() {
-	find . -iname "test-sysctl*" -not -iname "*.yml" -exec rm -rf {} \;
+	find . -iname "test-sysctl*" -not -iname "*.yml" -exec rm -rf {} \; || true
 }
 trap clean_up EXIT
 
 # Test code goes here
 moby build -output kernel+initrd test-sysctl.yml
-RESULT="$(linuxkit run qemu -kernel test-sysctl)"
+RESULT="$(linuxkit run test-sysctl)"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -5,7 +5,7 @@ github.com/docker/infrakit cb420e3e50ea60afe58538b1d3cab1cb14059433
 github.com/golang/protobuf c9c7427a2a70d2eb3bafa0ab2dc163e45f143317
 github.com/googleapis/gax-go 8c5154c0fe5bf18cf649634d4c6df50897a32751
 github.com/mitchellh/go-ps 4fdf99ab29366514c69ccccddab5dc58b8d84062
-github.com/moby/hyperkit 70205a6d5143340299a679af259f70dfcd7cf8a4
+github.com/moby/hyperkit ffbde436bf43219808ebe24dc8f6aacdb0ab57bd
 github.com/packethost/packngo 91d54000aa56874149d348a884ba083c41d38091
 github.com/rneugeba/iso9660wrap 4606f848a055435cdef85305960b0e1bb788d506
 github.com/surma/gocpio fcb68777e7dc4ea43ffce871b552c0d073c17495

--- a/vendor/github.com/moby/hyperkit/go/pty_util_darwin.go
+++ b/vendor/github.com/moby/hyperkit/go/pty_util_darwin.go
@@ -1,0 +1,70 @@
+package hyperkit
+
+/*
+Most of this code was copied and adjusted from:
+https://github.com/containerd/console
+which is under Apache License Version 2.0, January 2004
+*/
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func tcget(fd uintptr, p *unix.Termios) error {
+	return ioctl(fd, unix.TIOCGETA, uintptr(unsafe.Pointer(p)))
+}
+
+func tcset(fd uintptr, p *unix.Termios) error {
+	return ioctl(fd, unix.TIOCSETA, uintptr(unsafe.Pointer(p)))
+}
+
+func ioctl(fd, flag, data uintptr) error {
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
+		return err
+	}
+	return nil
+}
+
+func saneTerminal(f *os.File) error {
+	// Go doesn't have a wrapper for any of the termios ioctls.
+	var termios unix.Termios
+	if err := tcget(f.Fd(), &termios); err != nil {
+		return err
+	}
+	// Set -onlcr so we don't have to deal with \r.
+	termios.Oflag &^= unix.ONLCR
+	return tcset(f.Fd(), &termios)
+}
+
+func setRaw(f *os.File) error {
+	var termios unix.Termios
+	if err := tcget(f.Fd(), &termios); err != nil {
+		return err
+	}
+	termios = cfmakeraw(termios)
+	termios.Oflag = termios.Oflag | unix.OPOST
+	return tcset(f.Fd(), &termios)
+}
+
+// isTerminal checks if the provided file is a terminal
+func isTerminal(f *os.File) bool {
+	var termios unix.Termios
+	if tcget(f.Fd(), &termios) != nil {
+		return false
+	}
+	return true
+}
+
+func cfmakeraw(t unix.Termios) unix.Termios {
+	t.Iflag = uint64(uint32(t.Iflag) & ^uint32((unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)))
+	t.Oflag = uint64(uint32(t.Oflag) & ^uint32(unix.OPOST))
+	t.Lflag = uint64(uint32(t.Lflag) & ^(uint32(unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)))
+	t.Cflag = uint64(uint32(t.Cflag) & ^(uint32(unix.CSIZE | unix.PARENB)))
+	t.Cflag = t.Cflag | unix.CS8
+	t.Cc[unix.VMIN] = 1
+	t.Cc[unix.VTIME] = 0
+
+	return t
+}

--- a/vendor/github.com/moby/hyperkit/go/pty_util_fallback.go
+++ b/vendor/github.com/moby/hyperkit/go/pty_util_fallback.go
@@ -1,0 +1,24 @@
+// +build !darwin
+
+package hyperkit
+
+import (
+	"log"
+	"os"
+)
+
+func saneTerminal(f *os.File) error {
+	log.Fatal("Function not supported on your OS")
+	return nil
+}
+
+func setRaw(f *os.File) error {
+	log.Fatal("Function not supported on your OS")
+	return nil
+}
+
+// isTerminal checks if the provided file is a terminal
+func isTerminal(f *os.File) bool {
+	log.Fatal("Function not supported on your OS")
+	return false
+}

--- a/vendor/github.com/moby/hyperkit/go/vendor.conf
+++ b/vendor/github.com/moby/hyperkit/go/vendor.conf
@@ -1,1 +1,2 @@
 github.com/mitchellh/go-ps 4fdf99ab29366514c69ccccddab5dc58b8d84062
+golang.org/x/sys b90f89a1e7a9c1f6b918820b3daa7f08488c8594


### PR DESCRIPTION
The newly vendored HyperKit go bindings allow for redirection of stdout (resolves #1923) and thus allows us to use HyperKit on OSX for the kernel and most of the package tests.

Ideally we would set labels on which platforms these tests are run, but there seems to be an [issue](https://github.com/linuxkit/rtf/issues/16) with labels and `rtf`.