### PR TITLE
kernel: Update to 4.11.7/4.9.34/4.4.74

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -93,8 +93,8 @@ endef
 # Build Targets
 # Debug targets only for latest stable and LTS stable
 #
-$(eval $(call kernel,4.11.6,4.11.x))
-$(eval $(call kernel,4.11.6,4.11.x,_dbg))
-$(eval $(call kernel,4.9.33,4.9.x))
-$(eval $(call kernel,4.9.33,4.9.x,_dbg))
-$(eval $(call kernel,4.4.73,4.4.x))
+$(eval $(call kernel,4.11.7,4.11.x))
+$(eval $(call kernel,4.11.7,4.11.x,_dbg))
+$(eval $(call kernel,4.9.34,4.9.x))
+$(eval $(call kernel,4.9.34,4.9.x,_dbg))
+$(eval $(call kernel,4.4.74,4.4.x))

--- a/kernel/kernel_config-4.11.x
+++ b/kernel/kernel_config-4.11.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.11.6 Kernel Configuration
+# Linux/x86 4.11.7 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/kernel_config-4.4.x
+++ b/kernel/kernel_config-4.4.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.73 Kernel Configuration
+# Linux/x86 4.4.74 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/kernel_config-4.9.x
+++ b/kernel/kernel_config-4.9.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.33 Kernel Configuration
+# Linux/x86 4.9.34 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.11.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.11.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From c42e6607e11e3b4c383c708945780eab5f33d115 Mon Sep 17 00:00:00 2001
+From eabe7c9b745f9b3bef37306727299eab4a176262 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/14] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.11.x/0002-vmbus-introduce-in-place-packet-iterator.patch
+++ b/kernel/patches-4.11.x/0002-vmbus-introduce-in-place-packet-iterator.patch
@@ -1,4 +1,4 @@
-From 0157dd928e72c3cabb79e31fe0f93a0044fca5f5 Mon Sep 17 00:00:00 2001
+From 7d877a010a560cc0348099b4c8e3bf234b196626 Mon Sep 17 00:00:00 2001
 From: stephen hemminger <stephen@networkplumber.org>
 Date: Mon, 27 Feb 2017 10:26:48 -0800
 Subject: [PATCH 02/14] vmbus: introduce in-place packet iterator

--- a/kernel/patches-4.11.x/0003-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
+++ b/kernel/patches-4.11.x/0003-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
@@ -1,4 +1,4 @@
-From 5dbc4d9dfc828cf15dba41423fbc643bc7a6a803 Mon Sep 17 00:00:00 2001
+From 9775eefb28bc96d40ade1e8ea051b28a493c3257 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:12 -0600
 Subject: [PATCH 03/14] vmbus: vmbus_open(): reset onchannel_callback on error

--- a/kernel/patches-4.11.x/0004-vmbus-add-the-matching-tasklet_enable-in-vmbus_close.patch
+++ b/kernel/patches-4.11.x/0004-vmbus-add-the-matching-tasklet_enable-in-vmbus_close.patch
@@ -1,4 +1,4 @@
-From 078cc623ad8b8bc567506f70362ca907249b9cae Mon Sep 17 00:00:00 2001
+From b701c1a304b18af51c4b3b8dc732d5199e521200 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:15 -0600
 Subject: [PATCH 04/14] vmbus: add the matching tasklet_enable() in

--- a/kernel/patches-4.11.x/0005-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.11.x/0005-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 6d6a2c8fdacea15f2d381b12b01d9bb8918ad881 Mon Sep 17 00:00:00 2001
+From 1cff3eedd1eaedb858d3f0954ea7023c4743eb9f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:20 -0600
 Subject: [PATCH 05/14] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.11.x/0006-vmbus-dynamically-enqueue-dequeue-a-channel-on-vmbus.patch
+++ b/kernel/patches-4.11.x/0006-vmbus-dynamically-enqueue-dequeue-a-channel-on-vmbus.patch
@@ -1,4 +1,4 @@
-From 5a79110cc9236ae8a256e5772fc7fb20e054e295 Mon Sep 17 00:00:00 2001
+From a039437a4ea724f1215076e9bcfc434105a9667c Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:23 -0600
 Subject: [PATCH 06/14] vmbus: dynamically enqueue/dequeue a channel on

--- a/kernel/patches-4.11.x/0007-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
+++ b/kernel/patches-4.11.x/0007-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
@@ -1,4 +1,4 @@
-From 13669d0ed72229a4a6aaf70931045618bf1b93e5 Mon Sep 17 00:00:00 2001
+From b5d4003d346fc2d990242ca318f5439da5365288 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:26 -0600
 Subject: [PATCH 07/14] hv_sock: implements Hyper-V transport for Virtual

--- a/kernel/patches-4.11.x/0008-VMCI-only-try-to-load-on-VMware-hypervisor.patch
+++ b/kernel/patches-4.11.x/0008-VMCI-only-try-to-load-on-VMware-hypervisor.patch
@@ -1,4 +1,4 @@
-From 094bc3a4d02e4b2859aaf17ffaca0dc39bbdca54 Mon Sep 17 00:00:00 2001
+From 8128c4c8eb73c2e7e2211c97237c66c9f670f980 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:29 -0600
 Subject: [PATCH 08/14] VMCI: only try to load on VMware hypervisor

--- a/kernel/patches-4.11.x/0009-hv_sock-add-the-support-of-auto-loading.patch
+++ b/kernel/patches-4.11.x/0009-hv_sock-add-the-support-of-auto-loading.patch
@@ -1,4 +1,4 @@
-From 0bf563e22285a5e47e8bec9a072cb711fa8fb8ef Mon Sep 17 00:00:00 2001
+From 6ba4d7ec83ef53c74326f3df0194744a8a3a2439 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:35 -0600
 Subject: [PATCH 09/14] hv_sock: add the support of auto-loading

--- a/kernel/patches-4.11.x/0010-hvsock-fix-a-race-in-hvs_stream_dequeue.patch
+++ b/kernel/patches-4.11.x/0010-hvsock-fix-a-race-in-hvs_stream_dequeue.patch
@@ -1,4 +1,4 @@
-From f388e1b30b8d0e121035e4598545e6d5c500204f Mon Sep 17 00:00:00 2001
+From c910448b6f03ae034ec17e5a0652055fea21aa4f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Tue, 16 May 2017 22:14:03 +0800
 Subject: [PATCH 10/14] hvsock: fix a race in hvs_stream_dequeue()

--- a/kernel/patches-4.11.x/0011-hvsock-fix-vsock_dequeue-enqueue_accept-race.patch
+++ b/kernel/patches-4.11.x/0011-hvsock-fix-vsock_dequeue-enqueue_accept-race.patch
@@ -1,4 +1,4 @@
-From fd936b22fd146f933fe8c8f246c3b2ea8d96a3ba Mon Sep 17 00:00:00 2001
+From 655c44f5f5d64198e7732e0c4c0b777c6f857c59 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 19 May 2017 21:49:59 +0800
 Subject: [PATCH 11/14] hvsock: fix vsock_dequeue/enqueue_accept race

--- a/kernel/patches-4.11.x/0012-Drivers-hv-vmbus-Fix-rescind-handling.patch
+++ b/kernel/patches-4.11.x/0012-Drivers-hv-vmbus-Fix-rescind-handling.patch
@@ -1,4 +1,4 @@
-From de7f4206672ba05e075a2169c6c89eb4e493c286 Mon Sep 17 00:00:00 2001
+From 25b0cb9e9edae902c5381f1ee7135a49f584b1e1 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Sun, 30 Apr 2017 16:21:18 -0700
 Subject: [PATCH 12/14] Drivers: hv: vmbus: Fix rescind handling

--- a/kernel/patches-4.11.x/0013-vmbus-fix-hv_percpu_channel_deq-enq-race.patch
+++ b/kernel/patches-4.11.x/0013-vmbus-fix-hv_percpu_channel_deq-enq-race.patch
@@ -1,4 +1,4 @@
-From 340f3ef0217391cc819c5f86bae178ef3a63d07e Mon Sep 17 00:00:00 2001
+From a7623f6457a6af31e1938ae6be55b46d2bc924fe Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 5 Jun 2017 16:13:18 +0800
 Subject: [PATCH 13/14] vmbus:  fix hv_percpu_channel_deq/enq race

--- a/kernel/patches-4.11.x/0014-vmbus-add-vmbus-onoffer-onoffer_rescind-sync.patch
+++ b/kernel/patches-4.11.x/0014-vmbus-add-vmbus-onoffer-onoffer_rescind-sync.patch
@@ -1,4 +1,4 @@
-From 9ec29a4f7fedfbde713c328a5b3012c993e30f1e Mon Sep 17 00:00:00 2001
+From 099d558865029028ecf526cd09c63119f434f478 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 5 Jun 2017 21:32:00 +0800
 Subject: [PATCH 14/14] vmbus: add vmbus onoffer/onoffer_rescind sync.

--- a/kernel/patches-4.4.x/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
+++ b/kernel/patches-4.4.x/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
@@ -1,4 +1,4 @@
-From a7ab275b7c2abfe523187057a331e127fb7a0773 Mon Sep 17 00:00:00 2001
+From d54db2f6ef15bf1bb4bb60072756abd4419ac7d9 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 17 Dec 2015 16:53:43 +0800
 Subject: [PATCH 01/44] virtio: make find_vqs() checkpatch.pl-friendly

--- a/kernel/patches-4.4.x/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
+++ b/kernel/patches-4.4.x/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
@@ -1,4 +1,4 @@
-From da3c419b89b1a171a677ca086d89ad0e611de03e Mon Sep 17 00:00:00 2001
+From 21f69559f7781710dbbb134da0fd36d4d4bfd03f Mon Sep 17 00:00:00 2001
 From: Julia Lawall <julia.lawall@lip6.fr>
 Date: Sat, 21 Nov 2015 18:39:17 +0100
 Subject: [PATCH 02/44] VSOCK: constify vmci_transport_notify_ops structures

--- a/kernel/patches-4.4.x/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
+++ b/kernel/patches-4.4.x/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
@@ -1,4 +1,4 @@
-From 872f8584a36a483280a806b6d0afde83c8f0ceed Mon Sep 17 00:00:00 2001
+From 1f8002273552b3e31f4255bfc60f60ae4e862f53 Mon Sep 17 00:00:00 2001
 From: Claudio Imbrenda <imbrenda@linux.vnet.ibm.com>
 Date: Tue, 22 Mar 2016 17:05:52 +0100
 Subject: [PATCH 03/44] AF_VSOCK: Shrink the area influenced by prepare_to_wait

--- a/kernel/patches-4.4.x/0004-vsock-make-listener-child-lock-ordering-explicit.patch
+++ b/kernel/patches-4.4.x/0004-vsock-make-listener-child-lock-ordering-explicit.patch
@@ -1,4 +1,4 @@
-From 0f5ac5dc71f20dfb46a2c1094171677661ef0aa0 Mon Sep 17 00:00:00 2001
+From c8dc3e9da5364cc99ce3e625dac34cd1868588d9 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 23 Jun 2016 16:28:58 +0100
 Subject: [PATCH 04/44] vsock: make listener child lock ordering explicit

--- a/kernel/patches-4.4.x/0005-VSOCK-transport-specific-vsock_transport-functions.patch
+++ b/kernel/patches-4.4.x/0005-VSOCK-transport-specific-vsock_transport-functions.patch
@@ -1,4 +1,4 @@
-From b6de8e0498109efeb6a8414004a933c906b59318 Mon Sep 17 00:00:00 2001
+From 4bf54df767428ec18cb2d1f8550806163386825e Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:30 +0100
 Subject: [PATCH 05/44] VSOCK: transport-specific vsock_transport functions

--- a/kernel/patches-4.4.x/0006-VSOCK-defer-sock-removal-to-transports.patch
+++ b/kernel/patches-4.4.x/0006-VSOCK-defer-sock-removal-to-transports.patch
@@ -1,4 +1,4 @@
-From 134048e777be5ab1cec359b736cb74cffc194880 Mon Sep 17 00:00:00 2001
+From 46ad8affca21edda770e5a277d98fc05697f49cd Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:31 +0100
 Subject: [PATCH 06/44] VSOCK: defer sock removal to transports

--- a/kernel/patches-4.4.x/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
+++ b/kernel/patches-4.4.x/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
@@ -1,4 +1,4 @@
-From 7b0206c352ca32f02da0ba4678ab1cbdd8bbe73a Mon Sep 17 00:00:00 2001
+From 4d95dc6a0b180fb0f9e095472b327787e060b797 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:32 +0100
 Subject: [PATCH 07/44] VSOCK: Introduce virtio_vsock_common.ko

--- a/kernel/patches-4.4.x/0008-VSOCK-Introduce-virtio_transport.ko.patch
+++ b/kernel/patches-4.4.x/0008-VSOCK-Introduce-virtio_transport.ko.patch
@@ -1,4 +1,4 @@
-From a7fe0590b83d21b7cc9d6b7b99a2ef3480fa8a51 Mon Sep 17 00:00:00 2001
+From 16dd1c86ad405e7581e1dbf7fc6796a4996a9737 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:33 +0100
 Subject: [PATCH 08/44] VSOCK: Introduce virtio_transport.ko

--- a/kernel/patches-4.4.x/0009-VSOCK-Introduce-vhost_vsock.ko.patch
+++ b/kernel/patches-4.4.x/0009-VSOCK-Introduce-vhost_vsock.ko.patch
@@ -1,4 +1,4 @@
-From a2c0cb91703f2841d98ab0819e6b9b5916db28c5 Mon Sep 17 00:00:00 2001
+From 1ab9d8f8b8711ca9c151e43e23780f0475a6d06e Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:34 +0100
 Subject: [PATCH 09/44] VSOCK: Introduce vhost_vsock.ko

--- a/kernel/patches-4.4.x/0010-VSOCK-Add-Makefile-and-Kconfig.patch
+++ b/kernel/patches-4.4.x/0010-VSOCK-Add-Makefile-and-Kconfig.patch
@@ -1,4 +1,4 @@
-From 1c31c8246f50c31a1e4bc6b2228758ffd063d2e2 Mon Sep 17 00:00:00 2001
+From 7a85d424f072e08808929f1911eec5afd139cc33 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:35 +0100
 Subject: [PATCH 10/44] VSOCK: Add Makefile and Kconfig

--- a/kernel/patches-4.4.x/0011-VSOCK-Use-kvfree.patch
+++ b/kernel/patches-4.4.x/0011-VSOCK-Use-kvfree.patch
@@ -1,4 +1,4 @@
-From 0232cfa27fdd20b03a54e0f0aa034366b6a8b486 Mon Sep 17 00:00:00 2001
+From 9e70f70e0544f67955206e3daa6718c2bb69f50f Mon Sep 17 00:00:00 2001
 From: Wei Yongjun <weiyj.lk@gmail.com>
 Date: Tue, 2 Aug 2016 13:50:42 +0000
 Subject: [PATCH 11/44] VSOCK: Use kvfree()

--- a/kernel/patches-4.4.x/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
+++ b/kernel/patches-4.4.x/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
@@ -1,4 +1,4 @@
-From fe052d854cdbe49a8baffac66963bc18d122a5a1 Mon Sep 17 00:00:00 2001
+From 79235b89627325730f467538cc6930b752e70274 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 4 Aug 2016 14:52:53 +0100
 Subject: [PATCH 12/44] vhost/vsock: fix vhost virtio_vsock_pkt use-after-free

--- a/kernel/patches-4.4.x/0013-virtio-vsock-fix-include-guard-typo.patch
+++ b/kernel/patches-4.4.x/0013-virtio-vsock-fix-include-guard-typo.patch
@@ -1,4 +1,4 @@
-From f4c7332b02ca9e4ae80181fc1d87d0a9bbf9e9a1 Mon Sep 17 00:00:00 2001
+From 15e83cf74b9b7b192db436f12bccf3918d9be253 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Fri, 5 Aug 2016 13:52:09 +0100
 Subject: [PATCH 13/44] virtio-vsock: fix include guard typo

--- a/kernel/patches-4.4.x/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
+++ b/kernel/patches-4.4.x/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
@@ -1,4 +1,4 @@
-From 5e502ae4a8f1bf835e6408fc78a1765f51ddb125 Mon Sep 17 00:00:00 2001
+From 5e1ac4ddabdf932e79eef6434a92ce7800d20873 Mon Sep 17 00:00:00 2001
 From: Gerard Garcia <ggarcia@deic.uab.cat>
 Date: Wed, 10 Aug 2016 17:24:34 +0200
 Subject: [PATCH 14/44] vhost/vsock: drop space available check for TX vq

--- a/kernel/patches-4.4.x/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/kernel/patches-4.4.x/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,4 +1,4 @@
-From 8f6f53556832dfb277d2e0c5ea503246be81aedb Mon Sep 17 00:00:00 2001
+From 38d1c8303b17a7f5907ba6a95409f472b08d6a7f Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
 Subject: [PATCH 15/44] VSOCK: Only allow host network namespace to use

--- a/kernel/patches-4.4.x/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
+++ b/kernel/patches-4.4.x/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
@@ -1,4 +1,4 @@
-From d77bb8fc3849e1fa131cb60ae88e8c0e308638fd Mon Sep 17 00:00:00 2001
+From 70b5a3de98b223d5cbde7a2282c175b3af070f8e Mon Sep 17 00:00:00 2001
 From: Jake Oshins <jakeo@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:41 -0800
 Subject: [PATCH 16/44] drivers:hv: Define the channel type for Hyper-V PCI

--- a/kernel/patches-4.4.x/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
+++ b/kernel/patches-4.4.x/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
@@ -1,4 +1,4 @@
-From 9b03fb8edf624da46b63619c7457364b2105558c Mon Sep 17 00:00:00 2001
+From 35ab83acaf12ac268d8f0c23410b377973828963 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:43 -0800
 Subject: [PATCH 17/44] Drivers: hv: vmbus: Use uuid_le type consistently

--- a/kernel/patches-4.4.x/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
+++ b/kernel/patches-4.4.x/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
@@ -1,4 +1,4 @@
-From 066d23bcd1f7f411c8197e459c592160002e6048 Mon Sep 17 00:00:00 2001
+From ab8bbb657b0c4160c47995b2ef8e8eef986eba15 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:44 -0800
 Subject: [PATCH 18/44] Drivers: hv: vmbus: Use uuid_le_cmp() for comparing

--- a/kernel/patches-4.4.x/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
+++ b/kernel/patches-4.4.x/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
@@ -1,4 +1,4 @@
-From eac620960a72cbb65490315a84e962594fb3c324 Mon Sep 17 00:00:00 2001
+From 6da9128a57c87feb0c476249e27d957d3aa488cd Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:48 -0800
 Subject: [PATCH 19/44] Drivers: hv: vmbus: do sanity check of channel state in

--- a/kernel/patches-4.4.x/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
+++ b/kernel/patches-4.4.x/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
@@ -1,4 +1,4 @@
-From 6f5dc56496e57510dd1a00d9f5fce580b76f2719 Mon Sep 17 00:00:00 2001
+From 245423a362a1da468343c13e769ae18d6eae261c Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:50 -0800
 Subject: [PATCH 20/44] Drivers: hv: vmbus: release relid on error in

--- a/kernel/patches-4.4.x/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
+++ b/kernel/patches-4.4.x/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
@@ -1,4 +1,4 @@
-From c7719ca663995d6bc720c19be7d5f26b52f9d604 Mon Sep 17 00:00:00 2001
+From 2b4065774fa5a757bbeaa87c29f6683abc798e39 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:51 -0800
 Subject: [PATCH 21/44] Drivers: hv: vmbus: channge

--- a/kernel/patches-4.4.x/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
+++ b/kernel/patches-4.4.x/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
@@ -1,4 +1,4 @@
-From ec2710bd3ed119b3956acb94f09f2a0f862e3a08 Mon Sep 17 00:00:00 2001
+From a6a5675a6a53af64f2f959ed8771ce75cab88905 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Mon, 14 Dec 2015 19:02:00 -0800
 Subject: [PATCH 22/44] Drivers: hv: remove code duplication between

--- a/kernel/patches-4.4.x/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
+++ b/kernel/patches-4.4.x/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
@@ -1,4 +1,4 @@
-From 0b89e5b7f0da6bd8d17ceeb1f9cad04a7474bcff Mon Sep 17 00:00:00 2001
+From f71657d1534f594e880dd9679afc624dc18c3e80 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Dec 2015 12:21:22 -0800
 Subject: [PATCH 23/44] Drivers: hv: vmbus: fix the building warning with

--- a/kernel/patches-4.4.x/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
+++ b/kernel/patches-4.4.x/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
@@ -1,4 +1,4 @@
-From 94314f134a85814267d4fa269f706d006946fdca Mon Sep 17 00:00:00 2001
+From ff2a6f7f7ee97d4134949a5320ab6edebb61cb99 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Tue, 15 Dec 2015 16:27:27 -0800
 Subject: [PATCH 24/44] Drivers: hv: vmbus: Treat Fibre Channel devices as

--- a/kernel/patches-4.4.x/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
+++ b/kernel/patches-4.4.x/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
@@ -1,4 +1,4 @@
-From 6797df497d7ff22007b1410f9528d7a9d6af118c Mon Sep 17 00:00:00 2001
+From 774c27bf877b57e935503e793bcab59b67760b54 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Fri, 25 Dec 2015 20:00:30 -0800
 Subject: [PATCH 25/44] Drivers: hv: vmbus: Add vendor and device atttributes

--- a/kernel/patches-4.4.x/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
+++ b/kernel/patches-4.4.x/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
@@ -1,4 +1,4 @@
-From 126cb3ed942608e926983b036040215a3b2a7265 Mon Sep 17 00:00:00 2001
+From b7fa5bbf2cdeda43d5e2b3ba18ba52f665ae158b Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:37 -0800
 Subject: [PATCH 26/44] Drivers: hv: vmbus: add a helper function to set a

--- a/kernel/patches-4.4.x/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
+++ b/kernel/patches-4.4.x/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
@@ -1,4 +1,4 @@
-From f3c98341da6474cc6a455da186fb50d2e6470ab7 Mon Sep 17 00:00:00 2001
+From 94c1405985cfa85e8c2cc41c300c6733c8362f65 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:38 -0800
 Subject: [PATCH 27/44] Drivers: hv: vmbus: define the new offer type for

--- a/kernel/patches-4.4.x/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
+++ b/kernel/patches-4.4.x/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
@@ -1,4 +1,4 @@
-From df87a3033a8fb6c8c315987a689a50b6ea41f6d9 Mon Sep 17 00:00:00 2001
+From 18eb938c6db8b9c7dffb7c3b78223a608dbd4754 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:39 -0800
 Subject: [PATCH 28/44] Drivers: hv: vmbus: vmbus_sendpacket_ctl: hvsock: avoid

--- a/kernel/patches-4.4.x/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
+++ b/kernel/patches-4.4.x/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
@@ -1,4 +1,4 @@
-From b337b6399bcea6eba637d4027e02edcb4ae7be8d Mon Sep 17 00:00:00 2001
+From d083af622027f48d514b52e666120d44a85b8d89 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:40 -0800
 Subject: [PATCH 29/44] Drivers: hv: vmbus: define a new VMBus message type for

--- a/kernel/patches-4.4.x/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
+++ b/kernel/patches-4.4.x/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
@@ -1,4 +1,4 @@
-From 5a9a71bd0cfab45781ba7a5067b7a6b6b5d30047 Mon Sep 17 00:00:00 2001
+From 890cafa3332a85d39b28327f9b13e3b6c7d6efc6 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:41 -0800
 Subject: [PATCH 30/44] Drivers: hv: vmbus: add a hvsock flag in struct

--- a/kernel/patches-4.4.x/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
+++ b/kernel/patches-4.4.x/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
@@ -1,4 +1,4 @@
-From b7d6a94f1b533fdb6719d919999c923b139041ab Mon Sep 17 00:00:00 2001
+From 980e9f3bdc7ac24f92c5a46db3c853c4d51fdccd Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:42 -0800
 Subject: [PATCH 31/44] Drivers: hv: vmbus: add a per-channel rescind callback

--- a/kernel/patches-4.4.x/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
+++ b/kernel/patches-4.4.x/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
@@ -1,4 +1,4 @@
-From 27412510d8387afed98b7c9578669334e2c915e9 Mon Sep 17 00:00:00 2001
+From d71994a9123b077422d25caa7fe8dd5d6cc00e2b Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:43 -0800
 Subject: [PATCH 32/44] Drivers: hv: vmbus: add an API

--- a/kernel/patches-4.4.x/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
+++ b/kernel/patches-4.4.x/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
@@ -1,4 +1,4 @@
-From 5008faf3f6693444332bd46ca955cbab742eaec9 Mon Sep 17 00:00:00 2001
+From 7bfc57aa67900875d2cc85b83ea105ac2f8a5ea2 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:45 -0800
 Subject: [PATCH 33/44] Drivers: hv: vmbus: Give control over how the ring

--- a/kernel/patches-4.4.x/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
+++ b/kernel/patches-4.4.x/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
@@ -1,4 +1,4 @@
-From 02c09488deec0c48a6779b79ebbc8d79bc49fc6a Mon Sep 17 00:00:00 2001
+From 6a5dbd141d423dd1be2f3073831295dade952266 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:16 -0800
 Subject: [PATCH 34/44] Drivers: hv: vmbus: avoid wait_for_completion() on

--- a/kernel/patches-4.4.x/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
+++ b/kernel/patches-4.4.x/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
@@ -1,4 +1,4 @@
-From 1f479feb70f6499fc6a76d16cd27a46c406a7506 Mon Sep 17 00:00:00 2001
+From 0cd87aa963fd820068c9540b7ff7cb71427e554f Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:18 -0800
 Subject: [PATCH 35/44] Drivers: hv: vmbus: avoid unneeded compiler

--- a/kernel/patches-4.4.x/0036-kcm-Kernel-Connection-Multiplexor-module.patch
+++ b/kernel/patches-4.4.x/0036-kcm-Kernel-Connection-Multiplexor-module.patch
@@ -1,4 +1,4 @@
-From c7bee5cc4968ffbbda4572a7875b84d49c8eaa96 Mon Sep 17 00:00:00 2001
+From 60940b6fabc9998ec1d3be1f2cb76a96c453a71b Mon Sep 17 00:00:00 2001
 From: Tom Herbert <tom@herbertland.com>
 Date: Mon, 7 Mar 2016 14:11:06 -0800
 Subject: [PATCH 36/44] kcm: Kernel Connection Multiplexor module

--- a/kernel/patches-4.4.x/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4.x/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From ab0ec69e498e9fc4f559bb75e87ea468477128f7 Mon Sep 17 00:00:00 2001
+From c003d6b3a50a00a849f74e0480d479d2b4638591 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:51:09 -0700
 Subject: [PATCH 37/44] net: add the AF_KCM entries to family name tables

--- a/kernel/patches-4.4.x/0038-net-Add-Qualcomm-IPC-router.patch
+++ b/kernel/patches-4.4.x/0038-net-Add-Qualcomm-IPC-router.patch
@@ -1,4 +1,4 @@
-From a269d65358dc73d02f116d14753d8ff012ec7f9d Mon Sep 17 00:00:00 2001
+From f11c159a5ba9ad5ef841fd346be564fd133368b7 Mon Sep 17 00:00:00 2001
 From: Courtney Cavin <courtney.cavin@sonymobile.com>
 Date: Wed, 27 Apr 2016 12:13:03 -0700
 Subject: [PATCH 38/44] net: Add Qualcomm IPC router

--- a/kernel/patches-4.4.x/0039-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.4.x/0039-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 249bd23c69270854f5565b2658b4ff76c2d09c6d Mon Sep 17 00:00:00 2001
+From 9f4e0efcd1de4ec21001681dd09d525d603ee3c1 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 15 May 2016 09:53:11 -0700
 Subject: [PATCH 39/44] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.4.x/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4.x/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From 8723825fa9f9460e80e9fe9323594a477c6fac7a Mon Sep 17 00:00:00 2001
+From 7819faefe7fca19c1c4bd888cd9a925bc0fc9916 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:53:08 -0700
 Subject: [PATCH 40/44] net: add the AF_HYPERV entries to family name tables

--- a/kernel/patches-4.4.x/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
+++ b/kernel/patches-4.4.x/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
@@ -1,4 +1,4 @@
-From b540433a501bc1258ddd6c92245388cdd678a2da Mon Sep 17 00:00:00 2001
+From e17441686ee04ccdd8dece3182b0981e0aedfae0 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 21 May 2016 16:55:50 +0800
 Subject: [PATCH 41/44] Drivers: hv: vmbus: fix the race when querying &

--- a/kernel/patches-4.4.x/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.4.x/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From c138534f076346b593759207cdf530dec1ae7757 Mon Sep 17 00:00:00 2001
+From 3e92f9b394e2e8139837c6df95f1995ae0c82108 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 42/44] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.4.x/0043-fs-add-filp_clone_open-API.patch
+++ b/kernel/patches-4.4.x/0043-fs-add-filp_clone_open-API.patch
@@ -1,4 +1,4 @@
-From 168a009365fc0a4265f1397da70b485f95f6efb6 Mon Sep 17 00:00:00 2001
+From cedfd2418afee3b8dd90c296018b46e8e97c8f9c Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:49:38 -0800
 Subject: [PATCH 43/44] fs: add filp_clone_open API

--- a/kernel/patches-4.4.x/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
+++ b/kernel/patches-4.4.x/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
@@ -1,4 +1,4 @@
-From ab2fee51e3c398c7af5c958aec82dff1a4184ecd Mon Sep 17 00:00:00 2001
+From f6a8db10eaf2d4a2b6ed190c2ea8b653ab144663 Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:51:16 -0800
 Subject: [PATCH 44/44] binfmt_misc: add persistent opened binary handler for

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 9ec110b99b7bfb2a6b7049f67c736b59b9d7702c Mon Sep 17 00:00:00 2001
+From 1205f3c82be709022f1bc6d0011ae04dbc95117b Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From f189433bac55676e8333849641e532bfa53e4e53 Mon Sep 17 00:00:00 2001
+From daa94e5286814db40d05bef5e4f50810677ab6c6 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 54b1322914ec2e0e0d08363a1cbe79e573db0d8e Mon Sep 17 00:00:00 2001
+From b4a3e1d41b8ba8a848abad826178dd218a15e99a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 0b1ed67f0ffcdf5160872d386363c9c5e6bd66e5 Mon Sep 17 00:00:00 2001
+From d20e921e95309446488816cb5df8f71a3650b3d8 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 1d34aef3e09441cf3e419613b013f863f220606e Mon Sep 17 00:00:00 2001
+From 12b336a88d9b6320b371cc7f2a6da7044eecbb67 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From c4347caa33bb0d9941919a63eb650e48824dfa19 Mon Sep 17 00:00:00 2001
+From edabdfe299df2365149453dae57c518c6062a0d3 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From 28046dde546493fc42944d3c521eb3c535457221 Mon Sep 17 00:00:00 2001
+From 695f896acacdb16520a53f08a0a1a6a8ab1df7f8 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From 6ac1653829b11e4b6344d98bd3451e7b9acfc78f Mon Sep 17 00:00:00 2001
+From 1e188db4e456f215215900af1c21bf81dd4d2138 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 453edabef7cc860f93f39967c830bb24caf1ae93 Mon Sep 17 00:00:00 2001
+From 53d5a403fd7f58615ead72244b6a402ba15c8e54 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From 957317b8926419ff5dcd19c84ecd93f63ff6db0d Mon Sep 17 00:00:00 2001
+From 5727c5221ef2f78336810cb278c804c2096d385e Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 236f80adf178f799edbee75e0772dc1f11ad56ca Mon Sep 17 00:00:00 2001
+From dcdfed9cdb45bc98b748916e40b650d2ad07ed37 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 723d88551facf0f422f64b6a713db274afde7283 Mon Sep 17 00:00:00 2001
+From 407f802474b95ebb4efd3085089008d2cde438fa Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on


### PR DESCRIPTION
In particular this contains 1be7107fbe18eed3e319 ("mm: larger stack guard gap, between vmas") which is a fix for CVE-2017-1000364.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>