### PR TITLE
pkg/docker-ce: add vpnkit-expose-port

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -30,7 +30,7 @@ services:
   - name: ntpd
     image: "linuxkit/openntpd:45deeb05f736162d941c9bf494983f655ab80aa5"
   - name: docker
-    image: "linuxkit/docker-ce:668d62da6e3da081a8f8aca7db3e2a98adf5da59"
+    image: "linuxkit/docker-ce:dda71ff9fe5ebbfa794b98c57c32df286b212848"
     capabilities:
      - all
     net: host

--- a/pkg/docker-ce/Dockerfile
+++ b/pkg/docker-ce/Dockerfile
@@ -17,8 +17,10 @@ RUN apk add --no-cache --initdb -p /out \
 	xz
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
+FROM linuxkit/vpnkit-forwarder:883de832c2c3cb72cd9b01e3f7bd788649e0f2c2 AS vpnkit
 FROM scratch
 COPY --from=mirror /out/ /
+COPY --from=vpnkit /vpnkit-expose-port /usr/bin/vpnkit-expose-port
 
 # set up Docker group
 # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -27,7 +27,7 @@ services:
   - name: ntpd
     image: "linuxkit/openntpd:45deeb05f736162d941c9bf494983f655ab80aa5"
   - name: docker
-    image: "linuxkit/docker-ce:668d62da6e3da081a8f8aca7db3e2a98adf5da59"
+    image: "linuxkit/docker-ce:dda71ff9fe5ebbfa794b98c57c32df286b212848"
     capabilities:
      - all
     net: host

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -27,7 +27,7 @@ services:
   - name: ntpd
     image: "linuxkit/openntpd:45deeb05f736162d941c9bf494983f655ab80aa5"
   - name: docker
-    image: "linuxkit/docker-ce:668d62da6e3da081a8f8aca7db3e2a98adf5da59"
+    image: "linuxkit/docker-ce:dda71ff9fe5ebbfa794b98c57c32df286b212848"
     capabilities:
      - all
     net: host

--- a/projects/kubernetes/image-cache/Dockerfile
+++ b/projects/kubernetes/image-cache/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/docker-ce:668d62da6e3da081a8f8aca7db3e2a98adf5da59
+FROM linuxkit/docker-ce:dda71ff9fe5ebbfa794b98c57c32df286b212848
 ADD . /images
 ENTRYPOINT [ "/bin/sh", "-c" ]
 CMD [ "for image in /images/*.tar ; do docker image load -i $image && rm -f $image ; done" ]

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -38,7 +38,7 @@ services:
   - name: sshd
     image: "linuxkit/sshd:abc1f5e096982ebc3fb61c506aed3ac9c2ae4d55"
   - name: docker
-    image: "linuxkit/docker-ce:668d62da6e3da081a8f8aca7db3e2a98adf5da59"
+    image: "linuxkit/docker-ce:dda71ff9fe5ebbfa794b98c57c32df286b212848"
     capabilities:
      - all
     net: host

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -38,7 +38,7 @@ services:
   - name: sshd
     image: "linuxkit/sshd:abc1f5e096982ebc3fb61c506aed3ac9c2ae4d55"
   - name: docker
-    image: "linuxkit/docker-ce:668d62da6e3da081a8f8aca7db3e2a98adf5da59"
+    image: "linuxkit/docker-ce:dda71ff9fe5ebbfa794b98c57c32df286b212848"
     capabilities:
      - all
     net: host

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -24,7 +24,7 @@ services:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"
   - name: docker
-    image: "linuxkit/docker-ce:668d62da6e3da081a8f8aca7db3e2a98adf5da59"
+    image: "linuxkit/docker-ce:dda71ff9fe5ebbfa794b98c57c32df286b212848"
     capabilities:
      - all
     net: host


### PR DESCRIPTION
Adds vpnkit-expose-port to the docker-ce image.

vpnkit-expose-port is the dockerd userland proxy used to expose
forwarding ports with vpnkit. This adds the binary to the image in
/usr/bin/vpnkit-expose-port, but does not enable it by default.

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>
![ralph-nhspca-2926](https://user-images.githubusercontent.com/1076486/27196332-4e3f4a42-520a-11e7-9186-a6865da7307e.jpg)

