### PR TITLE
Split DfM blueprint in base and docker yml

### DIFF
--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -21,7 +21,13 @@ the [examples/](../examples/) directory.
 
 ### Docker for Mac
 
-An initial blueprint for the open source components of Docker for Mac is available in [docker-for-mac.yml](docker-for-mac.yml). The blueprint has support for controlling `dockerd` from the host via `vsudd` and port forwarding with VPNKit. It requires HyperKit, VPNKit and a Docker client on the host to run. The easiest way to install these at the moment is to install a recent version of Docker for Mac.
+An initial blueprint for the open source components of Docker for Mac is available in [docker-for-mac](docker-for-mac). The blueprint has support for controlling `dockerd` from the host via `vsudd` and port forwarding with VPNKit. It requires HyperKit, VPNKit and a Docker client on the host to run. The easiest way to install these at the moment is to install a recent version of Docker for Mac.
+
+To build it with Docker 17.06:
+
+```
+$ moby build -name docker-for-mac base.yml docker-17.06-ce.yml
+```
 
 To run the VM with a 500M disk:
 

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -32,7 +32,7 @@ $ moby build -name docker-for-mac base.yml docker-17.06-ce.yml
 To run the VM with a 500M disk:
 
 ```
-linuxkit run hyperkit -networking=vpnkit -vsock-ports=2375 -disk size=500M docker-for-mac
+linuxkit run hyperkit -networking=vpnkit -vsock-ports=2376 -disk size=500M docker-for-mac
 ```
 
 In another terminal you should now be able to access docker via the socket `guest.00000947` in the state directory (`docker-for-mac-state/` by default):

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -5,7 +5,7 @@ kernel:
 init:
   - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
   - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:b50181bc6e0084e5fcd6b6ad3cf433c4f66cae5a
+  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
 onboot:
   - name: sysctl
     image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
@@ -57,35 +57,9 @@ services:
         - /var/vpnkit:/port
     net: host
     command: ["/vpnkit-forwarder", "-vsockPort", "62373"]
-  # Run dockerd with the vpnkit userland proxy from the vpnkit-forwarder container.
-  # Bind mounts /var/run to allow vsudd to connect to docker.sock, /var/vpnkit
-  # for vpnkit coordination and /var/config/docker for the configuration file.
-  - name: docker-dfm
-    image: "linuxkit/docker-ce:9e125aa533108731d11f6d7ec17aba6ded0cb4eb"
-    capabilities:
-     - all
-    net: host
-    mounts:
-     - type: cgroup
-       options: ["rw","nosuid","noexec","nodev","relatime"]
-    binds:
-        - /var/lib/docker:/var/lib/docker
-        - /lib/modules:/lib/modules
-        - /var/vpnkit:/port
-        - /var/run:/var/run
-        - /var/config/docker:/var/config/docker
-    command: [ "/usr/bin/docker-init", "/usr/bin/dockerd", "--",
-            "--config-file", "/var/config/docker/daemon.json",
-            "--swarm-default-advertise-addr=eth0",
-            "--userland-proxy-path", "/usr/bin/vpnkit-expose-port",
-            "--storage-driver", "overlay2" ]
   # Monitor for image deletes and invoke a TRIM on the container filesystem
   - name: trim-after-delete
     image: "linuxkit/trim-after-delete:6cc6131300c287fcd40041a28119fee2fc874539"
-
-files:
-    - path: /var/config/docker/daemon.json
-      contents: '{ "debug": true }'
 
 trust:
     org:

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -48,7 +48,7 @@ services:
     image: "linuxkit/vsudd:9e5882b4450a97836e113bcad231f497aa7bdba4"
     binds:
         - /var/run:/var/run
-    command: ["/vsudd", "-inport", "2375:unix:/var/run/docker.sock"]
+    command: ["/vsudd", "-inport", "2376:unix:/var/run/docker.sock"]
   # vpnkit-forwarder forwards network traffic to/from the host via VSOCK port 62373. 
   # It needs access to the vpnkit 9P coordination share 
   - name: vpnkit-forwarder

--- a/blueprints/docker-for-mac/docker-17.06-ce.yml
+++ b/blueprints/docker-for-mac/docker-17.06-ce.yml
@@ -1,0 +1,27 @@
+services:
+  # Run dockerd with the vpnkit userland proxy from the vpnkit-forwarder container.
+  # Bind mounts /var/run to allow vsudd to connect to docker.sock, /var/vpnkit
+  # for vpnkit coordination and /var/config/docker for the configuration file.
+  - name: docker-dfm
+    image: "linuxkit/docker-ce:9e125aa533108731d11f6d7ec17aba6ded0cb4eb"
+    capabilities:
+     - all
+    net: host
+    mounts:
+     - type: cgroup
+       options: ["rw","nosuid","noexec","nodev","relatime"]
+    binds:
+        - /var/lib/docker:/var/lib/docker
+        - /lib/modules:/lib/modules
+        - /var/vpnkit:/port
+        - /var/run:/var/run
+        - /var/config/docker:/var/config/docker
+    command: [ "/usr/bin/docker-init", "/usr/bin/dockerd", "--",
+            "--config-file", "/var/config/docker/daemon.json",
+            "--swarm-default-advertise-addr=eth0",
+            "--userland-proxy-path", "/usr/bin/vpnkit-expose-port",
+            "--storage-driver", "overlay2" ]
+
+files:
+    - path: /var/config/docker/daemon.json
+      contents: '{ "debug": true }'

--- a/test/cases/000_build/200_blueprints/010_docker_for_mac/test.sh
+++ b/test/cases/000_build/200_blueprints/010_docker_for_mac/test.sh
@@ -18,7 +18,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Test code goes here
-moby build "${LINUXKIT_BLUEPRINTS_DIR}/${IMAGE_NAME}.yml" 
+moby build -name "${IMAGE_NAME}" "${LINUXKIT_BLUEPRINTS_DIR}/${IMAGE_NAME}/base.yml" "${LINUXKIT_BLUEPRINTS_DIR}/${IMAGE_NAME}/docker-17.06-ce.yml" 
 
 exit 0
 


### PR DESCRIPTION
This splits the Docker for Mac blueprint into a base and docker image. This allows the base to be built and tested with different versions of Docker in the future.

Bonus updates:
- vsock port now same as in Docker for Mac (was 2375, now 2376)
- update containerd to the version missed in https://github.com/linuxkit/linuxkit/pull/2113