### PR TITLE
Add experimental support for LCOW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 
 PREFIX?=/usr/local/
 
-MOBY_COMMIT=4db06aa1732b44a8cadd9c8577df0aa5c716e701
+MOBY_COMMIT=a824287800b1871fde9859f5b2bd9009eaefa990
 MOBY_VERSION=0.0
 bin/moby: tmp_moby_bin.tar | bin
 	tar xf $<

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -19,6 +19,7 @@ the [examples/](../examples/) directory.
 - Packet.net
 - ...
 
+
 ### Docker for Mac
 
 An initial blueprint for the open source components of Docker for Mac is available in [docker-for-mac](docker-for-mac). The blueprint has support for controlling `dockerd` from the host via `vsudd` and port forwarding with VPNKit. It requires HyperKit, VPNKit and a Docker client on the host to run. The easiest way to install these at the moment is to install a recent version of Docker for Mac.
@@ -42,3 +43,14 @@ $ docker -H unix://docker-for-mac-state/guest.00000947 ps
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ```
 
+### Linux Containers On Windows (LCOW)
+
+The [LCOW](./lcow.yml) file contains the blueprint for building a
+minimal Linux kernel and initrd for Linux Containers on
+Windows. Invoke it with `moby build lcow.yml` and you get a
+`lcow-kernel` and `lcow-initrd.img`. Rename `lcow-kernel` to
+`bootx64.efi` and `lcow-initrd.img` to `initrd.img` and then
+follow
+[these instructions](https://github.com/moby/moby/issues/33850). The
+process for creating the image is
+documented [here](https://github.com/Microsoft/opengcs).

--- a/blueprints/lcow.yml
+++ b/blueprints/lcow.yml
@@ -1,0 +1,9 @@
+kernel:
+  image: linuxkit/kernel:4.11.9
+  cmdline: "console=ttyS0"
+  tar: none
+init:
+  - linuxkit/init-lcow:ae67df4c4cabb35aae06898cb94fe03972a172e9
+trust:
+  org:
+    - linuxkit

--- a/pkg/init-lcow/Dockerfile
+++ b/pkg/init-lcow/Dockerfile
@@ -1,0 +1,41 @@
+FROM linuxkit/alpine:3744607156e6b67e3e7d083b15be9e7722215e73 AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    busybox \
+    e2fsprogs \
+    musl
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+FROM linuxkit/alpine:3744607156e6b67e3e7d083b15be9e7722215e73 AS build
+RUN apk add --no-cache build-base curl git go musl-dev
+ENV GOPATH=/go PATH=$PATH:/go/bin
+ENV OPENGCS_COMMIT=4e4e6f28a03e974e6c32f00a91d51f9605821fdd
+RUN git clone https://github.com/Microsoft/opengcs.git /go/src/github.com/Microsoft/opengcs && \
+    cd /go/src/github.com/Microsoft/opengcs && \
+    git checkout $OPENGCS_COMMIT && \
+    cd service && \
+    make
+RUN mkdir /out && \
+    cp -r /go/src/github.com/Microsoft/opengcs/service/bin /out/bin && \
+    cp /go/src/github.com/Microsoft/opengcs/kernelconfig/4.11/scripts/init_script /out/init && \
+    chmod ugo+rx /out/init && \
+    mkdir /out/sbin && \
+    curl -fSL "https://raw.githubusercontent.com/mirror/busybox/38d966943f5288bb1f2e7219f50a92753c730b14/examples/udhcp/simple.script" -o /out/sbin/udhcpc_config.script && \
+    chmod ugo+rx /out/sbin/udhcpc_config.script && \
+    mkdir -p /out/root/integration && \
+    cp /go/src/github.com/Microsoft/opengcs/kernelconfig/4.11/prebuildSandbox.vhdx /out/root/integration/prebuildSandbox.vhdx
+
+# This d line below should be removed once
+# https://github.com/Microsoft/opengcs/issues/52 is addressed and then
+# runc should be added via the YAML file
+FROM linuxkit/runc:a0f2894e50bacbd1ff82be41edff8b8e06e0b161 AS runc
+
+FROM scratch
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=mirror /out/ /
+COPY --from=build /out/ /
+COPY --from=runc /usr/bin/runc /sbin/runc
+

--- a/pkg/init-lcow/Makefile
+++ b/pkg/init-lcow/Makefile
@@ -1,0 +1,4 @@
+IMAGE=init-lcow
+NETWORK=1
+
+include ../package.mk

--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -302,6 +302,13 @@ func runQemuContainer(config QemuConfig) error {
 	var args []string
 	config, args = buildQemuCmdline(config)
 
+	// if user specify the "-fw" parameter, this should override the default in container context,
+	// with "-v" option, we will have the chance to assign an external FW binary to the containerized qemu
+	// instead of the fixed FW bin instealled by the build process of the image.
+	if config.UEFI {
+		binds = append(binds, "-v", fmt.Sprintf("%[1]s:%[1]s", config.FWPath))
+	}
+
 	dockerArgs := append([]string{"run", "--interactive", "--rm", "-w", cwd}, binds...)
 	dockerArgsImg := append([]string{"run", "--rm", "-w", cwd}, binds...)
 

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -27,8 +27,8 @@ RUN abuild-sign /mirror/$(uname -m)/APKINDEX.tar.gz
 # fetch OVMF for qemu EFI boot (this is not added as a package)
 RUN apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/community ovmf
 
-# set this as our repo
-RUN echo "/mirror" > /etc/apk/repositories && apk update
+# set this as our repo but keep a copy of the upstream for downstream use
+RUN mv /etc/apk/repositories /etc/apk/repositories.upstream && echo "/mirror" > /etc/apk/repositories && apk update
 
 # add Go validation tools
 COPY go-compile.sh /go/bin/
@@ -41,6 +41,7 @@ RUN go get -u github.com/LK4D4/vndr
 FROM alpine:3.6
 
 COPY --from=mirror /etc/apk/repositories /etc/apk/repositories
+COPY --from=mirror /etc/apk/repositories.upstream /etc/apk/repositories.upstream
 COPY --from=mirror /etc/apk/keys /etc/apk/keys/
 COPY --from=mirror /mirror /mirror/
 COPY --from=mirror /go/bin /go/bin/

--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -6,6 +6,9 @@ BASE=alpine:3.6
 
 default: push
 
+show-tag:
+	@sed -n -e '1s/# \(.*\/.*:[0-9a-f]\{40\}\)/\1/p;q' versions
+
 hash: Dockerfile Makefile packages
 	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	docker build --no-cache -t $(IMAGE):build .
@@ -15,7 +18,8 @@ push: hash
 	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(IMAGE):build $(ORG)/$(IMAGE):$(shell cat hash) && \
 		 DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(shell cat hash))
-	docker run --rm $(IMAGE):build find /mirror -name '*.apk' -exec basename '{}' .apk \; | sort | (echo '# automatically generated list of installed packages'; cat -) > versions
+	echo "# $(ORG)/$(IMAGE):$(shell cat hash)" > versions
+	docker run --rm $(IMAGE):build find /mirror -name '*.apk' -exec basename '{}' .apk \; | sort | (echo '# automatically generated list of installed packages'; cat -) >> versions
 	docker rmi $(IMAGE):build
 	rm -f hash
 

--- a/tools/alpine/versions
+++ b/tools/alpine/versions
@@ -1,3 +1,4 @@
+# linuxkit/alpine:3744607156e6b67e3e7d083b15be9e7722215e73
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r7
 alpine-baselayout-3.0.4-r0


### PR DESCRIPTION
A previous commit already added the kernel support (hopefully) necessary for LCOW (Linux Containers for Windows). This PR adds a new init container based on https://github.com/Microsoft/opengcs/blob/master/docs/customosbuildinstructions.md and a blueprint to create a kernel+initrd.

We currently can't test if this actually works...

![image](https://user-images.githubusercontent.com/3338098/28177452-bed259fe-67f2-11e7-887e-ecc47f330cea.png)
