### PR TITLE
ARM64: Adapt the kernel Dockerfile to multi-arch support

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -17,7 +17,6 @@ RUN apk add \
     kmod \
     libelf-dev \
     libressl-dev \
-    libunwind-dev \
     linux-headers \
     ncurses-dev \
     sed \
@@ -25,7 +24,11 @@ RUN apk add \
     tar \
     xz \
     xz-dev \
-    zlib-dev
+    zlib-dev  && \
+# libunwind-dev pkg is missed from arm64 now, below statement will be removed if this pkg is ready
+    if [ $(uname -m) == x86_64 ]; then \
+	apk add libunwind-dev; \
+    fi
 
 ARG KERNEL_VERSION
 ARG KERNEL_SERIES
@@ -50,13 +53,24 @@ RUN curl -fsSLO ${KERNEL_SHA256_SUMS} && \
     gpg2 --verify linux-${KERNEL_VERSION}.tar.sign linux-${KERNEL_VERSION}.tar && \
     cat linux-${KERNEL_VERSION}.tar | tar --absolute-names -x && mv /linux-${KERNEL_VERSION} /linux
 
-COPY kernel_config-${KERNEL_SERIES} /linux/arch/x86/configs/x86_64_defconfig
+# When using COPY with more than one source file, the destination must be a directory and end with a /
+COPY kernel_config-${KERNEL_SERIES}* /linux/
 COPY kernel_config.debug /linux/debug_config
 
-RUN if [ -n "${DEBUG}" ]; then \
-    sed -i 's/CONFIG_PANIC_ON_OOPS=y/# CONFIG_PANIC_ON_OOPS is not set/' /linux/arch/x86/configs/x86_64_defconfig; \
-    cat /linux/debug_config >> /linux/arch/x86/configs/x86_64_defconfig; \
-    fi
+RUN if [ $(uname -m) == x86_64 ]; then \
+        cp /linux/kernel_config-${KERNEL_SERIES} /linux/arch/x86/configs/x86_64_defconfig; \
+        if [ -n "${DEBUG}" ]; then \
+        sed -i 's/CONFIG_PANIC_ON_OOPS=y/# CONFIG_PANIC_ON_OOPS is not set/' /linux/arch/x86/configs/x86_64_defconfig; \
+        cat /linux/debug_config >> /linux/arch/x86/configs/x86_64_defconfig; \
+        fi \
+    elif [ $(uname -m) == aarch64 ]; then \
+        cp /linux/kernel_config-${KERNEL_SERIES}-aarch64 /linux/arch/arm64/configs/defconfig; \
+        if [ -n "${DEBUG}" ]; then \
+        sed -i 's/CONFIG_PANIC_ON_OOPS=y/# CONFIG_PANIC_ON_OOPS is not set/' /linux/arch/arm64/configs/defconfig; \
+        cat /linux/debug_config >> /linux/arch/arm64/configs/defconfig; \
+        fi \
+    fi && \
+    rm /linux/kernel_config-${KERNEL_SERIES}*
 
 # Apply local patches
 COPY patches-${KERNEL_SERIES} /patches
@@ -72,7 +86,11 @@ RUN mkdir /out
 RUN make defconfig && \
     make oldconfig && \
     make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
-    cp arch/x86_64/boot/bzImage /out/kernel && \
+    if [ $(uname -m) == x86_64 ]; then \
+      cp arch/x86_64/boot/bzImage /out/kernel; \
+    elif [ $(uname -m) == aarch64 ]; then \
+      cp arch/arm64/boot/Image.gz /out/kernel; \
+    fi && \
     cp System.map /out && \
     ([ -n "${DEBUG}" ] && cp vmlinux /out || true)
 


### PR DESCRIPTION
The original kernel Dockerfile hardcodes the amd64 as the
only arch supported, this patch removes this kind of hardcode
and make the Dockerfile is ready to support both amd64 and
arm64 by using the runtime ARCH type.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
