### PR TITLE
qemu: allow kvm and containerized options to be overridden by the env…

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -42,6 +42,19 @@ func haveKVM() bool {
 	return !os.IsNotExist(err)
 }
 
+func envOverrideBool(env string, b *bool) {
+	val := os.Getenv(env)
+	if val == "" {
+		return
+	}
+
+	var err error
+	*b, err = strconv.ParseBool(val)
+	if err != nil {
+		log.Fatal("Unable to parse %q=%q as a boolean", env, val)
+	}
+}
+
 func runQemu(args []string) {
 	invoked := filepath.Base(os.Args[0])
 	flags := flag.NewFlagSet("qemu", flag.ExitOnError)
@@ -88,6 +101,11 @@ func runQemu(args []string) {
 		log.Fatal("Unable to parse args")
 	}
 	remArgs := flags.Args()
+
+	// These envvars override the corresponding command line
+	// options. So this must remain after the `flags.Parse` above.
+	envOverrideBool("LINUXKIT_QEMU_KVM", enableKVM)
+	envOverrideBool("LINUXKIT_QEMU_CONTAINERIZED", qemuContainerized)
 
 	if len(remArgs) == 0 {
 		fmt.Println("Please specify the path to the image to boot")


### PR DESCRIPTION
…ironment

This is useful in the case where Moby is shelling out to LinuxKit for certain
image types (currently raw and qcow2). Currently to experiment with different
options (e.g. when comparing performance to CI) you have to edit either the
moby or linuxkit tool to change the options used.

The environment variables take precedence over any explict command line options
given.

Signed-off-by: Ian Campbell <ijc@docker.com>
