### PR TITLE
ARM64: Multi-arch support in qemu Dockerfile

### DIFF
--- a/tools/qemu/Dockerfile
+++ b/tools/qemu/Dockerfile
@@ -4,11 +4,24 @@ RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
     busybox \
     libarchive-tools \
-    qemu-img \
-    qemu-system-x86_64
+    qemu-img && \
+    case $(uname -m) in \
+    x86_64) \
+        apk add --no-cache --initdb -p /out qemu-system-x86_64; \
+        ;; \
+    aarch64) \
+        apk add --no-cache --initdb -p /out qemu-system-aarch64; \
+        ;; \
+    esac
 
-RUN mkdir -p /out/usr/share/ovmf \
-    && cp /usr/share/ovmf/bios.bin /out/usr/share/ovmf/bios.bin
+RUN case $(uname -m) in \
+    x86_64) \
+        mkdir -p /out/usr/share/ovmf \
+        && cp /usr/share/ovmf/bios.bin /out/usr/share/ovmf/bios.bin; \
+        ;; \
+    aarch64) \
+        ;; \
+    esac
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
 FROM scratch


### PR DESCRIPTION
Update the qemu Dockerfile to support both amd64 and arm64.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Change the qemu Dockerfile to support multi-arch(currently amd64 and arm64). We prefer the 'case' to 'if...else...' given the possible other architecture support in the future.
**- How I did it**
Take different action according to the ARCH type abstracted by runtime $(uname -m)
**- How to verify it**
'docker build' this file on both amd64 and arm64 platform, then 'docker run... /bin/ash' the built image, in the shell, to check if the qemu-system-ARCH has been installed correctly and the 'bios.bin' for amd64 is in the correct place. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/28258939-7290131c-6b06-11e7-945a-b459aab6c715.jpg)
