### PR TITLE
Disable qemu in container test

### DIFF
--- a/test/cases/010_platforms/000_qemu/100_container/test.sh
+++ b/test/cases/010_platforms/000_qemu/100_container/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # SUMMARY: Check that qemu runs containerised
-# LABELS:
+# LABELS: skip
+
+# this test is not working at present see https://github.com/linuxkit/linuxkit/issues/2020
 
 set -e
 


### PR DESCRIPTION
Failing for some time; see https://github.com/linuxkit/linuxkit/issues/2020

Signed-off-by: Justin Cormack <justin.cormack@docker.com>
