### PR TITLE
Service start of day cleanup

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/vpnkit-expose-port:e2b49a6c56fbf876ea24f0a5ce4ccae5f940d1be # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 services:
   - name: getty
     image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -6,7 +6,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -1,5 +1,5 @@
 IMAGE=containerd
 NETWORK=1
-DEPS=$(wildcard etc/init.d/*) etc/containerd/config.toml
+DEPS=$(wildcard etc/init.d/*) $(wildcard cmd/service/*.go) etc/containerd/config.toml
 
 include ../package.mk

--- a/pkg/containerd/cmd/service/main.go
+++ b/pkg/containerd/cmd/service/main.go
@@ -29,6 +29,7 @@ func main() {
 	flag.Usage = func() {
 		fmt.Printf("USAGE: %s [options] COMMAND\n\n", filepath.Base(os.Args[0]))
 		fmt.Printf("Commands:\n")
+		fmt.Printf("  system-init Prepare the system at start of day\n")
 		fmt.Printf("  start       Start a service\n")
 		fmt.Printf("  help        Print this message\n")
 		fmt.Printf("\n")
@@ -67,6 +68,8 @@ func main() {
 	switch args[0] {
 	case "start":
 		start(args[1:])
+	case "system-init":
+		systemInit(args[1:])
 	default:
 		fmt.Printf("%q is not valid command.\n\n", args[0])
 		flag.Usage()

--- a/pkg/containerd/cmd/service/system_init.go
+++ b/pkg/containerd/cmd/service/system_init.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/pkg/errors"
+)
+
+func cleanupTask(ctx context.Context, ctr containerd.Container) error {
+	task, err := ctr.Task(ctx, nil)
+	if err != nil {
+		if err == containerd.ErrNoRunningTask {
+			return nil
+		}
+		return errors.Wrap(err, "getting task")
+	}
+
+	deleteErr := make(chan error, 1)
+	deleteCtx, deleteCancel := context.WithCancel(ctx)
+	defer deleteCancel()
+
+	go func(ctx context.Context, ch chan error) {
+		_, err := task.Delete(ctx)
+		if err != nil {
+			ch <- errors.Wrap(err, "killing task")
+		}
+		ch <- nil
+	}(deleteCtx, deleteErr)
+
+	sig := syscall.SIGKILL
+	if err := task.Kill(ctx, sig); err != nil && err != containerd.ErrProcessExited {
+		return errors.Wrapf(err, "killing task with %q", sig)
+	}
+
+	select {
+	case err := <-deleteErr:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func systemInit(args []string) {
+	invoked := filepath.Base(os.Args[0])
+	flags := flag.NewFlagSet("system-init", flag.ExitOnError)
+	flags.Usage = func() {
+		fmt.Printf("USAGE: %s system-init\n\n", invoked)
+		fmt.Printf("Options:\n")
+		flags.PrintDefaults()
+	}
+
+	sock := flags.String("sock", "/run/containerd/containerd.sock", "Path to containerd socket")
+
+	if err := flags.Parse(args); err != nil {
+		log.Fatal("Unable to parse args")
+	}
+	args = flags.Args()
+
+	if len(args) != 0 {
+		fmt.Println("Unexpected argument")
+		flags.Usage()
+		os.Exit(1)
+	}
+
+	client, err := containerd.New(*sock)
+	if err != nil {
+		log.WithError(err).Fatal("creating containerd client")
+	}
+
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+
+	ctrs, err := client.Containers(ctx)
+	if err != nil {
+		log.WithError(err).Fatal("listing containers")
+	}
+
+	// None of the errors in this loop are fatal since we want to
+	// keep trying.
+	for _, ctr := range ctrs {
+		log.Infof("Cleaning up stale service: %q", ctr.ID())
+		log := log.WithFields(log.Fields{
+			"service": ctr.ID(),
+		})
+
+		if err := cleanupTask(ctx, ctr); err != nil {
+			log.WithError(err).Error("cleaning up task")
+		}
+
+		if err := ctr.Delete(ctx); err != nil {
+			log.WithError(err).Error("deleting container")
+		}
+	}
+}

--- a/pkg/containerd/etc/init.d/020-containerd
+++ b/pkg/containerd/etc/init.d/020-containerd
@@ -12,6 +12,8 @@ done
 
 # start service containers
 
+service system-init
+
 if [ -d /containers/services ]
 then
 	for f in $(find /containers/services -mindepth 1 -maxdepth 1 | sort)

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/wireguard/wireguard.yml
+++ b/projects/wireguard/wireguard.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
   - linuxkit/wireguard-utils:26fe3d38455f2d441549e3c54bdec1b26ac819b8
 onboot:

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 services:
   - name: acpid
     image: linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: dhcpcd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:6df23ac196332cafb9c0f8e32f328e22d612267d

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -6,7 +6,7 @@ kernel:
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
-  - linuxkit/containerd:f1f9c27e153b510e09b2e3f221181f87ade0fe1a
+  - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a `system-init` command to the `service` binary to setup the system ready for running system services at start of day. Initially this contains only code to remove any stale system containers from a previous boot in the case where `/var/lib/containerd` is on a persistent disk to solve the same issue as #2198.

~~This is currently WIP since it is based on (and thus for now includes) #2191. It will need rebasing once #2191 is merged. In the meantime only "containerd: Add a service command to cleanup stale containers on boot" is worth looking at.~~ #2191 is now merged, this PR has been rebased.

**- How I did it**

Added a new command described above and called it from `020-containerd` before starting the services.

**- How to verify it**

I've been running `service system-init` by hand from an init (not service, or you will be trying pull the rug out from under yourself and hang) based getty in the top level `linuxkit.yml`.

You could also configure a persistent disk for `/var/lib` or `/var/lib/containerd` and do an unclean reboot.

**- Description for the changelog**

Stale processes

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://i.ytimg.com/vi/kMZSJCgn_K8/maxresdefault.jpg "Gojira, From Mars to Sirius")](https://en.wikipedia.org/wiki/From_Mars_to_Sirius)
