### PR TITLE
getty: Mount all of hostroot and use host profile.d

### DIFF
--- a/pkg/getty/Dockerfile
+++ b/pkg/getty/Dockerfile
@@ -29,4 +29,4 @@ COPY --from=mirror /out/ /
 COPY usr/ /usr/
 COPY etc/ /etc/
 CMD ["/usr/bin/rungetty.sh"]
-LABEL org.mobyproject.config='{"pid": "host", "net":"host", "binds": ["/run:/run", "/tmp:/tmp", "/etc:/hostroot/etc", "/usr/bin/ctr:/usr/bin/ctr", "/usr/bin/runc:/usr/bin/runc", "/usr/bin/dist:/usr/bin/dist", "/var:/var","/containers:/containers","/dev:/dev","/sys:/sys"], "capabilities": ["all"]}'
+LABEL org.mobyproject.config='{"pid": "host", "net":"host", "binds": ["/run:/run", "/tmp:/tmp", "/:/hostroot", "/usr/bin/ctr:/usr/bin/ctr", "/usr/bin/runc:/usr/bin/runc", "/usr/bin/dist:/usr/bin/dist", "/var:/var","/containers:/containers","/dev:/dev","/sys:/sys"], "capabilities": ["all"]}'

--- a/pkg/getty/usr/bin/rungetty.sh
+++ b/pkg/getty/usr/bin/rungetty.sh
@@ -49,6 +49,15 @@ if [ -f $ROOTSHADOW ]; then
 	echo >> /etc/shadow
 fi
 
+# check for scripts that should be added to profile.d
+PROFILED=/hostroot/etc/profile.d/
+for f in ${PROFILED}*.sh; do
+	filename="$(basename ${f})"
+	if [ ! -f "/etc/profile.d/${filename}" ]; then
+		cp "${f}" /etc/profile.d/
+	fi
+done
+
 for opt in $(cat /proc/cmdline); do
 	case "$opt" in
 	console=*)


### PR DESCRIPTION
This commit does two things:

- Changes the mount from /etc:/hostroot/etc to /:/hostroot
  This allows for easier to access to other binaries that we added
  during the init section.
- The getty container will now add any files in /etc/profile.d to its
  own profile.d directory. This allows the user to add /hostroot/usr/bin
  to their path automatically.

A concrete example of where this is useful is with my CI worker I'm building with linuxkit.
Before this PR, I had to re-add **ALL** of the getty binds and add an additional bind for every binary and library that I added in my `init` containers.

e.g

```
name: getty
  image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
  env:
    - INSECURE=true
  binds:
    # defaults
    - "/run:/run"
    - "/tmp:/tmp"
    - "/etc:/hostroot/etc"
    - "/usr/bin/ctr:/usr/bin/ctr"
    - "/usr/bin/runc:/usr/bin/runc"
    - "/usr/bin/dist:/usr/bin/dist"
    - "/var:/var"
    - "/containers:/containers"
    - "/dev:/dev"
    - "/sys:/sys"
    # our stuff
    - "/usr/local/bin/make:/usr/local/bin/make"
    # I can't even begin to add a line for every git binary!
```

Now I use this:
```
services:
  name: getty
    image: "davetucker/getty:localdev"
    env:
      - INSECURE=true
files:
  - path: etc/profile.d/hostroot.sh
    contents: |
      export PATH="$PATH:/hostroot/bin:/hostroot/sbin:/hostroot/usr/bin:/hostroot/usr/sbin"
      export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/hostroot/usr/lib"
      export GIT_TEMPLATE_DIR="/hostroot/usr/share/git-core/templates"
```