### PR TITLE
Add some network namespace stress tests

### DIFF
--- a/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.4.76"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test.sh
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv4 and veth interfaces
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.4.76"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test.sh
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv4 and veth interfaces
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.4.76"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test.sh
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv6 and veth interfaces
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.4.76"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test.sh
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv6 and veth interfaces
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.4.76"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-tcp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test.sh
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv4 over the loopback interface
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.4.76"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-tcp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test.sh
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv6 over the loopback interface
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.4.76"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test.sh
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv4 and veth interfaces
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.4.76"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test.sh
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv4 and veth interfaces
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.4.76"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test.sh
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv6 and veth interfaces
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.4.76"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test.sh
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv6 and veth interfaces
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.4.76"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-udp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test.sh
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv4 over the loopback interface
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.4.76"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-udp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test.sh
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv6 over the loopback interface
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.9.36"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test.sh
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv4 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.9.36"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test.sh
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv4 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.9.36"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test.sh
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv6 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.9.36"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test.sh
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv6 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.9.36"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-tcp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test.sh
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv4 over the loopback interface
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.9.36"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-tcp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test.sh
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv6 over the loopback interface
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.9.36"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test.sh
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv4 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.9.36"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test.sh
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv4 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.9.36"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test.sh
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv6 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.9.36"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test.sh
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv6 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.9.36"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-udp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test.sh
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv4 over the loopback interface
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.9.36"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-udp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test.sh
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv6 over the loopback interface
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.11.9"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test.sh
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv4 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.11.9"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test.sh
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv4 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.11.9"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test.sh
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv6 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.11.9"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test.sh
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv6 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.11.9"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-tcp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test.sh
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv4 over the loopback interface
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.11.9"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-tcp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test.sh
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with TCP/IPv6 over the loopback interface
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.11.9"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test.sh
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv4 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.11.9"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test.sh
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv4 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.11.9"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test.sh
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv6 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.11.9"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test.sh
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv6 and veth interfaces
+# LABELS: kernel
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.11.9"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-udp", "-ip", "4"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test.sh
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv4 over the loopback interface
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
@@ -1,0 +1,17 @@
+kernel:
+  image: "linuxkit/kernel:4.11.9"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
+  - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f
+  - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
+onboot:
+  - name: test-netns
+    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-udp", "-ip", "6"]
+  - name: poweroff
+    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    command: ["/bin/sh", "/poweroff.sh", "3"]
+trust:
+  org:
+    - linuxkit

--- a/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test.sh
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Network namespace stress test with UDP/IPv6 over the loopback interface
+# LABELS: kernel-extra
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-netns*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-netns.yml
+RESULT="$(linuxkit run -cpus 2 test-netns)"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/pkg/netns/Dockerfile
+++ b/test/pkg/netns/Dockerfile
@@ -1,0 +1,16 @@
+FROM linuxkit/alpine:3d57ded3edd54e616210cf0c17e3bc15eed9d03a AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    busybox \
+    iperf3 \
+    iproute2 \
+    musl
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+FROM scratch
+COPY --from=mirror /out/ /
+COPY netns.sh runp.sh /
+
+LABEL org.mobyproject.config='{"pid": "host", "net":"host", "binds": ["/dev:/dev","/sys:/sys"], "capabilities": ["all"]}'
+

--- a/test/pkg/netns/Makefile
+++ b/test/pkg/netns/Makefile
@@ -1,0 +1,15 @@
+.PHONY: tag push
+default: push
+
+ORG?=linuxkit
+IMAGE=test-netns
+DEPS=Dockerfile Makefile
+
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
+
+tag: $(DEPS)
+	docker build --squash --no-cache -t $(ORG)/$(IMAGE):$(HASH) .
+
+push: tag
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/test/pkg/netns/netns.sh
+++ b/test/pkg/netns/netns.sh
@@ -1,0 +1,199 @@
+#! /bin/sh
+
+# Initialise the Random Number Seed with the PID
+RANDOM=$$
+
+# defaults
+ARG_TYPE=veth
+ARG_PROTO=tcp
+ARG_IP=4
+ARG_CONN=1
+ARG_ITER=10
+ARG_LEN=20
+ARG_REUSE=0
+
+usage() {
+    echo "Stress test for network namespace using iperf"
+    echo " -t  loopback|veth  Type of test [$ARG_TYPE]"
+    echo " -p  tcp|udp        Protocol to use [$ARG_PROTO]"
+    echo " -ip 4|6            IP version to use [$ARG_IP]"
+    echo " -c  <n>            Number of concurrent connections in ns [$ARG_CONN]"
+    echo " -i  <n>            Number of iterations [$ARG_ITER]"
+    echo " -l  <n>            Maximum length of test before killing [$ARG_LEN]"
+    echo " -r                 Re-use network namespace name"
+}
+
+# parse arguments
+while [[ $# -gt 0 ]]; do
+    key="$1"
+
+    case $key in
+        -t)
+            ARG_TYPE="$2"
+            shift
+            ;;
+        -p)
+            ARG_PROTO="$2"
+            shift
+            ;;
+        -ip)
+            ARG_IP="$2"
+            shift
+            ;;
+        -c)
+            ARG_CONN="$2"
+            shift
+            ;;
+        -i)
+            ARG_ITER="$2"
+            shift
+            ;;
+        -l)
+            ARG_LEN="$2"
+            shift
+            ;;
+        -r)
+            ARG_REUSE=1
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+echo "PID=$$"
+
+# Kill a random bit (client, server, network namespace, device) first
+# before cleaning up
+kill_all() {
+    ns=$1
+    pid_client=$2
+    pid_server=$3
+    host_dev=$4
+    ns_dev=$5
+
+    R=$(($RANDOM%$#))
+    case $R in
+        0)
+            echo "$ns: Remove namespace first"
+            ip netns del "$ns" > /dev/nukk 2>&1 || true
+            ;;
+        1)
+            echo "$ns: Kill client processes first"
+            kill "$pid_client"  > /dev/null 2>&1 || true
+            ;;
+        2)
+            echo "$ns: Kill server process first"
+            kill "$pid_server"  > /dev/null 2>&1 || true
+            ;;
+        3)
+            echo "$ns: Remove host netdev first"
+            ip link del "$host_dev"
+            ;;
+        4)
+            echo "$ns: Remove netns netdev first"
+            ip netns exec "$ns" ip link del "$ns_dev"
+            ;;
+    esac
+    kill "$pid_client" > /dev/null 2>&1 || true
+    kill "$pid_server" > /dev/null 2>&1 || true
+    ip netns del "$ns" > /dev/null 2>&1 || true
+    [ "$host_dev"x != x ] && (ip link del "$host_dev" > /dev/null 2>&1 || true) || true
+    [ "$ns_dev"x != x ] && (ip netns exec "$ns" ip link del "$ns_dev" > /dev/null 2>&1 || true) || true
+}
+
+# Run sock_stress in loopback mode in a network namespace
+loopback_run() {
+    id=$1 # unique ID for this run, used to create namespace
+    ip=$2 # 4 or 6 to select IP version to use
+    pr=$3 # protocol tcp or udp
+
+    # Use our PID as the ID to get unique namespaces
+    if [ "$ARG_REUSE" = "1" ]; then
+        ns="ns_$$"
+    else
+        ns="ns_$$_$id"
+    fi
+    ip netns add "$ns"
+    ip netns exec "$ns" ip link set lo up
+
+    ip netns exec "$ns" iperf3 -s --logfile /dev/null &
+    pid_server=$!
+    sleep 1
+    [ "$pr" = "udp" ] && o="-u"
+    ip netns exec "$ns" iperf3 -"$ip" "$o" -P "$ARG_CONN" -c localhost -t 10000 -i 20 &
+    pid_client=$!
+
+    # wait for a while before killing processes
+    sleep $(((RANDOM % $ARG_LEN )+1))
+
+    kill_all "$ns" "$pid_client" "$pid_server"
+}
+
+# Run sock_stress in with the client in a namespace
+veth_run() {
+    id=$1 # unique ID for this run, used to create namespace
+    ip=$2 # 4 or 6 to select IP version to use
+    pr=$3 # tcp or udp
+
+    # Use our PID as the ID to get unique namespaces
+    if [ "$ARG_REUSE" = "1" ]; then
+        ns="ns_$$"
+    else
+        ns="ns_$$_$id"
+    fi
+    dev_host="h-$$-$id"
+    dev_ns="n-$$-$id"
+    ip netns add "$ns"
+    ip netns exec "$ns" ip link set lo up
+
+    ip link add "$dev_host" type veth peer name "$dev_ns"
+    ip link set "$dev_ns" netns "$ns"
+
+    # derive IP addresses based on PID and $id
+    if [ "$ip" = "4" ]; then
+        sub0=$(($$%255))
+        sub1=$(($id%255))
+        mask=24
+        ip_host="10.$sub0.$sub1.1"
+        ip_ns="10.$sub0.$sub1.2"
+    else
+        # Make sure IPv6 is enabled on the interface
+        echo 0 > /proc/sys/net/ipv6/conf/"$dev_host"/disable_ipv6
+        sub0=$(printf "%x" $(($$%65535)))
+        sub1=$(printf "%x" $(($id%65535)))
+        mask=64
+        ip_host="2001:$sub0:$sub1::1"
+        ip_ns="2001:$sub0:$sub1::2"
+    fi
+    ip -"$ip" addr add "$ip_host"/"$mask" dev "$dev_host"
+    ip link set "$dev_host" up
+
+    ip netns exec "$ns" ip -"$ip" addr add "$ip_ns"/"$mask" dev "$dev_ns"
+    ip netns exec "$ns" ip link set "$dev_ns" up
+    sleep 2 # for IPv6 it takes a little while for the link to come up
+
+    ip netns exec "$ns" iperf3 -s --logfile /dev/null &
+    pid_server=$!
+    sleep 1
+    [ "$pr" = "udp" ] && o="-u"
+    iperf3 -"$ip" "$o" -P "$ARG_CONN" -c "$ip_ns" -t 10000 -i 20 &
+    pid_client=$!
+
+    # wait for a while before killing processes
+    sleep $(((RANDOM % $ARG_LEN )+1))
+
+    kill_all "$ns" "$pid_client" "$pid_server" "$dev_host" "$dev_ns"
+}
+
+for i in $(seq 1 "$ARG_ITER"); do
+    case $ARG_TYPE in
+        veth)
+            veth_run "$i" "$ARG_IP" "$ARG_PROTO"
+            ;;
+        loopback)
+            loopback_run "$i" "$ARG_IP" "$ARG_PROTO"
+    esac
+done

--- a/test/pkg/netns/runp.sh
+++ b/test/pkg/netns/runp.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+ITER=$1
+shift
+
+rm -rf ./logs
+mkdir -p ./logs
+
+fail() {
+    for f in ./logs/*; do
+        echo
+        echo "=== $f ==="
+        cat $f
+    done
+    echo
+    dmesg
+    echo "Test FAILED with $1"
+    exit 1
+}
+
+ns_before=$(ip netns list | wc -l)
+
+pids=""
+for i in $(seq 1 "$ITER"); do
+    "$@" > "./logs/$1-$i.log" 2>&1  &
+    pid=$!
+    pids="$pids $pid"
+    echo "Test $i started with PID=$pid"
+done
+
+for pid in $pids; do
+    wait "$pid"
+    [ $? -eq 0 ] || fail "$pid return non-zero"
+done
+
+dmesg | grep -q 'Call Trace:' && fail "Kernel backtrace"
+
+# A message like:
+# unregister_netdevice: waiting for lo to become free. Usage count = 1
+# is somewhat benign as it just waits for the ref count to go to 0. However
+# it may become a problem if we have to many of them
+nd=$(dmesg | grep -q 'unregister_netdevice' | wc -l)
+[ "$nd" -gt 10 ] && fail "unregister_netdevice more than 10 times"
+
+ns_after=$(ip netns list | wc -l)
+[ "$ns_before" != "$ns_after" ] && fail "NS leak: $ns_before != $ns_after"
+
+echo "netns test suite PASSED"

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -25,6 +25,7 @@ dosfstools
 e2fsprogs
 e2fsprogs-extra
 elfutils-dev
+expect
 flex
 gcc
 git
@@ -34,6 +35,8 @@ go
 gummiboot
 hvtools
 installkernel
+iperf3
+iproute2
 iptables
 jq
 kmod
@@ -71,6 +74,7 @@ strace
 swig
 syslinux
 tar
+tcpdump
 tini
 tzdata
 util-linux

--- a/tools/alpine/versions
+++ b/tools/alpine/versions
@@ -40,6 +40,7 @@ e2fsprogs-libs-1.43.4-r0
 elfutils-dev-0.168-r1
 elfutils-libelf-0.168-r1
 expat-2.2.0-r1
+expect-5.45-r3
 fakeroot-1.21-r1
 file-5.30-r0
 findmnt-2.28.2-r2
@@ -63,6 +64,8 @@ gummiboot-48.1-r0
 hvtools-4.4.15-r0
 icu-libs-58.2-r2
 installkernel-3.5-r0
+iperf3-3.1.7-r0
+iproute2-4.10.0-r1
 iptables-1.6.1-r0
 isl-0.17.1-r0
 jq-1.5-r3
@@ -117,6 +120,7 @@ libmspack-0.5_alpha-r0
 libnfs-1.11.0-r0
 libnftnl-libs-1.0.7-r0
 libogg-1.3.2-r1
+libpcap-1.8.1-r0
 libpciaccess-0.13.4-r1
 libpng-1.6.29-r1
 libressl-2.5.4-r0
@@ -200,6 +204,8 @@ sudo-1.8.19_p2-r0
 swig-3.0.10-r0
 syslinux-6.04_pre1-r1
 tar-1.29-r1
+tcl-8.6.6-r0
+tcpdump-4.9.0-r1
 tini-0.14.0-r0
 tzdata-2017a-r0
 usbredir-0.7-r2


### PR DESCRIPTION
These tests create a network name space (using `ip netns add`) and configure either the loopback interface or a `veth` pair (with one peer assigned to the network namespace). Then the interfaces are configured either with IPv4 or IPv6 addresses and `iperf3` is used to send some traffic (using multiple connections, 5 in the tests), either UDP or TCP, and either to or from the namespace (in case of the `veth` configuration).

After running traffic for semi random amount of time (up to 20s), we kill randomly either the `iperf` client or server, or remove one of the `veth` interfaces, or remove the network namespace, before cleaning up.

The above is repeated `<n>` times (20 times in the tests) as well as running 20 instances in parallel.

The test is designed to create stress on network namespace and be untidy in the cleanup to potentially trigger https://github.com/moby/moby/issues/5618. While we do see some messages of the form `unregister_netdevice: waiting for lo to become free. Usage count = X` these are benign as they are not repeated. However, we managed to trigger another issue with these tests (https://github.com/linuxkit/linuxkit/issues/2156) which requires more investigation.

The tests should be considered WIP (but should get merged after review for reference). We likely restructure and extend them in the future. They are not run by default and require `rtf` labels to be set to run.

![image](https://user-images.githubusercontent.com/3338098/27985611-0c96c104-63e6-11e7-889a-cc7185ee944e.png)
