### PR TITLE
Update Docker for Mac with ACPI and metadata support

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -8,6 +8,9 @@ init:
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
+  # support metadata for optional config in /var/config
+  - name: metadata
+    image: "linuxkit/metadata:231fa2a96626af8af6224d2f1d2d71d833f370ea"
   - name: sysctl
     image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
   - name: sysfs

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -36,6 +36,9 @@ onboot:
     image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
+  # Enable acpi to shutdown on power events
+  - name: acpid
+    image: linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918
   # Enable getty for easier debugging
   - name: getty
     image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"


### PR DESCRIPTION
- Adds the new ACPI service to the blueprint. This allows the VM to be shut down properly on power events (typically that the hyperkit process receives SIGTERM). (requires #2154)
- Adds the metadata package to use metadata configuration if available
