### PR TITLE
Fix and update packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: default
 VERSION="0.0" # dummy for now
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:6579a00b44686d0e504d513fc4860094769fe7df
+GO_COMPILE=linuxkit/go-compile:f68574b165475cff908190e0f1e86cbbb1884f86
 
 MOBY?=bin/moby
 LINUXKIT?=bin/linuxkit

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -3,22 +3,22 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/vpnkit-expose-port:b9bbd9b79c4682daec991c71934341b50772de00 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/vpnkit-expose-port:e2b49a6c56fbf876ea24f0a5ce4ccae5f940d1be # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: sysfs
-    image: "linuxkit/sysfs:b4091d81261f4582ff899a8510110fc4f2be2b49"
+    image: "linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc"
   - name: binfmt
-    image: "linuxkit/binfmt:24e2b996f7d6ad20bfa9c9f1564a3c6172db47ce"
+    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
   # Format and mount the disk image in /var/lib/docker
   - name: format
-    image: "linuxkit/format:ba085fdcac31c383acee3b4b91d78eb7095e5ac3"
+    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
   - name: mount
-    image: "linuxkit/mount:fe22dc5cbf109b4637b1caaafc76ccbf5140c3da"
+    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
     command: ["/mount.sh", "/var/lib/docker"]
   # mount-vpnkit mounts the 9p share used by vpnkit to coordinate port forwarding
   - name: mount-vpnkit
@@ -30,37 +30,37 @@ onboot:
     rootfsPropagation: shared
     command: ["sh", "-c", "mkdir -p /host_var/vpnkit/port && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   # Enable getty for easier debugging
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
         - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   # Run ntpd to keep time synchronised in the VM
   - name: ntpd
-    image: "linuxkit/openntpd:a4c642d52e985922fcd97db52e471db123cc6841"
+    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
   # VSOCK to unix domain socket forwarding. Forwards guest /var/run/docker.sock
   # to a socket on the host.
   - name: vsudd
-    image: "linuxkit/vsudd:9e5882b4450a97836e113bcad231f497aa7bdba4"
+    image: "linuxkit/vsudd:adad4b6ab7529b6b95339eb0752b0c81a218d185"
     binds:
         - /var/run:/var/run
     command: ["/vsudd", "-inport", "2376:unix:/var/run/docker.sock"]
   # vpnkit-forwarder forwards network traffic to/from the host via VSOCK port 62373. 
   # It needs access to the vpnkit 9P coordination share 
   - name: vpnkit-forwarder
-    image: "linuxkit/vpnkit-forwarder:79aaeefac19b396396a3d3073c0a082735e86673"
+    image: "linuxkit/vpnkit-forwarder:9c1545e7b093d1210118de7661d7346393ec195b"
     binds:
         - /var/vpnkit:/port
     net: host
     command: ["/vpnkit-forwarder", "-vsockPort", "62373"]
   # Monitor for image deletes and invoke a TRIM on the container filesystem
   - name: trim-after-delete
-    image: "linuxkit/trim-after-delete:6cc6131300c287fcd40041a28119fee2fc874539"
+    image: "linuxkit/trim-after-delete:2a5fcbe080cd4a45bd75c2ea3856c069475d706d"
 
 trust:
     org:

--- a/blueprints/docker-for-mac/docker-17.06-ce.yml
+++ b/blueprints/docker-for-mac/docker-17.06-ce.yml
@@ -3,7 +3,7 @@ services:
   # Bind mounts /var/run to allow vsudd to connect to docker.sock, /var/vpnkit
   # for vpnkit coordination and /var/config/docker for the configuration file.
   - name: docker-dfm
-    image: "linuxkit/docker-ce:9e125aa533108731d11f6d7ec17aba6ded0cb4eb"
+    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
     capabilities:
      - all
     net: host

--- a/docs/external-disk.md
+++ b/docs/external-disk.md
@@ -40,9 +40,9 @@ To simplify the process, two `onboot` images are available for you to use:
 ```yml
 onboot:
   - name: format
-    image: "linuxkit/format:ba085fdcac31c383acee3b4b91d78eb7095e5ac3"
+    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
   - name: mount
-    image: "linuxkit/mount:fe22dc5cbf109b4637b1caaafc76ccbf5140c3da"
+    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
     command: ["/mount.sh", "/var/external"]
 ```
 

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -22,7 +22,7 @@ docker run -it --rm \
 -v $(PWD):/go/src/github.com/docker/moby \
 -w /go/src/github.com/docker/moby \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:6579a00b44686d0e504d513fc4860094769fe7df
+linuxkit/go-compile:f68574b165475cff908190e0f1e86cbbb1884f86
 ```
 
 To update a single dependency:
@@ -32,7 +32,7 @@ docker run -it --rm \
 -v $(PWD):/go/src/github.com/docker/moby \
 -w /go/src/github.com/docker/moby \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:6579a00b44686d0e504d513fc4860094769fe7df \
+linuxkit/go-compile:f68574b165475cff908190e0f1e86cbbb1884f86 \
 github.com/docker/docker
 ```
 

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,23 +2,23 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: "linuxkit/metadata:09781c8a8097e5aa3ae522c74856d80e1da3b915"
+    image: "linuxkit/metadata:231fa2a96626af8af6224d2f1d2d71d833f370ea"
 services:
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: sshd
-    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
+    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,20 +2,20 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
 services:
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
   - name: sshd
-    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
+    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,35 +2,35 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: sysfs
-    image: linuxkit/sysfs:b4091d81261f4582ff899a8510110fc4f2be2b49
+    image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: binfmt
-    image: "linuxkit/binfmt:24e2b996f7d6ad20bfa9c9f1564a3c6172db47ce"
+    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
   - name: format
-    image: "linuxkit/format:ba085fdcac31c383acee3b4b91d78eb7095e5ac3"
+    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
   - name: mount
-    image: "linuxkit/mount:fe22dc5cbf109b4637b1caaafc76ccbf5140c3da"
+    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
   - name: ntpd
-    image: "linuxkit/openntpd:a4c642d52e985922fcd97db52e471db123cc6841"
+    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
   - name: docker
-    image: "linuxkit/docker-ce:9e125aa533108731d11f6d7ec17aba6ded0cb4eb"
+    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
     capabilities:
      - all
     net: host

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,27 +2,27 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: "linuxkit/metadata:09781c8a8097e5aa3ae522c74856d80e1da3b915"
+    image: "linuxkit/metadata:231fa2a96626af8af6224d2f1d2d71d833f370ea"
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: sshd
-    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
+    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,24 +2,24 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,16 +2,16 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,20 +2,20 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
   - name: node_exporter
-    image: "linuxkit/node_exporter:0e8d0f1d979507837ad88943864c02b310f7a78f"
+    image: "linuxkit/node_exporter:a058fe1c6a4440a9689022a9fd7cffdcfd56d52c"
 trust:
   org:
     - linuxkit

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,20 +2,20 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS1 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
 services:
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
   - name: sshd
-    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
+    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,16 +4,16 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
   - name: redis

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,24 +2,24 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
   - name: sshd
-    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
+    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,33 +2,33 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: "linuxkit/format:ba085fdcac31c383acee3b4b91d78eb7095e5ac3"
+    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
   - name: mount
-    image: "linuxkit/mount:fe22dc5cbf109b4637b1caaafc76ccbf5140c3da"
+    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
     command: ["/mount.sh", "/var/external"]
   - name: swap
-    image: "linuxkit/swap:cfdce4b41db13ce996cfa986b12b69b94f56f718"
+    image: "linuxkit/swap:b6d447b55da3c28bdd8a3f4e30fb42c1fa0157bb"
     # to use unencrypted swap, use:
     # command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G"]
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,22 +2,22 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: mount-vpnkit
     image: "alpine:3.6"
@@ -19,15 +19,15 @@ onboot:
     command: ["sh", "-c", "mkdir /host_var/vpnkit && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
 services:
   - name: sshd
-    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
+    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
   - name: vpnkit-forwarder
-    image: "linuxkit/vpnkit-forwarder:e2776b82ddfe82ed7f90e55d7a2b424e62e9a279"
+    image: "linuxkit/vpnkit-forwarder:9c1545e7b093d1210118de7661d7346393ec195b"
     binds:
         - /var/vpnkit:/port
     net: host
     command: ["/vpnkit-forwarder"]
   - name: vpnkit-expose-port
-    image: "linuxkit/vpnkit-forwarder:e2776b82ddfe82ed7f90e55d7a2b424e62e9a279"
+    image: "linuxkit/vpnkit-forwarder:9c1545e7b093d1210118de7661d7346393ec195b"
     net: none
     binds:
         - /var/vpnkit:/port

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,16 +2,16 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: vsudd
-    image: "linuxkit/vsudd:9e5882b4450a97836e113bcad231f497aa7bdba4"
+    image: "linuxkit/vsudd:adad4b6ab7529b6b95339eb0752b0c81a218d185"
     binds:
         - /run/containerd/containerd.sock:/run/containerd/containerd.sock
     command: ["/vsudd",

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,27 +2,27 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: "linuxkit/metadata:09781c8a8097e5aa3ae522c74856d80e1da3b915"
+    image: "linuxkit/metadata:231fa2a96626af8af6224d2f1d2d71d833f370ea"
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: sshd
-    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
+    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:a44da41b988024aa2c73b28dee8a51d026f6240b AS kernel-build
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS kernel-build
 RUN apk add \
     argp-standalone \
     automake \

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,25 +2,25 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: binfmt
-    image: "linuxkit/binfmt:24e2b996f7d6ad20bfa9c9f1564a3c6172db47ce"
+    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/pkg/auditd/Dockerfile
+++ b/pkg/auditd/Dockerfile
@@ -1,10 +1,10 @@
-FROM linuxkit/alpine:77e00ca02b6ee1bc0ad9cd595acf3f36917b028c AS build
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS build
 RUN apk add abuild gcc git
 
 ADD build.sh /
 RUN adduser -D -G abuild builder && sudo -u builder /build.sh
 
-FROM linuxkit/alpine:77e00ca02b6ee1bc0ad9cd595acf3f36917b028c AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 COPY --from=build /home/builder/*apk /
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/

--- a/pkg/auditd/Makefile
+++ b/pkg/auditd/Makefile
@@ -1,3 +1,4 @@
 IMAGE?=auditd
+NETWORK=1
 
 include ../package.mk

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,10 +1,10 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS qemu
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS qemu
 RUN apk add \
     qemu-aarch64 \
     qemu-arm \
     qemu-ppc64le
 
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/ca-certificates/Dockerfile
+++ b/pkg/ca-certificates/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 as alpine
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 as alpine
 
 RUN apk add ca-certificates
 

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 as alpine
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 as alpine
 RUN \
   apk add \
   btrfs-progs-dev \

--- a/pkg/dhcpcd/Dockerfile
+++ b/pkg/dhcpcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/docker-ce/Dockerfile
+++ b/pkg/docker-ce/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 # removed openssl as I do not think server needs it

--- a/pkg/docker-ce/Dockerfile
+++ b/pkg/docker-ce/Dockerfile
@@ -17,10 +17,8 @@ RUN apk add --no-cache --initdb -p /out \
 	xz
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/vpnkit-forwarder:e2776b82ddfe82ed7f90e55d7a2b424e62e9a279 AS vpnkit
 FROM scratch
 COPY --from=mirror /out/ /
-COPY --from=vpnkit /vpnkit-expose-port /usr/bin/vpnkit-expose-port
 
 # set up Docker group
 # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box

--- a/pkg/format/Dockerfile
+++ b/pkg/format/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/getty/Dockerfile
+++ b/pkg/getty/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,10 +1,10 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS build
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev
 
 ADD usermode-helper.c .
 RUN make usermode-helper
 
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/metadata/Dockerfile
+++ b/pkg/metadata/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/mkimage/Dockerfile
+++ b/pkg/mkimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/mount/Dockerfile
+++ b/pkg/mount/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/open-vm-tools/Dockerfile
+++ b/pkg/open-vm-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/openntpd/Dockerfile
+++ b/pkg/openntpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/qemu-ga/Dockerfile
+++ b/pkg/qemu-ga/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS build
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS build
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN mkdir -p /out/var/run
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,11 +1,11 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     tini
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 RUN mkdir -p /out/dev /out/proc /out/sys
 
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS build
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS build
 RUN apk add \
     argp-standalone \
     automake \

--- a/pkg/rngd/Makefile
+++ b/pkg/rngd/Makefile
@@ -1,3 +1,4 @@
 IMAGE=rngd
+NETWORK=1
 
 include ../package.mk

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 as alpine
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 as alpine
 RUN \
   apk add \
   bash \

--- a/pkg/sshd/Dockerfile
+++ b/pkg/sshd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/swap/Dockerfile
+++ b/pkg/swap/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/sysctl/Dockerfile
+++ b/pkg/sysctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/sysfs/Dockerfile
+++ b/pkg/sysfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/trim-after-delete/Dockerfile
+++ b/pkg/trim-after-delete/Dockerfile
@@ -1,5 +1,5 @@
 # We need the `fstrim` binary:
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/vpnkit-expose-port/Dockerfile
+++ b/pkg/vpnkit-expose-port/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS build
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 
@@ -11,5 +11,5 @@ RUN git clone https://github.com/moby/vpnkit.git /go/src/github.com/moby/vpnkit 
     make build/vpnkit-iptables-wrapper.linux build/vpnkit-expose-port.linux
 
 FROM scratch
-COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-iptables-wrapper.linux /usr/bin/vpnkit-iptables-wrapper
-COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-expose-port.linux /usr/bin/vpnkit-expose-port
+COPY --from=build /go/src/github.com/moby/vpnkit/go/build/vpnkit-iptables-wrapper.linux /usr/bin/vpnkit-iptables-wrapper
+COPY --from=build /go/src/github.com/moby/vpnkit/go/build/vpnkit-expose-port.linux /usr/bin/vpnkit-expose-port

--- a/pkg/vpnkit-forwarder/Dockerfile
+++ b/pkg/vpnkit-forwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/pkg/vsudd/Dockerfile
+++ b/pkg/vsudd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:c608d404c1cb36cce0c7d9303e30b52c9d81ccf0 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkit/kernel-clear-containers:4.9.x"
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
 onboot:
   - name: sysctl
     image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,32 +2,32 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
+  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: sysfs
-    image: linuxkit/sysfs:b4091d81261f4582ff899a8510110fc4f2be2b49
+    image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: binfmt
-    image: "linuxkit/binfmt:24e2b996f7d6ad20bfa9c9f1564a3c6172db47ce"
+    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
   - name: format
-    image: "linuxkit/format:ba085fdcac31c383acee3b4b91d78eb7095e5ac3"
+    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
   - name: mount
-    image: "linuxkit/mount:fe22dc5cbf109b4637b1caaafc76ccbf5140c3da"
+    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: ntpd
-    image: "linuxkit/openntpd:a4c642d52e985922fcd97db52e471db123cc6841"
+    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
   - name: docker
-    image: "linuxkit/docker-ce:9e125aa533108731d11f6d7ec17aba6ded0cb4eb"
+    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
     capabilities:
      - all
     net: host

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,32 +2,32 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
+  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
   - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: sysfs
-    image: linuxkit/sysfs:b4091d81261f4582ff899a8510110fc4f2be2b49
+    image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: binfmt
-    image: "linuxkit/binfmt:24e2b996f7d6ad20bfa9c9f1564a3c6172db47ce"
+    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
   - name: format
-    image: "linuxkit/format:ba085fdcac31c383acee3b4b91d78eb7095e5ac3"
+    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
   - name: mount
-    image: "linuxkit/mount:fe22dc5cbf109b4637b1caaafc76ccbf5140c3da"
+    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: ntpd
-    image: "linuxkit/openntpd:a4c642d52e985922fcd97db52e471db123cc6841"
+    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
   - name: docker
-    image: "linuxkit/docker-ce:9e125aa533108731d11f6d7ec17aba6ded0cb4eb"
+    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
     capabilities:
      - all
     net: host

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -2,30 +2,30 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: format
-    image: "linuxkit/format:ba085fdcac31c383acee3b4b91d78eb7095e5ac3"
+    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
   - name: mount
-    image: "linuxkit/mount:fe22dc5cbf109b4637b1caaafc76ccbf5140c3da"
+    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
     command: ["/mount.sh", "/var/lib/etcd"]
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: "linuxkit/metadata:4e73345cdcb4f7e9df07b0ee7aede652960297f2"
 services:
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: ntpd
-    image: "linuxkit/openntpd:a4c642d52e985922fcd97db52e471db123cc6841"
+    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
   - name: node_exporter
-    image: "linuxkit/node_exporter:0e8d0f1d979507837ad88943864c02b310f7a78f"
+    image: "linuxkit/node_exporter:a058fe1c6a4440a9689022a9fd7cffdcfd56d52c"
   - name: etcd
     image: "moby/etcd"
     capabilities:

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -2,15 +2,15 @@ kernel:
   image: "mobylinux/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: "linuxkit/metadata:4e73345cdcb4f7e9df07b0ee7aede652960297f2"

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -3,21 +3,21 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: binfmt
-    image: "linuxkit/binfmt:24e2b996f7d6ad20bfa9c9f1564a3c6172db47ce"
+    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/projects/kubernetes/image-cache/Dockerfile
+++ b/projects/kubernetes/image-cache/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/docker-ce:9e125aa533108731d11f6d7ec17aba6ded0cb4eb
+FROM linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
 ADD . /images
 ENTRYPOINT [ "/bin/sh", "-c" ]
 CMD [ "for image in /images/*.tar ; do docker image load -i $image && rm -f $image ; done" ]

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,19 +2,19 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: sysfs
-    image: linuxkit/sysfs:b4091d81261f4582ff899a8510110fc4f2be2b49
+    image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: binfmt
-    image: "linuxkit/binfmt:24e2b996f7d6ad20bfa9c9f1564a3c6172db47ce"
+    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
   - name: format
-    image: "linuxkit/format:ba085fdcac31c383acee3b4b91d78eb7095e5ac3"
+    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
   - name: mounts
     image: "linuxkit/kubernetes:latest-mounts"
     capabilities:
@@ -26,19 +26,19 @@ onboot:
      - /var:/var:rshared,rbind
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
   - name: ntpd
-    image: "linuxkit/openntpd:a4c642d52e985922fcd97db52e471db123cc6841"
+    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
   - name: sshd
-    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
+    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
   - name: docker
-    image: "linuxkit/docker-ce:9e125aa533108731d11f6d7ec17aba6ded0cb4eb"
+    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
     capabilities:
      - all
     net: host

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,19 +2,19 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: sysfs
-    image: linuxkit/sysfs:b4091d81261f4582ff899a8510110fc4f2be2b49
+    image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: binfmt
-    image: "linuxkit/binfmt:24e2b996f7d6ad20bfa9c9f1564a3c6172db47ce"
+    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
   - name: format
-    image: "linuxkit/format:ba085fdcac31c383acee3b4b91d78eb7095e5ac3"
+    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
   - name: mounts
     image: "linuxkit/kubernetes:latest-mounts"
     capabilities:
@@ -26,19 +26,19 @@ onboot:
      - /var:/var:rshared,rbind
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
   - name: ntpd
-    image: "linuxkit/openntpd:a4c642d52e985922fcd97db52e471db123cc6841"
+    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
   - name: sshd
-    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
+    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
   - name: docker
-    image: "linuxkit/docker-ce:9e125aa533108731d11f6d7ec17aba6ded0cb4eb"
+    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
     capabilities:
      - all
     net: host

--- a/projects/kubernetes/mounts.rb
+++ b/projects/kubernetes/mounts.rb
@@ -1,6 +1,6 @@
 import 'common.rb'
 
-from "linuxkit/mount:fe22dc5cbf109b4637b1caaafc76ccbf5140c3da"
+from "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
 
 script = [
   mount_bind_hostns_self("/etc/cni"), mount_make_hostns_rshared("/etc/cni"),

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: "mobylinux/kernel-landlock:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,22 +2,22 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037 # with runc, logwrite, startmemlogd
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: binfmt
-    image: "linuxkit/binfmt:24e2b996f7d6ad20bfa9c9f1564a3c6172db47ce"
+    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,23 +2,23 @@ kernel:
   image: "linuxkit/kernel:4.9.34"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - samoht/fdd
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
 services:
   - name: getty
     image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
 files:
   - path: etc/init.d/020-fdd-init
     mode: "0700"

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: dhcp-client
     image: miragesdk/dhcp-client:22aa9d527820534295a8cd59901c0c5197af6585
     net: host
@@ -28,9 +28,9 @@ onboot:
      - /lib:/lib     # for ifconfig
 services:
   - name: sshd
-    image: "linuxkit/sshd:7535658a08a01c61e2851e4bc1f6346e89412de8"
+    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
 files:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,20 +2,20 @@ kernel:
   image: "linuxkit/okernel:latest"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
+  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
   - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
 services:
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
   - name: sshd
-    image: "linuxkit/sshd:f095b62ddca658e99d5751872c933ef3d5d18cec"
+    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,25 +2,25 @@ kernel:
   image: "linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: binfmt
-    image: "linuxkit/binfmt:24e2b996f7d6ad20bfa9c9f1564a3c6172db47ce"
+    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,34 +2,34 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
     binds:
      - /etc/sysctl.d/01-swarmd.conf:/etc/sysctl.d/01-swarmd.conf
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: "linuxkit/format:ba085fdcac31c383acee3b4b91d78eb7095e5ac3"
+    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
   - name: mount
-    image: "linuxkit/mount:fe22dc5cbf109b4637b1caaafc76ccbf5140c3da"
+    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
     command: ["/mount.sh", "/var/lib/swarmd"]
   - name: metadata
     image: "linuxkit/metadata:4e73345cdcb4f7e9df07b0ee7aede652960297f2"
 services:
   - name: qemu-ga
-    image: "linuxkit/qemu-ga:2dbdc6523df576773b7c7d56d3a394429a4488ce"
+    image: "linuxkit/qemu-ga:585e4f0161a4df7583d5e0479d7621040c1ee140"
     binds:
       - /dev/vport0p1:/dev/vport0p1
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: ntpd
-    image: "linuxkit/openntpd:a4c642d52e985922fcd97db52e471db123cc6841"
+    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
   - name: swarmd
     image: "linuxkit/swarmd:1002422b78339a767559058d704b086889e90447"
     command: ["/usr/bin/swarmd", "--containerd-addr=/run/containerd/containerd.sock", "--log-level=debug", "--state-dir=/var/lib/swarmd"]

--- a/projects/swarmd/swarmd/Dockerfile
+++ b/projects/swarmd/swarmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS build
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS build
 
 RUN \
   apk update && apk upgrade && \

--- a/projects/wireguard/tools/Dockerfile
+++ b/projects/wireguard/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 as tools
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 as tools
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 RUN \
   apk update && \

--- a/projects/wireguard/wireguard.yml
+++ b/projects/wireguard/wireguard.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:24dfe632ed3ff53a026ee3fac046fd544434e2d6
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
   - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
   - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
   - linuxkit/wireguard-utils:26fe3d38455f2d441549e3c54bdec1b26ac819b8
@@ -13,11 +13,11 @@ onboot:
   - name: binfmt
     image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:69f951ce2a3a9534dbbc7ba8119e1df4391f06c0"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: nginx
     image: "nginx:alpine"
     capabilities:

--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -15,7 +15,7 @@ import (
 )
 
 // QemuImg is the version of qemu container
-const QemuImg = "linuxkit/qemu:c9691f5c50dd191e62b77eaa2f3dfd05ed2ed77c"
+const QemuImg = "linuxkit/qemu:bc5e096d3b440509954aa9341db3ff4d3d615344"
 
 // QemuConfig contains the config for Qemu
 type QemuConfig struct {

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,14 +2,14 @@ kernel:
   image: "linuxkit/kernel:4.4.75"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119"
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,14 +2,14 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119"
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -2,14 +2,14 @@ kernel:
   image: "linuxkit/kernel:4.11.8"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119"
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: check
     image: "kmod-test"
@@ -14,7 +14,7 @@ onboot:
     capabilities:
      - all
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,29 +2,29 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: sysfs
-    image: "linuxkit/sysfs:b4091d81261f4582ff899a8510110fc4f2be2b49"
+    image: "linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc"
   - name: binfmt
-    image: "linuxkit/binfmt:24e2b996f7d6ad20bfa9c9f1564a3c6172db47ce"
+    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
   - name: format
-    image: "linuxkit/format:ba085fdcac31c383acee3b4b91d78eb7095e5ac3"
+    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
   - name: mount
-    image: "linuxkit/mount:fe22dc5cbf109b4637b1caaafc76ccbf5140c3da"
+    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:b50b22dd574c5377708977af769f053009fff6d5"
+    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
   - name: docker
-    image: "linuxkit/docker-ce:9e125aa533108731d11f6d7ec17aba6ded0cb4eb"
+    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
     capabilities:
      - all
     net: host
@@ -36,7 +36,7 @@ services:
      - /lib/modules:/lib/modules
      - /run:/var/run
   - name: test-docker-bench
-    image: "linuxkit/test-docker-bench:5264fdfd098d2bfbacd88159e92bc59a9d2be6cc"
+    image: "linuxkit/test-docker-bench:4999d3484771e8466580c0dc2e479595e49faa85"
     ipc: host
     pid: host
     net: host

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: test
     image: "alpine:3.6"
@@ -13,7 +13,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: binfmt
-    image: "linuxkit/binfmt:24e2b996f7d6ad20bfa9c9f1564a3c6172db47ce"
+    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
   - name: test
     image: "alpine:3.6"
     readonly: true
@@ -16,7 +16,7 @@ onboot:
       - /proc/sys/fs/binfmt_misc:/binfmt_misc
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,10 +2,10 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: test
     image: "alpine:3.6"
@@ -15,7 +15,7 @@ onboot:
       - /etc:/host-etc
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -2,17 +2,17 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: test
     image: "linuxkit/test-containerd:b9b6046f1eb8ed8a15eb70523bc584e7da657baa"
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: test
     image: "alpine:3.6"
@@ -17,7 +17,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -2,17 +2,17 @@ kernel:
   image: "linuxkit/kernel:4.9.x"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
-  - linuxkit/ca-certificates:46b59484919bfa9af700e54e042048cb06261de4
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:6d35e3fe138aaeaf099b5b4f31b3f12ba725cb49"
+    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,14 +2,14 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: mkimage
-    image: "linuxkit/mkimage:3c01548c7166e710f8332e18773a28284bc13179"
+    image: "linuxkit/mkimage:a63b8ee4c5de335afc32ba850e0af319b25b96c0"
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,12 +2,12 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:3aa6bc663c2849ef239be7d941d3eaf3e6fcc018"
+    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: test
     image: "alpine:3.6"
     net: host
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,16 +2,16 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:291131ec026430371e7c36165c3f43734fbc2541
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: ltp
     image: "linuxkit/test-ltp:6df23ac196332cafb9c0f8e32f328e22d612267d"
     binds:
      - /etc/ltp/baseline:/etc/ltp/baseline
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
 files:
   - path: /etc/ltp/baseline
     contents: "100"

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,17 +4,17 @@ kernel:
   image: "linuxkit/kernel:4.9.35"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:36c56f0664d49c5a6adc1120d1bf5ba6ac30b389
-  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
-  - linuxkit/containerd:1e3e8f207421de8deac8cedc26a138d6b1661a0d
+  - linuxkit/init:24942921d1356bb801b30ca6d7197d2bfdcc26f9
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:e0607d117e0286792c5bd62d9a7e2a9c49be3bbf
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:6c1ca76dbf808d5c27d10cbf22a8d4399be5c8ae"
+    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
     image: "linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119"
   - name: poweroff
-    image: "linuxkit/poweroff:7404cf2295df89ccfa2dda41997a28307a90cf28"
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   image:

--- a/test/pkg/docker-bench/Dockerfile
+++ b/test/pkg/docker-bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:451603daf499e3a40308dbf5571dcffed2343ffa AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/test/pkg/docker-bench/Dockerfile
+++ b/test/pkg/docker-bench/Dockerfile
@@ -11,14 +11,14 @@ FROM scratch
 WORKDIR /
 COPY --from=mirror /out/ /
 
-# Add docker
-ENV DOCKER_BUCKET get.docker.com
-ENV DOCKER_VERSION 17.05.0-ce
-ENV DOCKER_SHA256 340e0b5a009ba70e1b644136b94d13824db0aeb52e09071410f35a95d94316d9
+# DOCKER_TYPE is stable, edge or test
+ENV DOCKER_TYPE stable
+ENV DOCKER_VERSION 17.06.0-ce
+ENV DOCKER_SHA256 e582486c9db0f4229deba9f8517145f8af6c5fae7a1243e6b07876bd3e706620
 
 # Install just the client
 RUN set -x \
-        && curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+        && curl -fSL "https://download.docker.com/linux/static/${DOCKER_TYPE}/$(uname -m)/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
         && echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
         && tar -xzvf docker.tgz \
         && mv docker/docker /usr/bin/ \

--- a/test/pkg/poweroff/Dockerfile
+++ b/test/pkg/poweroff/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:451603daf499e3a40308dbf5571dcffed2343ffa AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache

--- a/test/pkg/virtsock/Dockerfile
+++ b/test/pkg/virtsock/Dockerfile
@@ -1,10 +1,10 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     tini
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:451603daf499e3a40308dbf5571dcffed2343ffa AS build
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS build
 
 RUN apk add --no-cache go musl-dev git make
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -55,4 +55,4 @@ COPY --from=shellcheck /usr/local/lib/ /usr/local/lib/
 
 RUN apk update && apk upgrade -a
 
-ARG CONTAINERD_COMMIT=c215531a8f63a98a69134e804fea4ee6d354bb90
+ENV CONTAINERD_COMMIT=c215531a8f63a98a69134e804fea4ee6d354bb90

--- a/tools/alpine/versions
+++ b/tools/alpine/versions
@@ -1,9 +1,11 @@
 # automatically generated list of installed packages
+abuild-3.0.0_rc2-r7
 alpine-baselayout-3.0.4-r0
 alpine-keys-2.1-r1
 alsa-lib-1.1.3-r0
 apk-tools-2.7.2-r0
 argp-standalone-1.3-r2
+attr-2.4.47-r6
 automake-1.15-r0
 bash-4.3.48-r1
 bc-1.06.95-r2
@@ -37,13 +39,16 @@ e2fsprogs-libs-1.43.4-r0
 elfutils-dev-0.168-r1
 elfutils-libelf-0.168-r1
 expat-2.2.0-r1
+fakeroot-1.21-r1
 file-5.30-r0
 findmnt-2.28.2-r2
 flex-2.6.4-r1
 fortify-headers-0.8-r0
 fuse-2.9.7-r0
 g++-6.3.0-r4
+gc-7.6.0-r1
 gcc-6.3.0-r4
+gdbm-1.12-r0
 git-2.13.0-r0
 glib-2.52.1-r0
 gmp-6.1.2-r0
@@ -51,6 +56,8 @@ gmp-dev-6.1.2-r0
 gnupg-2.1.20-r0
 gnutls-3.5.13-r0
 go-1.8.1-r2
+guile-2.0.13-r0
+guile-libs-2.0.13-r0
 gummiboot-48.1-r0
 hvtools-4.4.15-r0
 icu-libs-58.2-r2
@@ -78,6 +85,7 @@ libc-dev-0.7.1-r0
 libc-utils-0.7.1-r0
 libcap-2.25-r1
 libcap-ng-0.7.8-r0
+libcap-ng-dev-0.7.8-r0
 libcom_err-1.43.4-r0
 libcurl-7.54.0-r0
 libdrm-2.4.80-r0
@@ -100,6 +108,7 @@ libisofs-1.4.6-r0
 libjpeg-turbo-1.5.1-r0
 libksba-1.3.4-r0
 libldap-2.4.44-r5
+libltdl-2.4.6-r1
 libmagic-5.30-r0
 libmnl-1.0.4-r0
 libmount-2.28.2-r2
@@ -132,6 +141,7 @@ libverto-0.2.5-r2
 linux-headers-4.4.6-r2
 lua5.2-libs-5.2.4-r2
 lz4-libs-1.7.5-r0
+lzip-1.19-r0
 lzo-2.10-r0
 m4-1.4.18-r0
 make-4.2.1-r0
@@ -158,12 +168,14 @@ openssh-server-7.5_p1-r1
 opus-1.1.4-r0
 p11-kit-0.23.2-r1
 patch-2.7.5-r1
+pax-utils-1.2.2-r0
 pcre-8.40-r2
 perl-5.24.1-r2
 pinentry-1.0.0-r0
 pixman-0.34.0-r0
 pkgconf-1.3.7-r0
 popt-1.16-r6
+python3-3.6.1-r2
 qemu-2.8.1-r1
 qemu-aarch64-2.8.1-r1
 qemu-arm-2.8.1-r1
@@ -180,8 +192,11 @@ slang-2.3.1-r0
 slang-dev-2.3.1-r0
 snappy-1.1.4-r1
 spice-server-0.13.3-r1
+sqlite-libs-3.18.0-r0
 squashfs-tools-4.3-r3
 strace-4.16-r1
+sudo-1.8.19_p2-r0
+swig-3.0.10-r0
 syslinux-6.04_pre1-r1
 tar-1.29-r1
 tini-0.14.0-r0

--- a/tools/go-compile/Dockerfile
+++ b/tools/go-compile/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:451603daf499e3a40308dbf5571dcffed2343ffa AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/tools/qemu/Dockerfile
+++ b/tools/qemu/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:5240cbd9cf371c8211c8f1968e57c51a32098c8f AS mirror
+FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \


### PR DESCRIPTION
- Fix the `containerd` commit hash. It was ignored then building (since #2062) 
- The `audit` and `rngd` packages need network access (introduced with #2135)
- The `docker-ce` package didn't build since `linuxkit/vpnkit-forwarder` package had  `/usr/bin/vpnkit-expose-port` removed (#2124)

Since the Makefiles of all packages changed with #2135 might as well update `linuxkit/alpine` and then all packages, tools and tests.