### PR TITLE
test: ensure ctr works in getty container

### DIFF
--- a/test/cases/040_packages/003_containerd/test.sh
+++ b/test/cases/040_packages/003_containerd/test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SUMMARY: Run contianerd test
+# SUMMARY: Run containerd test
 # LABELS:
 # REPEAT:
 

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -1,25 +1,18 @@
 kernel:
   image: "linuxkit/kernel:4.9.x"
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:17693d233dd009b2a3a8d23673cb85969e1dce80
   - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
   - linuxkit/containerd:a33cdcf50b8107ffe14c92802c460fe7ada39acd
   - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
 onboot:
-  - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
   - name: dhcpcd
     image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
     image: "linuxkit/getty:9f27c1272b6d128c9a09745e916f151d09cb0d27"
-    # to make insecure with passwordless root login, uncomment following lines
-    #env:
-    # - INSECURE=true
-  - name: rngd
-    image: "linuxkit/rngd:1fa4de44c961bb5075647181891a3e7e7ba51c31"
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/test/cases/040_packages/007_getty-containerd/test.exp
+++ b/test/cases/040_packages/007_getty-containerd/test.exp
@@ -1,0 +1,96 @@
+#!/usr/bin/env expect
+spawn linuxkit run test-ctr
+set pid [exp_pid]
+set timeout 60
+set prompt ":~# "
+
+expect {
+    timeout {
+        puts "FAILED boot"
+        exec kill -9 $pid
+        exit 1
+    }
+    "Welcome to LinuxKit" {
+        puts "SUCCESS boot"
+    }
+}
+expect {
+    timeout {
+        puts "FAILED login user"
+        exec kill -9 $pid
+        exit 1
+    }
+    "ogin: " {
+	send "root\n"
+    }
+}
+expect {
+    timeout {
+        puts "FAILED login pass"
+        exec kill -9 $pid
+        exit 1
+    }
+    "assword: " {
+	send "abcdefgh\n"
+    }
+}
+
+expect {
+    timeout {
+        puts "FAILED dist pull"
+        exec kill -9 $pid
+        exit 1
+    }
+    $prompt {
+	send "dist pull docker.io/library/redis:alpine\n"
+    }
+}
+expect {
+    timeout {
+        puts "FAILED dist pull"
+        exec kill -9 $pid
+        exit 1
+    }
+    $prompt {
+	puts "SUCCESS dist pull"
+	send "ctr run -t docker.io/library/redis:alpine test\n"
+    }
+}
+expect {
+    timeout {
+        puts "FAILED ctr run"
+        exec kill -9 $pid
+        exit 1
+    }
+    "The server is now ready to accept connections on port 6379" {
+	puts "SUCCESS ctr run"
+	# Ctrl-C
+	send "\003"
+    }
+}
+expect {
+    timeout {
+        puts "FAILED kill ctr"
+        exec kill -9 $pid
+        exit 1
+    }
+    $prompt {
+	send "poweroff -f\n"
+    }
+}
+expect {
+    timeout {
+        puts "FAILED poweroff"
+        exec kill -9 $pid
+        exit 1
+    }
+    "Power down" {
+        puts "SUCCESS poweroff"
+    }
+    eof {
+        puts "SUCCESS poweroff"
+    }
+}
+set waitval [wait -i $spawn_id]
+set exval [lindex $waitval 3]
+exit $exval

--- a/test/cases/040_packages/007_getty-containerd/test.sh
+++ b/test/cases/040_packages/007_getty-containerd/test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# SUMMARY: Check that ctr can run containers
+# LABELS:
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+NAME=test-ctr
+
+clean_up() {
+	find . -iname "test-ctr*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+moby build "${NAME}.yml"
+[ -f "${NAME}-kernel" ] || exit 1
+[ -f "${NAME}-initrd.img" ] || exit 1
+[ -f "${NAME}-cmdline" ]|| exit 1
+./test.exp
+exit 0


### PR DESCRIPTION
Fix a typo in the main containerd test too.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

**- What I did**

Added a test that `ctr run` (and `dist pull`) work from within the `getty` container, to avoid regressions in #2102.

**- How I did it**

Some `expect(1)` based insanity.

**- How to verify it**

The tests should pass.

**- Description for the changelog**

Doesn't need anything above the #2102 entry IMHO.

**- A picture of a cute animal (not mandatory but encouraged)**

[![](https://upload.wikimedia.org/wikipedia/en/1/15/Alice_in_Chains_Jar_of_Flies.jpg "Alice in Chains, Jar of Flies")](https://en.wikipedia.org/wiki/Jar_of_Flies)
