### PR TITLE
Add pkg/chronyd and update DfM blueprint

### DIFF
--- a/blueprints/docker-for-mac.yml
+++ b/blueprints/docker-for-mac.yml
@@ -5,7 +5,7 @@ kernel:
 init:
   - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
@@ -39,9 +39,11 @@ services:
         - INSECURE=true
   - name: rngd
     image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
-  # Run ntpd to keep time synchronised in the VM
-  - name: ntpd
-    image: "linuxkit/openntpd:a4c642d52e985922fcd97db52e471db123cc6841"
+  # Run chronyd to keep time synchronised in the VM
+  - name: chronyd
+    image: "linuxkit/chronyd:bacf63f7b3f4b4f1ddf22289a4220669023828a0-dirty"
+    binds:
+        - /var/config/chrony/chrony.conf:/etc/chrony/chrony.conf
   # VSOCK to unix domain socket forwarding. Forwards guest /var/run/docker.sock
   # to a socket on the host.
   - name: vsudd
@@ -86,6 +88,10 @@ services:
 files:
     - path: /var/config/docker/daemon.json
       contents: '{ "debug": true }'
+    - path: /var/config/chrony/chrony.conf
+      contents: "pool pool.ntp.org iburst minpoll 2\n
+      makestep 0.5 -1\n
+      cmdport 0\n"
 
 trust:
     org:

--- a/pkg/chronyd/Dockerfile
+++ b/pkg/chronyd/Dockerfile
@@ -1,0 +1,16 @@
+FROM linuxkit/alpine:bbc3bd5264ecc9bb366c571bb3eeaa670470ec5a AS mirror
+RUN apk version
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    chrony
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+FROM scratch
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=mirror /out/ /
+RUN mkdir -p /var/run/chrony && chown chrony.chrony /var/run/chrony && chmod 750 /var/run/chrony
+CMD ["/usr/sbin/chronyd", "-d" ]
+LABEL org.mobyproject.config='{"capabilities": ["CAP_SYS_TIME", "CAP_SETUID", "CAP_SETGID", "CAP_NET_BIND_SERVICE"]}'

--- a/pkg/chronyd/Makefile
+++ b/pkg/chronyd/Makefile
@@ -1,0 +1,4 @@
+include ../package.mk
+
+IMAGE=chronyd
+DEPS=

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -15,6 +15,7 @@ btrfs-progs-dev
 build-base
 ca-certificates
 cdrkit
+chrony
 cmake
 cryptsetup
 curl

--- a/tools/alpine/versions
+++ b/tools/alpine/versions
@@ -22,6 +22,7 @@ bzip2-1.0.6-r5
 ca-certificates-20161130-r2
 cdrkit-1.1.11-r2
 celt051-0.5.1.3-r0
+chrony-3.1-r1
 cmake-3.8.1-r0
 cryptsetup-1.7.5-r0
 cryptsetup-libs-1.7.5-r0


### PR DESCRIPTION
`chronyd` is used by Docker for Mac to synchronise time. This adds a package for starting `chronyd`, adds `chrony` to the alpine image and updates the Docker for Mac blueprint.

(Alpine and pkg/chronyd hashes are temporary as I can't update them)

![tincancat](https://user-images.githubusercontent.com/1076486/27710080-b8336874-5d1e-11e7-8d1e-f6baf2c6a0ca.jpg)

