### PR TITLE
ARM64: Adapt the kernel Dockerfile to multiarch support

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -17,7 +17,6 @@ RUN apk add \
     kmod \
     libelf-dev \
     libressl-dev \
-    libunwind-dev \
     linux-headers \
     ncurses-dev \
     sed \
@@ -25,7 +24,11 @@ RUN apk add \
     tar \
     xz \
     xz-dev \
-    zlib-dev
+    zlib-dev && \
+# libunwind-dev pkg is missed from arm64 now, below statement will be removed if the pkg is available.
+    if [ $(uname -m) == x86_64 ]; then \
+        apk add libunwind-dev; \
+    fi
 
 ARG KERNEL_VERSION
 ARG KERNEL_SERIES
@@ -50,13 +53,25 @@ RUN curl -fsSLO ${KERNEL_SHA256_SUMS} && \
     gpg2 --verify linux-${KERNEL_VERSION}.tar.sign linux-${KERNEL_VERSION}.tar && \
     cat linux-${KERNEL_VERSION}.tar | tar --absolute-names -x && mv /linux-${KERNEL_VERSION} /linux
 
-COPY kernel_config-${KERNEL_SERIES} /linux/arch/x86/configs/x86_64_defconfig
+# When using COPY with more than one source file, the destination must be a directory and end with a /
+COPY kernel_config-${KERNEL_SERIES}* /linux/
 COPY kernel_config.debug /linux/debug_config
 
-RUN if [ -n "${DEBUG}" ]; then \
-    sed -i 's/CONFIG_PANIC_ON_OOPS=y/# CONFIG_PANIC_ON_OOPS is not set/' /linux/arch/x86/configs/x86_64_defconfig; \
-    cat /linux/debug_config >> /linux/arch/x86/configs/x86_64_defconfig; \
-    fi
+RUN case $(uname -m) in \
+    x86_64) \
+        KERNEL_DEF_CONF=/linux/arch/x86/configs/x86_64_defconfig; \
+        cp /linux/kernel_config-${KERNEL_SERIES} ${KERNEL_DEF_CONF}; \
+        ;; \
+    aarch64) \
+        KERNEL_DEF_CONF=/linux/arch/arm64/configs/defconfig; \
+        cp /linux/kernel_config-${KERNEL_SERIES}-aarch64 ${KERNEL_DEF_CONF}; \
+        ;; \
+    esac  && \
+    if [ -n "${DEBUG}" ]; then \
+        sed -i 's/CONFIG_PANIC_ON_OOPS=y/# CONFIG_PANIC_ON_OOPS is not set/' ${KERNEL_DEF_CONF}; \
+        cat /linux/debug_config >> ${KERNEL_DEF_CONF}; \
+    fi && \
+    rm /linux/kernel_config-${KERNEL_SERIES}*
 
 # Apply local patches
 COPY patches-${KERNEL_SERIES} /patches
@@ -72,7 +87,14 @@ RUN mkdir /out
 RUN make defconfig && \
     make oldconfig && \
     make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
-    cp arch/x86_64/boot/bzImage /out/kernel && \
+    case $(uname -m) in \
+    x86_64) \
+        cp arch/x86_64/boot/bzImage /out/kernel; \
+        ;; \
+    aarch64) \
+        cp arch/arm64/boot/Image.gz /out/kernel; \
+        ;; \
+    esac && \
     cp System.map /out && \
     ([ -n "${DEBUG}" ] && cp vmlinux /out || true)
 


### PR DESCRIPTION
The original kernel Dockerfile hardcodes the amd64 as the
only arch supported, this patch removes this kind of hardcode
and make the Dockerfile is ready to support both amd64 and
arm64 by using the runtime arch type.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Remove the hardcode of x86
**- How I did it**
Get the info of the ARCH through runtime 'uname -m' command
**- How to verify it**
Build the kernel docker image on both arm64 and amd64 platform, then add this component into linuxkit.yml, run 'bin/moby build linuxkit.yml' 'bin/linuxkit run linuxkit'. you got it!

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


![summit](https://user-images.githubusercontent.com/29669302/28063021-656be74a-6662-11e7-8bfe-e5f206533411.jpg)
