### PR TITLE
Allow config test modprobe to fail

### DIFF
--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:6c1219678ff314c7790c4485d95744504e18205f
+    image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119
+    image: linuxkit/test-kernel-config:6c1219678ff314c7790c4485d95744504e18205f
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:6c1219678ff314c7790c4485d95744504e18205f
+    image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119
+    image: linuxkit/test-kernel-config:6c1219678ff314c7790c4485d95744504e18205f
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:6c1219678ff314c7790c4485d95744504e18205f
+    image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119
+    image: linuxkit/test-kernel-config:6c1219678ff314c7790c4485d95744504e18205f
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:9f08e3b99f8ac2f422251b3e8c94ce874ee34119
+    image: linuxkit/test-kernel-config:6c1219678ff314c7790c4485d95744504e18205f
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:6c1219678ff314c7790c4485d95744504e18205f
+    image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/pkg/kernel-config/check-kernel-config.sh
+++ b/test/pkg/kernel-config/check-kernel-config.sh
@@ -92,7 +92,7 @@ nfs \
 nfsd \
 ntfs
 do
-	modprobe $mod
+	modprobe $mod 2>/dev/null || true
 done
 
 # check filesystems that are built in


### PR DESCRIPTION
Do not assume that these are modules in all kernels.

You can now run it with `docker run linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76` on any docker host to see if the test passes.

![img_20170708_131641](https://user-images.githubusercontent.com/482364/28213437-f3791976-689d-11e7-8927-c2751061bf9b.jpg)
