### PR TITLE
cmd: Default disk "size" parameter to GB

### DIFF
--- a/docs/external-disk.md
+++ b/docs/external-disk.md
@@ -9,7 +9,7 @@ In order to make the disk available, you need to tell `linuxkit` where the disk 
 
 All local `linuxkit run` methods (currently `hyperkit`, `qemu`, and `vmware`) take a `-disk` argument:
 
-* `-disk path,size=100M,format=qcow2`. For size the default is in MB but `G` can be aspecified for GB. The format can be omitted for the platform default, and is only useful on `qemu` at present.
+* `-disk path,size=100M,format=qcow2`. For size the default is in GB but an `M` can be appended to specify sizes in MB. The format can be omitted for the platform default, and is only useful on `qemu` at present.
 
 If the _path` is specified it will use the disk at location _path_, if you do not provide `-disk `_path_, `linuxkit` assumes a default, which is _prefix_`-state/disk.img` for `hyperkit` and `vmware` and _prefix_`-disk.img` for `qemu`. 
 

--- a/src/cmd/linuxkit/util.go
+++ b/src/cmd/linuxkit/util.go
@@ -99,22 +99,23 @@ func stringToIntArray(l string, sep string) ([]int, error) {
 	return i, nil
 }
 
-// Parse a string which is either a number in MB, or a number with
-// either M (for Megabytes) or G (for GigaBytes) as a suffix and
-// returns the number in MB. Return 0 if string is empty.
+// This function parses the "size" parameter of a disk specification
+// and returns the size in MB. The "size" paramter defaults to GB, but
+// the unit can be explicitly set with either a G (for GB) or M (for
+// MB). It returns the disk size in MB.
 func getDiskSizeMB(s string) (int, error) {
 	if s == "" {
 		return 0, nil
 	}
 	sz := len(s)
-	if strings.HasSuffix(s, "G") {
+	if strings.HasSuffix(s, "M") {
 		i, err := strconv.Atoi(s[:sz-1])
 		if err != nil {
 			return 0, err
 		}
-		return i * 1024, nil
+		return i, nil
 	}
-	if strings.HasSuffix(s, "M") {
+	if strings.HasSuffix(s, "G") {
 		s = s[:sz-1]
 	}
 	return strconv.Atoi(s)


### PR DESCRIPTION
Most cloud providers allow disk size allocation on in units
of GB. Make it the default for linuxkit disk "size" arguments.
Users can override the unit by appending a M to the disk size.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>