### PR TITLE
build: Make GOOS and GOARCH over-writeable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ GO_COMPILE=linuxkit/go-compile:6579a00b44686d0e504d513fc4860094769fe7df
 
 MOBY?=bin/moby
 LINUXKIT?=bin/linuxkit
-GOOS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
-GOARCH=amd64
+GOOS?=$(shell uname -s | tr '[:upper:]' '[:lower:]')
+GOARCH?=amd64
 ifneq ($(GOOS),linux)
 CROSS=-e GOOS=$(GOOS) -e GOARCH=$(GOARCH)
 endif


### PR DESCRIPTION
The GOOS and GOARCH are currently set based on the host 'make'
is executed on. On macOS this sets up cross compilation with
a Linux container.

Making them over-writeable allows users to test different
cross compilations, e.g., trying to build Linux binaries on macOS.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>