### PR TITLE
ARM64: specify external firware binary for containerized qemu

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -302,6 +302,13 @@ func runQemuContainer(config QemuConfig) error {
 	var args []string
 	config, args = buildQemuCmdline(config)
 
+	// if user specify the "-fw" parameter, this should override the default in container context,
+	// with "-v" option, we will have the chance to assign an external FW binary to the containerized qemu
+	// instead of the fixed FW bin instealled by the build process of the image.
+	if config.UEFI {
+		binds = append(binds, "-v", fmt.Sprintf("%[1]s:%[1]s", config.FWPath))
+	}
+
 	dockerArgs := append([]string{"run", "--interactive", "--rm", "-w", cwd}, binds...)
 	dockerArgsImg := append([]string{"run", "--rm", "-w", cwd}, binds...)
 


### PR DESCRIPTION
Current implementation uses a fixed firmware(bios) binary
installed by the build process of the qemu container image,
which will prevent us from providing an external firmware binary
outside the container. This patch removes this limitation, thus we
can assign a firware binary image file with "-fw" option outside
the container.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Remove the original limitation when boot the kernel image in UEFI mode.
**- How I did it**
Add '-v' option when running qemu container to pass the external firmware bin into the container.
**- How to verify it**
Run below command in both x86 and arm64 platform:
'bin/linuxkit run qemu -containerized -fw "/home/arch/bios.bin" -uefi linuxkit
The kernel image will boot to shell successfully.
Without this patch, the same command will result in below error message:
qemu-system-x86_64: -pflash  /home/arch/bios.bin: Could not open '/home/arch/bios.bin': No such file or directory.

That's because '/home/arch/bios.bin' is a file in the host system while not a valid file inside the container.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
![summit](https://user-images.githubusercontent.com/29669302/28207156-2cbe409a-68bb-11e7-998c-0c3113c2b9a2.jpg)

