### PR TITLE
cmd: Unify the push coding style

### DIFF
--- a/docs/platform-azure.md
+++ b/docs/platform-azure.md
@@ -34,7 +34,7 @@ This will output a `azure.vhd` image.
 To deploy the `azure.vhd` image on Azure, invoke the following command:
 
 ```
-linuxkit run azure --resourceGroupName <resource-goup-name> --accountName <storageaccountname> --location westeurope <path-to-your-azure.vhd>
+linuxkit run azure --resource-group <resource-group-name> --storage-account <storage-account-name> --location westeurope <path-to-your-azure.vhd>
 ```
 
 Sample output of the command:

--- a/src/cmd/linuxkit/push.go
+++ b/src/cmd/linuxkit/push.go
@@ -38,11 +38,11 @@ func push(args []string) {
 		pushAzure(args[1:])
 	case "gcp":
 		pushGcp(args[1:])
+	case "vcenter":
+		pushVCenter(args[1:])
 	case "help", "-h", "-help", "--help":
 		pushUsage()
 		os.Exit(0)
-	case "vcenter":
-		pushVCenter(args[1:])
 	default:
 		log.Errorf("No 'push' backend specified.")
 	}

--- a/src/cmd/linuxkit/push_azure.go
+++ b/src/cmd/linuxkit/push_azure.go
@@ -13,15 +13,15 @@ func pushAzure(args []string) {
 	flags := flag.NewFlagSet("azure", flag.ExitOnError)
 	invoked := filepath.Base(os.Args[0])
 	flags.Usage = func() {
-		fmt.Printf("USAGE: %s push azure [options] name\n\n", invoked)
-		fmt.Printf("'imagePath' specifies the path (absolute or relative) of a\n")
-		fmt.Printf("VHD image be uploaded to an Azure Storage Account\n")
+		fmt.Printf("USAGE: %s push azure [options] path\n\n", invoked)
+		fmt.Printf("Push a disk image to Azure\n")
+		fmt.Printf("'path' specifies the path to a VHD. It will be uploaded to an Azure Storage Account.\n")
 		fmt.Printf("Options:\n\n")
 		flags.PrintDefaults()
 	}
 
-	resourceGroupName := flags.String("resourceGroupName", "", "Name of resource group to be used for VM")
-	accountName := flags.String("accountName", "", "Name of the storage account")
+	resourceGroup := flags.String("resource-group", "", "Name of resource group to be used for VM")
+	accountName := flags.String("storage-account", "", "Name of the storage account")
 
 	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
@@ -29,11 +29,11 @@ func pushAzure(args []string) {
 
 	remArgs := flags.Args()
 	if len(remArgs) == 0 {
-		fmt.Printf("Please specify the image to push\n")
+		fmt.Printf("Please specify the path to the image to push\n")
 		flags.Usage()
 		os.Exit(1)
 	}
-	imagePath := remArgs[0]
+	path := remArgs[0]
 
 	subscriptionID := getEnvVarOrExit("AZURE_SUBSCRIPTION_ID")
 	tenantID := getEnvVarOrExit("AZURE_TENANT_ID")
@@ -43,5 +43,5 @@ func pushAzure(args []string) {
 
 	initializeAzureClients(subscriptionID, tenantID, clientID, clientSecret)
 
-	uploadVMImage(*resourceGroupName, *accountName, imagePath)
+	uploadVMImage(*resourceGroup, *accountName, path)
 }

--- a/src/cmd/linuxkit/push_vcenter.go
+++ b/src/cmd/linuxkit/push_vcenter.go
@@ -21,6 +21,12 @@ func pushVCenter(args []string) {
 
 	flags := flag.NewFlagSet("vCenter", flag.ExitOnError)
 	invoked := filepath.Base(os.Args[0])
+	flags.Usage = func() {
+		fmt.Printf("USAGE: %s push vcenter [options] path \n\n", invoked)
+		fmt.Printf("'path' specifies the full path of an ISO image. It will be pushed to a vCenter cluster.\n")
+		fmt.Printf("Options:\n\n")
+		flags.PrintDefaults()
+	}
 
 	newVM.vCenterURL = flags.String("url", os.Getenv("VCURL"), "URL of VMware vCenter in the format of https://username:password@VCaddress/sdk")
 	newVM.dsName = flags.String("datastore", os.Getenv("VCDATASTORE"), "The name of the DataStore to host the image")
@@ -29,13 +35,6 @@ func pushVCenter(args []string) {
 	newVM.path = flags.String("path", "", "Path to a specific image")
 
 	newVM.vmFolder = flags.String("folder", "", "A folder on the datastore to push the image too")
-
-	flags.Usage = func() {
-		fmt.Printf("USAGE: %s push vcenter [options] path \n\n", invoked)
-		fmt.Printf("'path' specifies the full path of an image that will be pushed\n")
-		fmt.Printf("Options:\n\n")
-		flags.PrintDefaults()
-	}
 
 	if err := flags.Parse(args); err != nil {
 		log.Fatalln("Unable to parse args")
@@ -51,7 +50,7 @@ func pushVCenter(args []string) {
 
 	// Ensure an iso has been passed to the vCenter push Command
 	if !strings.HasSuffix(*newVM.path, ".iso") {
-		log.Fatalln("Please pass an \".iso\" file as the path")
+		log.Fatalln("Please specify an '.iso' file")
 	}
 
 	// Test any passed in files before uploading image


### PR DESCRIPTION
- Use 'flags' for the subcommand FlagSet
- Use %v to print errors
- Use 'path' for the path
- Fix cases where the 'path' refers to a different directory
- Don't use CamelCase for command line options

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
