### PR TITLE
Add Avi Deitcher as a maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,6 +11,7 @@
 [Org]
 	[Org."Core maintainers"]
 		people = [
+			"deitch",
 			"ijc",
 			"justincormack",
 			"riyazdf",
@@ -24,6 +25,10 @@
 # in the people section.
 
 	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+	[People.deitch]
+	Name = "Avi Deitcher"
+	Email = "avi@atomicinc.com"
+	GitHub = "deitch"
 
 	[People.ijc]
 	Name = "Ian Campbell"


### PR DESCRIPTION
Avi has been contributing to many areas of LinuxKit, including support
for containerised `getty`, encrypted swap and other areas.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![loriculus_vernalis_-ganeshgudi _karnataka _india_-male-8-1c](https://user-images.githubusercontent.com/482364/27634972-49a74fbe-5bfd-11e7-9958-36885c01c72d.jpg)
