### PR TITLE
kernel update to 4.11.5/4.9.32/4.4.72 + init update

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 services:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS1 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -93,8 +93,8 @@ endef
 # Build Targets
 # Debug targets only for latest stable and LTS stable
 #
-$(eval $(call kernel,4.11.4,4.11.x))
-$(eval $(call kernel,4.11.4,4.11.x,_dbg))
-$(eval $(call kernel,4.9.31,4.9.x))
-$(eval $(call kernel,4.9.31,4.9.x,_dbg))
-$(eval $(call kernel,4.4.71,4.4.x))
+$(eval $(call kernel,4.11.5,4.11.x))
+$(eval $(call kernel,4.11.5,4.11.x,_dbg))
+$(eval $(call kernel,4.9.32,4.9.x))
+$(eval $(call kernel,4.9.32,4.9.x,_dbg))
+$(eval $(call kernel,4.4.72,4.4.x))

--- a/kernel/kernel_config-4.11.x
+++ b/kernel/kernel_config-4.11.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.11.4 Kernel Configuration
+# Linux/x86 4.11.5 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/kernel_config-4.4.x
+++ b/kernel/kernel_config-4.4.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.71 Kernel Configuration
+# Linux/x86 4.4.72 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/kernel_config-4.9.x
+++ b/kernel/kernel_config-4.9.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.31 Kernel Configuration
+# Linux/x86 4.9.32 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.11.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.11.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 500dc604f95708446c0a074d84716dfa5d3c55d8 Mon Sep 17 00:00:00 2001
+From 127b8dfcad5c397493b686c8628882c4fddc901a Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/14] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.11.x/0002-vmbus-introduce-in-place-packet-iterator.patch
+++ b/kernel/patches-4.11.x/0002-vmbus-introduce-in-place-packet-iterator.patch
@@ -1,4 +1,4 @@
-From 7fc081c8a985556a4bef220fc6fd8fd20639f226 Mon Sep 17 00:00:00 2001
+From 5dbe55d14a71b1570b6e8cecc3430a1982c6f5a7 Mon Sep 17 00:00:00 2001
 From: stephen hemminger <stephen@networkplumber.org>
 Date: Mon, 27 Feb 2017 10:26:48 -0800
 Subject: [PATCH 02/14] vmbus: introduce in-place packet iterator

--- a/kernel/patches-4.11.x/0003-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
+++ b/kernel/patches-4.11.x/0003-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
@@ -1,4 +1,4 @@
-From 1d63d56461390883f4818f701c374a54379d7d21 Mon Sep 17 00:00:00 2001
+From 0a4a8d69cb07100ac094b2895265dc5fcbce9539 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:12 -0600
 Subject: [PATCH 03/14] vmbus: vmbus_open(): reset onchannel_callback on error

--- a/kernel/patches-4.11.x/0004-vmbus-add-the-matching-tasklet_enable-in-vmbus_close.patch
+++ b/kernel/patches-4.11.x/0004-vmbus-add-the-matching-tasklet_enable-in-vmbus_close.patch
@@ -1,4 +1,4 @@
-From f5f0b3c2685ff47d3e7a019801819a20dd04f971 Mon Sep 17 00:00:00 2001
+From 52ca5fae32b3f70fced17326b8ce8eee20114a8f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:15 -0600
 Subject: [PATCH 04/14] vmbus: add the matching tasklet_enable() in

--- a/kernel/patches-4.11.x/0005-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.11.x/0005-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From ecf3df3b127a9537d155f8542adba266c3c71aae Mon Sep 17 00:00:00 2001
+From b374a3bc8945eb66703cb818c11ac56ca966102a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:20 -0600
 Subject: [PATCH 05/14] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.11.x/0006-vmbus-dynamically-enqueue-dequeue-a-channel-on-vmbus.patch
+++ b/kernel/patches-4.11.x/0006-vmbus-dynamically-enqueue-dequeue-a-channel-on-vmbus.patch
@@ -1,4 +1,4 @@
-From 60a7f882c6ba48ee48c91d79d85eb14365444348 Mon Sep 17 00:00:00 2001
+From 5231cf45eead7d2f3deefe394305c2f4945f7ed3 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:23 -0600
 Subject: [PATCH 06/14] vmbus: dynamically enqueue/dequeue a channel on

--- a/kernel/patches-4.11.x/0007-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
+++ b/kernel/patches-4.11.x/0007-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
@@ -1,4 +1,4 @@
-From 00887e3d98575897e80881f462a2a4d56157135e Mon Sep 17 00:00:00 2001
+From bb0ecf843ead58403c7e4352c388de19dd00f815 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:26 -0600
 Subject: [PATCH 07/14] hv_sock: implements Hyper-V transport for Virtual

--- a/kernel/patches-4.11.x/0008-VMCI-only-try-to-load-on-VMware-hypervisor.patch
+++ b/kernel/patches-4.11.x/0008-VMCI-only-try-to-load-on-VMware-hypervisor.patch
@@ -1,4 +1,4 @@
-From e4ad24e6481887b2419306ddea61298645f14e2f Mon Sep 17 00:00:00 2001
+From 6e6891d2b7e99502d2a9e6e2b8b8e1a1b830f6b2 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:29 -0600
 Subject: [PATCH 08/14] VMCI: only try to load on VMware hypervisor

--- a/kernel/patches-4.11.x/0009-hv_sock-add-the-support-of-auto-loading.patch
+++ b/kernel/patches-4.11.x/0009-hv_sock-add-the-support-of-auto-loading.patch
@@ -1,4 +1,4 @@
-From 2782da00ad2d3f24b9ba4c5418ebd50dff0fa00c Mon Sep 17 00:00:00 2001
+From 56361b185e888458dd63123a3c5d2c2ed45dd5fd Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:35 -0600
 Subject: [PATCH 09/14] hv_sock: add the support of auto-loading

--- a/kernel/patches-4.11.x/0010-hvsock-fix-a-race-in-hvs_stream_dequeue.patch
+++ b/kernel/patches-4.11.x/0010-hvsock-fix-a-race-in-hvs_stream_dequeue.patch
@@ -1,4 +1,4 @@
-From a1fb69445672e790cb4c1b9c105af09eec69cd64 Mon Sep 17 00:00:00 2001
+From 171f34b26e6b9503beccd8a94eefdf55ce19647a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Tue, 16 May 2017 22:14:03 +0800
 Subject: [PATCH 10/14] hvsock: fix a race in hvs_stream_dequeue()

--- a/kernel/patches-4.11.x/0011-hvsock-fix-vsock_dequeue-enqueue_accept-race.patch
+++ b/kernel/patches-4.11.x/0011-hvsock-fix-vsock_dequeue-enqueue_accept-race.patch
@@ -1,4 +1,4 @@
-From 80782b837e261c1b8c56c919a8a2f9e750ea4a03 Mon Sep 17 00:00:00 2001
+From 05cf68f729dcee9f88243d28adb1e0fb6056f32f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 19 May 2017 21:49:59 +0800
 Subject: [PATCH 11/14] hvsock: fix vsock_dequeue/enqueue_accept race

--- a/kernel/patches-4.11.x/0012-Drivers-hv-vmbus-Fix-rescind-handling.patch
+++ b/kernel/patches-4.11.x/0012-Drivers-hv-vmbus-Fix-rescind-handling.patch
@@ -1,4 +1,4 @@
-From 50fe52376c8d8bd905b45697fc7fe91f5da9c34e Mon Sep 17 00:00:00 2001
+From 4d43e9f950eab1df52c348b886ecd9af3b1f2638 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Sun, 30 Apr 2017 16:21:18 -0700
 Subject: [PATCH 12/14] Drivers: hv: vmbus: Fix rescind handling

--- a/kernel/patches-4.11.x/0013-vmbus-fix-hv_percpu_channel_deq-enq-race.patch
+++ b/kernel/patches-4.11.x/0013-vmbus-fix-hv_percpu_channel_deq-enq-race.patch
@@ -1,4 +1,4 @@
-From 30cda9241fff7666faf2e0f0427df2c5fba2019d Mon Sep 17 00:00:00 2001
+From 7b2412f68cddfb5cd03b2c88543820c759b96821 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 5 Jun 2017 16:13:18 +0800
 Subject: [PATCH 13/14] vmbus:  fix hv_percpu_channel_deq/enq race

--- a/kernel/patches-4.11.x/0014-vmbus-add-vmbus-onoffer-onoffer_rescind-sync.patch
+++ b/kernel/patches-4.11.x/0014-vmbus-add-vmbus-onoffer-onoffer_rescind-sync.patch
@@ -1,4 +1,4 @@
-From a51f61d1b7a12097545cb23508faef7d3a4384f2 Mon Sep 17 00:00:00 2001
+From 19b5ecfa8c422e1c903ce3bbf893ce2fe56e1c4c Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 5 Jun 2017 21:32:00 +0800
 Subject: [PATCH 14/14] vmbus: add vmbus onoffer/onoffer_rescind sync.

--- a/kernel/patches-4.4.x/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
+++ b/kernel/patches-4.4.x/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
@@ -1,4 +1,4 @@
-From 43a3eef0a82fa29a342499953f4923875bb778bd Mon Sep 17 00:00:00 2001
+From c758876f90045d28dd0636d2949f157078c3f984 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 17 Dec 2015 16:53:43 +0800
 Subject: [PATCH 01/44] virtio: make find_vqs() checkpatch.pl-friendly
@@ -215,5 +215,5 @@ index e5ce8ab0b8b0..6e6cb0c9d7cb 100644
  	u64 (*get_features)(struct virtio_device *vdev);
  	int (*finalize_features)(struct virtio_device *vdev);
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
+++ b/kernel/patches-4.4.x/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
@@ -1,4 +1,4 @@
-From 9a20888fad006bbe00a00c7810cda3b6af6af604 Mon Sep 17 00:00:00 2001
+From 0ed9891811b7425a320aa14067457864303eeb55 Mon Sep 17 00:00:00 2001
 From: Julia Lawall <julia.lawall@lip6.fr>
 Date: Sat, 21 Nov 2015 18:39:17 +0100
 Subject: [PATCH 02/44] VSOCK: constify vmci_transport_notify_ops structures
@@ -73,5 +73,5 @@ index dc9c7929a2f9..21e591dafb03 100644
  	vmci_transport_notify_pkt_socket_destruct,
  	vmci_transport_notify_pkt_poll_in,
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
+++ b/kernel/patches-4.4.x/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
@@ -1,4 +1,4 @@
-From 0e5febfb95c4fed753824b145ad91d2a0dd4eb6d Mon Sep 17 00:00:00 2001
+From 4769cb4d7bae936db55ccf5505657db5e3c44b81 Mon Sep 17 00:00:00 2001
 From: Claudio Imbrenda <imbrenda@linux.vnet.ibm.com>
 Date: Tue, 22 Mar 2016 17:05:52 +0100
 Subject: [PATCH 03/44] AF_VSOCK: Shrink the area influenced by prepare_to_wait
@@ -332,5 +332,5 @@ index 9b5bd6d142dc..b5f1221f48d4 100644
  	release_sock(sk);
  	return err;
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0004-vsock-make-listener-child-lock-ordering-explicit.patch
+++ b/kernel/patches-4.4.x/0004-vsock-make-listener-child-lock-ordering-explicit.patch
@@ -1,4 +1,4 @@
-From 2dea3a8940311a0f387c3f7cc4c216dc565ff51e Mon Sep 17 00:00:00 2001
+From d0135d287f2c5ee15a42fbc35186be9f9ba43ced Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 23 Jun 2016 16:28:58 +0100
 Subject: [PATCH 04/44] vsock: make listener child lock ordering explicit
@@ -59,5 +59,5 @@ index b5f1221f48d4..b96ac918e0ba 100644
  
  		/* If the listener socket has received an error, then we should
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0005-VSOCK-transport-specific-vsock_transport-functions.patch
+++ b/kernel/patches-4.4.x/0005-VSOCK-transport-specific-vsock_transport-functions.patch
@@ -1,4 +1,4 @@
-From b6d53c08588ab8d1ce87939fee30a3fd62ec95f1 Mon Sep 17 00:00:00 2001
+From 6c3d10ea4778be5229a5139498f200aaf658e913 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:30 +0100
 Subject: [PATCH 05/44] VSOCK: transport-specific vsock_transport functions
@@ -55,5 +55,5 @@ index b96ac918e0ba..e34d96f8bde2 100644
  MODULE_DESCRIPTION("VMware Virtual Socket Family");
  MODULE_VERSION("1.0.1.0-k");
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0006-VSOCK-defer-sock-removal-to-transports.patch
+++ b/kernel/patches-4.4.x/0006-VSOCK-defer-sock-removal-to-transports.patch
@@ -1,4 +1,4 @@
-From 308b5f237f0c4881bd7cc347d5752ac88515afb4 Mon Sep 17 00:00:00 2001
+From 5693e15bb358f58823d459702e4bdc199bc49fe0 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:31 +0100
 Subject: [PATCH 06/44] VSOCK: defer sock removal to transports
@@ -79,5 +79,5 @@ index 662bdd20a748..5f8c99eb104c 100644
  		vmci_datagram_destroy_handle(vmci_trans(vsk)->dg_handle);
  		vmci_trans(vsk)->dg_handle = VMCI_INVALID_HANDLE;
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
+++ b/kernel/patches-4.4.x/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
@@ -1,4 +1,4 @@
-From 850b740ed9152079ebccda95d424eb15b89910b4 Mon Sep 17 00:00:00 2001
+From 8fc57b00a1add26d3e700405db8802ec9229443e Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:32 +0100
 Subject: [PATCH 07/44] VSOCK: Introduce virtio_vsock_common.ko
@@ -1492,5 +1492,5 @@ index 000000000000..a53b3a16b4f1
 +MODULE_AUTHOR("Asias He");
 +MODULE_DESCRIPTION("common code for virtio vsock");
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0008-VSOCK-Introduce-virtio_transport.ko.patch
+++ b/kernel/patches-4.4.x/0008-VSOCK-Introduce-virtio_transport.ko.patch
@@ -1,4 +1,4 @@
-From 6a71312dfdb74e28554120b41e537073438b2388 Mon Sep 17 00:00:00 2001
+From 5965e12fe1e6237539cd21e3df6c9b6ec75e17b3 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:33 +0100
 Subject: [PATCH 08/44] VSOCK: Introduce virtio_transport.ko
@@ -659,5 +659,5 @@ index 000000000000..699dfabdbccd
 +MODULE_DESCRIPTION("virtio transport for vsock");
 +MODULE_DEVICE_TABLE(virtio, id_table);
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0009-VSOCK-Introduce-vhost_vsock.ko.patch
+++ b/kernel/patches-4.4.x/0009-VSOCK-Introduce-vhost_vsock.ko.patch
@@ -1,4 +1,4 @@
-From b9e3f9634e50e75c471eb0a7e13a640625183016 Mon Sep 17 00:00:00 2001
+From 21318c60b1a6cb5b7494e7f86f9eb433c143cfab Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:34 +0100
 Subject: [PATCH 09/44] VSOCK: Introduce vhost_vsock.ko
@@ -773,5 +773,5 @@ index ab3731917bac..b30647697774 100644
 +
  #endif
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0010-VSOCK-Add-Makefile-and-Kconfig.patch
+++ b/kernel/patches-4.4.x/0010-VSOCK-Add-Makefile-and-Kconfig.patch
@@ -1,4 +1,4 @@
-From f8e129d2b7b8298fa4a789a1c2c5b5bec11a8970 Mon Sep 17 00:00:00 2001
+From da80226b5dd691fa7335e94ac2d0353b8393a360 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:35 +0100
 Subject: [PATCH 10/44] VSOCK: Add Makefile and Kconfig
@@ -102,5 +102,5 @@ index 2ce52d70f224..bc27c70e0e59 100644
 +
 +vmw_vsock_virtio_transport_common-y += virtio_transport_common.o
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0011-VSOCK-Use-kvfree.patch
+++ b/kernel/patches-4.4.x/0011-VSOCK-Use-kvfree.patch
@@ -1,4 +1,4 @@
-From d9803c2f8f21151ee88ed76e34e21e6b37a98364 Mon Sep 17 00:00:00 2001
+From 24a3e4e45b868fb582b39dd3d664e5f9bb5135df Mon Sep 17 00:00:00 2001
 From: Wei Yongjun <weiyj.lk@gmail.com>
 Date: Tue, 2 Aug 2016 13:50:42 +0000
 Subject: [PATCH 11/44] VSOCK: Use kvfree()
@@ -29,5 +29,5 @@ index 028ca16c2d36..0ddf3a2dbfc4 100644
  
  static int vhost_vsock_dev_open(struct inode *inode, struct file *file)
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
+++ b/kernel/patches-4.4.x/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
@@ -1,4 +1,4 @@
-From c003fa054ea3c74f4604f409879921e27959e602 Mon Sep 17 00:00:00 2001
+From 34fe73a48dfb5e4b2f86924c6844cd615fa85b1c Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 4 Aug 2016 14:52:53 +0100
 Subject: [PATCH 12/44] vhost/vsock: fix vhost virtio_vsock_pkt use-after-free
@@ -49,5 +49,5 @@ index 0ddf3a2dbfc4..e3b30ea9ece5 100644
  	}
  
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0013-virtio-vsock-fix-include-guard-typo.patch
+++ b/kernel/patches-4.4.x/0013-virtio-vsock-fix-include-guard-typo.patch
@@ -1,4 +1,4 @@
-From 16aeafd3f232aa8cf7d5228f3af2c45cd4f375fb Mon Sep 17 00:00:00 2001
+From 63213f2e9e9e5e4867212af91e2ca79b0ef1a85b Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Fri, 5 Aug 2016 13:52:09 +0100
 Subject: [PATCH 13/44] virtio-vsock: fix include guard typo
@@ -24,5 +24,5 @@ index 6b011c19b50f..1d57ed3d84d2 100644
  #include <linux/types.h>
  #include <linux/virtio_ids.h>
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
+++ b/kernel/patches-4.4.x/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
@@ -1,4 +1,4 @@
-From c6db3282328714eda96b51d1f2cf7d1fd96dd708 Mon Sep 17 00:00:00 2001
+From 887224b743a816e79fb33b044a4097d94e3bfa75 Mon Sep 17 00:00:00 2001
 From: Gerard Garcia <ggarcia@deic.uab.cat>
 Date: Wed, 10 Aug 2016 17:24:34 +0200
 Subject: [PATCH 14/44] vhost/vsock: drop space available check for TX vq
@@ -57,5 +57,5 @@ index 699dfabdbccd..936d7eee62d0 100644
  		}
  
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/kernel/patches-4.4.x/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,4 +1,4 @@
-From 1bda3ad2cd6cdee93ef9cb05743428dfb815675b Mon Sep 17 00:00:00 2001
+From 2bcf64d8c3d54cfa86265c9ffaba00c18c8fe0d1 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
 Subject: [PATCH 15/44] VSOCK: Only allow host network namespace to use
@@ -27,5 +27,5 @@ index 17dbbe64cd73..1bb1b016e945 100644
  		return -EINVAL;
  
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
+++ b/kernel/patches-4.4.x/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
@@ -1,4 +1,4 @@
-From d20bb91435977018e300c64dd5ed7e3ad8da4b6e Mon Sep 17 00:00:00 2001
+From 18eb32951e64dfccbbcad77edb0b3ec6553f520c Mon Sep 17 00:00:00 2001
 From: Jake Oshins <jakeo@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:41 -0800
 Subject: [PATCH 16/44] drivers:hv: Define the channel type for Hyper-V PCI
@@ -59,5 +59,5 @@ index ae6a711dcd1d..10dda1e3b560 100644
   */
  
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
+++ b/kernel/patches-4.4.x/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
@@ -1,4 +1,4 @@
-From ba23e5a08a09a11374cf68f54f8409c16bed7096 Mon Sep 17 00:00:00 2001
+From db963e1b4c889a03ed65ae92bb2753a81cd0d767 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:43 -0800
 Subject: [PATCH 17/44] Drivers: hv: vmbus: Use uuid_le type consistently
@@ -293,5 +293,5 @@ index 9f5cdd49ff0b..8e8c69bee78f 100644
  	strcpy(alias, "vmbus:");
  	strcat(alias, guid_name);
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
+++ b/kernel/patches-4.4.x/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
@@ -1,4 +1,4 @@
-From ef0df99bf8c62bbebbffba08f13059d7562a2e63 Mon Sep 17 00:00:00 2001
+From 8280104a62584fdd744f0885ddf3dcf1341abdf3 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:44 -0800
 Subject: [PATCH 18/44] Drivers: hv: vmbus: Use uuid_le_cmp() for comparing
@@ -51,5 +51,5 @@ index f1fbb6b98f5c..e71f3561dbab 100644
  
  	return NULL;
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
+++ b/kernel/patches-4.4.x/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
@@ -1,4 +1,4 @@
-From 464d40f2c505ebd36b3db44aff580ce05fb4dc36 Mon Sep 17 00:00:00 2001
+From 42ec6b68ad82ac78339dd687a31d33e5fae53c16 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:48 -0800
 Subject: [PATCH 19/44] Drivers: hv: vmbus: do sanity check of channel state in
@@ -38,5 +38,5 @@ index d037454fe7b8..b00cdfb725de 100644
  	channel->sc_creation_callback = NULL;
  	/* Stop callback and cancel the timer asap */
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
+++ b/kernel/patches-4.4.x/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
@@ -1,4 +1,4 @@
-From 0de058c12b898a20609de30d775e9a02decde219 Mon Sep 17 00:00:00 2001
+From cc4b9ddedd56f801794fa84ccfd22571fe2ccf9d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:50 -0800
 Subject: [PATCH 20/44] Drivers: hv: vmbus: release relid on error in
@@ -70,5 +70,5 @@ index 9b4525c56376..8529dd2ebc3d 100644
  	}
  
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
+++ b/kernel/patches-4.4.x/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
@@ -1,4 +1,4 @@
-From 1280469d5b7915c2b9252f463f1666898d0a0260 Mon Sep 17 00:00:00 2001
+From c143e7a4334c363240d0bb1bb5240d2121ce669f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:51 -0800
 Subject: [PATCH 21/44] Drivers: hv: vmbus: channge
@@ -112,5 +112,5 @@ index 75e383e6d03d..9a95beb87015 100644
  	struct workqueue_struct *work_queue;
  };
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
+++ b/kernel/patches-4.4.x/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
@@ -1,4 +1,4 @@
-From ba9435e62063343443a6028eb2e896891e128aaa Mon Sep 17 00:00:00 2001
+From 8421b9eb13fc7cfcef114933f3b74aa8d6faab11 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Mon, 14 Dec 2015 19:02:00 -0800
 Subject: [PATCH 22/44] Drivers: hv: remove code duplication between
@@ -122,5 +122,5 @@ index b00cdfb725de..def21d34f3ea 100644
  }
  EXPORT_SYMBOL_GPL(vmbus_recvpacket_raw);
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
+++ b/kernel/patches-4.4.x/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
@@ -1,4 +1,4 @@
-From bcafde97590ffd1b71ac16eec63b67ccf369b3d4 Mon Sep 17 00:00:00 2001
+From 4566625267f3c47439b439547f90b57c7952b9eb Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Dec 2015 12:21:22 -0800
 Subject: [PATCH 23/44] Drivers: hv: vmbus: fix the building warning with
@@ -68,5 +68,5 @@ index 4712d7d07b8c..9e2de6a7cc96 100644
   */
  #define HV_VSS_GUID \
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
+++ b/kernel/patches-4.4.x/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
@@ -1,4 +1,4 @@
-From fef4a1875034e823d3ac25364f9b916b0a6446cb Mon Sep 17 00:00:00 2001
+From 1c592000a7e3698fde5eb6d43898b820213becf8 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Tue, 15 Dec 2015 16:27:27 -0800
 Subject: [PATCH 24/44] Drivers: hv: vmbus: Treat Fibre Channel devices as
@@ -38,5 +38,5 @@ index 306c7dff6c77..763d0c19c16f 100644
  	{ HV_NIC_GUID, },
  	/* NetworkDirect Guest RDMA */
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
+++ b/kernel/patches-4.4.x/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
@@ -1,4 +1,4 @@
-From 73b0ada69d989050ac44ae903f7b9f9f97daa183 Mon Sep 17 00:00:00 2001
+From 873d8d76251d437298911b7f71aa7ea57a9f6b5b Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Fri, 25 Dec 2015 20:00:30 -0800
 Subject: [PATCH 25/44] Drivers: hv: vmbus: Add vendor and device atttributes
@@ -351,5 +351,5 @@ index 9e2de6a7cc96..51c98fd6044d 100644
  	struct device device;
  
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
+++ b/kernel/patches-4.4.x/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
@@ -1,4 +1,4 @@
-From 25652b0d0c7de208e0dcb83fd6af501612a56123 Mon Sep 17 00:00:00 2001
+From a44f3825d2f27a00736e8a1e494118e4ffe863d1 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:37 -0800
 Subject: [PATCH 26/44] Drivers: hv: vmbus: add a helper function to set a
@@ -32,5 +32,5 @@ index 51c98fd6044d..934542ac1394 100644
  
  int vmbus_request_offers(void);
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
+++ b/kernel/patches-4.4.x/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
@@ -1,4 +1,4 @@
-From 8d873555a36ab0e4ab7a4c6fe19656c0249886db Mon Sep 17 00:00:00 2001
+From 62513cb1aae6ead55a340f93681d14caa68859c5 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:38 -0800
 Subject: [PATCH 27/44] Drivers: hv: vmbus: define the new offer type for
@@ -40,5 +40,5 @@ index 934542ac1394..a4f105d55881 100644
  					    enum hv_signal_policy policy)
  {
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
+++ b/kernel/patches-4.4.x/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
@@ -1,4 +1,4 @@
-From 25f3e7a20154ed505297bc97d794bed7ca06d82b Mon Sep 17 00:00:00 2001
+From 91dc5ae7e3b0b0dbb93792c0df7ce71e50de06ab Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:39 -0800
 Subject: [PATCH 28/44] Drivers: hv: vmbus: vmbus_sendpacket_ctl: hvsock: avoid
@@ -41,5 +41,5 @@ index def21d34f3ea..a42104ed0b59 100644
  
  	return ret;
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
+++ b/kernel/patches-4.4.x/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
@@ -1,4 +1,4 @@
-From 08972e2d8c500f113e3dc714b99cc95356ab4389 Mon Sep 17 00:00:00 2001
+From 4cc3ff6f615b18001f8f1c6abac2c8286a40ad2f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:40 -0800
 Subject: [PATCH 29/44] Drivers: hv: vmbus: define a new VMBus message type for
@@ -97,5 +97,5 @@ index a4f105d55881..191bc5d0ffbf 100644
 +				  const uuid_le *shv_host_servie_id);
  #endif /* _HYPERV_H */
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
+++ b/kernel/patches-4.4.x/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
@@ -1,4 +1,4 @@
-From e6d370a2b07f47799c73c61c3c94d0267ff312a7 Mon Sep 17 00:00:00 2001
+From f286375b4b7d94f569e84d2f9ea96b67a2425d3a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:41 -0800
 Subject: [PATCH 30/44] Drivers: hv: vmbus: add a hvsock flag in struct
@@ -60,5 +60,5 @@ index 191bc5d0ffbf..05966e279ec8 100644
  	uuid_le dev_type;
  	const struct hv_vmbus_device_id *id_table;
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
+++ b/kernel/patches-4.4.x/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
@@ -1,4 +1,4 @@
-From 3b3258dae7ae94d13caef75c50cc44197cb8a003 Mon Sep 17 00:00:00 2001
+From 8b62f165be3c5765dee3d0bfcd14ec0ede8960b6 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:42 -0800
 Subject: [PATCH 31/44] Drivers: hv: vmbus: add a per-channel rescind callback
@@ -68,5 +68,5 @@ index 05966e279ec8..ad04017ba06f 100644
   * Retrieve the (sub) channel on which to send an outgoing request.
   * When a primary channel has multiple sub-channels, we choose a
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
+++ b/kernel/patches-4.4.x/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
@@ -1,4 +1,4 @@
-From 68a2a95f38cb202da0aab3b3ef288ecb00053b25 Mon Sep 17 00:00:00 2001
+From 8ca25de31b2695469bf0476a8d0a35e26da53fc1 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:43 -0800
 Subject: [PATCH 32/44] Drivers: hv: vmbus: add an API
@@ -149,5 +149,5 @@ index ad04017ba06f..993318a6d147 100644
  			resource_size_t min, resource_size_t max,
  			resource_size_t size, resource_size_t align,
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
+++ b/kernel/patches-4.4.x/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
@@ -1,4 +1,4 @@
-From dd2b91ed63bd1dc27761e40be7bd105c1bc0e7fe Mon Sep 17 00:00:00 2001
+From 560ce514f39936d039b2b835587efd2c200028cd Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:45 -0800
 Subject: [PATCH 33/44] Drivers: hv: vmbus: Give control over how the ring
@@ -204,5 +204,5 @@ index 993318a6d147..6c9695ef757e 100644
  {
  	return !!(c->offermsg.offer.chn_flags &
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
+++ b/kernel/patches-4.4.x/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
@@ -1,4 +1,4 @@
-From 194d0ff456cdd1e126c02fcd72fa917a96a9d0c7 Mon Sep 17 00:00:00 2001
+From 45ff72e7d42c547410ca0243d6d293200d1f1a5b Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:16 -0800
 Subject: [PATCH 34/44] Drivers: hv: vmbus: avoid wait_for_completion() on
@@ -96,5 +96,5 @@ index a220efc297c4..d9801855ad4e 100644
  	 * In crash handler we can't schedule synic cleanup for all CPUs,
  	 * doing the cleanup for current CPU only. This should be sufficient
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
+++ b/kernel/patches-4.4.x/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
@@ -1,4 +1,4 @@
-From e57335acce39ce93c1b2e07254b4a9b024415cff Mon Sep 17 00:00:00 2001
+From 4aaafd0b5239969df0a7a21da4f817a214af3853 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:18 -0800
 Subject: [PATCH 35/44] Drivers: hv: vmbus: avoid unneeded compiler
@@ -35,5 +35,5 @@ index f70e35278b94..c892db5df665 100644
  			continue;
  		}
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0036-kcm-Kernel-Connection-Multiplexor-module.patch
+++ b/kernel/patches-4.4.x/0036-kcm-Kernel-Connection-Multiplexor-module.patch
@@ -1,4 +1,4 @@
-From 446c43dde2e0c8c33a78c85224264bf86bee2a64 Mon Sep 17 00:00:00 2001
+From 75d1d2db0e1a7a79aad797a4f53b8bb5cc1d5e05 Mon Sep 17 00:00:00 2001
 From: Tom Herbert <tom@herbertland.com>
 Date: Mon, 7 Mar 2016 14:11:06 -0800
 Subject: [PATCH 36/44] kcm: Kernel Connection Multiplexor module
@@ -2308,5 +2308,5 @@ index 000000000000..649d246c6799
 +MODULE_LICENSE("GPL");
 +MODULE_ALIAS_NETPROTO(PF_KCM);
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4.x/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From ff64614d801f1559a0cf8466bf1c5898b7c59161 Mon Sep 17 00:00:00 2001
+From 85fef9042ee57487e7dc702f9bed8e045ce04d82 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:51:09 -0700
 Subject: [PATCH 37/44] net: add the AF_KCM entries to family name tables
@@ -48,5 +48,5 @@ index bd2fad27891e..ef337bf176f7 100644
  
  /*
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0038-net-Add-Qualcomm-IPC-router.patch
+++ b/kernel/patches-4.4.x/0038-net-Add-Qualcomm-IPC-router.patch
@@ -1,4 +1,4 @@
-From 5095141c43b79c862611a8d80b8e6916d57200e7 Mon Sep 17 00:00:00 2001
+From fd8ecd7bf812fd5ff9a8cd7a012186934aa1562a Mon Sep 17 00:00:00 2001
 From: Courtney Cavin <courtney.cavin@sonymobile.com>
 Date: Wed, 27 Apr 2016 12:13:03 -0700
 Subject: [PATCH 38/44] net: Add Qualcomm IPC router
@@ -1303,5 +1303,5 @@ index 000000000000..84ebce73aa23
 +MODULE_DESCRIPTION("Qualcomm IPC-Router SMD interface driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0039-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.4.x/0039-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 7fbe9efe9ecf2ecdfc65bc34a1f318899dc5c3ee Mon Sep 17 00:00:00 2001
+From 66ec420d8bcd8b94d7a106ebb611fc7c241111a8 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 15 May 2016 09:53:11 -0700
 Subject: [PATCH 39/44] hv_sock: introduce Hyper-V Sockets
@@ -1801,5 +1801,5 @@ index 000000000000..b91bd608bf39
 +MODULE_DESCRIPTION("Hyper-V Sockets");
 +MODULE_LICENSE("Dual BSD/GPL");
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4.x/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From 4242dcb301bd1999efff217dbf1fbe8d84e72cc7 Mon Sep 17 00:00:00 2001
+From 0543fb70b612a731de2c9cfb6dc3e3fe2dce2609 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:53:08 -0700
 Subject: [PATCH 40/44] net: add the AF_HYPERV entries to family name tables
@@ -45,5 +45,5 @@ index ef337bf176f7..1c5f0a2ef836 100644
  
  /*
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
+++ b/kernel/patches-4.4.x/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
@@ -1,4 +1,4 @@
-From 7b3690fc708abc186e2ac9ff42ed07667688eb9f Mon Sep 17 00:00:00 2001
+From 0413a9e9841cd745fd51a0fe6b2b611804dc873b Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 21 May 2016 16:55:50 +0800
 Subject: [PATCH 41/44] Drivers: hv: vmbus: fix the race when querying &
@@ -129,5 +129,5 @@ index c892db5df665..0a543170eba0 100644
  err_free_chan:
  	free_channel(newchannel);
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.4.x/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From a2dfd77b6f0be7875d3f1a226773e2d3c4a5de0c Mon Sep 17 00:00:00 2001
+From bd26f88f957c88d3948b63d805ab29b7b5a42e6b Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 42/44] vmbus: Don't spam the logs with unknown GUIDs
@@ -26,5 +26,5 @@ index 0a543170eba0..120ee22c945e 100644
  }
  
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0043-fs-add-filp_clone_open-API.patch
+++ b/kernel/patches-4.4.x/0043-fs-add-filp_clone_open-API.patch
@@ -1,4 +1,4 @@
-From b9d2472104af8d9105cea73d08502aee537cadc5 Mon Sep 17 00:00:00 2001
+From 8103790a404d812534cd65ad49b5527c66e2f9bb Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:49:38 -0800
 Subject: [PATCH 43/44] fs: add filp_clone_open API
@@ -60,5 +60,5 @@ index 157b9940dd73..9d993f928ea0 100644
  {
  	struct open_flags op;
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.4.x/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
+++ b/kernel/patches-4.4.x/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
@@ -1,4 +1,4 @@
-From 6428f751a854d26960e2c716e292afbd64220f5e Mon Sep 17 00:00:00 2001
+From 892967f7b77fa8560603caecf0209d956764130c Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:51:16 -0800
 Subject: [PATCH 44/44] binfmt_misc: add persistent opened binary handler for
@@ -128,5 +128,5 @@ index 78f005f37847..4beb3d9e0001 100644
  	return count;
  }
 -- 
-2.11.1
+2.13.0
 

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From f362cabb29dbdba34de667cf1bcbc011fed7e784 Mon Sep 17 00:00:00 2001
+From 5ff2a7a5fa25c04a4e5502e7c3dd10a3a3acffa5 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 20a8ecb884aaae0e43d2ce631d799b73f7825828 Mon Sep 17 00:00:00 2001
+From 5c1ec722a77a95545759d0dc3e13d1e000b2ee67 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 345e0d8b616922b8c7efb9bf3132f6d706d9c050 Mon Sep 17 00:00:00 2001
+From f7a253414ac0ee8968a8687b99b0c7f42befbaf2 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 70d9b4de7ab8d510f1370b81901a29e51485bb17 Mon Sep 17 00:00:00 2001
+From 602063d1d3d4e755b5b25955734652f1c24ce93f Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From dbd801cfa0ca1bd8a218b63547e755fd93b10303 Mon Sep 17 00:00:00 2001
+From 25b1031f1ca0d3f45c00e7817276aa49d8be1e61 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From b005bf4a7605ae77dbb6547be58a2a00c1a204ed Mon Sep 17 00:00:00 2001
+From 5aab2a5cb6a6a7390211cc7e8a899fdfdd7a352a Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From e90c65ae67af6caf6dcdc6737b7fedcbefba1f5e Mon Sep 17 00:00:00 2001
+From 570e85d4c44c17639d24ece7049d9e7646ae0abc Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From c3effb92348cc1e120705f16ad134ce059c2a2d2 Mon Sep 17 00:00:00 2001
+From e6971607ff36209e365aacaeada39b3f47059477 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From b140005685c86b44df788ade32cc887c2954a180 Mon Sep 17 00:00:00 2001
+From d8f6fa63c928d9c34b0ef9fd33bc27d23235010f Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From 6d6402672f5f6ff6940653f0d0e1534ed44648d2 Mon Sep 17 00:00:00 2001
+From 633e5d8a656c85525cb26fa7d3e719843de6c234 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From bd98313228b6ec9018c83f02586fa7a07fafac36 Mon Sep 17 00:00:00 2001
+From b1d8498bfed8083a41e6968a96f6d3105532b5f0 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 0656da868b410cfd818b9551411c40ac9c8c42ef Mon Sep 17 00:00:00 2001
+From 56ad9048b71a7e51e6cf9126c1ba94dc66399df9 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.4.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.11.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d922e569486e07d977cea056d6ddf1ac2152c62a
+  - linuxkit/init:781cec2360313a6d4aca25f5e90623294f8432f7
   - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:


### PR DESCRIPTION
Along with this PR I'm going to push a kernel update which will enable the usermode helper for the 4.11 kernels. This requires the `init` update in this PR.