### PR TITLE
Fix formatting error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ output a raw bootable disk image. See `moby build -help` for more information.
 
 ### Booting and Testing
 
-You can use `linuxkit run <name>` or `linuxkit run <name>.<format> to execute the image you created with `moby build <name>.yml`.
+You can use `linuxkit run <name>` or `linuxkit run <name>.<format>` to execute the image you created with `moby build <name>.yml`.
 This will use a suitable backend for your platform or you can choose one, for example VMWare.
 See `linuxkit run --help`.
 


### PR DESCRIPTION
**- What I did**
Add missing backtick (`)

**- How I did it**
Add missing backtick (\`) through github's editing features. This automatically forked it. Then I cloned it locally and checked out the patch-branch. Then did `git commit -s --amend`

**- How to verify it**
A visual diff of the README.md should now show a 'better' README.md around the section of 
*Booting and Testing*

**- Description for the changelog**
Fix formatting error in README.md



