### PR TITLE
Only use console=ttyS0 for tests

### DIFF
--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -1,6 +1,6 @@
 kernel:
   image: "linuxkit/kernel:4.9.x"
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -1,6 +1,6 @@
 kernel:
   image: "linuxkit/kernel:4.9.x"
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,6 +1,6 @@
 kernel:
   image: "linuxkit/kernel:4.9.x"
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,6 +1,6 @@
 kernel:
   image: "linuxkit/kernel:4.9.x"
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -1,6 +1,6 @@
 kernel:
   image: "linuxkit/kernel:4.9.x"
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -1,6 +1,6 @@
 kernel:
   image: "linuxkit/kernel:4.9.x"
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,6 +1,6 @@
 kernel:
   image: "linuxkit/kernel:4.9.x"
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -1,6 +1,6 @@
 kernel:
   image: "linuxkit/kernel:4.9.x"
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -1,6 +1,6 @@
 kernel:
   image: "linuxkit/kernel:4.9.x"
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f


### PR DESCRIPTION
If you also use console=tty0 you lose the output of commands running from
the system, as they run on the second console which is discarded.

Also drop page-poison as not relevant for tests.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![3278](https://user-images.githubusercontent.com/482364/27025070-64e96dda-4f59-11e7-8814-a9d99ac690d6.jpg)
