### PR TITLE
auditd: add missing build.sh file

### DIFF
--- a/pkg/auditd/Dockerfile
+++ b/pkg/auditd/Dockerfile
@@ -1,10 +1,10 @@
-FROM linuxkit/alpine:cdb4e4d12ada4071a6c6a60bf4c14d35171ffae8 AS build
+FROM linuxkit/alpine:77e00ca02b6ee1bc0ad9cd595acf3f36917b028c AS build
 RUN apk add abuild gcc git
 
 ADD build.sh /
 RUN adduser -D -G abuild builder && sudo -u builder /build.sh
 
-FROM linuxkit/alpine:cdb4e4d12ada4071a6c6a60bf4c14d35171ffae8 AS mirror
+FROM linuxkit/alpine:77e00ca02b6ee1bc0ad9cd595acf3f36917b028c AS mirror
 COPY --from=build /home/builder/*apk /
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/

--- a/pkg/auditd/build.sh
+++ b/pkg/auditd/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+AUDIT_HASH=59763dd8e587d1821f2d039b2bf446c3a31ea58e
+
+set -e
+
+cd /home/builder
+
+git clone https://github.com/alpinelinux/aports && cd aports && git checkout $AUDIT_HASH
+cd testing/audit
+
+abuild-keygen -a
+abuild -F -r
+
+find ~/packages
+cp ~/packages/testing/$(abuild -A)/*apk ~


### PR DESCRIPTION
Whoops :)

This file is referenced in the dockerfile, but i forgot to add it in the other PR.