### PR TITLE
Consistently don't use quotes around image names

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -1,6 +1,6 @@
 # This is a blueprint for building the open source components of Docker for Mac
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:e2b49a6c56fbf876ea24f0a5ce4ccae5f940d1be # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
@@ -10,22 +10,22 @@ init:
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata
-    image: "linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb"
+    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs
-    image: "linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc"
+    image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: binfmt
-    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   # Format and mount the disk image in /var/lib/docker
   - name: format
-    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
+    image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mount
-    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
+    image: linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf
     command: ["/mount.sh", "/var/lib/docker"]
   # mount-vpnkit mounts the 9p share used by vpnkit to coordinate port forwarding
   - name: mount-vpnkit
-    image: "alpine:3.6"
+    image: alpine:3.6
     binds:
         - /var/:/host_var:rbind,rshared
     capabilities:
@@ -33,7 +33,7 @@ onboot:
     rootfsPropagation: shared
     command: ["sh", "-c", "mkdir -p /host_var/vpnkit/port && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   # Enable acpi to shutdown on power events
@@ -41,35 +41,35 @@ services:
     image: linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918
   # Enable getty for easier debugging
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
         - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   # Run ntpd to keep time synchronised in the VM
   - name: ntpd
-    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
+    image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   # VSOCK to unix domain socket forwarding. Forwards guest /var/run/docker.sock
   # to a socket on the host.
   - name: vsudd
-    image: "linuxkit/vsudd:adad4b6ab7529b6b95339eb0752b0c81a218d185"
+    image: linuxkit/vsudd:adad4b6ab7529b6b95339eb0752b0c81a218d185
     binds:
         - /var/run:/var/run
     command: ["/vsudd", "-inport", "2376:unix:/var/run/docker.sock"]
   # vpnkit-forwarder forwards network traffic to/from the host via VSOCK port 62373. 
   # It needs access to the vpnkit 9P coordination share 
   - name: vpnkit-forwarder
-    image: "linuxkit/vpnkit-forwarder:9c1545e7b093d1210118de7661d7346393ec195b"
+    image: linuxkit/vpnkit-forwarder:9c1545e7b093d1210118de7661d7346393ec195b
     binds:
         - /var/vpnkit:/port
     net: host
     command: ["/vpnkit-forwarder", "-vsockPort", "62373"]
   # Monitor for image deletes and invoke a TRIM on the container filesystem
   - name: trim-after-delete
-    image: "linuxkit/trim-after-delete:2a5fcbe080cd4a45bd75c2ea3856c069475d706d"
+    image: linuxkit/trim-after-delete:2a5fcbe080cd4a45bd75c2ea3856c069475d706d
   # When the host resumes from sleep, force a clock resync
   - name: host-timesync-daemon
-    image: "linuxkit/host-timesync-daemon:e6c15e6ef75d302c1c22827bac249598fb365a83"
+    image: linuxkit/host-timesync-daemon:e6c15e6ef75d302c1c22827bac249598fb365a83
 
 trust:
     org:

--- a/blueprints/docker-for-mac/docker-17.06-ce.yml
+++ b/blueprints/docker-for-mac/docker-17.06-ce.yml
@@ -3,7 +3,7 @@ services:
   # Bind mounts /var/run to allow vsudd to connect to docker.sock, /var/vpnkit
   # for vpnkit coordination and /var/config/docker for the configuration file.
   - name: docker-dfm
-    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
+    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
     capabilities:
      - all
     net: host

--- a/docs/external-disk.md
+++ b/docs/external-disk.md
@@ -40,9 +40,9 @@ To simplify the process, two `onboot` images are available for you to use:
 ```yml
 onboot:
   - name: format
-    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
+    image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mount
-    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
+    image: linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf
     command: ["/mount.sh", "/var/external"]
 ```
 

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -80,7 +80,7 @@ This will create a local kernel image called
 `linuxkit/kernel:4.9.33-<hash>-dirty` assuming you haven't committed you local changes. You can then use this in your YAML file as:
 ```
 kernel:
-  image: "linuxkit/kernel:4.9.33-<hash>-dirty"
+  image: linuxkit/kernel:4.9.33-<hash>-dirty
 ```
 
 If you have committed your local changes, the `-dirty` will not be appended. Then you can also override the Hub organisation to use the image elsewhere with:

--- a/docs/virtual-os-tools.md
+++ b/docs/virtual-os-tools.md
@@ -25,7 +25,7 @@ Usage:
 ```
 services:
   - name: open-vm-tools
-    image: "linuxkit/open-vm-tools:<HASH>"
+    image: linuxkit/open-vm-tools:<HASH>
 ```
 
 ### Qemu GuestAgent

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,21 +8,21 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: "linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb"
+    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
 services:
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: sshd
-    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
+    image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx
-    image: "nginx:alpine"
+    image: nginx:alpine
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,14 +8,14 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: sshd
-    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
+    image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,29 +8,29 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs
     image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: binfmt
-    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: format
-    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
+    image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mount
-    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
+    image: linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: ntpd
-    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
+    image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: docker
-    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
+    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
     capabilities:
      - all
     net: host

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,25 +8,25 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: "linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb"
+    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: sshd
-    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
+    image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx
-    image: "nginx:alpine"
+    image: nginx:alpine
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,18 +8,18 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,11 +7,11 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,15 +7,15 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: node_exporter
-    image: "linuxkit/node_exporter:a058fe1c6a4440a9689022a9fd7cffdcfd56d52c"
+    image: linuxkit/node_exporter:a058fe1c6a4440a9689022a9fd7cffdcfd56d52c
 trust:
   org:
     - linuxkit

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS1 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,14 +8,14 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: sshd
-    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
+    image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -9,15 +9,15 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
   - name: redis
-    image: "redis:3.0.7-alpine"
+    image: redis:3.0.7-alpine
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,18 +8,18 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: sshd
-    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
+    image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,29 +8,29 @@ init:
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
+    image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mount
-    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
+    image: linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf
     command: ["/mount.sh", "/var/external"]
   - name: swap
-    image: "linuxkit/swap:b6d447b55da3c28bdd8a3f4e30fb42c1fa0157bb"
+    image: linuxkit/swap:b6d447b55da3c28bdd8a3f4e30fb42c1fa0157bb
     # to use unencrypted swap, use:
     # command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G"]
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: nginx
-    image: "nginx:alpine"
+    image: nginx:alpine
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,18 +8,18 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: nginx
-    image: "nginx:alpine"
+    image: nginx:alpine
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: mount-vpnkit
-    image: "alpine:3.6"
+    image: alpine:3.6
     binds:
         - /var/:/host_var:rbind,rshared
     capabilities:
@@ -19,15 +19,15 @@ onboot:
     command: ["sh", "-c", "mkdir /host_var/vpnkit && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
 services:
   - name: sshd
-    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
+    image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
   - name: vpnkit-forwarder
-    image: "linuxkit/vpnkit-forwarder:9c1545e7b093d1210118de7661d7346393ec195b"
+    image: linuxkit/vpnkit-forwarder:9c1545e7b093d1210118de7661d7346393ec195b
     binds:
         - /var/vpnkit:/port
     net: host
     command: ["/vpnkit-forwarder"]
   - name: vpnkit-expose-port
-    image: "linuxkit/vpnkit-forwarder:9c1545e7b093d1210118de7661d7346393ec195b"
+    image: linuxkit/vpnkit-forwarder:9c1545e7b093d1210118de7661d7346393ec195b
     net: none
     binds:
         - /var/vpnkit:/port

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,11 +7,11 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: vsudd
-    image: "linuxkit/vsudd:adad4b6ab7529b6b95339eb0752b0c81a218d185"
+    image: linuxkit/vsudd:adad4b6ab7529b6b95339eb0752b0c81a218d185
     binds:
         - /run/containerd/containerd.sock:/run/containerd/containerd.sock
     command: ["/vsudd",

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,25 +8,25 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: "linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb"
+    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: sshd
-    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
+    image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx
-    image: "nginx:alpine"
+    image: nginx:alpine
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,21 +8,21 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: binfmt
-    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: nginx
-    image: "nginx:alpine"
+    image: nginx:alpine
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN

--- a/pkg/getty/README.md
+++ b/pkg/getty/README.md
@@ -10,7 +10,7 @@ If you want a console getty, add the following to your `moby.yml`:
 ```
 services:
   - name: getty
-    image: "linuxkit/getty:<hash>"
+    image: linuxkit/getty:<hash>
 ```
 
 The above will launch a getty for each console defined in the cmdline, i.e. `/proc/cmdline`.

--- a/pkg/swap/README.md
+++ b/pkg/swap/README.md
@@ -8,7 +8,7 @@ Normally, unless you are running explicitly in a desktop version, LinuxKit image
 ```
 onboot:
   - name: swap
-    image: "linuxkit/swap:<hash>"
+    image: linuxkit/swap:<hash>
     command: ["swap.sh","--path","/var/external/swap","--size","2G"]
 ```
 

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -1,11 +1,11 @@
 kernel:
-  image: "linuxkit/kernel-clear-containers:4.9.x"
+  image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
 onboot:
   - name: sysctl
-    image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
+    image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c
 services:
   - name: rngd
 files:

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
@@ -8,26 +8,26 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs
     image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: binfmt
-    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: format
-    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
+    image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mount
-    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
+    image: linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: ntpd
-    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
+    image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: docker
-    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
+    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
     capabilities:
      - all
     net: host
@@ -40,7 +40,7 @@ services:
      - /var/run:/var/run
      - /var/html:/var/html
   - name: compose
-    image: "linuxkitprojects/compose:0535e78608f57702745dfd56fbe78d28d237e469"
+    image: linuxkitprojects/compose:0535e78608f57702745dfd56fbe78d28d237e469
     binds:
      - /var/run:/var/run
      - /var/compose:/compose

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
@@ -8,26 +8,26 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs
     image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: binfmt
-    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: format
-    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
+    image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mount
-    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
+    image: linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: ntpd
-    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
+    image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: docker
-    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
+    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
     capabilities:
      - all
     net: host
@@ -40,7 +40,7 @@ services:
      - /var/run:/var/run
      - /var/html:/var/html
   - name: compose
-    image: "linuxkitprojects/compose:0535e78608f57702745dfd56fbe78d28d237e469"
+    image: linuxkitprojects/compose:0535e78608f57702745dfd56fbe78d28d237e469
     binds:
      - /var/run:/var/run
      - /var/compose:/compose

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
@@ -8,26 +8,26 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: format
-    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
+    image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mount
-    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
+    image: linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf
     command: ["/mount.sh", "/var/lib/etcd"]
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: "linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb"
+    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
 services:
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: ntpd
-    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
+    image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: node_exporter
-    image: "linuxkit/node_exporter:a058fe1c6a4440a9689022a9fd7cffdcfd56d52c"
+    image: linuxkit/node_exporter:a058fe1c6a4440a9689022a9fd7cffdcfd56d52c
   - name: etcd
-    image: "moby/etcd"
+    image: moby/etcd
     capabilities:
      - CAP_CHOWN
      - CAP_SETUID

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "mobylinux/kernel:4.9.x"
+  image: mobylinux/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
@@ -8,17 +8,17 @@ init:
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: "linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb"
+    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
 services:
   - name: rngd
-    image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
+    image: mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9
   - name: prometheus
-    image: "moby/prom-us-central1-f"
+    image: moby/prom-us-central1-f
     binds:
       - /dev:/dev
       - /var/lib/misc:/data

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148"
+  image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
   - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
@@ -9,17 +9,17 @@ init:
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: binfmt
-    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: nginx
-    image: "nginx:alpine"
+    image: nginx:alpine
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,15 +8,15 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs
     image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: binfmt
-    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: format
-    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
+    image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mounts
-    image: "linuxkit/kubernetes:latest-mounts"
+    image: linuxkit/kubernetes:latest-mounts
     capabilities:
      - all
     pid: host
@@ -26,19 +26,19 @@ onboot:
      - /var:/var:rshared,rbind
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: ntpd
-    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
+    image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: sshd
-    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
+    image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
   - name: docker
-    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
+    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
     capabilities:
      - all
     net: host
@@ -55,15 +55,15 @@ services:
      - /opt/cni:/opt/cni:rshared,rbind
     rootfsPropagation: shared
   - name: kubernetes-image-cache-common
-    image: "linuxkit/kubernetes:latest-image-cache-common"
+    image: linuxkit/kubernetes:latest-image-cache-common
     binds:
       - /var/run:/var/run
   - name: kubernetes-image-cache-control-plane
-    image: "linuxkit/kubernetes:latest-image-cache-control-plane"
+    image: linuxkit/kubernetes:latest-image-cache-control-plane
     binds:
       - /var/run:/var/run
   - name: kubelet
-    image: "linuxkit/kubernetes:latest"
+    image: linuxkit/kubernetes:latest
     capabilities:
      - all
     net: host

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,15 +8,15 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs
     image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: binfmt
-    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: format
-    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
+    image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mounts
-    image: "linuxkit/kubernetes:latest-mounts"
+    image: linuxkit/kubernetes:latest-mounts
     capabilities:
      - all
     pid: host
@@ -26,19 +26,19 @@ onboot:
      - /var:/var:rshared,rbind
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: ntpd
-    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
+    image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: sshd
-    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
+    image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
   - name: docker
-    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
+    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
     capabilities:
      - all
     net: host
@@ -55,11 +55,11 @@ services:
      - /opt/cni:/opt/cni:rshared,rbind
     rootfsPropagation: shared
   - name: kubernetes-image-cache-common
-    image: "linuxkit/kubernetes:latest-image-cache-common"
+    image: linuxkit/kubernetes:latest-image-cache-common
     binds:
       - /var/run:/var/run
   - name: kubelet
-    image: "linuxkit/kubernetes:latest"
+    image: linuxkit/kubernetes:latest
     capabilities:
      - all
     net: host

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "mobylinux/kernel-landlock:4.9.x"
+  image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
@@ -8,10 +8,10 @@ init:
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
-    image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
+    image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c
 services:
   - name: rngd
-    image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
+    image: mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9
 trust:
   image:
     - linuxkit/kernel

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd
@@ -9,17 +9,17 @@ init:
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: binfmt
-    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: nginx
-    image: "nginx:alpine"
+    image: nginx:alpine
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.34"
+  image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -9,16 +9,16 @@ init:
   - samoht/fdd
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: "linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05"
+    image: linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
 files:
   - path: etc/init.d/020-fdd-init
     mode: "0700"

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -28,9 +28,9 @@ onboot:
      - /lib:/lib     # for ifconfig
 services:
   - name: sshd
-    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
+    image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
 files:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/okernel:latest"
+  image: linuxkit/okernel:latest
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
@@ -8,14 +8,14 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: sshd
-    image: "linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb"
+    image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/projects/selinux/selinux.yml
+++ b/projects/selinux/selinux.yml
@@ -1,11 +1,11 @@
 kernel:
-  image: "mobylinux/kernel-selinux:4.9.x"
+  image: mobylinux/kernel-selinux:4.9.x
   cmdline: "console=ttyS0 page_poison=1 security=selinux selinux=1"
 init:
   - "mobylinux/init:b5249a412536b4e69f8e1f668680d2ae185cc505"
 onboot:
   - name: sysctl
-    image: "mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
+    image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c
     net: host
     pid: host
     ipc: host
@@ -14,7 +14,7 @@ onboot:
     readonly: true
 services:
   - name: rngd
-    image: "mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9"
+    image: mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9
     capabilities:
      - CAP_SYS_ADMIN
     oomScoreAdj: -800

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5"
+  image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,21 +8,21 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: binfmt
-    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
     env:
      - INSECURE=true
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: nginx
-    image: "nginx:alpine"
+    image: nginx:alpine
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,32 +8,32 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
     binds:
      - /etc/sysctl.d/01-swarmd.conf:/etc/sysctl.d/01-swarmd.conf
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
+    image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mount
-    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
+    image: linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf
     command: ["/mount.sh", "/var/lib/swarmd"]
   - name: metadata
-    image: "linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb"
+    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
 services:
   - name: getty
-    image: "linuxkit/getty:9f27c1272b6d128c9a09745e916f151d09cb0d27"
+    image: linuxkit/getty:9f27c1272b6d128c9a09745e916f151d09cb0d27
     env:
      - INSECURE=true
   - name: qemu-ga
-    image: "linuxkit/qemu-ga:585e4f0161a4df7583d5e0479d7621040c1ee140"
+    image: linuxkit/qemu-ga:585e4f0161a4df7583d5e0479d7621040c1ee140
     binds:
       - /dev/vport0p1:/dev/vport0p1
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: ntpd
-    image: "linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90"
+    image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: weave
     image: weaveworks/weave@sha256:05172329b6ff72099db7bb891ac311b89948a3064ca9b8641c6b4abe38548677 # Must match swarmd/Dockerfile
     command: ["/bin/sh", "/home/weave/weaver-wrapper"]
@@ -45,7 +45,7 @@ services:
       - /var:/var
       - /var/lib/swarmd:/weavedb
   - name: swarmd
-    image: "linuxkitprojects/swarmd:1cd4c061cc7327750d2a12c267db6d4d9e26b1d3"
+    image: linuxkitprojects/swarmd:1cd4c061cc7327750d2a12c267db6d4d9e26b1d3
     command: ["/usr/bin/swarmd", "--containerd-addr=/run/containerd/containerd.sock", "--log-level=debug", "--state-dir=/var/lib/swarmd"]
     capabilities:
      - all

--- a/projects/wireguard/wireguard.yml
+++ b/projects/wireguard/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel-wireguard:4.9.15-2ca28b7589b673373a33274023ca870a3a77e081"
+  image: linuxkit/kernel-wireguard:4.9.15-2ca28b7589b673373a33274023ca870a3a77e081
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
@@ -9,17 +9,17 @@ init:
   - linuxkit/wireguard-utils:26fe3d38455f2d441549e3c54bdec1b26ac819b8
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64"
+    image: linuxkit/sysctl:225c52c2d6f04a040663bac84cabf81825027f64
   - name: binfmt
-    image: "linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d"
+    image: linuxkit/binfmt:603e5f064b3e8a64088c0fcf7a80d2783541ee1d
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: nginx
-    image: "nginx:alpine"
+    image: nginx:alpine
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 services:
   - name: acpid
-    image: "linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918"
+    image: linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,9 +7,9 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: check-kernel-config
-    image: "linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119"
+    image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,9 +7,9 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: check-kernel-config
-    image: "linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119"
+    image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,9 +7,9 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: check-kernel-config
-    image: "linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119"
+    image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,14 +7,14 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: check
-    image: "kmod-test"
+    image: kmod-test
     binds:
      - /dev:/dev
      - /lib/modules:/lib/modules
     capabilities:
      - all
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-tcp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-tcp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-udp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.4.76"
+  image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-udp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-tcp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-tcp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-udp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-udp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-tcp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-tcp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-tcp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-r", "-i", "20", "-c", "5", "-t", "veth", "-p", "-udp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-udp", "-ip", "4"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.11.9"
+  image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,10 +7,10 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test-netns
-    image: "linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776"
+    image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776
     command: ["/bin/sh", "/runp.sh", "20", "/netns.sh", "-i", "20", "-c", "5", "-t", "loopback", "-p", "-udp", "-ip", "6"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,23 +8,23 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs
-    image: "linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc"
+    image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: binfmt
-    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: format
-    image: "linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954"
+    image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mount
-    image: "linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf"
+    image: linuxkit/mount:b24bd97ae43397b469dbaadd80f17f291c817bdf
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: rngd
-    image: "linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b"
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: docker
-    image: "linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190"
+    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
     capabilities:
      - all
     net: host
@@ -36,7 +36,7 @@ services:
      - /lib/modules:/lib/modules
      - /run:/var/run
   - name: test-docker-bench
-    image: "linuxkit/test-docker-bench:4999d3484771e8466580c0dc2e479595e49faa85"
+    image: linuxkit/test-docker-bench:4999d3484771e8466580c0dc2e479595e49faa85
     ipc: host
     pid: host
     net: host

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,13 +7,13 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: test
-    image: "alpine:3.6"
+    image: alpine:3.6
     readonly: true
     binds:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,16 +7,16 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: binfmt
-    image: "linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5"
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: test
-    image: "alpine:3.6"
+    image: alpine:3.6
     readonly: true
     binds:
       - /check.sh:/check.sh
       - /proc/sys/fs/binfmt_misc:/binfmt_misc
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,14 +8,14 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: test
-    image: "alpine:3.6"
+    image: alpine:3.6
     readonly: true
     binds:
       - /check.sh:/check.sh
       - /etc:/host-etc
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,11 +8,11 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: test
-    image: "linuxkit/test-containerd:b9b6046f1eb8ed8a15eb70523bc584e7da657baa"
+    image: linuxkit/test-containerd:b9b6046f1eb8ed8a15eb70523bc584e7da657baa
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,17 +7,17 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: test
-    image: "alpine:3.6"
+    image: alpine:3.6
     readonly: true
     net: host
     binds:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.x"
+  image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -8,11 +8,11 @@ init:
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: "linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c"
+    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,9 +7,9 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: mkimage
-    image: "linuxkit/mkimage:a63b8ee4c5de335afc32ba850e0af319b25b96c0"
+    image: linuxkit/mkimage:a63b8ee4c5de335afc32ba850e0af319b25b96c0
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,9 +7,9 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: sysctl
-    image: "linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0"
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: test
-    image: "alpine:3.6"
+    image: alpine:3.6
     net: host
     pid: host
     ipc: host
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -7,11 +7,11 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: ltp
-    image: "linuxkit/test-ltp:6df23ac196332cafb9c0f8e32f328e22d612267d"
+    image: linuxkit/test-ltp:6df23ac196332cafb9c0f8e32f328e22d612267d
     binds:
      - /etc/ltp/baseline:/etc/ltp/baseline
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
 files:
   - path: /etc/ltp/baseline
     contents: "100"

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: "linuxkit/kernel:4.9.36"
+  image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
@@ -9,12 +9,12 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 onboot:
   - name: dhcpcd
-    image: "linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41"
+    image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
-    image: "linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119"
+    image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119
   - name: poweroff
-    image: "linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05"
+    image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   image:


### PR DESCRIPTION
These are not needed, but we are inconsistent. Been waiting for a
quiet moment to fix this since I noticed while doing a presentation...

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

