### PR TITLE
Update https-unikernel example to latest API

### DIFF
--- a/projects/miragesdk/examples/https-unikernel/Dockerfile
+++ b/projects/miragesdk/examples/https-unikernel/Dockerfile
@@ -1,8 +1,8 @@
-FROM ocaml/opam@sha256:a469435632d0cacbceab799d7e48201b727d025fa1805cbbe210d94233b251ad
+FROM ocaml/opam@sha256:523988cb7ac4c51e1c6e2f00658686c320330000859f49e1ec8fe3d6df046a26
 #FROM ocaml/opam:debian-9_ocaml-4.04.0
-RUN opam pin add -yn capnp 'https://github.com/talex5/capnp-ocaml.git#demo1'
-RUN opam pin add -yn capnp-rpc 'https://github.com/talex5/capnp-rpc.git#demo1'
-RUN opam pin add -yn capnp-rpc-lwt 'https://github.com/talex5/capnp-rpc.git#demo1'
+RUN opam pin add -yn capnp 'https://github.com/talex5/capnp-ocaml.git#demo2'
+RUN opam pin add -yn capnp-rpc 'https://github.com/talex5/capnp-rpc.git#demo2'
+RUN opam pin add -yn capnp-rpc-lwt 'https://github.com/talex5/capnp-rpc.git#demo2'
 RUN opam depext -i -y jbuilder lwt cohttp astring tls capnp camlzip alcotest cohttp
 RUN sudo apt-get install -y screen python-pip python-setuptools python-dev --no-install-recommends
 RUN pip install cython pycapnp

--- a/projects/miragesdk/examples/https-unikernel/README.md
+++ b/projects/miragesdk/examples/https-unikernel/README.md
@@ -23,13 +23,12 @@ The easiest way to build and run is using Docker:
 
 Once inside the container, you can run all the services in a single process like this:
 
-    reset
     https-unikernel-single
 
 You should be able to try out the service by opening <https://localhost:8443> in a browser.
 
 You can also run the service as three separate processes.
-The easiest way to do this is by running `screen`.
+The easiest way to do this is by creating multiple windows in `screen` (which is running by default in the Docker image).
 
 First, start the store:
 
@@ -64,7 +63,7 @@ $ python
 ( ok = "<p>It works!</p><p>Powered by Irmin.</p>\n" )
 ```
 
-(or just do `python test_store.py`)
+(or just do `python src/test_store.py`)
 
 
 [Cap'n Proto RPC]: https://capnproto.org/rpc.html

--- a/projects/miragesdk/examples/https-unikernel/opam
+++ b/projects/miragesdk/examples/https-unikernel/opam
@@ -8,7 +8,7 @@ build: [
 ]
 depends: [
   "lwt"
-  "cohttp"
+  "cohttp" {>="0.21.0" & <"0.99"}
   "astring"
   "tls"
   "irmin-unix"

--- a/projects/miragesdk/examples/https-unikernel/src/common.ml
+++ b/projects/miragesdk/examples/https-unikernel/src/common.ml
@@ -11,7 +11,7 @@ let connect ~switch path =
     exit 1
   end;
   let endpoint = Endpoint.of_socket ~switch socket in
-  let conn = CapTP.of_endpoint ~switch endpoint in
+  let conn = CapTP.connect ~switch endpoint in
   CapTP.bootstrap conn
 
 let rm_socket path =
@@ -33,7 +33,7 @@ let listen ~switch ~offer path =
     Logs.info (fun f -> f "Got connection on %S" path);
     Lwt_switch.with_switch @@ fun switch ->     (* todo: with_child_switch *)
     let endpoint = Endpoint.of_socket ~switch (Lwt_unix.unix_file_descr c) in
-    ignore (CapTP.of_endpoint ~switch ~offer endpoint);
+    ignore (CapTP.connect ~switch ~offer endpoint);
     loop () in
   loop ()
 

--- a/projects/miragesdk/examples/https-unikernel/src/jbuild
+++ b/projects/miragesdk/examples/https-unikernel/src/jbuild
@@ -1,25 +1,11 @@
-(* -*- tuareg -*- *)
-open Jbuild_plugin.V1
+(jbuild_version 1)
 
-let extra_flags =
-  match Sys.getenv "JBUILD_STATIC" with
-  | "true" -> "-cclib -static"
-  | x -> failwith (Printf.sprintf "JBUILD_STATIC: unknown value %S" x)
-  | exception Not_found -> ""
-
-let sexp = Printf.sprintf {|
-  (jbuild_version 1)
-
-  (executables (
-    (names (main store_main http_main tls_main))
-    (libraries (capnp-rpc-lwt cohttp.lwt irmin-unix cmdliner fmt.tty))
-    (flags (:standard -w -53-55 %s))
-  ))
-  (rule
-   ((targets (proto.ml proto.mli))
-    (deps (proto.capnp))
-    (action  (run capnpc -o ocaml ${<}))))
-|} extra_flags
-
-let () =
-  send sexp
+(executables (
+  (names (main store_main http_main tls_main))
+  (libraries (capnp-rpc-lwt cohttp.lwt irmin-unix cmdliner fmt.tty))
+  (flags (:standard -w -53-55))
+))
+(rule
+ ((targets (proto.ml proto.mli))
+  (deps (proto.capnp))
+  (action  (run capnpc -o ocaml ${<}))))

--- a/projects/miragesdk/examples/https-unikernel/src/main.ml
+++ b/projects/miragesdk/examples/https-unikernel/src/main.ml
@@ -21,15 +21,15 @@ let () =
     begin
       Store.service () >>= fun service ->
       let tags = Logs.Tag.add Common.Actor.tag (`Green, "Store ") Logs.Tag.empty in
-      let _ : CapTP.t = CapTP.of_endpoint ~offer:service ~tags ~switch store_to_http in
+      let _ : CapTP.t = CapTP.connect ~offer:service ~tags ~switch store_to_http in
       Lwt.return ()
     end
     >>= fun () ->
     begin
       let tags = Logs.Tag.add Common.Actor.tag (`Red, "HTTP  ") Logs.Tag.empty in
-      let store = CapTP.bootstrap (CapTP.of_endpoint ~tags ~switch http_to_store) in
+      let store = CapTP.bootstrap (CapTP.connect ~tags ~switch http_to_store) in
       let service = Http_server.service store in
-      let _ : CapTP.t = CapTP.of_endpoint ~offer:service ~tags ~switch http_to_tls in
+      let _ : CapTP.t = CapTP.connect ~offer:service ~tags ~switch http_to_tls in
       Lwt.return ()
     end
     >>= fun () ->

--- a/projects/miragesdk/examples/https-unikernel/src/store.ml
+++ b/projects/miragesdk/examples/https-unikernel/src/store.ml
@@ -13,8 +13,10 @@ let service () =
   Irmin_store.Repo.v config >>= fun repo ->
   Irmin_store.of_branch repo Irmin_store.Branch.master >|= fun db ->
   Api.Builder.Store.local @@
-    object (_ : Api.Builder.Store.service)
-      method get req =
+    object
+      inherit Api.Builder.Store.service
+
+      method get_impl req =
         let module P = Api.Reader.Store.Get_params in
         let module R = Api.Builder.Store.GetResults in
         let params = P.of_payload req in


### PR DESCRIPTION
**- What I did**

Updated the `projects/miragesdk/examples/https-unikernel` example to use the latest library versions. This also avoids a build failure due to `irmin-watcher-0.2.0.tbz` having moved (reported by Nick Betteridge).

**- How to verify it**

Follow the instructions in the example's `README.md` to build and run the example.

**- Description for the changelog**

Update https-unikernel example to latest API.