### PR TITLE
sig-security: add preliminary agenda for 2017-07-19

### DIFF
--- a/reports/sig-security/2017-07-19.md
+++ b/reports/sig-security/2017-07-19.md
@@ -1,0 +1,22 @@
+# 2017-07-19
+Time: **9am PDT** (12pm EDT, 5pm BST) [see the time in your timezone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Linuxkit+Security+SIG&iso=20170719T09&p1=224)
+
+Meeting location: https://docker.zoom.us/j/779801882
+
+Announcement: Coming soon
+
+Previous meeting notes: [2017-07-05](2017-07-05.md)
+
+## Agenda
+- Introductions & Administrivia (5 min)
+- WireGuard deep dive - @zx2c4 (45 min)
+  - Differences from other VPNs
+  - Signal Protocol
+  - Usage with network namespaces
+  - demo
+- Project updates (10 min)
+- Next meeting: 2017-08-02
+  - deep dive TBD
+  - we can propose additional deep dives and discussion topics!
+
+## Meeting Notes


### PR DESCRIPTION
Exciting WireGuard deep-dive planned from @zx2c4 (let me know if you'd like a different/modified description in the agenda).  I'll follow up with emails/forum posts once we finalize this.

<img src="https://www.petfinder.com/wp-content/uploads/2013/03/160142171-632x353.jpg" width="400"></img>

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
