### PR TITLE
Use existing securetty

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -20,7 +20,7 @@ onboot:
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
+    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
 services:
   - name: getty
-    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
+    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
+    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
+    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:c977f27c234d55b85172813b8451f67ea86be4a3
 services:
   - name: getty
-    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
+    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -13,7 +13,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
+    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
     env:
      - INSECURE=true
   - name: redis

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
+    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -24,7 +24,7 @@ onboot:
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
+    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
+    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
 services:
   - name: getty
-    image: linuxkit/getty:5ab31289889d61a5d2ecbeea8e36ce74ac54737c
+    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
     env:
      - INSECURE=true
   - name: rngd

--- a/pkg/getty/README.md
+++ b/pkg/getty/README.md
@@ -16,6 +16,12 @@ services:
 The above will launch a getty for each console defined in the cmdline, i.e. `/proc/cmdline`.
 
 
+### securetty
+Every console defined in the `cmdline` **must** also already exist in `/etc/securetty` if you wish to login on that tty as root. If it does not exist, a getty will be started, but you will not be able to login as root. A warning message will be sent to that tty.
+
+If you are using a console that is not in `securetty`, you can add it by overriding the default `securetty` file in the linuxkit root filesystem using `files:` in your moby `.yml` file.
+
+
 ### Login Options
 There are 3 ways to launch a getty on a linuxkit instance:
 

--- a/pkg/getty/usr/bin/rungetty.sh
+++ b/pkg/getty/usr/bin/rungetty.sh
@@ -35,7 +35,8 @@ start_getty() {
 	fi
 
 	if ! grep -q -w "$tty" "$securetty"; then
-		echo "$tty" >> "$securetty"
+		# we could not find the tty in securetty, so start a getty but warn that root login will not work
+		echo "getty: cmdline has console=$tty but does not exist in $securetty; will not be able to log in as root on this tty $tty." > /dev/$tty
 	fi
 	# respawn forever
 	infinite_loop setsid.getty -w /sbin/agetty $loginargs $line $speed $tty $term &
@@ -47,6 +48,13 @@ if [ -f $ROOTSHADOW ]; then
 	cp $ROOTSHADOW /etc/shadow
 	# just in case someone forgot a newline
 	echo >> /etc/shadow
+fi
+
+ROOTSTTY=/hostroot/etc/securetty
+if [ -f $ROOTSTTY ]; then
+	cp $ROOTSTTY /etc/securetty
+	# just in case someone forgot a newline
+	echo >> /etc/securetty
 fi
 
 for opt in $(cat /proc/cmdline); do


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed `pkg/getty` as follows:

* Instead of _modifying_ `/etc/securetty` to match `console=` lines, _read_ `/etc/securetty` to determine if a getty can be started for a given tty device
* If a console tty device does *not* exist in `/etc/securetty`, refuse to start a `getty` on that terminal, and report an error message
* Override default in-container `/etc/securetty` with file from rootfs, similar to `/etc/getty.shadow`

**- How I did it**
Typing. :-)

**- How to verify it**
Try the following scenarios:

1. Build with securetty matching console, see getty is available
2. Build with securetty *not* matching console, see error message and getty is not available 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use existing tty to determine whether to start a getty, rather than override securetty just because `console=...` appears in cmdline

closes #2097 


**- A picture of a cute animal (not mandatory but encouraged)**
![Nazgul fell beast](https://vignette3.wikia.nocookie.net/lotr/images/7/7d/Fell_beast_bfme.jpg/revision/latest?cb=20120602125522)

Yes, a Nazgul fell beast. Really.