### PR TITLE
example: Remove docker.json from linuxkit.yml

### DIFF
--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -26,8 +26,6 @@ services:
      - CAP_SETGID
      - CAP_DAC_OVERRIDE
 files:
-  - path: etc/docker/daemon.json
-    contents: '{"debug": true}'
   - path: etc/containerd/config.toml
     contents: |
       state = "/run/containerd"


### PR DESCRIPTION
The 'docker.json' file is not used in the top level
example and was merely there as an example use of the
'file' section. Since we now have the containerd config
file in the 'file' section the 'docker.json' entry is
no longer needed.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>