### PR TITLE
Backend vCenter: add the datacenter parameter

### DIFF
--- a/src/cmd/linuxkit/push_vcenter.go
+++ b/src/cmd/linuxkit/push_vcenter.go
@@ -34,7 +34,6 @@ func pushVCenter(args []string) {
 	newVM.vCenterURL = flags.String("url", os.Getenv("VCURL"), "URL of VMware vCenter in the format of https://username:password@VCaddress/sdk")
 	newVM.dcName = flags.String("datacenter", os.Getenv("VCDATACENTER"), "The name of the DataCenter to host the image")
 	newVM.dsName = flags.String("datastore", os.Getenv("VCDATASTORE"), "The name of the DataStore to host the image")
-	newVM.networkName = flags.String("network", os.Getenv("VCNETWORK"), "The network label the VM will use")
 	newVM.vSphereHost = flags.String("hostname", os.Getenv("VCHOST"), "The server that will host the image")
 	newVM.path = flags.String("path", "", "Path to a specific image")
 

--- a/src/cmd/linuxkit/push_vcenter.go
+++ b/src/cmd/linuxkit/push_vcenter.go
@@ -32,6 +32,7 @@ func pushVCenter(args []string) {
 	}
 
 	newVM.vCenterURL = flags.String("url", os.Getenv("VCURL"), "URL of VMware vCenter in the format of https://username:password@VCaddress/sdk")
+	newVM.dcName = flags.String("datacenter", os.Getenv("VCDATACENTER"), "The name of the DataCenter to host the image")
 	newVM.dsName = flags.String("datastore", os.Getenv("VCDATASTORE"), "The name of the DataStore to host the image")
 	newVM.networkName = flags.String("network", os.Getenv("VCNETWORK"), "The network label the VM will use")
 	newVM.vSphereHost = flags.String("hostname", os.Getenv("VCHOST"), "The server that will host the image")

--- a/src/cmd/linuxkit/run_vcenter.go
+++ b/src/cmd/linuxkit/run_vcenter.go
@@ -20,6 +20,7 @@ import (
 
 type vmConfig struct {
 	vCenterURL  *string
+	dcName      *string
 	dsName      *string
 	networkName *string
 	vSphereHost *string
@@ -44,6 +45,7 @@ func runVcenter(args []string) {
 	invoked := filepath.Base(os.Args[0])
 
 	newVM.vCenterURL = flags.String("url", os.Getenv("VCURL"), "URL of VMware vCenter in the format of https://username:password@VCaddress/sdk")
+	newVM.dcName = flags.String("datacenter", os.Getenv("VCDATACENTER"), "The name of the Datacenter to host the VM")
 	newVM.dsName = flags.String("datastore", os.Getenv("VCDATASTORE"), "The name of the DataStore to host the VM")
 	newVM.networkName = flags.String("network", os.Getenv("VCNETWORK"), "The network label the VM will use")
 	newVM.vSphereHost = flags.String("hostname", os.Getenv("VCHOST"), "The server that will run the VM")
@@ -178,7 +180,7 @@ func vCenterConnect(ctx context.Context, newVM vmConfig) (*govmomi.Client, *obje
 	f := find.NewFinder(c.Client, true)
 
 	// Find one and only datacenter, not sure how VMware linked mode will work
-	dc, err := f.DefaultDatacenter(ctx)
+	dc, err := f.DatacenterOrDefault(ctx, *newVM.dcName)
 	if err != nil {
 		log.Fatalf("No Datacenter instance could be found inside of vCenter %v", err)
 	}


### PR DESCRIPTION
**- What I did**
- Added the parameter `datacenter` for the vCenter backend
- **(looking for feedback on that one)** Deleted the `checkFile` and `uploadFile` step when using the `run` command

**- How I did it**
By using the govmomi function [DatacenterOrDefault](https://github.com/vmware/govmomi/blob/master/find/finder.go#L384) instead of DefaultDatacenter.

**- How to verify it**
- requirement: have vCenter with multiple datacenters

Upload the Linuxkit image to vCenter:
```
linuxkit push vcenter -datastore <your_vsphere_datastore> -hostname <your_vsphere_host> -network "<your_vsphere_network>" -url "https://<your_vsphere_username>:<your_vsphere_password>@<your_vsphere_server>/sdk" -datacenter "<your_vsphere_datacenter>" -folder <your_vsphere_folder_in_datastore> <path_to_your_local_linuxkit_iso>
```

Run the Linuxkit image on vCenter:
```
linuxkit run vcenter -cpus 4 -mem 4096 -persistentSize 4096 -datastore <your_vsphere_datastore> -hostname <your_vsphere_host> -network "<your_vsphere_network>" -url "https://<your_vsphere_username>:<your_vsphere_password>@<your_vsphere_server>/sdk" -datacenter "<your_vsphere_datacenter>" <datastore_path_to_the_linuxkit_iso>
```

**- Description for the changelog**
Backend vCenter: added the datacenter parameter