### PR TITLE
Make it more obvious that getty/sshd are namespaced

### DIFF
--- a/blueprints/docker-for-mac.yml
+++ b/blueprints/docker-for-mac.yml
@@ -34,7 +34,7 @@ onboot:
 services:
   # Enable getty for easier debugging
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
         - INSECURE=true
   - name: rngd

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -18,7 +18,7 @@ services:
   - name: rngd
     image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
   - name: sshd
-    image: "linuxkit/sshd:f095b62ddca658e99d5751872c933ef3d5d18cec"
+    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -15,7 +15,7 @@ services:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
   - name: sshd
-    image: "linuxkit/sshd:f095b62ddca658e99d5751872c933ef3d5d18cec"
+    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -20,7 +20,7 @@ onboot:
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -16,13 +16,13 @@ onboot:
     image: "linuxkit/metadata:09781c8a8097e5aa3ae522c74856d80e1da3b915"
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
   - name: rngd
     image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
   - name: sshd
-    image: "linuxkit/sshd:f095b62ddca658e99d5751872c933ef3d5d18cec"
+    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -15,7 +15,7 @@ services:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
   - name: sshd
-    image: "linuxkit/sshd:f095b62ddca658e99d5751872c933ef3d5d18cec"
+    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -13,7 +13,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
   - name: redis

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -11,7 +11,7 @@ onboot:
     image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
   - name: rngd
@@ -19,7 +19,7 @@ services:
   - name: dhcpcd
     image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
   - name: sshd
-    image: "linuxkit/sshd:f095b62ddca658e99d5751872c933ef3d5d18cec"
+    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -24,7 +24,7 @@ onboot:
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -11,7 +11,7 @@ onboot:
     image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -19,7 +19,7 @@ onboot:
     command: ["sh", "-c", "mkdir /host_var/vpnkit && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
 services:
   - name: sshd
-    image: "linuxkit/sshd:f095b62ddca658e99d5751872c933ef3d5d18cec"
+    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
   - name: vpnkit-forwarder
     image: "linuxkit/vpnkit-forwarder:e2776b82ddfe82ed7f90e55d7a2b424e62e9a279"
     binds:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -16,13 +16,13 @@ onboot:
     image: "linuxkit/metadata:09781c8a8097e5aa3ae522c74856d80e1da3b915"
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
   - name: rngd
     image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
   - name: sshd
-    image: "linuxkit/sshd:f095b62ddca658e99d5751872c933ef3d5d18cec"
+    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -16,7 +16,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
   - name: rngd

--- a/pkg/getty/etc/motd
+++ b/pkg/getty/etc/motd
@@ -1,1 +1,4 @@
-Welcome to LinuxKit 
+Welcome to LinuxKit!
+
+NOTE: This system is namespaced.
+The namespace you are currently in may not be the root.

--- a/pkg/getty/etc/profile.d/namespace.sh
+++ b/pkg/getty/etc/profile.d/namespace.sh
@@ -1,0 +1,1 @@
+export PS1="(ns: getty) $PS1"

--- a/pkg/getty/usr/bin/rungetty.sh
+++ b/pkg/getty/usr/bin/rungetty.sh
@@ -31,14 +31,14 @@ start_getty() {
 	# are we secure or insecure?
 	loginargs=
 	if [ "$INSECURE" == "true" ]; then
-		loginargs="-n -l /bin/sh"
+		loginargs="-a root"
 	fi
 
 	if ! grep -q -w "$tty" "$securetty"; then
 		echo "$tty" >> "$securetty"
 	fi
 	# respawn forever
-	infinite_loop setsid.getty -w /sbin/getty $loginargs $line $speed $tty $term &
+	infinite_loop setsid.getty -w /sbin/agetty $loginargs $line $speed $tty $term &
 }
 
 # check if we have /etc/getty.shadow

--- a/pkg/sshd/etc/motd
+++ b/pkg/sshd/etc/motd
@@ -1,1 +1,4 @@
-Welcome to LinuxKit 
+Welcome to LinuxKit!
+
+NOTE: This system is namespaced.
+The namespace you are currently in may not be the root.

--- a/pkg/sshd/etc/profile.d/namespace.sh
+++ b/pkg/sshd/etc/profile.d/namespace.sh
@@ -1,0 +1,1 @@
+export PS1="(ns: sshd) $PS1"

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -26,7 +26,7 @@ onboot:
      - /var:/var:rshared,rbind
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
   - name: rngd
@@ -36,7 +36,7 @@ services:
   - name: ntpd
     image: "linuxkit/openntpd:a4c642d52e985922fcd97db52e471db123cc6841"
   - name: sshd
-    image: "linuxkit/sshd:f095b62ddca658e99d5751872c933ef3d5d18cec"
+    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
   - name: docker
     image: "linuxkit/docker-ce:530912564c0b648aeeab2459c7b82ce40d48fd6a"
     capabilities:

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -26,7 +26,7 @@ onboot:
      - /var:/var:rshared,rbind
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
   - name: rngd
@@ -36,7 +36,7 @@ services:
   - name: ntpd
     image: "linuxkit/openntpd:a4c642d52e985922fcd97db52e471db123cc6841"
   - name: sshd
-    image: "linuxkit/sshd:f095b62ddca658e99d5751872c933ef3d5d18cec"
+    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
   - name: docker
     image: "linuxkit/docker-ce:530912564c0b648aeeab2459c7b82ce40d48fd6a"
     capabilities:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -28,9 +28,9 @@ onboot:
      - /lib:/lib     # for ifconfig
 services:
   - name: sshd
-    image: "linuxkit/sshd:f095b62ddca658e99d5751872c933ef3d5d18cec"
+    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
 files:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -16,7 +16,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
     env:
      - INSECURE=true
   - name: rngd

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -12,7 +12,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)


### PR DESCRIPTION
This PR fixes #2078 by implementing the suggestions from the discussion there

- Add a reminder in the MOTD
- Add a reminder in the $PS1

To do this I used `agetty` from `util-linux` instead of the provided busybox getty

Note: this will fail CI as I don't have signing permissions for getty