### PR TITLE
docker-for-mac: clear the default namespace on start

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -44,6 +44,12 @@ onboot:
     binds:
         - /var:/host_var
     command: ["sh", "-c", "mv -v /host_var/log /host_var/lib && ln -vs /var/lib/log /host_var/log"]
+  # remove old containers from the previous boot
+  - name: remove-old-state
+    image: alpine:3.6
+    binds:
+        - /var:/host_var
+    command: ["sh", "-c", "rm -rf /host_var/lib/containerd/io.containerd.runtime.v1.linux/default"]
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]


### PR DESCRIPTION

**- What I did**

Fixed a bug in the `docker-for-mac` blueprint which would cause it to fail to boot if the disk isn't empty i.e. on second and subsequent boots.

**- How I did it**

I delete the directory `/var/lib/containerd/io.containerd.runtime.v1.linux/default` in an `onboot` action before starting `services`. I first tried to modify the `010-containerd` script but unfortunately this is run before the disk is mounted, so the old entries later magically reappear. 

**- How to verify it**

Boot the `docker-for-mac` example twice, without erasing the disk between runs. Without the patch you'll see errors like
```
Starting service: "acpid"
FATA[0000] failed to create task                         error="rpc error: code = Unknown desc = runtime create failed: mkdir /var/lib/containerd/io.containerd.runtime.v1.linux/default/acpid: file exists" service=acpid
```

With the patch, there are no errors and all the services start correctly.