### PR TITLE
Add ACPI hyperkit test and update platform docs

### DIFF
--- a/docs/platform-hyperkit.md
+++ b/docs/platform-hyperkit.md
@@ -31,6 +31,12 @@ The HyperKit backend support configuring a persistent disk using the
 standard `linuxkit` `-disk` syntax.  Currently, only one disk is
 supported and the disk is in raw format.
 
+## Power management
+
+HyperKit sends an ACPI power event when it receives SIGTERM to allow the VM to
+shut down properly. The VM has to be able to receive ACPI events to initiate the
+shutdown.  This is provided by the [`acpid` package](../pkg/acpid). An example
+is available in the [Docker for Mac blueprint](../blueprints/docker-for-mac/base.yml).
 
 ## Networking
 

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.exp
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.exp
@@ -1,0 +1,52 @@
+#!/usr/bin/env expect
+spawn linuxkit run hyperkit hyperkit-acpi
+set vm_spawn_id $spawn_id
+set pid [exp_pid]
+set timeout 30
+
+expect {
+    timeout {
+        puts "FAILED boot"
+        exec kill -9 $pid
+        exit 1
+    }
+    "Welcome to LinuxKit" {
+        puts "SUCCESS boot"
+    }
+}
+
+expect {
+    timeout {
+        puts "FAILED ACPI not started"
+        exec kill -9 $pid
+        exit 1
+    }
+    "acpid/shim.sock" {
+        puts "SUCCESS acpid started"
+    }
+}
+
+set f [open "hyperkit-acpi-state/hyperkit.pid" r]
+set hyperkit_pid [read $f]
+close $f
+
+sleep 2
+spawn kill -TERM $hyperkit_pid
+
+expect -i $vm_spawn_id {
+    timeout {
+        puts "FAILED shutdown on SIGTERM"
+        exec kill -9 $pid
+        exit 1
+    }
+    "reboot: Power down" {
+        puts "SUCCESS ACPI shutdown"
+    }
+    eof {
+        puts "SUCCESS ACPI shutdown"
+    }
+}
+
+set waitval [wait -i $vm_spawn_id]
+set exval [lindex $waitval 3]
+exit $exval

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.sh
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# SUMMARY: Check that the kernel+initrd image boots on hyperkit
+# LABELS:
+
+set -e
+set -x
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+NAME=hyperkit-acpi
+
+clean_up() {
+	echo $(pwd)
+	# remove any files, containers, images etc
+	rm -rf "${NAME}"* || true
+}
+trap clean_up EXIT
+
+moby build -output kernel+initrd -name "${NAME}" test.yml
+[ -f "${NAME}-kernel" ] || exit 1
+[ -f "${NAME}-initrd.img" ] || exit 1
+[ -f "${NAME}-cmdline" ]|| exit 1
+./test.exp
+exit 0

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,0 +1,13 @@
+kernel:
+  image: "linuxkit/kernel:4.9.35"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+services:
+  - name: acpid
+    image: "linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918"
+trust:
+  org:
+    - linuxkit


### PR DESCRIPTION
- Add minimal acpi example
- Update hyperkit platform docs

I wasn't sure where to add the documentation for this as it is most likely similar for all platforms. I added it to hyperkit specifically though, as that's the platform I'm working on at the moment. 

This only adds a minimal example, but perhaps ACPI support should be included in more of the existing examples?

(see also previous discussion in #2154)
