### PR TITLE
Run make tag on pkg directory to check packages build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,18 +59,21 @@ ci:
 	$(MAKE)
 	$(MAKE) install
 	$(MAKE) -C test all
+	$(MAKE) -C pkg tag
 
 ci-tag:
 	$(MAKE) clean
 	$(MAKE)
 	$(MAKE) install
 	$(MAKE) -C test all
+	$(MAKE) -C pkg tag
 
 ci-pr:
 	$(MAKE) clean
 	$(MAKE)
 	$(MAKE) install
 	$(MAKE) -C test pr
+	$(MAKE) -C pkg tag
 
 .PHONY: clean
 clean:

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,10 +1,10 @@
 DIRS = $(shell find . -type d -depth 1)
 .PHONY: clean dirs $(DIRS)
 
-push: $(DIRS)
+push:
+	@set -e; for d in $(DIRS); do make -C "$$d"; done
 
-$(DIRS):
-	$(MAKE) -C $@
+tag:
+	@set -e; for d in $(DIRS); do make -C "$$d" tag; done
 
-clean:
-	rm -f hash
+clean: ;


### PR DESCRIPTION
This at least checks for buildability of packages, even if we
are not yet pushing them.

See https://github.com/linuxkit/linuxkit/issues/1991 for what it mitigates.
Will not pass until this is fixed.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![moorhen](https://user-images.githubusercontent.com/482364/26903857-1e684d02-4bd7-11e7-841a-d9f4e417f077.jpg)
