### PR TITLE
Re-enable content trust on build test

### DIFF
--- a/test/cases/000_build/000_outputs/test.sh
+++ b/test/cases/000_build/000_outputs/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 
 trap clean_up EXIT
 
-moby build -disable-content-trust -output kernel+initrd,iso-bios,iso-efi,gcp,raw,qcow2,vmdk -name "${NAME}" test.yml
+moby build -output kernel+initrd,iso-bios,iso-efi,gcp,raw,qcow2,vmdk -name "${NAME}" test.yml
 [ -f "${NAME}-kernel" ] || exit 1
 [ -f "${NAME}-initrd.img" ] || exit 1
 [ -f "${NAME}-cmdline" ] || exit 1


### PR DESCRIPTION
I disabled this for speed when content trust cache was not working

See also #1995

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![01_bird_in_amber ngsversion 1496862800770 adapt 1190 1](https://user-images.githubusercontent.com/482364/26924162-8783167c-4c3c-11e7-94b2-46deb397ae65.jpg)

