### PR TITLE
Move onboot startup script to runc package

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:e2b49a6c56fbf876ea24f0a5ce4ccae5f940d1be # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 services:
   - name: getty
     image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -1,5 +1,5 @@
 IMAGE=containerd
 NETWORK=1
-DEPS=$(wildcard etc/init.d/*)
+DEPS=$(wildcard etc/init.d/*) etc/containerd/config.toml
 
 include ../package.mk

--- a/pkg/containerd/etc/init.d/020-containerd
+++ b/pkg/containerd/etc/init.d/020-containerd
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-# set global ulimits TODO move to /etc/limits.conf
-ulimit -n 1048576
-ulimit -p unlimited
-
 # bring up containerd
 printf "\nStarting containerd\n"
 /usr/bin/containerd &
@@ -13,20 +9,6 @@ while [ ! -S /run/containerd/containerd.sock ]
 do
 	sleep 0.1
 done
-
-# start onboot containers, run to completion
-
-if [ -d /containers/onboot ]
-then
-	for f in $(find /containers/onboot -mindepth 1 -maxdepth 1 | sort)
-	do
-		base="$(basename $f)"
-		/bin/mount --bind "$f/rootfs" "$f/rootfs"
-		mount -o remount,rw "$f/rootfs"
-		/usr/bin/runc run --bundle "$f" "$(basename $f)"
-		printf " - $base\n"
-	done
-fi
 
 # start service containers
 

--- a/pkg/init/bin/rc.init
+++ b/pkg/init/bin/rc.init
@@ -114,6 +114,10 @@ mount --make-rshared /var
 # make / rshared
 mount --make-rshared /
 
+# set global ulimits TODO move to /etc/limits.conf?
+ulimit -n 1048576
+ulimit -p unlimited
+
 # execute other init processes
 INITS="$(find /etc/init.d -type f | sort)"
 for f in $INITS

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -25,3 +25,4 @@ FROM scratch
 WORKDIR /
 ENTRYPOINT []
 COPY --from=alpine /usr/bin/runc /usr/bin/
+COPY etc etc/

--- a/pkg/runc/Makefile
+++ b/pkg/runc/Makefile
@@ -1,4 +1,5 @@
 IMAGE=runc
 NETWORK=1
+DEPS=$(wildcard etc/init.d/*)
 
 include ../package.mk

--- a/pkg/runc/etc/init.d/010-onboot
+++ b/pkg/runc/etc/init.d/010-onboot
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# start onboot containers, run to completion
+
+if [ -d /containers/onboot ]
+then
+	for f in $(find /containers/onboot -mindepth 1 -maxdepth 1 | sort)
+	do
+		base="$(basename $f)"
+		/bin/mount --bind "$f/rootfs" "$f/rootfs"
+		mount -o remount,rw "$f/rootfs"
+		/usr/bin/runc run --bundle "$f" "$(basename $f)"
+		printf " - $base\n"
+	done
+fi

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:b1766e4c4c09f63ac4925a6e4612852a93f7e73b
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/okernel:latest
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/wireguard/wireguard.yml
+++ b/projects/wireguard/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-wireguard:4.9.15-2ca28b7589b673373a33274023ca870a3a77e081
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:cbd7ae748f0a082516501a3e914fa0c924ee941e
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:f1130450206d4f64f0ddc13d15bb68435aa1ff61
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
   - linuxkit/wireguard-utils:26fe3d38455f2d441549e3c54bdec1b26ac819b8
 onboot:

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 services:
   - name: acpid
     image: linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test
     image: alpine:3.6

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: test

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:a63b8ee4c5de335afc32ba850e0af319b25b96c0

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:a63b8ee4c5de335afc32ba850e0af319b25b96c0

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -4,7 +4,6 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:6df23ac196332cafb9c0f8e32f328e22d612267d

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:14a38303ee9dcb4541c00e2b87404befc1ba2083
-  - linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161
-  - linuxkit/containerd:389e67c3c1fc009c1315f32b3e2b6659691a3ad4
+  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41


### PR DESCRIPTION
    As onboot does not use containerd at all, this means you can run very
    minimal setups with just `runc` if you use no services, for example
    most of our tests do not actually use services, or if you have other
    similar very minimal use cases.
    
    Move ulimit setup to `init` which makes more sense.

![frog](https://user-images.githubusercontent.com/482364/28126463-738e1f22-6721-11e7-9e56-d9200151c8a5.jpeg)
