### PR TITLE
Use less memory in /init

### DIFF
--- a/blueprints/docker-for-mac.yml
+++ b/blueprints/docker-for-mac.yml
@@ -3,7 +3,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
 onboot:

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 services:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS1 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/pkg/init/init
+++ b/pkg/init/init
@@ -2,6 +2,14 @@
 
 /bin/mount -t tmpfs tmpfs /mnt
 
+# just copying everything uses a lot of space, so use mv which frees it up
+# copy directory structure under /containers
+find /containers -type d | cpio -p /mnt 2> /dev/null
+# move files under /containers
+find /containers -not -type d -exec mv {} /mnt/{} \;
+# delete remaining directories
+rm -rf /containers
+
 /bin/cp -a / /mnt 2>/dev/null
 
 /bin/mount -t proc -o noexec,nosuid,nodev proc /proc

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.4.74"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.11.7"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
   - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
+  - linuxkit/init:e7f7119d21c423d64db186fe6fe011edd7422418
   - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:


### PR DESCRIPTION
Previously we would copy the whole root filesystem to a new
tmpfs root, then free it up. We do this as `pivot_root` fails
on an initrd, it wants a real mounted `tmpfs`.
    
Copying it all used a lot of memory, as it uses twice as much
and each tmpfs can only be 50% of RAM, so it needs four times
as much memory as the unpacked size.
    
Instead, for `/containers` which is the largest part, move each
file one by one, so that they are freed after the move. This
should almost halve the memory requirement.

![zebra](https://user-images.githubusercontent.com/482364/27461397-2d0da76a-576e-11e7-9825-342161621421.gif)
