### PR TITLE
Simplify Makefiles for Packages

### DIFF
--- a/pkg/binfmt/Makefile
+++ b/pkg/binfmt/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=binfmt
-DEPS=Dockerfile Makefile main.go $(wildcard etc/binmft.d/*)
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=main.go $(wildcard etc/binmft.d/*)

--- a/pkg/ca-certificates/Makefile
+++ b/pkg/ca-certificates/Makefile
@@ -1,15 +1,3 @@
-.PHONY: tag push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=ca-certificates
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-default: push
-
-tag: Dockerfile
-	docker build --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=containerd
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-default: push
-
-tag: Dockerfile
-	docker build -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+NETWORK=1

--- a/pkg/dhcpcd/Makefile
+++ b/pkg/dhcpcd/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=dhcpcd
-DEPS=Dockerfile Makefile dhcpcd.conf usr/lib/dhcpcd/dhcpcd-hooks/10-mtu
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=dhcpcd.conf $(wildcard usr/lib/dhcpcd/dhcpcd-hooks/*)

--- a/pkg/docker-ce/Makefile
+++ b/pkg/docker-ce/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=docker-ce
-DEPS=Dockerfile
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+NETWORK=1

--- a/pkg/format/Makefile
+++ b/pkg/format/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=format
-DEPS=Dockerfile format.sh
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=format.sh

--- a/pkg/getty/Makefile
+++ b/pkg/getty/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=getty
-DEPS=Dockerfile usr/bin/rungetty.sh
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=usr/bin/rungetty.sh $(wildcard etc/*) $(wildcard etc/init.d/*)

--- a/pkg/init/Makefile
+++ b/pkg/init/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=init
-DEPS=Dockerfile init $(wildcard etc/*) $(wildcard etc/init.d/*) usermode-helper.c
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=init usermode-helper.c $(wildcard etc/*) $(wildcard etc/init.d/*)

--- a/pkg/metadata/Makefile
+++ b/pkg/metadata/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=metadata
-DEPS=Dockerfile Makefile $(wildcard *.go)
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=$(wildcard *.go)

--- a/pkg/mkimage/Makefile
+++ b/pkg/mkimage/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=mkimage
-DEPS=Dockerfile mkimage.sh
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=mkimage.sh

--- a/pkg/mount/Makefile
+++ b/pkg/mount/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=mount
-DEPS=Dockerfile mount.sh
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=mount.sh

--- a/pkg/node_exporter/Makefile
+++ b/pkg/node_exporter/Makefile
@@ -1,15 +1,3 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=node_exporter
-DEPS=Dockerfile
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/open-vm-tools/Makefile
+++ b/pkg/open-vm-tools/Makefile
@@ -1,15 +1,3 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=open-vm-tools
-DEPS=Dockerfile Makefile
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/openntpd/Makefile
+++ b/pkg/openntpd/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=openntpd
-DEPS=Dockerfile etc/ntpd.conf
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=etc/ntpd.conf

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -1,0 +1,17 @@
+.PHONY: tag push
+default: push
+
+ORG?=linuxkit
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
+BASE_DEPS=Dockerfile Makefile
+
+tag: $(BASE_DEPS) $(DEPS)
+ifndef $(NETWORK)
+	docker build -t $(ORG)/$(IMAGE):$(HASH) .
+else
+	docker build --network=none -t $(ORG)/$(IMAGE):$(HASH) .
+endif
+
+push: tag
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/qemu-ga/Makefile
+++ b/pkg/qemu-ga/Makefile
@@ -1,14 +1,3 @@
-.PHONY: tag push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=qemu-ga
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-default: push
-
-tag: Dockerfile
-	docker build --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/rngd/Makefile
+++ b/pkg/rngd/Makefile
@@ -1,15 +1,3 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=rngd
-DEPS=Dockerfile
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/runc/Makefile
+++ b/pkg/runc/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=runc
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-default: push
-
-tag: Dockerfile
-	docker build -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+NETWORK=1

--- a/pkg/sshd/Makefile
+++ b/pkg/sshd/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=sshd
-DEPS=Dockerfile etc/motd etc/ssh/sshd_config usr/bin/ssh.sh
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=etc/motd etc/ssh/sshd_config usr/bin/ssh.sh

--- a/pkg/swap/Makefile
+++ b/pkg/swap/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=swap
-DEPS=Dockerfile swap.sh
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=swap.sh

--- a/pkg/sysctl/Makefile
+++ b/pkg/sysctl/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=sysctl
-DEPS=Dockerfile Makefile main.go
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=main.go

--- a/pkg/sysfs/Makefile
+++ b/pkg/sysfs/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=sysfs
-DEPS=Dockerfile Makefile main.go
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=main.go

--- a/pkg/vpnkit-forwarder/Makefile
+++ b/pkg/vpnkit-forwarder/Makefile
@@ -1,15 +1,5 @@
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=vpnkit-forwarder
-DEPS=$(wildcard *.go) Makefile Dockerfile
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
-
+DEPS=$(wildcard *.go)
+NETWORK=1

--- a/pkg/vsudd/Makefile
+++ b/pkg/vsudd/Makefile
@@ -1,15 +1,5 @@
-default: push
+include ../package.mk
 
-ORG?=linuxkit
 IMAGE=vsudd
-DEPS=$(wildcard *.go) Makefile Dockerfile
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --squash --no-cache -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
-
+DEPS=$(wildcard *.go)
+NETWORK=1


### PR DESCRIPTION
These now inherit from a top-level package.mk
Options like use of the network can be enabled on a per package basis
This removes a lot of duplicate code and make the maintenace of these
Makefiles much easier

Signed-off-by: Dave Tucker <dt@docker.com>