### PR TITLE
Update linuxkit/init to gettyless; add getty to relevant examples

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
@@ -19,6 +19,10 @@ onboot:
     image: "linuxkit/mount:ff5338822f20375b8913f5a80f9ed4f6ea9a592b"
     command: ["/mount.sh", "/var/lib/docker"]
 services:
+  - name: getty
+    image: "linuxkit/getty:148946d72d1c96df3ea91cb8ee4f9583cd3cc5c2"
+    env:
+     - INSECURE=true
   - name: rngd
     image: "linuxkit/rngd:1fa4de44c961bb5075647181891a3e7e7ba51c31"
   - name: dhcpcd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
@@ -15,6 +15,10 @@ onboot:
   - name: metadata
     image: "linuxkit/metadata:31a0b0f5557c6123beaa9c33e3400ae3c03447e0"
 services:
+  - name: getty
+    image: "linuxkit/getty:148946d72d1c96df3ea91cb8ee4f9583cd3cc5c2"
+    env:
+     - INSECURE=true
   - name: rngd
     image: "linuxkit/rngd:1fa4de44c961bb5075647181891a3e7e7ba51c31"
   - name: sshd

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
@@ -13,13 +13,13 @@ onboot:
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
-  - name: rngd
-    image: "linuxkit/rngd:1fa4de44c961bb5075647181891a3e7e7ba51c31"
   - name: getty
     image: "linuxkit/getty:148946d72d1c96df3ea91cb8ee4f9583cd3cc5c2"
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true
+  - name: rngd
+    image: "linuxkit/rngd:1fa4de44c961bb5075647181891a3e7e7ba51c31"
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,13 +2,18 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+services:
+  - name: getty
+    image: "linuxkit/getty:148946d72d1c96df3ea91cb8ee4f9583cd3cc5c2"
+    env:
+     - INSECURE=true
 trust:
   org:
     - linuxkit

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,10 +2,14 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 services:
+  - name: getty
+    image: "linuxkit/getty:148946d72d1c96df3ea91cb8ee4f9583cd3cc5c2"
+    env:
+     - INSECURE=true
   - name: rngd
     image: "linuxkit/rngd:1fa4de44c961bb5075647181891a3e7e7ba51c31"
   - name: dhcpcd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS1 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:
@@ -12,6 +12,10 @@ onboot:
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
+  - name: getty
+    image: "linuxkit/getty:148946d72d1c96df3ea91cb8ee4f9583cd3cc5c2"
+    env:
+     - INSECURE=true
   - name: redis
     image: "redis:3.0.7-alpine"
     capabilities:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
@@ -10,6 +10,10 @@ onboot:
   - name: sysctl
     image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
 services:
+  - name: getty
+    image: "linuxkit/getty:148946d72d1c96df3ea91cb8ee4f9583cd3cc5c2"
+    env:
+     - INSECURE=true
   - name: rngd
     image: "linuxkit/rngd:1fa4de44c961bb5075647181891a3e7e7ba51c31"
   - name: dhcpcd

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
@@ -23,6 +23,10 @@ onboot:
     # command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G"]
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
+  - name: getty
+    image: "linuxkit/getty:148946d72d1c96df3ea91cb8ee4f9583cd3cc5c2"
+    env:
+     - INSECURE=true
   - name: rngd
     image: "linuxkit/rngd:1fa4de44c961bb5075647181891a3e7e7ba51c31"
   - name: nginx

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
@@ -10,6 +10,10 @@ onboot:
   - name: sysctl
     image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
 services:
+  - name: getty
+    image: "linuxkit/getty:148946d72d1c96df3ea91cb8ee4f9583cd3cc5c2"
+    env:
+     - INSECURE=true
   - name: rngd
     image: "linuxkit/rngd:1fa4de44c961bb5075647181891a3e7e7ba51c31"
   - name: dhcpcd

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:
@@ -14,7 +14,7 @@ services:
     image: "linuxkit/vsudd:a66df914201aac784195d5b78262f622fe7f910c"
     binds:
         - /run/containerd/containerd.sock:/run/containerd/containerd.sock
-    command: ["/vsudd", 
+    command: ["/vsudd",
         "-inport", "2374:unix:/run/containerd/containerd.sock"]
 
 trust:


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Updated `linuxkit/init` to the gettyless version per #1978  and inserted `linuxkit/getty` as a `service` per #1977 for relevant examples. 

**- How I did it**

Updated the yml files.

**- How to verify it**

Build and run them.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Update init in images to use gettyless and use getty where relevant.


**- A picture of a cute animal (not mandatory but encouraged)**

Per the request on the other PRs to update examples.