### PR TITLE
Update timetable

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ There is an [overview of the security considerations and direction](docs/securit
 ## Roadmap
 
 This project was extensively reworked from the code we are shipping in Docker Editions, and the result is not yet production quality. The plan is to return to production
-quality during Q2 2017, and rebase the Docker Editions on this open source project.
+quality during Q3 2017, and rebase the Docker Editions on this open source project during this quarter. We plan to start making stable releases on this timescale.
 
 This is an open project without fixed judgements, open to the community to set the direction. The guiding principles are:
 - Security informs design


### PR DESCRIPTION
We did not ship stable releases in Q2, and will not until `containerd` is stable and
editions are switched over which is being worked on now.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![stable](https://user-images.githubusercontent.com/482364/27796443-e31e7426-6001-11e7-8bce-0de1d35cd8ca.jpg)
