### PR TITLE
fixes #2145 - /var/run should symlink to /run

### DIFF
--- a/pkg/init-lcow/Dockerfile
+++ b/pkg/init-lcow/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache --initdb -p /out \
     busybox \
     e2fsprogs \
     musl
-RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache /out/var/run
 
 FROM linuxkit/alpine:3744607156e6b67e3e7d083b15be9e7722215e73 AS build
 RUN apk add --no-cache build-base curl git go musl-dev
@@ -38,4 +38,5 @@ WORKDIR /
 COPY --from=mirror /out/ /
 COPY --from=build /out/ /
 COPY --from=runc /usr/bin/runc /sbin/runc
+RUN ln -s /run /var/
 

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 
 # Remove apk residuals. We have a read-only rootfs, so apk is of no use.
-RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache /out/var/run
 
 FROM scratch
 ENTRYPOINT []
@@ -20,3 +20,4 @@ COPY --from=mirror /out/ /
 COPY init /
 COPY etc etc/
 COPY bin bin/
+RUN ln -s /run /var/


### PR DESCRIPTION
Signed-off-by: Jacob Blain Christen <dweomer5@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* removed `/out/var/run` from the "build" layer
* created symlink `/var/run` pointing to `/run`

**- How I did it**
Last layer in the init container is `RUN ln -s /run /var/`

**- How to verify it**
Before:
> $ docker cp $(docker create linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc sh):/ - | tar tv | grep '/run'
> tar: Removing leading `/' from member names
> lrwxrwxrwx 0/0               0 2017-07-14 14:02 /bin/run-parts -> /bin/busybox
> drwxr-xr-x 0/0               0 2017-07-14 14:02 /run/
> __drwxr-xr-x 0/0               0 2017-07-14 14:02 /var/run/__

After:
> docker cp $(docker create linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc-dirty sh):/ - | tar tv | grep /run
> tar: Removing leading `/' from member names
> lrwxrwxrwx 0/0               0 2017-07-16 21:21 /bin/run-parts -> /bin/busybox
> drwxr-xr-x 0/0               0 2017-07-16 21:21 /run/
> __lrwxrwxrwx 0/0               0 2017-07-16 21:21 /var/run -> /run__

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
`/var/run` is once again correctly symlinked to `/run`

**- A picture of a cute animal (not mandatory but encouraged)**
