### PR TITLE
Make runc a static pie executable

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -5,7 +5,7 @@ kernel:
 init:
   - linuxkit/vpnkit-expose-port:e2b49a6c56fbf876ea24f0a5ce4ccae5f940d1be # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   # support metadata for optional config in /var/config

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 services:
   - name: getty

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -5,7 +5,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -17,8 +17,7 @@ RUN mkdir -p $GOPATH/src/github.com/opencontainers && \
   git clone https://github.com/opencontainers/runc.git
 WORKDIR $GOPATH/src/github.com/opencontainers/runc
 RUN git checkout $RUNC_COMMIT
-# TODO static pie, currently no easy way to change build options
-RUN make static BUILDTAGS="seccomp"
+RUN make static BUILDTAGS="seccomp" EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS="-extldflags \\\"-fno-PIC -static\\\""
 RUN cp runc /usr/bin/
 
 FROM scratch

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - samoht/fdd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: sysctl

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/wireguard/wireguard.yml
+++ b/projects/wireguard/wireguard.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
   - linuxkit/wireguard-utils:26fe3d38455f2d441549e3c54bdec1b26ac819b8

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 services:
   - name: acpid

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:a63b8ee4c5de335afc32ba850e0af319b25b96c0

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: ltp

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -5,7 +5,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:a626edd428b575d10b994be0d4c5b034838e9946
-  - linuxkit/runc:f5b28379fc969237e0fb11aa1ed946622150e9a0
+  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd


### PR DESCRIPTION
This was waiting for the runc update as I got the extra variables added a while back.

I think this is the last non static pie executable. Will try to work out a way to test this at some point see #1297 (I did test by hand)

![dogpie](https://user-images.githubusercontent.com/482364/28217466-0fcf9aaa-68ad-11e7-90bd-3115d11ae45a.jpg)


