### PR TITLE
Use library org in examples to verify nginx, other official images

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -32,5 +32,4 @@ services:
 trust:
   org:
     - linuxkit
-  image:
-    - nginx:alpine
+    - library

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -40,3 +40,4 @@ services:
 trust:
   org:
     - linuxkit
+    - library

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -30,5 +30,4 @@ services:
 trust:
   org:
     - linuxkit
-  image:
-    - nginx:alpine
+    - library

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -52,5 +52,4 @@ files:
 trust:
   org:
     - linuxkit
-  image:
-    - nginx:alpine
+    - library


### PR DESCRIPTION
`library` org refers to the [official images](https://hub.docker.com/explore/) on docker hub, which includes nginx, alpine, etc

<img src="https://s-media-cache-ak0.pinimg.com/736x/8e/a7/e9/8ea7e9713b9dfc8ae564ca2103033ea0.jpg" width="350"></img>
Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
