### PR TITLE
Move ttyS0 after tty0 as it is more common

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 page_poison=1"
+  cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS1 page_poison=1"
+  cmdline: "console=ttyS1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -2,7 +2,7 @@
 # connect: nc localhost 6379
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 page_poison=1"
+  cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=tty0 page_poison=1"
+  cmdline: "console=tty0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.36
-  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+  cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
   - linuxkit/runc:2310ad9d266cf5d9c4d07613bd2135ed7eb8a21f


### PR DESCRIPTION
This means more users will see console output at boot time.

Remove page poison from example CLIs, we should document this
elsewhere and put in blueprints, but it is unnecessary in every example

Signed-off-by: Justin Cormack <justin.cormack@docker.com>
