### PR TITLE
linuxkit: Fix qemu run behaviour when file does not exist

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -170,6 +170,9 @@ func runQemu(args []string) {
 
 	// user not trying to boot off ISO or kernel, so assume booting from a disk image
 	if !*kernelBoot && !*isoBoot {
+		if _, err := os.Stat(path); err != nil {
+			log.Fatalf("Boot disk image %s does not exist", path)
+		}
 		// currently no way to set format, but autodetect probably works
 		d := Disks{DiskConfig{Path: path}}
 		disks = append(d, disks...)


### PR DESCRIPTION
This commit fixes an issue reported on Slack where `linuxkit run` will
assume that a file that is neither a kernel or iso must be a disk image
without first checking that it exists. This would result in `qemu-img`
attempting to create a disk with 0 size due to the default behaviour of
creating disk images that do not exist.

Before:
```
$ linuxkit -v run qemu foo
DEBU[0000] Creating new qemu disk [foo] format
DEBU[0000] [/usr/local/bin/qemu-img create -f  foo 0M]

FATA[0000] Error creating disk [foo] format :  exit status 1
```

After:
```
$ linuxkit -v run qemu foo
FATA[0000] foo is not a valid disk image
```