### PR TITLE
DfM: Add support for exposing swarm service ports

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -3,6 +3,7 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
+  - linuxkit/vpnkit-expose-port:b9bbd9b79c4682daec991c71934341b50772de00 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
   - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
   - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
@@ -52,7 +53,7 @@ services:
   # vpnkit-forwarder forwards network traffic to/from the host via VSOCK port 62373. 
   # It needs access to the vpnkit 9P coordination share 
   - name: vpnkit-forwarder
-    image: "linuxkit/vpnkit-forwarder:e2776b82ddfe82ed7f90e55d7a2b424e62e9a279"
+    image: "linuxkit/vpnkit-forwarder:79aaeefac19b396396a3d3073c0a082735e86673"
     binds:
         - /var/vpnkit:/port
     net: host

--- a/blueprints/docker-for-mac/docker-17.06-ce.yml
+++ b/blueprints/docker-for-mac/docker-17.06-ce.yml
@@ -11,11 +11,14 @@ services:
      - type: cgroup
        options: ["rw","nosuid","noexec","nodev","relatime"]
     binds:
-        - /var/lib/docker:/var/lib/docker
-        - /lib/modules:/lib/modules
-        - /var/vpnkit:/port
-        - /var/run:/var/run
-        - /var/config/docker:/var/config/docker
+     - /var/lib/docker:/var/lib/docker
+     - /lib/modules:/lib/modules
+     - /var/vpnkit:/port
+     - /var/vpnkit:/port # vpnkit control 9p mount
+     - /var/run:/var/run
+     - /var/config/docker:/var/config/docker
+     - /usr/bin/vpnkit-expose-port:/usr/bin/vpnkit-expose-port # userland proxy
+     - /usr/bin/vpnkit-iptables-wrapper:/usr/bin/iptables # iptables wrapper 
     command: [ "/usr/bin/docker-init", "/usr/bin/dockerd", "--",
             "--config-file", "/var/config/docker/daemon.json",
             "--swarm-default-advertise-addr=eth0",

--- a/pkg/vpnkit-expose-port/Dockerfile
+++ b/pkg/vpnkit-expose-port/Dockerfile
@@ -1,0 +1,15 @@
+FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+
+RUN apk add --no-cache go musl-dev git build-base
+ENV GOPATH=/go PATH=$PATH:/go/bin 
+ENV COMMIT=db7b7b0f8147f29360d69dc81af9e2877647f0de
+
+RUN git clone https://github.com/moby/vpnkit.git /go/src/github.com/moby/vpnkit && \
+    cd /go/src/github.com/moby/vpnkit && \
+    git checkout $COMMIT && \
+    cd go && \
+    make build/vpnkit-iptables-wrapper.linux build/vpnkit-expose-port.linux
+
+FROM scratch
+COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-iptables-wrapper.linux /usr/bin/vpnkit-iptables-wrapper
+COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-expose-port.linux /usr/bin/vpnkit-expose-port

--- a/pkg/vpnkit-expose-port/Makefile
+++ b/pkg/vpnkit-expose-port/Makefile
@@ -1,0 +1,6 @@
+IMAGE=vpnkit-expose-port
+DEPS=$(wildcard *.go)
+NETWORK=1
+
+include ../package.mk
+

--- a/pkg/vpnkit-expose-port/README.md
+++ b/pkg/vpnkit-expose-port/README.md
@@ -1,0 +1,9 @@
+### vpnkit-expose-port
+
+This init-package provides `vpnkit-expose-port` and `vpnkit-iptables-wrapper` from [vpnkit](http://github.com/moby/vpnkit.git). The binaries are installed on the host in `/usr/local/bin` and can be bind mounted into a container with `dockerd`.
+
+`vpnkit-expose-port` is a userland proxy that opens ports on the host by demand. To enable it, start `dockerd` with `--userland-proxy-path` pointing to the bind mounted binary.
+
+`vpnkit-iptables-wrapper` is a wrapper for iptables that opens ports via vpnkit for swarm services. It has to be bind mounted as `iptables` in $PATH before the regular `iptables` binary.
+
+To coordinate with `vpnkit` both tools require access to the 9P port configuration mount point.

--- a/pkg/vpnkit-forwarder/Dockerfile
+++ b/pkg/vpnkit-forwarder/Dockerfile
@@ -2,15 +2,14 @@ FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 
-ENV COMMIT=2d6d82167cf81c665c05d1425a79adfbc1a71177
+ENV COMMIT=db7b7b0f8147f29360d69dc81af9e2877647f0de
 
 RUN git clone https://github.com/moby/vpnkit.git /go/src/github.com/moby/vpnkit && \
     cd /go/src/github.com/moby/vpnkit && \
     git checkout $COMMIT && \
     cd go && \
-    make all
+    make build/vpnkit-forwarder.linux
 
 FROM scratch
 COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-forwarder.linux /vpnkit-forwarder
-COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-expose-port.linux /vpnkit-expose-port
 CMD ["/vpnkit-forwarder"]

--- a/pkg/vpnkit-forwarder/README.md
+++ b/pkg/vpnkit-forwarder/README.md
@@ -1,9 +1,7 @@
 ### vpnkit-forwarder
 
-This package provides `vpnkit-forwarder` and `vpnkit-expose-port` from [vpnkit](http://github.com/moby/vpnkit.git).
+This package provides `vpnkit-forwarder` from [vpnkit](http://github.com/moby/vpnkit.git).
 
-`vpnkit-forwarder` is a forwarding daemon used by Docker for Desktop to forward ports from Docker containers to the host via VSOCK.  
+`vpnkit-forwarder` is a forwarding daemon used by Docker for Desktop to forward ports from Docker containers to the host via VSOCK.
 
-`vpnkit-expose-port` is a userland proxy that opens ports by demand.
-
-To coordinate with `vpnkit` both tools require access to the 9P port configuration mount point.
+To coordinate with `vpnkit` it requires access to the 9P port configuration mount point.


### PR DESCRIPTION
Add support for forwarding swarm service ports to the host in the Docker for Mac blueprint. This should now work: 

`docker service create --publish 8080:80 nginx`

This PR adds a new package for binaries that are not part of the `pkg/vpnkit-forwarder` service called `pkg/vpnkit-expose-port`. The two binaries in this package are `vpnkit-expose-port` (userland proxy) and `vpnkit-iptables-wrapper` (iptables wrapper for swarm, new in this PR). 

These binaries have to be either copied into the dockerd container (e.g. in a multistage build) or bind-mounted into it by using `pkg/vpnkit-expose-port` as an init-container. I've updated `docker-for-mac.yml` to use it as an init-container, as we can then use a standard `docker-ce` package (yml hashes are currently temporary).

`docker-ce` already includes the `vpnkit-expose-port` binary at the moment, but it can be removed from that package if this is merged.

There may be alternative ways to do this, for example by adding the binaries directly in `docker-ce`. However, since the new `vpnkit-iptables-wrapper` is very Docker for Mac specific it seemed better to not include it directly. If we later get support for service composition, that could probably be used too: https://github.com/moby/tool/issues/92

(this also updates to latest containerd, which was missed in https://github.com/linuxkit/linuxkit/pull/2113)

![6193147deee2e648713e2b65ec84da8f](https://user-images.githubusercontent.com/1076486/27688998-d91b9efe-5cdc-11e7-828c-c7e4f651d3a6.jpg)
