### PR TITLE
FIX Docs Link: ./kernel to ../kernel/README.md

### DIFF
--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -72,7 +72,7 @@ configuration.
 
 To build and test locally modified kernels, e.g., to try a different
 kernel config or new patches, the existing kernel build system in the
-[`./kernel`](./kernel) can be re-used. For example, assuming the
+[`./kernel`](../kernel/README.md) can be re-used. For example, assuming the
 current 4.9 kernel is 4.9.28, you can build a local kernel with:
 ```
 make build_4.9.28 HASH=foo

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -72,7 +72,7 @@ configuration.
 
 To build and test locally modified kernels, e.g., to try a different
 kernel config or new patches, the existing kernel build system in the
-[`./kernel`](../kernel/README.md) can be re-used. For example, assuming the
+[`../kernel`](../kernel/) can be re-used. For example, assuming the
 current 4.9 kernel is 4.9.28, you can build a local kernel with:
 ```
 make build_4.9.28 HASH=foo


### PR DESCRIPTION
Signed-off-by: Nathan Dautenhahn <ndd@cis.upenn.edu>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Converted link of .kernel in docs/kernels.md to point to ../kernel/README.md

**- How I did it**

Modified it. 

**- How to verify it**

Read it and verify link works

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

FIX Docs Link: ./kernel to ../kernel/README.md

**- A picture of a cute animal (not mandatory but encouraged)**
