### PR TITLE
pkg/init: Do not run inits in the background

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:e2b49a6c56fbf876ea24f0a5ce4ccae5f940d1be # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 services:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/pkg/init/bin/rc.init
+++ b/pkg/init/bin/rc.init
@@ -122,5 +122,5 @@ ulimit -p unlimited
 INITS="$(find /etc/init.d -type f | sort)"
 for f in $INITS
 do
-	$f &
+	$f
 done

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/okernel:latest
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/wireguard/wireguard.yml
+++ b/projects/wireguard/wireguard.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-wireguard:4.9.15-2ca28b7589b673373a33274023ca870a3a77e081
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 services:

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.11.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test-netns

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
 onboot:
   - name: sysctl

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.36
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
+  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:


### PR DESCRIPTION
We want them to run in sequence. For example we want mounts to be done (done by
`pkg/runc/etc/init.d/010-onboot`) before we start services (done by
`pkg/containerd/etc/init.d/020-containerd`). This was most likely introduced by
28b4245b122a ("Move onboot startup script to runc package").

None of the initscripts in pkg/* block, but some in projects (selinux and
logging, not updated here) do.

Signed-off-by: Ian Campbell <ijc@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Removed the `&` from the invocation in `/bin/rc.init`.

**- How I did it**

I pressed `x` in `vim`, twice IIRC.

**- How to verify it**

I booted the kubernetes example.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://upload.wikimedia.org/wikipedia/en/3/30/Pantera_The_Great_Southern_Trendkill.jpg "Pantera, The Great Southern Trendkill")](https://en.wikipedia.org/wiki/The_Great_Southern_Trendkill)
