### PR TITLE
Update .mailmap to make auto-generating work

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -10,9 +10,11 @@ Amir Chaudhry <amir.chaudhry@docker.com> <amirmc@gmail.com>
 Anil Madhavapeddy <anil.madhavapeddy@docker.com> <anil@recoil.org>
 Dan Finneran <dan@thebsdbox.co.uk> <dan@dev.fnnrn.me>
 Dan Finneran <dan@thebsdbox.co.uk> <daniel.finneran@gmail.com>
-Dave Scott <dave.scott@docker.com> <dave.scott@unikernel.com>
-Dave Scott <dave.scott@docker.com> <dave@recoil.org>
-Dave Scott <dave.scott@docker.com> <djs55@users.noreply.github.com>
+Dan Finneran <dan@thebsdbox.co.uk>
+David Scott <dave.scott@docker.com> <dave.scott@unikernel.com>
+David Scott <dave.scott@docker.com> <dave@recoil.org>
+David Scott <dave.scott@docker.com> <djs55@users.noreply.github.com>
+David Scott <dave.scott@docker.com>
 Dave Tucker <dt@docker.com> <dave@dtucker.co.uk>
 David Gageot <david.gageot@docker.com> <david@gageot.net>
 David Sheets <david.sheets@docker.com> <dsheets@docker.com>
@@ -26,6 +28,7 @@ Magnus Skjegstad <magnus.skjegstad@docker.com> <magnus@skjegstad.com>
 Mindy Preston <mindy.preston@docker.com> <meetup@yomimono.org>
 Nathan LeClaire <nathan.leclaire@docker.com> <nathan.leclaire@gmail.com>
 Nathan LeClaire <nathan.leclaire@docker.com> <nathanleclaire@gmail.com>
+Radu Matei <matei.radu94@gmail.com>
 Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com> <riyazdf@berkeley.edu>
 Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com> <riyazdf@gmail.com>
 Rolf Neugebauer <rolf.neugebauer@docker.com> <rneugeba@users.noreply.github.com>


### PR DESCRIPTION
relates to https://github.com/linuxkit/linuxkit/pull/1999

**- What I did**

When mapping e-mail addresses and names;

    <preferred@example.com> <foo@bar.com>

Maps `foo@bar.com` to `preferred@example.com`, whereas:

     Preferred Name <preferred@example.com> <foo@bar.com>

Will update the e-mail address _and_ set the preferred name, _if_ the original
e-mail address in the commit was `<foo@bar.com>` (otherwise the rule is not
executed).

Finally, this rule:

    Preferred Name <preferred@example.com>

Will set the name to `Preferred Name` if the e-mail address in the commit
matches `preferred@example.com`

**- How to verify it**

Empty the entries from the `AUTHORS` file, and regenerate it with `scripts/generate-authors.sh`. The generated AUTHORS file should not change

**- A picture of a cute animal (not mandatory but encouraged)**

![7dc0234036b4b6591045e39be34143c0](https://user-images.githubusercontent.com/1804568/26929734-0582f380-4c5b-11e7-9845-65c121b24f48.jpg)
