### PR TITLE
Makefile: Fix bug where network was not disabled

### DIFF
--- a/pkg/auditd/Makefile
+++ b/pkg/auditd/Makefile
@@ -1,3 +1,3 @@
-include ../package.mk
-
 IMAGE?=auditd
+
+include ../package.mk

--- a/pkg/binfmt/Makefile
+++ b/pkg/binfmt/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=binfmt
 DEPS=main.go $(wildcard etc/binmft.d/*)
+
+include ../package.mk

--- a/pkg/ca-certificates/Makefile
+++ b/pkg/ca-certificates/Makefile
@@ -1,3 +1,3 @@
-include ../package.mk
-
 IMAGE=ca-certificates
+
+include ../package.mk

--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=containerd
 NETWORK=1
+
+include ../package.mk

--- a/pkg/dhcpcd/Makefile
+++ b/pkg/dhcpcd/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=dhcpcd
 DEPS=dhcpcd.conf $(wildcard usr/lib/dhcpcd/dhcpcd-hooks/*)
+
+include ../package.mk

--- a/pkg/docker-ce/Makefile
+++ b/pkg/docker-ce/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=docker-ce
 NETWORK=1
+
+include ../package.mk

--- a/pkg/format/Makefile
+++ b/pkg/format/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=format
 DEPS=format.sh
+
+include ../package.mk

--- a/pkg/getty/Makefile
+++ b/pkg/getty/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=getty
 DEPS=usr/bin/rungetty.sh $(wildcard etc/*) $(wildcard etc/init.d/*)
+
+include ../package.mk

--- a/pkg/init/Makefile
+++ b/pkg/init/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=init
 DEPS=init usermode-helper.c $(wildcard etc/*) $(wildcard etc/init.d/*)
+
+include ../package.mk

--- a/pkg/metadata/Makefile
+++ b/pkg/metadata/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=metadata
 DEPS=$(wildcard *.go)
+
+include ../package.mk

--- a/pkg/mkimage/Makefile
+++ b/pkg/mkimage/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=mkimage
 DEPS=mkimage.sh
+
+include ../package.mk

--- a/pkg/mount/Makefile
+++ b/pkg/mount/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=mount
 DEPS=mount.sh
+
+include ../package.mk

--- a/pkg/node_exporter/Makefile
+++ b/pkg/node_exporter/Makefile
@@ -1,3 +1,3 @@
-include ../package.mk
-
 IMAGE=node_exporter
+
+include ../package.mk

--- a/pkg/open-vm-tools/Makefile
+++ b/pkg/open-vm-tools/Makefile
@@ -1,3 +1,3 @@
-include ../package.mk
-
 IMAGE=open-vm-tools
+
+include ../package.mk

--- a/pkg/openntpd/Makefile
+++ b/pkg/openntpd/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=openntpd
 DEPS=etc/ntpd.conf
+
+include ../package.mk

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -21,7 +21,7 @@ endif
 # Get a release tag, if present
 RELEASE=$(shell git tag -l --points-at HEAD)
 
-ifndef $(NETWORK)
+ifdef NETWORK
 NET_OPT=
 else
 NET_OPT=--network=none

--- a/pkg/qemu-ga/Makefile
+++ b/pkg/qemu-ga/Makefile
@@ -1,3 +1,3 @@
-include ../package.mk
-
 IMAGE=qemu-ga
+
+include ../package.mk

--- a/pkg/rngd/Makefile
+++ b/pkg/rngd/Makefile
@@ -1,3 +1,3 @@
-include ../package.mk
-
 IMAGE=rngd
+
+include ../package.mk

--- a/pkg/runc/Makefile
+++ b/pkg/runc/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=runc
 NETWORK=1
+
+include ../package.mk

--- a/pkg/sshd/Makefile
+++ b/pkg/sshd/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=sshd
 DEPS=etc/motd etc/ssh/sshd_config usr/bin/ssh.sh
+
+include ../package.mk

--- a/pkg/swap/Makefile
+++ b/pkg/swap/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=swap
 DEPS=swap.sh
+
+include ../package.mk

--- a/pkg/sysctl/Makefile
+++ b/pkg/sysctl/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=sysctl
 DEPS=main.go
+
+include ../package.mk

--- a/pkg/sysfs/Makefile
+++ b/pkg/sysfs/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=sysfs
 DEPS=main.go
+
+include ../package.mk

--- a/pkg/trim-after-delete/Makefile
+++ b/pkg/trim-after-delete/Makefile
@@ -1,4 +1,4 @@
-include ../package.mk
-
 IMAGE=trim-after-delete
 DEPS=$(wildcard *.go)
+
+include ../package.mk

--- a/pkg/vpnkit-forwarder/Makefile
+++ b/pkg/vpnkit-forwarder/Makefile
@@ -1,5 +1,5 @@
-include ../package.mk
-
 IMAGE=vpnkit-forwarder
 DEPS=$(wildcard *.go)
 NETWORK=1
+
+include ../package.mk

--- a/pkg/vsudd/Makefile
+++ b/pkg/vsudd/Makefile
@@ -1,5 +1,5 @@
-include ../package.mk
-
 IMAGE=vsudd
 DEPS=$(wildcard *.go)
 NETWORK=1
+
+include ../package.mk


### PR DESCRIPTION
This commit moves the include statement to the bottom of the file to
ensure that all variables are set before conditionals are evaluated.

I also changed the ifndef NETWORK to ifdef NETWORK as the former was
incorrect. We want `NET_OPTS="--network=none"` in cases where NETWORK is
not defined.

Fixes: #2134

Signed-off-by: Dave Tucker <dt@docker.com>