### PR TITLE
vpnkit-forwarder: add /pkg/vpnkit-forwarder

### DIFF
--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,0 +1,44 @@
+kernel:
+  image: "linuxkit/kernel:4.9.x"
+  cmdline: "console=ttyS0 page_poison=1"
+init:
+  - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+onboot:
+  - name: dhcpcd
+    image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+  - name: mount-vpnkit
+    image: "alpine:3.6"
+    binds:
+        - /var/:/host_var:rbind,rshared
+    capabilities:
+        - CAP_SYS_ADMIN
+    rootfsPropagation: shared
+    command: ["sh", "-c", "mkdir /host_var/vpnkit && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
+services:
+  - name: sshd
+    image: "linuxkit/sshd:abc1f5e096982ebc3fb61c506aed3ac9c2ae4d55"
+  - name: vpnkit-forwarder
+    image: "linuxkit/vpnkit-forwarder:883de832c2c3cb72cd9b01e3f7bd788649e0f2c2"
+    binds:
+        - /var/vpnkit:/port
+    net: host
+    command: ["/vpnkit-forwarder"]
+  - name: vpnkit-expose-port
+    image: "linuxkit/vpnkit-forwarder:883de832c2c3cb72cd9b01e3f7bd788649e0f2c2"
+    net: none
+    binds:
+        - /var/vpnkit:/port
+    command: ["/vpnkit-expose-port","-i",
+              "-host-ip","127.0.0.1","-host-port","22",
+              "-container-ip","127.0.0.1","-container-port","22","-no-local-ip"]
+
+files:
+  - path: root/.ssh/authorized_keys
+    contents: '#your ssh key here'
+
+trust:
+  org:
+    - linuxkit

--- a/pkg/vpnkit-forwarder/Dockerfile
+++ b/pkg/vpnkit-forwarder/Dockerfile
@@ -1,0 +1,16 @@
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+
+RUN apk add --no-cache go musl-dev git build-base
+ENV GOPATH=/go PATH=$PATH:/go/bin 
+ENV COMMIT=2d6d82167cf81c665c05d1425a79adfbc1a71177
+
+RUN git clone https://github.com/moby/vpnkit.git /go/src/github.com/moby/vpnkit && \
+    cd /go/src/github.com/moby/vpnkit && \
+    git checkout $COMMIT && \
+    cd go && \
+    make all
+
+FROM scratch
+COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-forwarder.linux /vpnkit-forwarder
+COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-expose-port.linux /vpnkit-expose-port
+CMD ["/vpnkit-forwarder"]

--- a/pkg/vpnkit-forwarder/Makefile
+++ b/pkg/vpnkit-forwarder/Makefile
@@ -1,0 +1,15 @@
+default: push
+
+ORG?=linuxkit
+IMAGE=vpnkit-forwarder
+DEPS=$(wildcard *.go) Makefile Dockerfile
+
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
+
+tag: $(DEPS)
+	docker build --squash --no-cache -t $(ORG)/$(IMAGE):$(HASH) .
+
+push: tag
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+

--- a/pkg/vpnkit-forwarder/README.md
+++ b/pkg/vpnkit-forwarder/README.md
@@ -1,0 +1,9 @@
+### vpnkit-forwarder
+
+This package provides `vpnkit-forwarder` and `vpnkit-expose-port` from [vpnkit](http://github.com/moby/vpnkit.git).
+
+`vpnkit-forwarder` is a forwarding daemon used by Docker for Desktop to forward ports from Docker containers to the host via VSOCK.  
+
+`vpnkit-expose-port` is a userland proxy that opens ports by demand.
+
+To coordinate with `vpnkit` both tools require access to the 9P port configuration mount point.


### PR DESCRIPTION
Adds /pkg/vpnkit-forwarder which downloads and builds `vpnkit-forwarder`
and `vpnkit-expose-port` from moby/vpnkit. Also includes an example for
forwarding `sshd` and updates the documentation for `hyperkit` to
include a `vpnkit` section.

`vpnkit` still requires a 9P mount for coordination, so the `socat`
forwarding is simpler to set up at the moment.

I've pushed to a temporary location so the example works.

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>
![cuteanimal05](https://user-images.githubusercontent.com/1076486/26970512-91c21992-4d01-11e7-896c-540b58581c5e.jpg)

