### PR TITLE
Add vmnet support to linuxkit run hyperkit

### DIFF
--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -20,6 +20,7 @@ const (
 	networkingNone         string = "none"
 	networkingDockerForMac        = "docker-for-mac"
 	networkingVPNKit              = "vpnkit"
+	networkingVMNet               = "vmnet"
 )
 
 // Process the run arguments and execute run
@@ -42,7 +43,7 @@ func runHyperKit(args []string) {
 	ipStr := flags.String("ip", "", "IP address for the VM")
 	state := flags.String("state", "", "Path to directory to keep VM state in")
 	vsockports := flags.String("vsock-ports", "", "List of vsock ports to forward from the guest on startup (comma separated). A unix domain socket for each port will be created in the state directory")
-	networking := flags.String("networking", networkingDockerForMac, "Networking mode. Valid options are 'docker-for-mac', 'vpnkit[,socket-path]' and 'none'. 'docker-for-mac' connects to the network used by Docker for Mac. 'vpnkit' connects to the VPNKit socket specified. If socket-path is omitted a new VPNKit instance will be started and 'vpnkit_eth.sock' will be created in the state directory. 'none' disables networking.`")
+	networking := flags.String("networking", networkingDockerForMac, "Networking mode. Valid options are 'docker-for-mac', 'vpnkit[,socket-path]', 'vmnet' and 'none'. 'docker-for-mac' connects to the network used by Docker for Mac. 'vpnkit' connects to the VPNKit socket specified. If socket-path is omitted a new VPNKit instance will be started and 'vpnkit_eth.sock' will be created in the state directory. 'vmnet' uses the Apple vmnet framework, requires root/sudo. 'none' disables networking.`")
 
 	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
@@ -160,6 +161,9 @@ func runHyperKit(args []string) {
 			// VSOCK port 62373 is used to pass traffic from host->guest
 			h.VSockPorts = append(h.VSockPorts, 62373)
 		}
+	case networkingVMNet:
+		h.VPNKitSock = ""
+		h.VMNet = true
 	case networkingNone:
 		h.VPNKitSock = ""
 	default:

--- a/vendor.conf
+++ b/vendor.conf
@@ -11,7 +11,7 @@ github.com/golang/protobuf c9c7427a2a70d2eb3bafa0ab2dc163e45f143317
 github.com/googleapis/gax-go 8c5154c0fe5bf18cf649634d4c6df50897a32751
 github.com/jmespath/go-jmespath bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 github.com/mitchellh/go-ps 4fdf99ab29366514c69ccccddab5dc58b8d84062
-github.com/moby/hyperkit bc326711a6dfb4b45d1fac9c25a7875d5a3e1913
+github.com/moby/hyperkit 2dbe405bfb05a93b2237516d1bffed850a4685f3
 github.com/packethost/packngo 91d54000aa56874149d348a884ba083c41d38091
 github.com/radu-matei/azure-sdk-for-go 3b12823551999669c9a325a32472508e0af7978e
 github.com/radu-matei/azure-vhd-utils e52754d5569d2a643a7775f72ff2a6cf524f4c25

--- a/vendor/github.com/moby/hyperkit/go/hyperkit.go
+++ b/vendor/github.com/moby/hyperkit/go/hyperkit.go
@@ -98,6 +98,9 @@ type HyperKit struct {
 	// VSock guest CID
 	VSockGuestCID int `json:"vsock_guest_cid"`
 
+	// VMNet whether to create vmnet network
+	VMNet bool `json:"vmnet"`
+
 	// 9P sockets
 	Sockets9P []Socket9P `json:"9p_sockets"`
 
@@ -412,6 +415,11 @@ func (h *HyperKit) buildArgs(cmdline string) {
 		} else {
 			a = append(a, "-s", fmt.Sprintf("%d:0,virtio-vpnkit,path=%s,uuid=%s", nextSlot, h.VPNKitSock, h.VPNKitKey))
 		}
+		nextSlot++
+	}
+
+	if h.VMNet {
+		a = append(a, "-s", fmt.Sprintf("%d:0,virtio-net", nextSlot))
 		nextSlot++
 	}
 


### PR DESCRIPTION
Allows routed networking, so long as you runhyperkit as root.

This has quite a few downsides, including the requirement to
run as root in order to set up the networking, but some people
really want VMs that are routable from the host.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![sudocat](https://user-images.githubusercontent.com/482364/27238682-aec47fe0-5282-11e7-9ec7-1238d66849c4.jpg)
