### PR TITLE
Fix Dead Link to VMWare File

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Currently supported platforms are:
   - [HyperKit (macOS)](docs/platform-hyperkit.md)
   - [Hyper-V (Windows)](docs/platform-hyperv.md)
   - [qemu (macOS, Linux, Windows)](docs/platform-qemu.md)
-  - [VMware (macOS, Windows)](dos/platform-vmware.md)
+  - [VMware (macOS, Windows)](docs/platform-vmware.md)
 - Cloud based platforms:
   - [Amazon Web Services](docs/platform-aws.md)
   - [Google Cloud](docs/platform-gcp.md)


### PR DESCRIPTION
**- What I did**
Fixed a typo in the main README.md that was causing a dead link to the
platform-vmware.md file.

**- How I did it**

**- How to verify it**
Click on it, it resolves now. 

**- Description for the changelog**
Fixed a typo in the main README.md that was causing a dead link to the
platform-vmware.md file.

Signed-off-by: Dave Freitag <dcfreita@us.ibm.com>
