### PR TITLE
tests: add build test for Docker for Mac blueprint

### DIFF
--- a/test/cases/000_build/200_blueprints/010_docker_for_mac/test.sh
+++ b/test/cases/000_build/200_blueprints/010_docker_for_mac/test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# SUMMARY: Test the Docker for Mac blueprint
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+IMAGE_NAME=docker-for-mac
+
+clean_up() {
+	# remove any files, containers, images etc
+	rm -rf ${IMAGE_NAME}*
+}
+
+trap clean_up EXIT
+
+# Test code goes here
+moby build "${LINUXKIT_BLUEPRINTS_DIR}/${IMAGE_NAME}.yml" 
+
+exit 0
+

--- a/test/cases/000_build/200_blueprints/group.sh
+++ b/test/cases/000_build/200_blueprints/group.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# SUMMARY: Check that the blueprint YAML files work
+# LABELS:
+
+group_init() {
+    # Group initialisation code goes here
+    return 0
+}
+
+group_deinit() {
+    # Group de-initialisation code goes here
+    return 0
+}
+
+CMD=$1
+case $CMD in
+init)
+    group_init
+    res=$?
+    ;;
+deinit)
+    group_deinit
+    res=$?
+    ;;
+*)
+    res=1
+    ;;
+esac
+
+exit $res
+

--- a/test/cases/group.sh
+++ b/test/cases/group.sh
@@ -11,6 +11,7 @@ group_init() {
     [ -r "${LINUXKIT_TMPDIR}" ] && rm -rf "${LINUXKIT_TMPDIR}"
     mkdir "${LINUXKIT_TMPDIR}"
     echo "export LINUXKIT_EXAMPLES_DIR=${RT_PROJECT_ROOT}/../../examples" >> "${LINUXKIT_TMPDIR}/env.sh"
+    echo "export LINUXKIT_BLUEPRINTS_DIR=${RT_PROJECT_ROOT}/../../blueprints" >> "${LINUXKIT_TMPDIR}/env.sh"
 
     if rt_label_set "gcp"; then
         # If we run GCP tests, make sure it is configured


### PR DESCRIPTION
Adds a new test group "linuxkit.build.blueprints" and a test for
building blueprints/docker-for-mac.yml, as requested in #2039.

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>
