### PR TITLE
tools: Fix the order sequence issue in Makefile

### DIFF
--- a/tools/go-compile/Makefile
+++ b/tools/go-compile/Makefile
@@ -1,4 +1,5 @@
-include ../../pkg/package.mk
-
 IMAGE=go-compile
 DEPS=compile.sh
+
+include ../../pkg/package.mk
+

--- a/tools/qemu/Makefile
+++ b/tools/qemu/Makefile
@@ -1,3 +1,4 @@
+IMAGE=qemu
+
 include ../../pkg/package.mk
 
-IMAGE=qemu


### PR DESCRIPTION
tools/qemu and toos/go-compile define the IMAGE after the
package.mk, which result in below error if 'make ORG=other_org':
...
invalid argument "other_org/:2c6d9e1d9c52167f4f2b7a8fd235eda318175c99"for t: invalid reference format
See 'docker build --help'.
../../pkg/package.mk:47: recipe for target 'tag' failed
make: *** [tag] Error 125

This because '../../pkg/package.mk' need to use IMAGE variable first.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the Makefile issue for some tools
**- How I did it**
Change the order sequence in the Make to meet the usage requirement
**- How to verify it**
Under, for instance, the tools/qemu:
make ORG=other_org

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/28258206-84232e9c-6b02-11e7-8cf0-473d5718e9f3.jpg)


