### PR TITLE
Use the user's ssh key automatically in ssh examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 
 PREFIX?=/usr/local/
 
-MOBY_COMMIT=e0aac90f4476c7dadfec9ab4116cf1363e51ce77
+MOBY_COMMIT=d8cc1b3f08df02ad563d3f548ac2527931a925a6
 bin/moby: Makefile | bin
 	docker run --rm --log-driver=none $(CROSS) $(GO_COMPILE) --clone-path github.com/moby/tool --clone https://github.com/moby/tool.git --commit $(MOBY_COMMIT) --package github.com/moby/tool/cmd/moby --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ > tmp_moby_bin.tar
 	tar xf tmp_moby_bin.tar > $@

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -18,7 +18,9 @@ services:
     image: "linuxkit/sshd:abc1f5e096982ebc3fb61c506aed3ac9c2ae4d55"
 files:
   - path: root/.ssh/authorized_keys
-    contents: '#public ssh key here'
+    source: ~/.ssh/id_rsa.pub
+    mode: "0600"
+    optional: true
 trust:
   org:
     - linuxkit

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -18,7 +18,9 @@ services:
     image: "linuxkit/sshd:abc1f5e096982ebc3fb61c506aed3ac9c2ae4d55"
 files:
   - path: root/.ssh/authorized_keys
-    contents: '#your ssh key here'
+    source: ~/.ssh/id_rsa.pub
+    mode: "0600"
+    optional: true
 trust:
   org:
     - linuxkit

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -22,7 +22,9 @@ services:
     image: "linuxkit/sshd:abc1f5e096982ebc3fb61c506aed3ac9c2ae4d55"
 files:
   - path: root/.ssh/authorized_keys
-    contents: '#your ssh key here'
+    source: ~/.ssh/id_rsa.pub
+    mode: "0600"
+    optional: true
 trust:
   org:
     - linuxkit

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -37,7 +37,9 @@ services:
 
 files:
   - path: root/.ssh/authorized_keys
-    contents: '#your ssh key here'
+    source: ~/.ssh/id_rsa.pub
+    mode: "0600"
+    optional: true
 
 trust:
   org:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -76,6 +76,8 @@ services:
     rootfsPropagation: shared
 files:
   - path: root/.ssh/authorized_keys
-    contents: '# Your ssh key goes here'
+    source: ~/.ssh/id_rsa.pub
+    mode: "0600"
+    optional: true
   - {path: etc/cni, directory: true}
   - {path: opt/cni, directory: true}

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -72,6 +72,8 @@ services:
     rootfsPropagation: shared
 files:
   - path: root/.ssh/authorized_keys
-    contents: '# Your ssh key goes here'
+    source: ~/.ssh/id_rsa.pub
+    mode: "0600"
+    optional: true
   - {path: etc/cni, directory: true}
   - {path: opt/cni, directory: true}

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -18,4 +18,6 @@ services:
     image: "linuxkit/sshd:abc1f5e096982ebc3fb61c506aed3ac9c2ae4d55"
 files:
   - path: root/.ssh/authorized_keys
-    contents: '#your ssh key here'
+    source: ~/.ssh/id_rsa.pub
+    mode: "0600"
+    optional: true


### PR DESCRIPTION
This requires moby tool update to support `~` in paths, but
makes everything much nicer.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>
