### PR TITLE
add an auditd container

### DIFF
--- a/pkg/auditd/Dockerfile
+++ b/pkg/auditd/Dockerfile
@@ -1,0 +1,29 @@
+FROM linuxkit/alpine:cdb4e4d12ada4071a6c6a60bf4c14d35171ffae8 AS build
+RUN apk add abuild gcc git
+
+ADD build.sh /
+RUN adduser -D -G abuild builder && sudo -u builder /build.sh
+
+FROM linuxkit/alpine:cdb4e4d12ada4071a6c6a60bf4c14d35171ffae8 AS mirror
+COPY --from=build /home/builder/*apk /
+
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --initdb -p /out alpine-baselayout tini
+RUN apk add --allow-untrusted -p /out /*apk
+
+# Remove apk residuals. We have a read-only rootfs, so apk is of no use.
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+FROM scratch
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=mirror /out/ /
+
+COPY auditd.conf /etc/audit
+COPY audit.rules /etc/audit
+COPY runaudit.sh /usr/bin
+
+CMD ["/sbin/tini", "/usr/bin/runaudit.sh"]
+
+LABEL org.mobyproject.config='{"pid": "host", "binds": ["/var/log:/var/log"], "capabilities": ["CAP_AUDIT_CONTROL", "CAP_AUDIT_READ", "CAP_AUDIT_WRITE", "CAP_SYS_NICE"]}'

--- a/pkg/auditd/Makefile
+++ b/pkg/auditd/Makefile
@@ -1,0 +1,3 @@
+include ../package.mk
+
+IMAGE?=auditd

--- a/pkg/auditd/audit.rules
+++ b/pkg/auditd/audit.rules
@@ -1,0 +1,12 @@
+## First rule - delete all
+-D
+
+## Increase the buffers to survive stress events.
+## Make this bigger for busy systems
+-b 8192
+
+## This determine how long to wait in burst of events
+--backlog_wait_time 0
+
+## Set failure mode to syslog
+-f 1

--- a/pkg/auditd/auditd.conf
+++ b/pkg/auditd/auditd.conf
@@ -1,0 +1,32 @@
+#
+# This file controls the configuration of the audit daemon
+#
+
+local_events = yes
+write_logs = no
+log_format = RAW
+flush = INCREMENTAL_ASYNC
+freq = 50
+priority_boost = 4
+disp_qos = lossy
+dispatcher = /sbin/audispd
+name_format = NONE
+##name = mydomain
+max_log_file_action = ROTATE
+space_left = 75
+space_left_action = SYSLOG
+action_mail_acct = root
+admin_space_left = 50
+admin_space_left_action = SUSPEND
+disk_full_action = SUSPEND
+disk_error_action = SUSPEND
+use_libwrap = yes
+##tcp_listen_port = 
+tcp_listen_queue = 5
+tcp_max_per_addr = 1
+##tcp_client_ports = 1024-65535
+tcp_client_max_idle = 0
+enable_krb5 = no
+krb5_principal = auditd
+##krb5_key_file = /etc/audit/audit.key
+distribute_network = no

--- a/pkg/auditd/runaudit.sh
+++ b/pkg/auditd/runaudit.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# load the audit rules into the kernel
+auditctl -R /etc/audit/audit.rules
+exec /sbin/auditd -f

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -1,3 +1,4 @@
+abuild
 alpine-baselayout
 alpine-keys
 apk-tools
@@ -36,6 +37,7 @@ iptables
 jq
 kmod
 libarchive-tools
+libcap-ng-dev
 libc-dev
 libc-utils
 libelf-dev
@@ -52,6 +54,7 @@ openrc
 openssh-server
 open-vm-tools
 patch
+python3
 qemu-aarch64
 qemu-arm
 qemu-guest-agent
@@ -64,6 +67,7 @@ sfdisk
 slang-dev
 squashfs-tools
 strace
+swig
 syslinux
 tar
 tini


### PR DESCRIPTION
Two things to note here: we unfortunately can't just exec audit, because it
dies if /var/log/audit doesn't exist, so we have to do a wrapper script.

Second, it also dies if it can't re-nice itself, so we have to give it
CAP_SYS_NICE as well as the audit caps.

I didn't add this to the default linuxkit.yml because the linuxkit/audit
repo doesn't exist yet, but we should probably (?) do that.

Closes #52

Signed-off-by: Tycho Andersen <tycho@docker.com>