### PR TITLE
Custom containerd client for use in init.

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -20,7 +20,7 @@ onboot:
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -16,7 +16,7 @@ onboot:
     image: "linuxkit/metadata:31a0b0f5557c6123beaa9c33e3400ae3c03447e0"
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
 trust:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 services:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 services:
   - name: getty
     image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 services:
   - name: getty
     image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS1 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS1 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -13,7 +13,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
   - name: redis

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -6,7 +6,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -11,7 +11,7 @@ onboot:
     image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -24,7 +24,7 @@ onboot:
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -11,7 +11,7 @@ onboot:
     image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -16,7 +16,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
   - name: rngd

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
@@ -34,7 +34,8 @@ files:
     contents: |
       state = "/run/containerd"
       root = "/var/lib/containerd"
-      snapshotter = "overlay"
+      snapshotter = "io.containerd.snapshotter.v1.overlayfs"
+      differ = "io.containerd.differ.v1.base-diff"
       subreaper = false
 
       [grpc]

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 as alpine
+FROM linuxkit/alpine:7cf5393e04fe0e26e9fa8f507379cacb64595918 as alpine
 RUN \
   apk add \
   btrfs-progs-dev \
@@ -9,7 +9,7 @@ RUN \
   linux-headers \
   make \
   && true
-ENV GOPATH=/root/go
+ENV GOPATH=/go PATH=$PATH:/go/bin
 ENV CONTAINERD_COMMIT=bdf9f5f7388e8203e63a74b89800f7f3dd4a7743
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
@@ -18,11 +18,16 @@ WORKDIR $GOPATH/src/github.com/containerd/containerd
 RUN git checkout $CONTAINERD_COMMIT
 RUN make binaries EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS="-extldflags \\\"-fno-PIC -static\\\""
 RUN cp bin/containerd bin/ctr bin/containerd-shim bin/dist /usr/bin/
+
+ADD cmd /go/src/cmd
+RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
+RUN go-compile.sh /go/src/cmd/service
+
 WORKDIR /
 COPY . .
 
 FROM scratch
 ENTRYPOINT []
 WORKDIR /
-COPY --from=alpine /usr/bin/containerd /usr/bin/ctr /usr/bin/dist /usr/bin/containerd-shim /usr/bin/
+COPY --from=alpine /usr/bin/containerd /usr/bin/ctr /usr/bin/dist /usr/bin/containerd-shim /go/bin/service /usr/bin/
 COPY --from=alpine /etc/containerd/config.toml /etc/containerd/

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   make \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin
-ENV CONTAINERD_COMMIT=bdf9f5f7388e8203e63a74b89800f7f3dd4a7743
+ENV CONTAINERD_COMMIT=c215531a8f63a98a69134e804fea4ee6d354bb90
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git

--- a/pkg/containerd/cmd/service/main.go
+++ b/pkg/containerd/cmd/service/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var (
+	defaultLogFormatter = &log.TextFormatter{}
+)
+
+// infoFormatter overrides the default format for Info() log events to
+// provide an easier to read output
+type infoFormatter struct {
+}
+
+func (f *infoFormatter) Format(entry *log.Entry) ([]byte, error) {
+	if entry.Level == log.InfoLevel {
+		return append([]byte(entry.Message), '\n'), nil
+	}
+	return defaultLogFormatter.Format(entry)
+}
+
+func main() {
+	flag.Usage = func() {
+		fmt.Printf("USAGE: %s [options] COMMAND\n\n", filepath.Base(os.Args[0]))
+		fmt.Printf("Commands:\n")
+		fmt.Printf("  start       Start a service\n")
+		fmt.Printf("  help        Print this message\n")
+		fmt.Printf("\n")
+		fmt.Printf("Run '%s COMMAND --help' for more information on the command\n", filepath.Base(os.Args[0]))
+		fmt.Printf("\n")
+		fmt.Printf("Options:\n")
+		flag.PrintDefaults()
+	}
+	flagQuiet := flag.Bool("q", false, "Quiet execution")
+	flagVerbose := flag.Bool("v", false, "Verbose execution")
+
+	// Set up logging
+	log.SetFormatter(new(infoFormatter))
+	log.SetLevel(log.InfoLevel)
+	flag.Parse()
+	if *flagQuiet && *flagVerbose {
+		fmt.Printf("Can't set quiet and verbose flag at the same time\n")
+		os.Exit(1)
+	}
+	if *flagQuiet {
+		log.SetLevel(log.ErrorLevel)
+	}
+	if *flagVerbose {
+		// Switch back to the standard formatter
+		log.SetFormatter(defaultLogFormatter)
+		log.SetLevel(log.DebugLevel)
+	}
+
+	args := flag.Args()
+	if len(args) < 1 {
+		fmt.Printf("Please specify a command.\n\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "start":
+		start(args[1:])
+	default:
+		fmt.Printf("%q is not valid command.\n\n", args[0])
+		flag.Usage()
+		os.Exit(1)
+	}
+}

--- a/pkg/containerd/cmd/service/skanky-vendor.sh
+++ b/pkg/containerd/cmd/service/skanky-vendor.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# We only need the containerd client and its transitive dependencies
+# and we conveniently have a checkout already. We actually prefer to
+# reuse containerd's vendoring for consistency anyway.
+
+set -eu
+ctrd=$1
+cp -r $ctrd/vendor/ vendor/
+# We need containerd itself of course
+mkdir -p vendor/github.com/containerd
+cp -r $ctrd vendor/github.com/containerd/containerd
+# Stop go finding nested vendorings
+rm -rf vendor/github.com/containerd/containerd/vendor

--- a/pkg/containerd/cmd/service/start.go
+++ b/pkg/containerd/cmd/service/start.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/namespaces"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func start(args []string) {
+	invoked := filepath.Base(os.Args[0])
+	flags := flag.NewFlagSet("start", flag.ExitOnError)
+	flags.Usage = func() {
+		fmt.Printf("USAGE: %s start [service]\n\n", invoked)
+		fmt.Printf("Options:\n")
+		flags.PrintDefaults()
+	}
+
+	sock := flags.String("sock", "/run/containerd/containerd.sock", "Path to containerd socket")
+
+	dumpSpec := flags.String("dump-spec", "", "Dump container spec to file before start")
+
+	if err := flags.Parse(args); err != nil {
+		log.Fatal("Unable to parse args")
+	}
+	args = flags.Args()
+
+	if len(args) != 1 {
+		fmt.Println("Please specify the service")
+		flags.Usage()
+		os.Exit(1)
+	}
+
+	service := args[0]
+	rootfs := filepath.Join("/containers/services", service, "rootfs")
+	log.Infof("Starting service: %q", service)
+	log := log.WithFields(log.Fields{
+		"service": service,
+	})
+
+	client, err := containerd.New(*sock)
+	if err != nil {
+		log.WithError(err).Fatal("creating containerd client")
+	}
+
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+
+	var spec *specs.Spec
+	specf, err := os.Open(filepath.Join("/containers/services", service, "config.json"))
+	if err != nil {
+		log.WithError(err).Fatal("failed to read service spec")
+	}
+	if err := json.NewDecoder(specf).Decode(&spec); err != nil {
+		log.WithError(err).Fatal("failed to parse service spec")
+	}
+
+	log.Debugf("Rootfs is %s", rootfs)
+
+	spec.Root.Path = rootfs
+
+	if *dumpSpec != "" {
+		d, err := os.Create(*dumpSpec)
+		if err != nil {
+			log.WithError(err).Fatal("failed to open file for spec dump")
+		}
+		enc := json.NewEncoder(d)
+		enc.SetIndent("", "    ")
+		if err := enc.Encode(&spec); err != nil {
+			log.WithError(err).Fatal("failed to write spec dump")
+		}
+
+	}
+
+	ctr, err := client.NewContainer(ctx, service, containerd.WithSpec(spec))
+	if err != nil {
+		log.WithError(err).Fatal("failed to create container")
+	}
+
+	io := func() (*containerd.IO, error) {
+		logfile := filepath.Join("/var/log", service+".log")
+		// We just need this to exist.
+		if err := ioutil.WriteFile(logfile, []byte{}, 0666); err != nil {
+			log.WithError(err).Fatal("failed to touch logfile")
+		}
+		return &containerd.IO{
+			Stdin:    "/dev/null",
+			Stdout:   logfile,
+			Stderr:   logfile,
+			Terminal: false,
+		}, nil
+	}
+
+	task, err := ctr.NewTask(ctx, io)
+	if err != nil {
+		// Don't bother to destroy the container here.
+		log.WithError(err).Fatal("failed to create task")
+	}
+
+	if err := task.Start(ctx); err != nil {
+		// Don't destroy the container here so it can be inspected for debugging.
+		log.WithError(err).Fatal("failed to start task")
+	}
+
+	log.Debugf("Started %s pid %d", ctr.ID(), task.Pid())
+}

--- a/pkg/containerd/etc/containerd/config.toml
+++ b/pkg/containerd/etc/containerd/config.toml
@@ -1,6 +1,7 @@
 state = "/run/containerd"
 root = "/var/lib/containerd"
-snapshotter = "overlay"
+snapshotter = "io.containerd.snapshotter.v1.overlayfs"
+differ = "io.containerd.differ.v1.base-diff"
 subreaper = false
 
 [grpc]

--- a/pkg/getty/Dockerfile
+++ b/pkg/getty/Dockerfile
@@ -28,4 +28,4 @@ COPY --from=mirror /out/ /
 COPY usr/ /usr/
 COPY etc/ /etc/
 CMD ["/usr/bin/rungetty.sh"]
-LABEL org.mobyproject.config='{"pid": "host", "net":"host", "binds": ["/run:/run", "/etc:/hostroot/etc","/tmp/ctr:/tmp/ctr", "/usr/bin/ctr:/usr/bin/ctr", "/usr/bin/runc:/usr/bin/runc", "/usr/bin/dist:/usr/bin/dist", "/var:/var","/containers:/containers","/dev:/dev","/sys:/sys"], "capabilities": ["all"]}'
+LABEL org.mobyproject.config='{"pid": "host", "net":"host", "binds": ["/run:/run", "/etc:/hostroot/etc", "/usr/bin/ctr:/usr/bin/ctr", "/usr/bin/runc:/usr/bin/runc", "/usr/bin/dist:/usr/bin/dist", "/var:/var","/containers:/containers","/dev:/dev","/sys:/sys"], "capabilities": ["all"]}'

--- a/pkg/init/etc/init.d/010-containerd
+++ b/pkg/init/etc/init.d/010-containerd
@@ -39,5 +39,3 @@ then
 		service start "$(basename $f)"
 	done
 fi
-
-wait

--- a/pkg/init/etc/init.d/010-containerd
+++ b/pkg/init/etc/init.d/010-containerd
@@ -34,12 +34,9 @@ if [ -d /containers/services ]
 then
 	for f in $(find /containers/services -mindepth 1 -maxdepth 1 | sort)
 	do
-		base="$(basename $f)"
 		/bin/mount --bind "$f/rootfs" "$f/rootfs"
 		mount -o remount,rw "$f/rootfs"
-		log="/var/log/$base.log"
-		ctr run --runtime-config "$f/config.json" --rootfs "$f/rootfs" --id "$(basename $f)" </dev/null 2>$log >$log &
-		printf " - $base\n"
+		service start "$(basename $f)"
 	done
 fi
 

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -26,7 +26,7 @@ onboot:
      - /var:/var:rshared,rbind
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -26,7 +26,7 @@ onboot:
      - /var:/var:rshared,rbind
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037 # with runc, logwrite, startmemlogd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037 # with runc, logwrite, startmemlogd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -30,7 +30,7 @@ services:
   - name: sshd
     image: "linuxkit/sshd:abc1f5e096982ebc3fb61c506aed3ac9c2ae4d55"
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
 files:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -16,7 +16,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:886d35fe30c47750e8cfbf2f73016e9d2cc6361a"
+    image: "linuxkit/getty:d0765e0a14733f9454010ac109a7c846a4e67fc5"
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl
@@ -34,7 +34,8 @@ files:
     contents: |
       state = "/run/containerd"
       root = "/var/lib/containerd"
-      snapshotter = "overlay"
+      snapshotter = "io.containerd.snapshotter.v1.overlayfs"
+      differ = "io.containerd.differ.v1.base-diff"
       subreaper = false
 
       [grpc]

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:2599bcd5013ce5962aa155ee8929c26160de13bd
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
   - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.4.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.4.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:2acaa564c1801dd2ae1546c70c472dc58ac030a1"

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:2acaa564c1801dd2ae1546c70c472dc58ac030a1"

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:2acaa564c1801dd2ae1546c70c472dc58ac030a1"

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:2acaa564c1801dd2ae1546c70c472dc58ac030a1"

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.11.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:2acaa564c1801dd2ae1546c70c472dc58ac030a1"

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.11.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:2acaa564c1801dd2ae1546c70c472dc58ac030a1"

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: check
     image: "kmod-test"

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: check
     image: "kmod-test"

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: sysctl

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: test
     image: "alpine:3.6"

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: test
     image: "alpine:3.6"

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: binfmt
     image: "linuxkit/binfmt:8ac5535f57f0c6f5fe88317b9d22a7677093c765"

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: binfmt
     image: "linuxkit/binfmt:8ac5535f57f0c6f5fe88317b9d22a7677093c765"

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: test

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
   - name: test

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: mkimage
     image: "linuxkit/mkimage:f4bf0c24261f7d120c8674892805ab3054eb8ac3"

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: mkimage
     image: "linuxkit/mkimage:f4bf0c24261f7d120c8674892805ab3054eb8ac3"

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: poweroff
     image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: ltp
     image: "linuxkit/test-ltp:6df23ac196332cafb9c0f8e32f328e22d612267d"

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: ltp
     image: "linuxkit/test-ltp:6df23ac196332cafb9c0f8e32f328e22d612267d"

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -6,7 +6,7 @@ kernel:
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
-  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
+  - linuxkit/containerd:04880f344709830aa4c938baa765764e644fc973
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
+  - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
   - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
+  - linuxkit/init:d04cb1ef203f3d3b320e2a7d0ded127d21cabd74
   - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:7858fceb91c26c1e2ae9d84ac1ea0c63bbe61e26
 onboot:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"


### PR DESCRIPTION
**- What I did**

Latest `ctr` has removed the `--runtime-config` option which we rely on. `ctr` is not (considered by containerd devs) to be a supported interface (it's more of a debug tool).

This PR replaces `/etc/init.d/010-containerd`'s use of `ctr` with a simple custom client written against the containerd client library.

**- How I did it**

The interesting commit message is:

>    init: replace ctr with a custom client using the containerd client library
>    
>    Currently it supports only `service start <SERVICE>`, but it could grow e.g.
>    `stop`, `exec` etc in the future (although you can still use `ctr` for those).
>    
>    I wasn't able yet to figure out how to make containerd do the rw bind step:
>        /bin/mount --bind "$f/rootfs" "$f/rootfs"
>        mount -o remount,rw "$f/rootfs"
>    So that remains for now.
>    
>    In order to be able to use go-compile.sh the containerd build needs to move
>    from /root/go to /go as the GOPATH.
>    
>    The vendoring situation is not ideal, but since this tool wants to be an exact
>    match for the containerd it seems tollerable to reuse its vendoring.
>    
>    Signed-off-by: Ian Campbell <ian.campbell@docker.com>

**- How to verify it**

Everything should just continue working.

**- Description for the changelog**

Switched away from `ctr` usage in init.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://upload.wikimedia.org/wikipedia/en/0/0a/Sorceress_Album_Cover.jpg "Opeth, Sorceress")
