### PR TITLE
Enhanced the AWS provider in the metadata package, to include more data.

### DIFF
--- a/pkg/metadata/provider_aws.go
+++ b/pkg/metadata/provider_aws.go
@@ -47,6 +47,25 @@ func (p *ProviderAWS) Extract() ([]byte, error) {
 		return nil, fmt.Errorf("AWS: Failed to write hostname: %s", err)
 	}
 
+	// public ipv4
+	awsMetaGet("public-ipv4", "public_ipv4", 0644)
+
+	// private ipv4
+	awsMetaGet("local-ipv4", "local_ipv4", 0644)
+
+	// availability zone
+	awsMetaGet("placement/availability-zone", "availability_zone", 0644)
+
+	// instance type
+	awsMetaGet("instance-type", "instance_type", 0644)
+
+	// instance-id
+	awsMetaGet("instance-id", "instance_id", 0644)
+
+	// local-hostname
+	awsMetaGet("local-hostname", "local_hostname", 0644)
+
+	// ssh
 	if err := p.handleSSH(); err != nil {
 		log.Printf("AWS: Failed to get ssh data: %s", err)
 	}
@@ -59,6 +78,21 @@ func (p *ProviderAWS) Extract() ([]byte, error) {
 		return nil, nil
 	}
 	return userData, nil
+}
+
+// lookup a value (lookupName) in aws metaservice and store in given fileName
+func awsMetaGet(lookupName string, fileName string, fileMode os.FileMode) {
+	if lookupValue, err := awsGet(metaDataURL + lookupName); err == nil {
+		// we got a value from the metadata server, now save to filesystem
+		err = ioutil.WriteFile(path.Join(ConfigPath, fileName), lookupValue, fileMode)
+		if err != nil {
+			// we couldn't save the file for some reason
+			log.Printf("AWS: Failed to write %s:%s %s", fileName, lookupValue, err)
+		}
+	} else {
+		// we did not get a value back from the metadata server
+		log.Printf("AWS: Failed to get %s: %s", lookupName, err)
+	}
 }
 
 // awsGet requests and extracts the requested URL


### PR DESCRIPTION
Signed-off-by: Ken Cochrane <kencochrane@gmail.com>

**- What I did**
There is a lot of metadata available from the AWS metadata service. We originally were only capturing a few fields, this PR adds some of the more common data as well to make it easily available when you need it.

New fields added:
- public ipv4 address
- private ipv4 address
- availability zone
- instance id
- instance type
- local hostname

**- How I did it**
changed the metadata package to query the data from AWS metadata service and write the data to the /var/config directory.

**- How to verify it**
build the package and run on aws, and then look inside of `/var/config` you will notice more data available.

**- Description for the changelog**
Enhanced the AWS provider in the metadata package, to include more data.
