### PR TITLE
Remove shellcheck from base

### DIFF
--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -38,9 +38,6 @@ RUN go get -u github.com/golang/lint/golint
 RUN go get -u github.com/gordonklaus/ineffassign
 RUN go get -u github.com/LK4D4/vndr
 
-FROM koalaman/shellcheck:v0.4.6@sha256:191b61e5f436fc51f22faaf2f4e0f77799f75977c7210377dd73a1a0f99ef8bd AS shellcheck
-
-
 FROM alpine:3.6
 
 COPY --from=mirror /etc/apk/repositories /etc/apk/repositories
@@ -49,9 +46,6 @@ COPY --from=mirror /mirror /mirror/
 COPY --from=mirror /go/bin /go/bin/
 COPY --from=mirror /usr/share/ovmf/bios.bin /usr/share/ovmf/bios.bin
 COPY --from=mirror /Dockerfile /Dockerfile
-
-COPY --from=shellcheck /usr/local/bin/shellcheck /usr/local/bin/shellcheck
-COPY --from=shellcheck /usr/local/lib/ /usr/local/lib/
 
 RUN apk update && apk upgrade -a
 


### PR DESCRIPTION
We should use this from a container at top level instead; it makes it
much harder to port to other architectures if we have to have this as
it is written in Haskell making a multi arch build much harder.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![400px-nautilus_species_shells](https://user-images.githubusercontent.com/482364/28091153-d64d4336-6686-11e7-9ee7-1bf497d29ea0.png)
