### PR TITLE
copy setsid to setsidu so it does not get overwritten by busybox when…

### DIFF
--- a/pkg/getty/Dockerfile
+++ b/pkg/getty/Dockerfile
@@ -9,6 +9,17 @@ RUN apk add --no-cache --initdb -p /out \
     util-linux \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+#
+# We require a version of `setsid(1)` which supports the `-w`
+# option, which is not available in all implementations (e.g. the
+# `busybox` implementation does not support it). When this is run
+# as part of a LinuxKit `init` image (rather than as a standalone
+# container) we cannot guarantee which version of `setsid` will
+# be present once the layers are combined, so we take a copy of
+# our own, known good, version for use later.
+RUN cp /out/usr/bin/setsid /out/usr/bin/setsid.getty
+# we really do not want a rogue inittab here
+RUN rm -rf /out/etc/inittab
 
 FROM scratch
 ENTRYPOINT ["/sbin/tini","-s","-v","--"]

--- a/pkg/getty/usr/bin/rungetty.sh
+++ b/pkg/getty/usr/bin/rungetty.sh
@@ -7,12 +7,11 @@ infinite_loop() {
 	done
 }
 
-# run getty on all known consoles - except those already in inittab
+# run getty on all known consoles
 start_getty() {
 	tty=${1%,*}
 	speed=${1#*,}
-	inittab="$2"
-	securetty="$3"
+	securetty="$2"
 	line=
 	term="linux"
 	[ "$speed" = "$1" ] && speed=115200
@@ -39,7 +38,7 @@ start_getty() {
 		echo "$tty" >> "$securetty"
 	fi
 	# respawn forever
-	infinite_loop setsid -w /sbin/getty $loginargs $line $speed $tty $term &
+	infinite_loop setsid.getty -w /sbin/getty $loginargs $line $speed $tty $term &
 }
 
 # check if we have /etc/getty.shadow
@@ -53,7 +52,7 @@ fi
 for opt in $(cat /proc/cmdline); do
 	case "$opt" in
 	console=*)
-		start_getty ${opt#console=} /etc/inittab /etc/securetty
+		start_getty ${opt#console=} /etc/securetty
 	esac
 done
 


### PR DESCRIPTION
… used in init

Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Ensure correct `setsid` is available to `rungetty.sh`
* Remove unused but breaking `/etc/inittab`

**- How I did it**

1. `cp /usr/bin/setsid /usr/bin/setidu`
2. In `rungetty.sh`, use `setsidu`
3. In `Dockerfile`, do `/bin/rm -f /out/etc/inittab`

In `services` mode, this is unneeded but still works. In `init` mode, this is needed because any other container may have the original alpine `setsid` which is `setsid -> /bin/busybox`, which does not work.
**- How to verify it**
Run it in each of `services` mode and `init` mode. For `init`, check it as first or any later order.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Lock down correct `setsid` binary.

**- A picture of a cute animal (not mandatory but encouraged)**


As discussed in thread with @justincormack 