### PR TITLE
Small alpine mirror improvements

### DIFF
--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -27,8 +27,8 @@ RUN abuild-sign /mirror/$(uname -m)/APKINDEX.tar.gz
 # fetch OVMF for qemu EFI boot (this is not added as a package)
 RUN apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/community ovmf
 
-# set this as our repo
-RUN echo "/mirror" > /etc/apk/repositories && apk update
+# set this as our repo but keep a copy of the upstream for downstream use
+RUN mv /etc/apk/repositories /etc/apk/repositories.upstream && echo "/mirror" > /etc/apk/repositories && apk update
 
 # add Go validation tools
 COPY go-compile.sh /go/bin/
@@ -41,6 +41,7 @@ RUN go get -u github.com/LK4D4/vndr
 FROM alpine:3.6
 
 COPY --from=mirror /etc/apk/repositories /etc/apk/repositories
+COPY --from=mirror /etc/apk/repositories.upstream /etc/apk/repositories.upstream
 COPY --from=mirror /etc/apk/keys /etc/apk/keys/
 COPY --from=mirror /mirror /mirror/
 COPY --from=mirror /go/bin /go/bin/

--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -6,6 +6,9 @@ BASE=alpine:3.6
 
 default: push
 
+show-tag:
+	@sed -n -e '1s/# \(.*\/.*:[0-9a-f]\{40\}\)/\1/p;q' versions
+
 hash: Dockerfile Makefile packages
 	DOCKER_CONTENT_TRUST=1 docker pull $(BASE)
 	docker build --no-cache -t $(IMAGE):build .
@@ -15,7 +18,8 @@ push: hash
 	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(IMAGE):build $(ORG)/$(IMAGE):$(shell cat hash) && \
 		 DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(shell cat hash))
-	docker run --rm $(IMAGE):build find /mirror -name '*.apk' -exec basename '{}' .apk \; | sort | (echo '# automatically generated list of installed packages'; cat -) > versions
+	echo "# $(ORG)/$(IMAGE):$(shell cat hash)" > versions
+	docker run --rm $(IMAGE):build find /mirror -name '*.apk' -exec basename '{}' .apk \; | sort | (echo '# automatically generated list of installed packages'; cat -) >> versions
 	docker rmi $(IMAGE):build
 	rm -f hash
 

--- a/tools/alpine/versions
+++ b/tools/alpine/versions
@@ -1,3 +1,4 @@
+# linuxkit/alpine:3744607156e6b67e3e7d083b15be9e7722215e73
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r7
 alpine-baselayout-3.0.4-r0


### PR DESCRIPTION
**- What I did**

Two things:
* Kept a copy of the original (upstream Alpine) `/etc/apk/repositories`. This will be useful in dependent containers which want to include a working `apk` configuration by avoiding the need to include alpine version numbers there
* Record the hash of the pushed alpine bash container, currently this relies on the committer remembering to include it in the commit message. `tools/alpine` now supports the `show-tag` target like `pkg/package.mk` based builds do.

Note that nothing here is updated to use the new alpine hash.

Note2 I had planned to use the first change to add `apk` to the `getty` and `sshd` containers but ran into a blocker, see #2206.

**- How I did it**

Updated the `Dockerfile` and `Makefile`

**- How to verify it**

This should validate both of my claims together:
```
docker run -it --rm $(make --no-print-directory -C tools/alpine/ show-tag) cat /etc/apk/repositories.upstream
```

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://upload.wikimedia.org/wikipedia/en/b/b1/Wiseblood_%28Corrosion_of_Conformity_album%29_cover_art.jpg "Corrosion of Conformity, Wiseblood")](https://en.wikipedia.org/wiki/Wiseblood_(Corrosion_of_Conformity_album))
