### PR TITLE
Fixes/improvements to `pkg/package.mk`

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -22,7 +22,7 @@ HASH_COMMIT?=HEAD # Setting this is only really useful with the show-tag target
 HASH?=$(shell git ls-tree --full-tree $(HASH_COMMIT) -- $(CURDIR) | awk '{print $$3}')
 
 ifneq ($(HASH_COMMIT),HEAD) # Others can't be dirty by definition
-DIRTY=$(shell git diff-index --quiet HEAD -- $(CURDIR) || echo "-dirty")
+DIRTY=$(shell  git update-index -q --refresh && git diff-index --quiet HEAD -- $(CURDIR) || echo "-dirty")
 endif
 endif
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -12,25 +12,21 @@
 # which is specific to a given kernel. perf packages are tagged the same way
 # kernel packages.
 
-# Git tree hash of this directory. Override to force build
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 # Name and Org on Hub
 ORG?=linuxkit
 IMAGE:=kernel
 IMAGE_PERF:=kernel-perf
 
-# Add '-dirty' to hash if the repository is not clean. make does not
-# concatenate strings without spaces, so we use the documented trick
-# of replacing the space with nothing.
-DIRTY=$(shell git diff-index --quiet HEAD --; echo $$?)
-ifneq ($(DIRTY),0)
-HASH+=-dirty
-nullstring :=
-space := $(nullstring) $(nullstring)
-TAG=$(subst $(space),,$(HASH))
-else
-TAG=$(HASH)
+ifeq ($(HASH),)
+HASH_COMMIT?=HEAD # Setting this is only really useful with the show-tag target
+HASH?=$(shell git ls-tree --full-tree $(HASH_COMMIT) -- $(CURDIR) | awk '{print $$3}')
+
+ifneq ($(HASH_COMMIT),HEAD) # Others can't be dirty by definition
+DIRTY=$(shell git diff-index --quiet HEAD -- $(CURDIR) || echo "-dirty")
 endif
+endif
+
+TAG=$(HASH)$(DIRTY)
 
 .PHONY: check tag push
 # Targets:
@@ -59,14 +55,18 @@ build_$(2)$(3): Dockerfile Makefile $(wildcard patches-$(2)/*) kernel_config-$(2
 			--no-cache -t $(ORG)/$(IMAGE):$(1)$(3)-$(TAG) .
 
 push_$(2)$(3): build_$(2)$(3)
-	@if [ $(DIRTY) -ne 0 ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+	@if [ x"$(DIRTY)" !=  x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
 	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(1)$(3)-$(TAG) || \
 		(DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(1)$(3)-$(TAG) && \
 		 docker tag $(ORG)/$(IMAGE):$(1)$(3)-$(TAG) $(ORG)/$(IMAGE):$(1)$(3) && \
 		 DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(1)$(3))
 
+show-tag_$(2)$(3):
+	@echo $(ORG)/$(IMAGE):$(1)$(3)-$(TAG)
+
 build: build_$(2)$(3)
 push: push_$(2)$(3)
+show-tags: show-tag_$(2)$(3)
 
 ifneq ($(2), 4.4.x)
 build_perf_$(2)$(3): build_$(2)$(3)
@@ -76,7 +76,7 @@ build_perf_$(2)$(3): build_$(2)$(3)
 	 		--no-cache --network=none -t $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG) .
 
 push_perf_$(2)$(3): build_perf_$(2)$(3)
-	@if [ $(DIRTY) -ne 0 ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+	@if [ x"$(DIRTY)" != x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
 	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG) || \
 		(DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG) && \
 		 docker tag $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG) $(ORG)/$(IMAGE_PERF):$(1)$(3) && \

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,4 +1,4 @@
-DIRS = $(shell find . -type d -depth 1)
+DIRS = $(shell find . -maxdepth 1 -mindepth 1 -type d)
 .PHONY: clean dirs $(DIRS)
 
 push:

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -6,7 +6,7 @@ HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 BASE_DEPS=Dockerfile Makefile
 
 DIRTY=$(shell git diff-index --quiet HEAD -- ../$(notdir $(CURDIR)) || echo "-dirty")
-TAG=$(HASH)$(DIRTY)
+TAG=$(ORG)/$(IMAGE):$(HASH)$(DIRTY)
 
 # Get a release tag, if present
 RELEASE=$(shell git tag -l --points-at HEAD)
@@ -18,19 +18,19 @@ NET_OPT=--network=none
 endif
 
 show-tag:
-	@echo $(ORG)/$(IMAGE):$(TAG)
+	@echo $(TAG)
 
 tag: $(BASE_DEPS) $(DEPS)
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(TAG) || \
-	docker build $(NET_OPT) -t $(ORG)/$(IMAGE):$(TAG) .
+	DOCKER_CONTENT_TRUST=1 docker pull $(TAG) || \
+	docker build $(NET_OPT) -t $(TAG) .
 
 push: tag
 ifneq ($(DIRTY),)
 	$(error Your repository is not clean. Will not push package image.)
 endif
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(TAG) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(TAG)
+	DOCKER_CONTENT_TRUST=1 docker pull $(TAG) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(TAG)
 ifneq ($(RELEASE),)
-	docker tag $(ORG)/$(IMAGE):$(TAG) $(ORG)/$(IMAGE):$(RELEASE)	
+	docker tag $(TAG) $(ORG)/$(IMAGE):$(RELEASE)
 	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(RELEASE)
 endif

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -2,14 +2,18 @@
 default: push
 
 ORG?=linuxkit
+ifeq ($(HASH),)
 HASH_COMMIT?=HEAD # Setting this is only really useful with the show-tag target
 HASH?=$(shell git ls-tree --full-tree $(HASH_COMMIT) -- $(CURDIR) | awk '{print $$3}')
-BASE_DEPS=Dockerfile Makefile
 
 ifneq ($(HASH_COMMIT),HEAD) # Others can't be dirty by definition
 DIRTY=$(shell git diff-index --quiet HEAD -- $(CURDIR) || echo "-dirty")
 endif
+endif
+
 TAG=$(ORG)/$(IMAGE):$(HASH)$(DIRTY)
+
+BASE_DEPS=Dockerfile Makefile
 
 # Get a release tag, if present
 RELEASE=$(shell git tag -l --points-at HEAD)

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -2,10 +2,10 @@
 default: push
 
 ORG?=linuxkit
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
+HASH?=$(shell git ls-tree --full-tree HEAD -- $(CURDIR) | awk '{print $$3}')
 BASE_DEPS=Dockerfile Makefile
 
-DIRTY=$(shell git diff-index --quiet HEAD -- ../$(notdir $(CURDIR)) || echo "-dirty")
+DIRTY=$(shell git diff-index --quiet HEAD -- $(CURDIR) || echo "-dirty")
 TAG=$(ORG)/$(IMAGE):$(HASH)$(DIRTY)
 
 # Get a release tag, if present

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -5,18 +5,8 @@ ORG?=linuxkit
 HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 BASE_DEPS=Dockerfile Makefile
 
-# Add '-dirty' to hash if the repository is not clean. make does not
-# concatenate strings without spaces, so we use the documented trick
-# of replacing the space with nothing.
-DIRTY=$(shell git diff-index --quiet HEAD --; echo $$?)
-ifneq ($(DIRTY),0)
-HASH+=-dirty
-nullstring :=
-space := $(nullstring) $(nullstring)
-TAG=$(subst $(space),,$(HASH))
-else
-TAG=$(HASH)
-endif
+DIRTY=$(shell git diff-index --quiet HEAD -- ) || echo "-dirty")
+TAG=$(HASH)$(DIRTY)
 
 # Get a release tag, if present
 RELEASE=$(shell git tag -l --points-at HEAD)
@@ -35,7 +25,7 @@ tag: $(BASE_DEPS) $(DEPS)
 	docker build $(NET_OPT) -t $(ORG)/$(IMAGE):$(TAG) .
 
 push: tag
-ifneq ($(DIRTY),0)
+ifneq ($(DIRTY),)
 	$(error Your repository is not clean. Will not push package image.)
 endif
 	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(TAG) || \

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -2,10 +2,13 @@
 default: push
 
 ORG?=linuxkit
-HASH?=$(shell git ls-tree --full-tree HEAD -- $(CURDIR) | awk '{print $$3}')
+HASH_COMMIT?=HEAD # Setting this is only really useful with the show-tag target
+HASH?=$(shell git ls-tree --full-tree $(HASH_COMMIT) -- $(CURDIR) | awk '{print $$3}')
 BASE_DEPS=Dockerfile Makefile
 
+ifneq ($(HASH_COMMIT),HEAD) # Others can't be dirty by definition
 DIRTY=$(shell git diff-index --quiet HEAD -- $(CURDIR) || echo "-dirty")
+endif
 TAG=$(ORG)/$(IMAGE):$(HASH)$(DIRTY)
 
 # Get a release tag, if present

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -5,7 +5,7 @@ ORG?=linuxkit
 HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 BASE_DEPS=Dockerfile Makefile
 
-DIRTY=$(shell git diff-index --quiet HEAD -- ) || echo "-dirty")
+DIRTY=$(shell git diff-index --quiet HEAD -- ../$(notdir $(CURDIR)) || echo "-dirty")
 TAG=$(HASH)$(DIRTY)
 
 # Get a release tag, if present

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -7,7 +7,7 @@ HASH_COMMIT?=HEAD # Setting this is only really useful with the show-tag target
 HASH?=$(shell git ls-tree --full-tree $(HASH_COMMIT) -- $(CURDIR) | awk '{print $$3}')
 
 ifneq ($(HASH_COMMIT),HEAD) # Others can't be dirty by definition
-DIRTY=$(shell git diff-index --quiet HEAD -- $(CURDIR) || echo "-dirty")
+DIRTY=$(shell git update-index -q --refresh && git diff-index --quiet HEAD -- $(CURDIR) || echo "-dirty")
 endif
 endif
 

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -1,4 +1,4 @@
-.PHONY: tag push
+.PHONY: image tag show-tag
 default: push
 
 ORG?=linuxkit
@@ -26,6 +26,9 @@ NET_OPT=
 else
 NET_OPT=--network=none
 endif
+
+show-tag:
+	@echo $(ORG)/$(IMAGE):$(TAG)
 
 tag: $(BASE_DEPS) $(DEPS)
 	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(TAG) || \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,4 @@
-DIRS = $(shell find . -type d -depth 1)
+DIRS = $(shell find . -maxdepth 1 -mindepth 1 -type d)
 .PHONY: clean dirs $(DIRS)
 
 push: $(DIRS)

--- a/tools/go-compile/Makefile
+++ b/tools/go-compile/Makefile
@@ -1,15 +1,4 @@
-.PHONY: tag push
-default: push
+include ../../pkg/package.mk
 
-ORG?=linuxkit
 IMAGE=go-compile
-DEPS=Dockerfile Makefile compile.sh
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)
+DEPS=compile.sh

--- a/tools/qemu/Makefile
+++ b/tools/qemu/Makefile
@@ -1,15 +1,3 @@
-.PHONY: tag push
-default: push
+include ../../pkg/package.mk
 
-ORG?=linuxkit
 IMAGE=qemu
-DEPS=Dockerfile Makefile
-
-HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
-
-tag: $(DEPS)
-	DOCKER_CONTENT_TRUST=1 docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
-
-push: tag
-	docker pull $(ORG)/$(IMAGE):$(HASH) || \
-	docker push $(ORG)/$(IMAGE):$(HASH)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Various fixes/improvements to `pkg/package.mk`:
* Added a convenience target to print out the tag
* Simplified implementation of `-dirty` suffix and restricted it to only consider the package directory (same as for the hash itself)
* Consolidated the uses of `$(ORG)/$(IMAGE):$(HASH)`
* Fixed hash calculation for Jessie era git (loosely based on https://github.com/linuxkit/linuxkit/pull/2063#issuecomment-310465640)

**- How I did it**

Typing.

**- How to verify it**

I used:
```
$ for pkg in init containerd ; do make -C pkg/$pkg --no-print-directory show-tag; ( cd pkg/$pkg && make show-tag ); done
linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389-dirty
linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389-dirty
linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
```

On both my Stretch (ish, git 2.11.0) and in a Jessie container (git 2.1.4).

**- Description for the changelog**

Improvements to package build, including compatibility with Jessie era git tooling.

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://upload.wikimedia.org/wikipedia/en/f/f5/Death_Angel_-_The_Dream_Calls_for_Blood_cover.jpg "Death Angel, The Dream Calls for Blood")](https://en.wikipedia.org/wiki/The_Dream_Calls_for_Blood)
