### PR TITLE
Update hyperkit and support multiple disks

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -12,7 +12,7 @@ github.com/golang/protobuf c9c7427a2a70d2eb3bafa0ab2dc163e45f143317
 github.com/googleapis/gax-go 8c5154c0fe5bf18cf649634d4c6df50897a32751
 github.com/jmespath/go-jmespath bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 github.com/mitchellh/go-ps 4fdf99ab29366514c69ccccddab5dc58b8d84062
-github.com/moby/hyperkit ffbde436bf43219808ebe24dc8f6aacdb0ab57bd
+github.com/moby/hyperkit bc326711a6dfb4b45d1fac9c25a7875d5a3e1913
 github.com/packethost/packngo 91d54000aa56874149d348a884ba083c41d38091
 github.com/radu-matei/azure-sdk-for-go 3b12823551999669c9a325a32472508e0af7978e
 github.com/radu-matei/azure-vhd-utils e52754d5569d2a643a7775f72ff2a6cf524f4c25


### PR DESCRIPTION
Now hyperkit Go API has multiple disk support, allow using them from linuxkit

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![gophers](https://user-images.githubusercontent.com/482364/27200539-e08c116e-51ce-11e7-9d78-0f79452a2928.jpg)
