### PR TITLE
Update Moby tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Dockerfile.media
 *.img
 *.tag
 *.iso
+*.raw
 *.vhd
 *.vmdk
 *.vmdk.lck

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 PREFIX?=/usr/local/
 
-MOBY_COMMIT=3a16c02f100d1e01ea405a33d21a02de2a85904f
+MOBY_COMMIT=e0aac90f4476c7dadfec9ab4116cf1363e51ce77
 bin/moby: Makefile | bin
 	docker run --rm --log-driver=none $(CROSS) $(GO_COMPILE) --clone-path github.com/moby/tool --clone https://github.com/moby/tool.git --commit $(MOBY_COMMIT) --package github.com/moby/tool/cmd/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
 	tar xf tmp_moby_bin.tar > $@

--- a/docs/platform-gcp.md
+++ b/docs/platform-gcp.md
@@ -50,11 +50,11 @@ Make sure to download the credentials in JSON format and store them somewhere sa
 
 ## Build an image
 
-When using `moby build ...` to build an image, specify `-output gcp-img` to
+When using `moby build ...` to build an image, specify `-output gcp` to
 build an image in a format that GCP will understand. For example:
 
 ```
-moby build -output gcp-img myprefix.yml
+moby build -output gcp myprefix.yml
 ```
 
 This will create a local `myprefix.img.tar.gz` compressed image file.

--- a/test/Makefile
+++ b/test/Makefile
@@ -31,7 +31,7 @@ gcp-hack: ../artifacts/test.img.tar.gz
 ../artifacts/test.img.tar.gz:
 	rm -rf ../artifacts
 	mkdir -p ../artifacts
-	$(MOBY) build -output gcp-img -pull -name ../artifacts/test hack/test.yml
+	$(MOBY) build -output gcp -pull -name ../artifacts/test hack/test.yml
 
 define check_test_log
 	@cat $1 |grep -q 'test suite PASSED'
@@ -40,7 +40,7 @@ endef
 .PHONY: ltp
 ltp: export CLOUDSDK_IMAGE_NAME?=test-ltp
 ltp: $(LINUXKIT) test-ltp.img.tar.gz
-	$(MOBY) build -output gcp-img -pull hack/test-ltp.yml
+	$(MOBY) build -output gcp -pull hack/test-ltp.yml
 	$(LINUXKIT) push gcp test-ltp.img.tar.gz
 	$(LINUXKIT) run gcp -skip-cleanup -machine n1-highcpu-4 $(CLOUDSDK_IMAGE_NAME) | tee test-ltp.log
 	$(call check_test_log, test-ltp.log)

--- a/test/cases/000_build/000_outputs/test.sh
+++ b/test/cases/000_build/000_outputs/test.sh
@@ -17,15 +17,14 @@ clean_up() {
 
 trap clean_up EXIT
 
-moby build -disable-content-trust -output tar,kernel+initrd,iso-bios,iso-efi,img,img-gz,qcow2,vmdk -name "${NAME}" test.yml
-[ -f "${NAME}.tar" ] || exit 1
+moby build -disable-content-trust -output kernel+initrd,iso-bios,iso-efi,gcp,raw,qcow2,vmdk -name "${NAME}" test.yml
 [ -f "${NAME}-kernel" ] || exit 1
 [ -f "${NAME}-initrd.img" ] || exit 1
 [ -f "${NAME}-cmdline" ] || exit 1
 [ -f "${NAME}.iso" ] || exit 1
 [ -f "${NAME}-efi.iso" ] || exit 1
-[ -f "${NAME}.img" ] || exit 1
-[ -f "${NAME}.img.gz" ] || exit 1
+[ -f "${NAME}.img.tar.gz" ] || exit 1
+[ -f "${NAME}.raw" ] || exit 1
 [ -f "${NAME}.qcow2" ] || exit 1
 # VHD currently requires a lot of memory, disable for now
 # [ -f "${NAME}.vhd" ] || exit 1

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.sh
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 
 trap clean_up EXIT
 
-moby build -output img -name "${NAME}" test.yml
-[ -f "${NAME}.img" ] || exit 1
-linuxkit run qemu "${NAME}.img" | grep -q "Welcome to LinuxKit"
+moby build -output raw -name "${NAME}" test.yml
+[ -f "${NAME}.raw" ] || exit 1
+linuxkit run qemu "${NAME}.raw" | grep -q "Welcome to LinuxKit"
 exit 0

--- a/test/cases/020_kernel/000_config_4.4.x/test.sh
+++ b/test/cases/020_kernel/000_config_4.4.x/test.sh
@@ -15,7 +15,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build -output kernel+initrd test-kernel-config
+moby build -output kernel+initrd test-kernel-config.yml
 RESULT="$(linuxkit run qemu -kernel test-kernel-config)"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/020_kernel/001_config_4.9.x/test.sh
+++ b/test/cases/020_kernel/001_config_4.9.x/test.sh
@@ -15,7 +15,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build -output kernel+initrd test-kernel-config
+moby build -output kernel+initrd test-kernel-config.yml
 RESULT="$(linuxkit run qemu test-kernel-config)"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/020_kernel/003_config_4.11.x/test.sh
+++ b/test/cases/020_kernel/003_config_4.11.x/test.sh
@@ -15,7 +15,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build -output kernel+initrd test-kernel-config
+moby build -output kernel+initrd test-kernel-config.yml
 RESULT="$(linuxkit run qemu test-kernel-config)"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/020_kernel/010_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.9.x/test.sh
@@ -22,6 +22,6 @@ docker pull linuxkit/kernel:4.9.x
 # Build a package
 docker build -t ${IMAGE_NAME} .
 # Build a LinuxKit image with kernel module (and test script)
-moby build -output kernel+initrd kmod
+moby build -output kernel+initrd kmod.yml
 # Run it
 linuxkit run qemu kmod | grep -q "Hello LinuxKit"

--- a/test/cases/040_packages/002_binfmt/test.sh
+++ b/test/cases/040_packages/002_binfmt/test.sh
@@ -16,7 +16,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build -output kernel+initrd test-binfmt
+moby build -output kernel+initrd test-binfmt.yml
 RESULT="$(linuxkit run qemu -kernel test-binfmt)"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"

--- a/test/cases/040_packages/003_ca-certificates/test.sh
+++ b/test/cases/040_packages/003_ca-certificates/test.sh
@@ -16,7 +16,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build -output kernel+initrd test-ca-certificates
+moby build -output kernel+initrd test-ca-certificates.yml
 RESULT="$(linuxkit run qemu -kernel test-ca-certificates)"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"

--- a/test/cases/040_packages/004_dhcpcd/test.sh
+++ b/test/cases/040_packages/004_dhcpcd/test.sh
@@ -16,7 +16,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build -output kernel+initrd test-dhcpcd
+moby build -output kernel+initrd test-dhcpcd.yml
 RESULT="$(linuxkit run qemu -kernel test-dhcpcd)"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"

--- a/test/cases/040_packages/019_sysctl/test.sh
+++ b/test/cases/040_packages/019_sysctl/test.sh
@@ -16,7 +16,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build -output kernel+initrd test-sysctl
+moby build -output kernel+initrd test-sysctl.yml
 RESULT="$(linuxkit run qemu -kernel test-sysctl)"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"


### PR DESCRIPTION
- rename img→raw and gcp-img→gcp
- support creating `docker` outputs, see https://github.com/moby/tool/tree/master/examples
- less memory usage via streaming outputs
- allow specification of multiple yaml files in a single command line, improves modularity
- notary fixes and local cache, so does not pull as much
- you now have to specify the full filename of the yaml file, you cannot omit the suffix

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![heronfish](https://user-images.githubusercontent.com/482364/26888242-4ad81690-4ba2-11e7-9d0a-680815b49d82.jpg)
