### PR TITLE
fix package builds in some cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,18 +59,21 @@ ci:
 	$(MAKE)
 	$(MAKE) install
 	$(MAKE) -C test all
+	$(MAKE) -C pkg tag
 
 ci-tag:
 	$(MAKE) clean
 	$(MAKE)
 	$(MAKE) install
 	$(MAKE) -C test all
+	$(MAKE) -C pkg tag
 
 ci-pr:
 	$(MAKE) clean
 	$(MAKE)
 	$(MAKE) install
 	$(MAKE) -C test pr
+	$(MAKE) -C pkg tag
 
 .PHONY: clean
 clean:

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,10 +1,10 @@
 DIRS = $(shell find . -type d -depth 1)
 .PHONY: clean dirs $(DIRS)
 
-push: $(DIRS)
+push:
+	@set -e; for d in $(DIRS); do make -C "$$d"; done
 
-$(DIRS):
-	$(MAKE) -C $@
+tag:
+	@set -e; for d in $(DIRS); do make -C "$$d" tag; done
 
-clean:
-	rm -f hash
+clean: ;

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS qemu
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS qemu
 RUN apk add \
     qemu-aarch64 \
     qemu-arm \

--- a/pkg/ca-certificates/Dockerfile
+++ b/pkg/ca-certificates/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf as alpine
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 as alpine
 
 RUN apk add ca-certificates
 

--- a/pkg/dhcpcd/Dockerfile
+++ b/pkg/dhcpcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/docker-ce/Dockerfile
+++ b/pkg/docker-ce/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 # removed openssl as I do not think server needs it

--- a/pkg/format/Dockerfile
+++ b/pkg/format/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/mkimage/Dockerfile
+++ b/pkg/mkimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/mount/Dockerfile
+++ b/pkg/mount/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/open-vm-tools/Dockerfile
+++ b/pkg/open-vm-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/openntpd/Dockerfile
+++ b/pkg/openntpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/qemu-ga/Dockerfile
+++ b/pkg/qemu-ga/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS build
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS build
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN mkdir -p /out/var/run
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     tini

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache --initdb -p /out \
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 RUN mkdir -p /out/dev /out/proc /out/sys
 
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS build
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS build
 RUN apk add \
     argp-standalone \
     automake \

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf as alpine
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 as alpine
 RUN \
   apk add \
   bash \

--- a/pkg/sshd/Dockerfile
+++ b/pkg/sshd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/swap/Dockerfile
+++ b/pkg/swap/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/sysctl/Dockerfile
+++ b/pkg/sysctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/sysfs/Dockerfile
+++ b/pkg/sysfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/vsudd/Dockerfile
+++ b/pkg/vsudd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/projects/swarmd/swarmd/Dockerfile
+++ b/projects/swarmd/swarmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS build
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS build
 
 RUN \
   apk update && apk upgrade && \

--- a/projects/wireguard/tools/Dockerfile
+++ b/projects/wireguard/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf as tools
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 as tools
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 RUN \
   apk update && \

--- a/test/pkg/virtsock/Dockerfile
+++ b/test/pkg/virtsock/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf AS mirror
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     tini


### PR DESCRIPTION
0eb21735ae1b73d6012beff2898aaae49bf46f34 accidentally broke some package
builds by switching linuxkit/alpine to linuxkit/containerd. Let's revert
the ones that shouldn't be there.

Closes #1991

Signed-off-by: Tycho Andersen <tycho@docker.com>