### PR TITLE
tools: Bring back mkimage-gcp

### DIFF
--- a/tools/mkimage-gcp/Dockerfile
+++ b/tools/mkimage-gcp/Dockerfile
@@ -1,0 +1,5 @@
+FROM linuxkit/guestfs:2657580764d5791e103647237dac5a0276533e2e@sha256:8f99eba6720df17bce8893052d7ca9a07cdc9cd09b335a5a9c57ebd5a44934be
+
+COPY . .
+
+ENTRYPOINT [ "/make-gcp" ]

--- a/tools/mkimage-gcp/Makefile
+++ b/tools/mkimage-gcp/Makefile
@@ -1,0 +1,27 @@
+.PHONY: tag push
+
+IMAGE=mkimage-gcp
+
+default: push
+
+hash: Dockerfile make-gcp
+	tar cf - $^ | docker build --no-cache -t $(IMAGE):build -
+	docker run --entrypoint sh --rm $(IMAGE):build -c "(cat $^; apt list --installed 2>/dev/null) | sha1sum" | sed 's/ .*//' > hash
+
+push: hash
+	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		(docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash) && \
+		 docker push linuxkit/$(IMAGE):$(shell cat hash))
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+tag: hash
+	docker pull linuxkit/$(IMAGE):$(shell cat hash) || \
+		docker tag $(IMAGE):build linuxkit/$(IMAGE):$(shell cat hash)
+	docker rmi $(IMAGE):build
+	rm -f hash
+
+clean:
+	rm -f hash
+
+.DELETE_ON_ERROR:

--- a/tools/mkimage-gcp/make-gcp
+++ b/tools/mkimage-gcp/make-gcp
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+set -e
+
+mkdir -p /tmp/image
+cd /tmp/image
+
+# input is a tarball of kernel and initrd.img on stdin
+# output is a compressed tarball of a raw disk image on stdout
+
+mkdir -p files
+
+cd files
+
+# extract. As guestfs base is currently Debian, no compression support
+# only if stdin is a tty, if so need files volume mounted...
+[ -t 0 ] || tar xf -
+
+INITRD="$(find . -name '*.img')"
+KERNEL="$(find . -name kernel -or -name bzImage)"
+CMDLINE="$*"
+
+[ "$KERNEL" = "./kernel" ] || mv "$KERNEL" kernel
+[ "$INITRD" = "./initrd.img" ] || mv "$INITRD" initrd.img
+
+# clean up subdirectories
+find . -mindepth 1 -maxdepth 1 -type d | xargs rm -rf
+
+# should be externally provided as GCP specific
+GCP_CONFIG="earlyprintk=ttyS0,115200 console=ttyS0,115200 vsyscall=emulate page_poison=1"
+
+CFG="DEFAULT linux
+LABEL linux
+    KERNEL /kernel
+    INITRD /initrd.img
+    APPEND ${CMDLINE}
+"
+
+printf "$CFG" > syslinux.cfg
+
+cd ..
+
+tar cf files.tar -C files .
+
+virt-make-fs --size=1G --type=ext4 --partition files.tar disk.raw
+
+guestfish -a disk.raw -m /dev/sda1 <<EOF
+  upload /usr/lib/SYSLINUX/mbr.bin /mbr.bin
+  copy-file-to-device /mbr.bin /dev/sda size:440
+  rm /mbr.bin
+  extlinux /
+  part-set-bootable /dev/sda 1 true
+EOF
+
+tar cf - disk.raw | gzip -9


### PR DESCRIPTION
This was incorrectly removed in e782a469d522d473efbafee7b951dea4627136b7

Signed-off-by: Dave Tucker <dt@docker.com>