### PR TITLE
MirageSDK: Use newer dhcp client

### DIFF
--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -13,7 +13,7 @@ services:
   - name: rngd
     image: mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9
   - name: dhcp-client
-    image: mobylinux/dhcp-client:a7a6b49b0ff51ffa2f44ac848cd649e29f946e0c
+    image: linuxkitprojects/dhcp-client:6c231135a88d42e7d18d2ba952f0798910550cbd
     net: host
     capabilities:
      - CAP_NET_ADMIN # to bring eth0 up

--- a/projects/miragesdk/src/Dockerfile
+++ b/projects/miragesdk/src/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.5 as capnp
 RUN mkdir -p /src
 RUN apk update && apk add autoconf automake libtool linux-headers git g++ make
 
-RUN cd /src && git clone https://github.com/sandstorm-io/capnproto.git
+RUN cd /src && git clone -b v0.6.0 https://github.com/sandstorm-io/capnproto.git
 WORKDIR /src/capnproto/c++
 RUN ./setup-autotools.sh
 RUN autoreconf -i
@@ -21,17 +21,17 @@ FROM ocaml/opam:alpine-3.5_ocaml-4.04.0 as sdk
 RUN git -C /home/opam/opam-repository pull && opam update -u
 
 COPY --from=capnp /usr/local/bin/capnp /usr/local/bin/
-COPY --from=capnp /usr/local/lib/libcapnpc-0.6-dev.so /usr/local/lib/
-COPY --from=capnp /usr/local/lib/libcapnp-0.6-dev.so /usr/local/lib/
-COPY --from=capnp /usr/local/lib/libkj-0.6-dev.so /usr/local/lib/
+COPY --from=capnp /usr/local/lib/libcapnpc-0.6.0.so /usr/local/lib/
+COPY --from=capnp /usr/local/lib/libcapnp-0.6.0.so /usr/local/lib/
+COPY --from=capnp /usr/local/lib/libkj-0.6.0.so /usr/local/lib/
 
 RUN sudo mkdir -p /src
 USER opam
 WORKDIR /src
 
-RUN opam pin add jbuilder 1.0+beta7 -n
+RUN opam pin add jbuilder 1.0+beta9 -n
 
-RUN opam depext -uiy cstruct lwt logs irmin-git rawlink tuntap astring rresult \
+RUN opam depext -uiy cstruct cstruct-lwt lwt lwt logs irmin-git rawlink tuntap astring rresult \
     mirage-flow-lwt mirage-channel-lwt io-page decompress capnp
 
 RUN opam list

--- a/projects/miragesdk/src/Dockerfile
+++ b/projects/miragesdk/src/Dockerfile
@@ -18,7 +18,6 @@ RUN which capnp
 ### SDK
 
 FROM ocaml/opam:alpine-3.5_ocaml-4.04.0 as sdk
-RUN git -C /home/opam/opam-repository pull && opam update -u
 
 COPY --from=capnp /usr/local/bin/capnp /usr/local/bin/
 COPY --from=capnp /usr/local/lib/libcapnpc-0.6.0.so /usr/local/lib/
@@ -29,7 +28,8 @@ RUN sudo mkdir -p /src
 USER opam
 WORKDIR /src
 
-RUN opam pin add jbuilder 1.0+beta9 -n
+RUN git -C /home/opam/opam-repository pull && opam update -u
+RUN opam pin add jbuilder 1.0+beta10 -n
 
 RUN opam depext -uiy cstruct cstruct-lwt lwt lwt logs irmin-git rawlink tuntap astring rresult \
     mirage-flow-lwt mirage-channel-lwt io-page decompress capnp
@@ -64,7 +64,7 @@ RUN sudo cp /src/_build/default/dhcp-client/main.exe /bin/dhcp-client
 
 FROM sdk as calf
 
-RUN opam pin add charrua-client https://github.com/yomimono/charrua-client.git#state-halfway -n
+RUN opam pin add charrua-client https://github.com/yomimono/charrua-client.git#with-cdhcpc -n
 RUN opam pin add mirage-net-fd 0.2.0 -n
 RUN opam depext -iy mirage-net-fd charrua-client lwt mirage-types-lwt cmdliner
 
@@ -77,6 +77,7 @@ RUN sudo chown opam -R /src
 RUN opam config exec -- jbuilder build dhcp-client-calf/unikernel.exe
 RUN sudo mkdir -p /bin/calf
 RUN sudo cp /src/_build/default/dhcp-client-calf/unikernel.exe /bin/calf/dhcp-client-calf
+USER 0
 
 ### Final build
 

--- a/projects/miragesdk/src/Makefile
+++ b/projects/miragesdk/src/Makefile
@@ -23,13 +23,13 @@ hash: Makefile Dockerfile $(FILES) .build
 	| sha1sum | sed 's/ .*//' > $@
 
 tag: .build
-	docker tag $(IMAGE) mobylinux/$(IMAGE):$(shell cat hash)
+	docker tag $(IMAGE) linuxkitprojects/$(IMAGE):$(shell cat hash)
 
 push: hash .build
 	docker pull $(BASE)
-	docker pull mobylinux/$(IMAGE):$(shell cat hash) || \
-		(docker tag $(IMAGE) mobylinux/$(IMAGE):$(shell cat hash) && \
-		 docker push mobylinux/$(IMAGE):$(shell cat hash))
+	docker pull linuxkitprojects/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE) linuxkitprojects/$(IMAGE):$(shell cat hash) && \
+		 docker push linuxkitprojects/$(IMAGE):$(shell cat hash))
 
 clean::
 	rm -rf hash .build


### PR DESCRIPTION
**- What I did**

Changed the MirageSDK dhcp client example to use a branch of `charrua-client` with a better API for MirageSDK.

**- A picture of a cute animal (not mandatory but encouraged)**
![whale_cat](https://user-images.githubusercontent.com/4086825/26989609-6122f0fa-4d19-11e7-9e67-01fc54239fa4.jpg)
