### PR TITLE
Bind /etc/docker/daemon.json in examples/docker.yml 

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -40,6 +40,7 @@ services:
     binds:
      - /var/lib/docker:/var/lib/docker
      - /lib/modules:/lib/modules
+     - /etc/docker/daemon.json:/etc/docker/daemon.json
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
bind /etc/docker/daemon.json so dockerd can read it

**- How to verify it**
With following setting the dockerd is also listening on TCP:

    files:
         - path: etc/docker/daemon.json
           contents: '{"debug": false, "hosts":["tcp://0.0.0.0:2375","unix:///var/run/docker.sock"]}'

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


![red-ara](http://eskipaper.com/images/red-ara-parrot-1.jpg)