### PR TITLE
fix that docker.yml wasn't working correctly

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -42,6 +42,8 @@ services:
      - /lib/modules:/lib/modules
      - /etc/docker/daemon.json:/etc/docker/daemon.json
 files:
+  - path: var/lib/docker
+    directory: true
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'
 trust:


### PR DESCRIPTION
**- What I did**

fix that docker.yml wasn't working correctly

**- How I did it**

add the configs to make directory before docker container running.

**- How to verify it**

1. build original docker.yml, and run it. ensure that 

**- Description for the changelog**

I wanted to try moby and linuxkit, so I downloaded example/docker.yml, built it, and ran it with linuxkit.
but I can't execure /bin/sh on docker in my environment. I looked for the cause, so I found following logs.

```
FATA[0000] failed to create task                         error="rpc error: code = Unknown desc = runtime create failed: OCI runtime create failed: container_linux.go:265: starting container process caused \"process_linux.go:348: container init caused \\\"rootfs_linux.go:57: mounting \\\\\\\"/var/lib/docker\\\\\\\" to rootfs \\\\\\\"/containers/services/docker/rootfs\\\\\\\" at \\\\\\\"/var/lib/docker\\\\\\\" caused \\\\\\\"stat /var/lib/docker: no such file or directory\\\\\\\"\\\"\"" service=docker
 - 004-mount
```

It seems to occur that /var/lib/docker is missing, so I added the configs.

Here are some infomations for my environment.

```
(ns: getty) linuxkit-525400123456:~# ctr version
Client:
  Version: 3455ffc0
  Revision: 3455ffc08c553db0ca9fe60b4ba2b3e8a2dc960b

Server:
  Version: 3455ffc0
  Revision: 3455ffc08c553db0ca9fe60b4ba2b3e8a2dc960b
(ns: getty) linuxkit-525400123456:~# ctr tasks list
TASK      PID    STATUS    
dhcpcd    415    RUNNING
getty     547    RUNNING
ntpd      605    RUNNING
rngd      658    STOPPED
(ns: getty) linuxkit-525400123456:~# ctr containers list
CONTAINER    IMAGE    RUNTIME                           LABELS    
dhcpcd       -        io.containerd.runtime.v1.linux    -         
docker       -        io.containerd.runtime.v1.linux    -         
getty        -        io.containerd.runtime.v1.linux    -         
ntpd         -        io.containerd.runtime.v1.linux    -         
rngd         -        io.containerd.runtime.v1.linux    -
```

**- A picture of a cute animal (not mandatory but encouraged)**

I look for my google photos, but I don't have it. :<
