### PR TITLE
alpine: include gnupg and zfs packages

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:4f0ddee221c46f142e5a190dd43d2e07256ef98d AS kernel-build
+FROM linuxkit/alpine:700ec47ad83e392e38896da2f8b1a30f0683dfe4 AS kernel-build
 RUN apk add \
     argp-standalone \
     automake \

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:700ec47ad83e392e38896da2f8b1a30f0683dfe4 AS kernel-build
+FROM linuxkit/alpine:a44da41b988024aa2c73b28dee8a51d026f6240b AS kernel-build
 RUN apk add \
     argp-standalone \
     automake \

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -27,6 +27,7 @@ flex
 gcc
 git
 gmp-dev
+gnupg
 go
 gummiboot
 hvtools

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -74,4 +74,5 @@ xfsprogs
 xorriso
 xz
 xz-dev
+zfs
 zlib-dev

--- a/tools/alpine/versions
+++ b/tools/alpine/versions
@@ -48,6 +48,7 @@ git-2.13.0-r0
 glib-2.52.1-r0
 gmp-6.1.2-r0
 gmp-dev-6.1.2-r0
+gnupg-2.1.20-r0
 gnutls-3.5.13-r0
 go-1.8.1-r2
 gummiboot-48.1-r0
@@ -67,6 +68,7 @@ libacl-2.2.52-r3
 libaio-0.3.110-r0
 libarchive-3.3.1-r1
 libarchive-tools-3.3.1-r1
+libassuan-2.4.3-r0
 libatomic-6.3.0-r4
 libattr-2.4.47-r6
 libblkid-2.28.2-r2
@@ -88,12 +90,16 @@ libexecinfo-dev-1.1-r0
 libfdisk-2.28.2-r2
 libffi-3.2.1-r3
 libgcc-6.3.0-r4
+libgcrypt-1.7.7-r0
 libgmpxx-6.1.2-r0
 libgomp-6.3.0-r4
+libgpg-error-1.27-r0
 libintl-0.19.8.1-r1
 libisoburn-1.4.6-r0
 libisofs-1.4.6-r0
 libjpeg-turbo-1.5.1-r0
+libksba-1.3.4-r0
+libldap-2.4.44-r5
 libmagic-5.30-r0
 libmnl-1.0.4-r0
 libmount-2.28.2-r2
@@ -142,6 +148,7 @@ ncurses-libs-6.0-r7
 ncurses-terminfo-6.0-r7
 ncurses-terminfo-base-6.0-r7
 nettle-3.3-r0
+npth-1.2-r0
 oniguruma-6.2.0-r0
 open-vm-tools-10.1.0-r7
 openntpd-6.0_p1-r3
@@ -153,6 +160,7 @@ p11-kit-0.23.2-r1
 patch-2.7.5-r1
 pcre-8.40-r2
 perl-5.24.1-r2
+pinentry-1.0.0-r0
 pixman-0.34.0-r0
 pkgconf-1.3.7-r0
 popt-1.16-r6

--- a/tools/alpine/versions
+++ b/tools/alpine/versions
@@ -196,5 +196,7 @@ xorriso-1.4.6-r0
 xz-5.2.3-r0
 xz-dev-5.2.3-r0
 xz-libs-5.2.3-r0
+zfs-0.6.5.9-r1
+zfs-libs-0.6.5.9-r1
 zlib-1.2.11-r0
 zlib-dev-1.2.11-r0


### PR DESCRIPTION
Include `gnupg` package in the base alpine image for kernel signing verification (see https://github.com/linuxkit/linuxkit/issues/2088)

Also include `zfs` from other issue and discussion at moby summit

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>

