### PR TITLE
Fix DIRS find command to work on more system

### DIFF
--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,4 +1,4 @@
-DIRS = $(shell find . -type d -depth 1)
+DIRS = $(shell find . -maxdepth 1 -mindepth 1 -type d)
 .PHONY: clean dirs $(DIRS)
 
 push:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,4 @@
-DIRS = $(shell find . -type d -depth 1)
+DIRS = $(shell find . -maxdepth 1 -mindepth 1 -type d)
 .PHONY: clean dirs $(DIRS)
 
 push: $(DIRS)


### PR DESCRIPTION
Tested this out with osx `/usr/bin/find` and nixos/nixpkgs `find (GNU findutils) 4.6.0` 👼

/cc @justincormack @ijc 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>