### PR TITLE
[Work in progress] always-pxe support for Packet

### DIFF
--- a/src/cmd/linuxkit/run_packet.go
+++ b/src/cmd/linuxkit/run_packet.go
@@ -82,10 +82,9 @@ func runPacket(args []string) {
 	}
 	hostname := getStringValue(packetHostnameVar, *hostNameFlag, "")
 	name := getStringValue(packetNameVar, *nameFlag, prefix)
-	alwaysPXE := getStringValue(packetAlwaysPXEVar, *alwaysPXEFlag, defaultAlwaysPXE)
 	osType := "custom_ipxe"
 	billing := "hourly"
-	userData := fmt.Sprintf("#!ipxe\n\ndhcp\nset always_pxe %s\nset base-url %s\nset kernel-params ip=dhcp nomodeset ro serial console=ttyS1,115200\nkernel ${base-url}/%s-kernel ${kernel-params}\ninitrd ${base-url}/%s-initrd.img\nboot", alwaysPXE, url, name, name)
+	userData := fmt.Sprintf("#!ipxe\n\ndhcp\nset always_pxe %s\nset base-url %s\nset kernel-params ip=dhcp nomodeset ro serial console=ttyS1,115200\nkernel ${base-url}/%s-kernel ${kernel-params}\ninitrd ${base-url}/%s-initrd.img\nboot", alwaysPXEFlag, url, name, name)
 	log.Debugf("Using userData of:\n%s\n", userData)
 	initrdURL := fmt.Sprintf("%s/%s-initrd.img", url, name)
 	kernelURL := fmt.Sprintf("%s/%s-kernel", url, name)

--- a/src/cmd/linuxkit/run_packet.go
+++ b/src/cmd/linuxkit/run_packet.go
@@ -13,17 +13,17 @@ import (
 )
 
 const (
-	packetDefaultZone     = "ams1"
-	packetDefaultMachine  = "baremetal_0"
-	packetDefaultHostname = "moby"
-	packetDefaultAlwaysPXE = "false"
-	packetBaseURL         = "PACKET_BASE_URL"
-	packetZoneVar         = "PACKET_ZONE"
-	packetMachineVar      = "PACKET_MACHINE"
-	packetAPIKeyVar       = "PACKET_API_KEY"
-	packetProjectIDVar    = "PACKET_PROJECT_ID"
-	packetHostnameVar     = "PACKET_HOSTNAME"
-	packetNameVar         = "PACKET_NAME"
+	packetDefaultZone      = "ams1"
+	packetDefaultMachine   = "baremetal_0"
+	packetDefaultHostname  = "moby"
+	packetDefaultAlwaysPXE = "true"
+	packetBaseURL          = "PACKET_BASE_URL"
+	packetZoneVar          = "PACKET_ZONE"
+	packetMachineVar       = "PACKET_MACHINE"
+	packetAPIKeyVar        = "PACKET_API_KEY"
+	packetProjectIDVar     = "PACKET_PROJECT_ID"
+	packetHostnameVar      = "PACKET_HOSTNAME"
+	packetNameVar          = "PACKET_NAME"
 )
 
 // ValidateHTTPURL does a sanity check that a URL returns a 200 or 300 response
@@ -51,7 +51,7 @@ func runPacket(args []string) {
 	baseURLFlag := flags.String("base-url", "", "Base URL that the kernel and initrd are served from.")
 	zoneFlag := flags.String("zone", packetDefaultZone, "Packet Zone")
 	machineFlag := flags.String("machine", packetDefaultMachine, "Packet Machine Type")
-	alwaysPXEFlag := flags.String("always-pxe", packetDefaultAlwaysPXE, "Reboot from PXE every time. Defaults to false")
+	alwaysPXEFlag := flags.String("always-pxe", packetDefaultAlwaysPXE, "Reboot from PXE every time. Defaults to true")
 	apiKeyFlag := flags.String("api-key", "", "Packet API key")
 	projectFlag := flags.String("project-id", "", "Packet Project ID")
 	hostNameFlag := flags.String("hostname", packetDefaultHostname, "Hostname of new instance")

--- a/src/cmd/linuxkit/run_packet.go
+++ b/src/cmd/linuxkit/run_packet.go
@@ -16,6 +16,7 @@ const (
 	packetDefaultZone     = "ams1"
 	packetDefaultMachine  = "baremetal_0"
 	packetDefaultHostname = "moby"
+	packetDefaultAlwaysPXE = "false"
 	packetBaseURL         = "PACKET_BASE_URL"
 	packetZoneVar         = "PACKET_ZONE"
 	packetMachineVar      = "PACKET_MACHINE"
@@ -50,6 +51,7 @@ func runPacket(args []string) {
 	baseURLFlag := flags.String("base-url", "", "Base URL that the kernel and initrd are served from.")
 	zoneFlag := flags.String("zone", packetDefaultZone, "Packet Zone")
 	machineFlag := flags.String("machine", packetDefaultMachine, "Packet Machine Type")
+	alwaysPXEFlag := flags.String("always-pxe", packetDefaultAlwaysPXE, "Reboot from PXE every time. Defaults to false")
 	apiKeyFlag := flags.String("api-key", "", "Packet API key")
 	projectFlag := flags.String("project-id", "", "Packet Project ID")
 	hostNameFlag := flags.String("hostname", packetDefaultHostname, "Hostname of new instance")
@@ -80,9 +82,10 @@ func runPacket(args []string) {
 	}
 	hostname := getStringValue(packetHostnameVar, *hostNameFlag, "")
 	name := getStringValue(packetNameVar, *nameFlag, prefix)
+	alwaysPXE := getStringValue(packetAlwaysPXEVar, *alwaysPXEFlag, defaultAlwaysPXE)
 	osType := "custom_ipxe"
 	billing := "hourly"
-	userData := fmt.Sprintf("#!ipxe\n\ndhcp\nset base-url %s\nset kernel-params ip=dhcp nomodeset ro serial console=ttyS1,115200\nkernel ${base-url}/%s-kernel ${kernel-params}\ninitrd ${base-url}/%s-initrd.img\nboot", url, name, name)
+	userData := fmt.Sprintf("#!ipxe\n\ndhcp\nset always-pxe %s\set base-url %s\nset kernel-params ip=dhcp nomodeset ro serial console=ttyS1,115200\nkernel ${base-url}/%s-kernel ${kernel-params}\ninitrd ${base-url}/%s-initrd.img\nboot", alwaysPXE, url, name, name)
 	log.Debugf("Using userData of:\n%s\n", userData)
 	initrdURL := fmt.Sprintf("%s/%s-initrd.img", url, name)
 	kernelURL := fmt.Sprintf("%s/%s-kernel", url, name)

--- a/src/cmd/linuxkit/run_packet.go
+++ b/src/cmd/linuxkit/run_packet.go
@@ -85,7 +85,7 @@ func runPacket(args []string) {
 	alwaysPXE := getStringValue(packetAlwaysPXEVar, *alwaysPXEFlag, defaultAlwaysPXE)
 	osType := "custom_ipxe"
 	billing := "hourly"
-	userData := fmt.Sprintf("#!ipxe\n\ndhcp\nset always-pxe %s\set base-url %s\nset kernel-params ip=dhcp nomodeset ro serial console=ttyS1,115200\nkernel ${base-url}/%s-kernel ${kernel-params}\ninitrd ${base-url}/%s-initrd.img\nboot", alwaysPXE, url, name, name)
+	userData := fmt.Sprintf("#!ipxe\n\ndhcp\nset always_pxe %s\nset base-url %s\nset kernel-params ip=dhcp nomodeset ro serial console=ttyS1,115200\nkernel ${base-url}/%s-kernel ${kernel-params}\ninitrd ${base-url}/%s-initrd.img\nboot", alwaysPXE, url, name, name)
 	log.Debugf("Using userData of:\n%s\n", userData)
 	initrdURL := fmt.Sprintf("%s/%s-initrd.img", url, name)
 	kernelURL := fmt.Sprintf("%s/%s-kernel", url, name)


### PR DESCRIPTION
Work in progress.  Closes #2065.

Add a flag `--always-pxe` defaulting to `false` that if set to `true` will cause the machine to reboot from PXE.

Not yet tested, this is work in progress.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a new flag, set default to current default behavior, if flag set to true then new behavior.

**- How I did it**

Parse arguments and update the custom iPXE boot string

**- How to verify it**

Address the question of what the right default is (it might be "true" in which case no option flag is needed).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add persistent iPXE support for Packet

**- A picture of a cute animal (not mandatory but encouraged)**

```
 _   /|
 \'o.O'
 =(___)=
    U
```