### PR TITLE
pkg: Update content trust handling.

### DIFF
--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -7,16 +7,16 @@ HASH_COMMIT?=HEAD # Setting this is only really useful with the show-tag target
 HASH?=$(shell git ls-tree --full-tree $(HASH_COMMIT) -- $(CURDIR) | awk '{print $$3}')
 
 ifneq ($(HASH_COMMIT),HEAD) # Others can't be dirty by definition
-DIRTY=$(shell git update-index -q --refresh && git diff-index --quiet HEAD -- $(CURDIR) || echo "-dirty")
+DIRTY:=$(shell git update-index -q --refresh && git diff-index --quiet HEAD -- $(CURDIR) || echo "-dirty")
 endif
 endif
 
-TAG=$(ORG)/$(IMAGE):$(HASH)$(DIRTY)
+TAG:=$(ORG)/$(IMAGE):$(HASH)$(DIRTY)
 
 BASE_DEPS=Dockerfile Makefile
 
 # Get a release tag, if present
-RELEASE=$(shell git tag -l --points-at HEAD)
+RELEASE:=$(shell git tag -l --points-at HEAD)
 
 ifdef NETWORK
 NET_OPT=

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -24,20 +24,24 @@ else
 NET_OPT=--network=none
 endif
 
+ifeq ($(DOCKER_CONTENT_TRUST),)
+ifndef NOTRUST
+export DOCKER_CONTENT_TRUST=1
+endif
+endif
+
 show-tag:
 	@echo $(TAG)
 
 tag: $(BASE_DEPS) $(DEPS)
-	DOCKER_CONTENT_TRUST=1 docker pull $(TAG) || \
-	docker build $(NET_OPT) -t $(TAG) .
+	docker pull $(TAG) || docker build $(NET_OPT) -t $(TAG) .
 
 push: tag
 ifneq ($(DIRTY),)
 	$(error Your repository is not clean. Will not push package image.)
 endif
-	DOCKER_CONTENT_TRUST=1 docker pull $(TAG) || \
-	DOCKER_CONTENT_TRUST=1 docker push $(TAG)
+	docker pull $(TAG) || docker push $(TAG)
 ifneq ($(RELEASE),)
 	docker tag $(TAG) $(ORG)/$(IMAGE):$(RELEASE)
-	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(RELEASE)
+	docker push $(ORG)/$(IMAGE):$(RELEASE)
 endif

--- a/projects/swarmd/swarmd/Makefile
+++ b/projects/swarmd/swarmd/Makefile
@@ -1,5 +1,6 @@
 ORG?=linuxkitprojects
 IMAGE=swarmd
 NETWORK=1
+NOTRUST=1
 
 include ../../../pkg/package.mk


### PR DESCRIPTION
Firstly add option to disable content trust, for the use of e.g. projects which
are pushing to the linuxkitprojects org (which has no trust setup) rather than
the main linuxkit org.

Secondly, when trust _is_ enabled then enable it globally, in particular it is
now active for the `docker build` and hence containers referenced in
Dockerfiles via "FROM" will be checked.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Made it possible for individual packages to opt out of docker content trust. Use this for `projects/swarmd/swarmd`.

**- How I did it**

If `DOCKER_CONTENT_TRUST` is not already set in the environment then set it by default unless the package has opted out by setting `NOTRUST`, which I set in the swarmd package.

**- How to verify it**

`make -C projects/swarmd/swarmd push` should not ask you for your notary password. While make -C `pkg/something push` should (iff you have modified and committed to that package.

**- Description for the changelog**
Per package control of trust on push.

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://upload.wikimedia.org/wikipedia/en/6/66/Reverend_Bizarre_-_In_the_Rectory_of_the_Bizarre_Reverend.jpg "Reverend Bizarre, In the Rectory of the Bizarre Reverend")](https://en.wikipedia.org/wiki/In_the_Rectory_of_the_Bizarre_Reverend)