### PR TITLE
Add pkg/acpid

### DIFF
--- a/pkg/acpid/Dockerfile
+++ b/pkg/acpid/Dockerfile
@@ -1,0 +1,22 @@
+FROM linuxkit/alpine:2e362f4459ba4491655061cccdd2fcc7a2de5eb3 AS mirror
+
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    busybox
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+FROM linuxkit/alpine:2e362f4459ba4491655061cccdd2fcc7a2de5eb3 AS mirror2
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    busybox-initscripts
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+FROM scratch
+COPY --from=mirror /out/ /
+COPY --from=mirror2 /out/etc/acpi /etc/acpi
+
+CMD ["/sbin/acpid", "-f", "-d"]
+
+LABEL org.mobyproject.config='{"binds": ["/dev:/dev"], "pid": "host"}'
+

--- a/pkg/acpid/Makefile
+++ b/pkg/acpid/Makefile
@@ -1,0 +1,3 @@
+IMAGE=acpid
+
+include ../package.mk

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -13,6 +13,7 @@ bsd-compat-headers
 btrfs-progs
 btrfs-progs-dev
 build-base
+busybox-initscripts
 ca-certificates
 cdrkit
 cmake

--- a/tools/alpine/versions
+++ b/tools/alpine/versions
@@ -20,6 +20,7 @@ btrfs-progs-dev-4.10.2-r0
 btrfs-progs-libs-4.10.2-r0
 build-base-0.5-r0
 busybox-1.26.2-r5
+busybox-initscripts-3.1-r1
 bzip2-1.0.6-r5
 ca-certificates-20161130-r2
 cdrkit-1.1.11-r2

--- a/tools/alpine/versions
+++ b/tools/alpine/versions
@@ -99,7 +99,7 @@ libexecinfo-dev-1.1-r0
 libfdisk-2.28.2-r2
 libffi-3.2.1-r3
 libgcc-6.3.0-r4
-libgcrypt-1.7.7-r0
+libgcrypt-1.7.8-r0
 libgmpxx-6.1.2-r0
 libgomp-6.3.0-r4
 libgpg-error-1.27-r0
@@ -151,9 +151,9 @@ mkinitfs-3.1.0-r0
 mpc1-1.0.3-r0
 mpfr3-3.1.5-r0
 mtools-4.0.18-r1
-musl-1.1.16-r10
-musl-dev-1.1.16-r10
-musl-utils-1.1.16-r10
+musl-1.1.16-r13
+musl-dev-1.1.16-r13
+musl-utils-1.1.16-r13
 ncurses-dev-6.0-r7
 ncurses-libs-6.0-r7
 ncurses-terminfo-6.0-r7


### PR DESCRIPTION
This adds a new service for running busybox's `acpid`. It needs `busybox-initscripts` for `/etc/acpi`, which contains the poweroff script. I've tested this with Docker for Mac and it successfully shuts down on power button events.

Alpine hash is temporary