### PR TITLE
[WIP] Build and Sign Packages in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,20 +82,20 @@ collect-artifacts: artifacts/test.img.tar.gz artifacts/test-ltp.img.tar.gz
 ci: test-cross
 	$(MAKE)
 	$(MAKE) install
+	$(MAKE) -C pkg check
 	$(MAKE) -C test all
-	$(MAKE) -C pkg tag
 
 ci-tag: test-cross
 	$(MAKE)
 	$(MAKE) install
+	$(MAKE) -C pkg check
 	$(MAKE) -C test all
-	$(MAKE) -C pkg tag
 
 ci-pr: test-cross
 	$(MAKE)
 	$(MAKE) install
+	$(MAKE) -C pkg check
 	$(MAKE) -C test pr
-	$(MAKE) -C pkg tag
 
 .PHONY: clean
 clean:

--- a/pkg/.gitignore
+++ b/pkg/.gitignore
@@ -1,0 +1,1 @@
+override.yml

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,5 +1,7 @@
 DIRS = $(shell find . -type d -depth 1)
-.PHONY: clean dirs $(DIRS)
+export OVERRIDES = $(CURDIR)/override.yml
+
+.PHONY: clean dirs check hash $(DIRS)
 
 push:
 	@set -e; for d in $(DIRS); do make -C "$$d"; done
@@ -7,4 +9,11 @@ push:
 tag:
 	@set -e; for d in $(DIRS); do make -C "$$d" tag; done
 
-clean: ;
+check:
+	@set -e; for d in $(DIRS); do make -C "$$d" check; done
+
+hash:
+	@set -e; for d in $(DIRS); do make -C "$$d" hash; done
+
+clean:
+	rm -f $(OVERRIDES)

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -2,8 +2,17 @@
 default: push
 
 ORG?=linuxkit
+STAGE_ORG?=linuxkit.datakit.ci:5000
 HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 BASE_DEPS=Dockerfile Makefile
+OVERRIDES?=override.yml
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	TIMEOUT=timeout
+else
+	TIMEOUT=gtimeout
+endif
 
 tag: $(BASE_DEPS) $(DEPS)
 ifndef $(NETWORK)
@@ -15,3 +24,11 @@ endif
 push: tag
 	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
 	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+
+hash:
+	@echo "$(ORG)/$(IMAGE):$(HASH)"
+
+check:
+	@$(TIMEOUT) 5 notary -s https://notary.docker.io lookup docker.io/$(ORG)/$(IMAGE) $(HASH) > /dev/null || \
+	$(MAKE) ORG=$(STAGE_ORG) push && \
+	echo "- source: $(ORG)/$(IMAGE)\n  subsitute: $(STAGE_ORG)/$(IMAGE):$(HASH)\n" >> $(OVERRIDES)


### PR DESCRIPTION
This PR is a work in progress.

So far it adds:
- Make target to check if package is on hub, if not, build it
- Integration of above target to the top-level Makefile

What's not understood yet is:
- Is this sufficient to test changes to a package or will they fail as the locally built image isn't signed?
- Is CI configured with a key and delegation for the linuxkit repos
- Are we happy to run a `make -C push` on `master` and `tag` CI jobs