### PR TITLE
docker-ce: add git binary

### DIFF
--- a/blueprints/docker-for-mac/docker-17.06-ce.yml
+++ b/blueprints/docker-for-mac/docker-17.06-ce.yml
@@ -3,7 +3,7 @@ services:
   # Bind mounts /var/run to allow vsudd to connect to docker.sock, /var/vpnkit
   # for vpnkit coordination and /var/config/docker for the configuration file.
   - name: docker-dfm
-    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
+    image: linuxkit/docker-ce:baf282455697809fc4e2ee398567d9a4d6c061d9
     capabilities:
      - all
     net: host

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -30,7 +30,7 @@ services:
   - name: ntpd
     image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: docker
-    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
+    image: linuxkit/docker-ce:baf282455697809fc4e2ee398567d9a4d6c061d9
     capabilities:
      - all
     net: host

--- a/pkg/docker-ce/Dockerfile
+++ b/pkg/docker-ce/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --no-cache --initdb -p /out \
 	curl \
 	e2fsprogs \
 	e2fsprogs-extra \
+	git \
 	iptables \
 	musl \
 	xfsprogs \

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -27,7 +27,7 @@ services:
   - name: ntpd
     image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: docker
-    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
+    image: linuxkit/docker-ce:baf282455697809fc4e2ee398567d9a4d6c061d9
     capabilities:
      - all
     net: host

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -27,7 +27,7 @@ services:
   - name: ntpd
     image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: docker
-    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
+    image: linuxkit/docker-ce:baf282455697809fc4e2ee398567d9a4d6c061d9
     capabilities:
      - all
     net: host

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -38,7 +38,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
   - name: docker
-    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
+    image: linuxkit/docker-ce:baf282455697809fc4e2ee398567d9a4d6c061d9
     capabilities:
      - all
     net: host

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -38,7 +38,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
   - name: docker
-    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
+    image: linuxkit/docker-ce:baf282455697809fc4e2ee398567d9a4d6c061d9
     capabilities:
      - all
     net: host

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -24,7 +24,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: docker
-    image: linuxkit/docker-ce:9b937df179bdbebbc70243779978057df0b54190
+    image: linuxkit/docker-ce:baf282455697809fc4e2ee398567d9a4d6c061d9
     capabilities:
      - all
     net: host


### PR DESCRIPTION

**- What I did**

Fixed the following `docker build` cases:

```
$ cat > docker-compose.yml <<EOT
version: '2'

services:
  test:
    build: "https://github.com/dnephin/docker-build-from-url.git"
EOT

$ docker-compose build
```
and
```
$ curl  -d "" --unix-socket /var/run/docker.sock http://unix/v1.22/build?remote=https%3A%2F%2Fgithub.com%2Fdnephin%2Fdocker-build-from-url.git
```

Previously you would see an error like:
```
$ curl  -d "" --unix-socket /var/run/docker.sock http://unix/v1.22/build?remote=https%3A%2F%2Fgithub.com%2Fdnephin%2Fdocker-build-from-url.git
failed to init repo at /var/lib/docker/tmp/docker-build-git645459714: : exec: "git": executable file not found in $PATH
```

**- How I did it**

I added the `git` binary to the `docker-ce` container: it seems that the docker daemon will occasionally want to fork/exec `git`.
