### PR TITLE
Update kernels to 4.11.11/4.9.38/4.4.77

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -1,6 +1,6 @@
 # This is a blueprint for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:e2b49a6c56fbf876ea24f0a5ce4ccae5f940d1be # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/blueprints/lcow.yml
+++ b/blueprints/lcow.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
   tar: none
 init:

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -104,8 +104,8 @@ endef
 # Build Targets
 # Debug targets only for latest stable and LTS stable
 #
-$(eval $(call kernel,4.11.10,4.11.x))
-$(eval $(call kernel,4.11.10,4.11.x,_dbg))
-$(eval $(call kernel,4.9.37,4.9.x))
-$(eval $(call kernel,4.9.37,4.9.x,_dbg))
-$(eval $(call kernel,4.4.76,4.4.x))
+$(eval $(call kernel,4.11.11,4.11.x))
+$(eval $(call kernel,4.11.11,4.11.x,_dbg))
+$(eval $(call kernel,4.9.38,4.9.x))
+$(eval $(call kernel,4.9.38,4.9.x,_dbg))
+$(eval $(call kernel,4.4.77,4.4.x))

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -104,8 +104,8 @@ endef
 # Build Targets
 # Debug targets only for latest stable and LTS stable
 #
-$(eval $(call kernel,4.11.9,4.11.x))
-$(eval $(call kernel,4.11.9,4.11.x,_dbg))
-$(eval $(call kernel,4.9.36,4.9.x))
-$(eval $(call kernel,4.9.36,4.9.x,_dbg))
+$(eval $(call kernel,4.11.10,4.11.x))
+$(eval $(call kernel,4.11.10,4.11.x,_dbg))
+$(eval $(call kernel,4.9.37,4.9.x))
+$(eval $(call kernel,4.9.37,4.9.x,_dbg))
 $(eval $(call kernel,4.4.76,4.4.x))

--- a/kernel/kernel_config-4.11.x
+++ b/kernel/kernel_config-4.11.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.11.10 Kernel Configuration
+# Linux/x86 4.11.11 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/kernel_config-4.11.x
+++ b/kernel/kernel_config-4.11.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.11.9 Kernel Configuration
+# Linux/x86 4.11.10 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/kernel_config-4.4.x
+++ b/kernel/kernel_config-4.4.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.76 Kernel Configuration
+# Linux/x86 4.4.77 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/kernel_config-4.9.x
+++ b/kernel/kernel_config-4.9.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.37 Kernel Configuration
+# Linux/x86 4.9.38 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/kernel_config-4.9.x
+++ b/kernel/kernel_config-4.9.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.36 Kernel Configuration
+# Linux/x86 4.9.37 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.11.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.11.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 0000941078ee46f1f5338719c9c9d3f97f4e1d8b Mon Sep 17 00:00:00 2001
+From 2472312b26a41cfa55cfefc2e377938c2051273a Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/20] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.11.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.11.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 2472312b26a41cfa55cfefc2e377938c2051273a Mon Sep 17 00:00:00 2001
+From b1a0dceab001d2dd4958c3d87e158d325dd781d2 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/20] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.11.x/0002-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
+++ b/kernel/patches-4.11.x/0002-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
@@ -1,4 +1,4 @@
-From 1156b1422d79db972a6b91206c26176518070a85 Mon Sep 17 00:00:00 2001
+From 4687d8de9349e5c950281bbcc4082353050be0f7 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:12 -0600
 Subject: [PATCH 02/20] vmbus: vmbus_open(): reset onchannel_callback on error

--- a/kernel/patches-4.11.x/0002-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
+++ b/kernel/patches-4.11.x/0002-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
@@ -1,4 +1,4 @@
-From 74179b20aa60d2f7feb6556b121cff15dde79e9b Mon Sep 17 00:00:00 2001
+From 1156b1422d79db972a6b91206c26176518070a85 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:12 -0600
 Subject: [PATCH 02/20] vmbus: vmbus_open(): reset onchannel_callback on error

--- a/kernel/patches-4.11.x/0003-vmbus-add-the-matching-tasklet_enable-in-vmbus_close.patch
+++ b/kernel/patches-4.11.x/0003-vmbus-add-the-matching-tasklet_enable-in-vmbus_close.patch
@@ -1,4 +1,4 @@
-From 59bd8092e0637c1e47baeb8cac83d71ed3ee85fb Mon Sep 17 00:00:00 2001
+From f162e6e627a2dbf63e4370824c044901f5d836e4 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:15 -0600
 Subject: [PATCH 03/20] vmbus: add the matching tasklet_enable() in

--- a/kernel/patches-4.11.x/0003-vmbus-add-the-matching-tasklet_enable-in-vmbus_close.patch
+++ b/kernel/patches-4.11.x/0003-vmbus-add-the-matching-tasklet_enable-in-vmbus_close.patch
@@ -1,4 +1,4 @@
-From f162e6e627a2dbf63e4370824c044901f5d836e4 Mon Sep 17 00:00:00 2001
+From 359532a38e2252d220b8ad656f2ab2e04342d98b Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:15 -0600
 Subject: [PATCH 03/20] vmbus: add the matching tasklet_enable() in

--- a/kernel/patches-4.11.x/0004-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.11.x/0004-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 5bddcbe8e03893267d2674da93894007f5be08b7 Mon Sep 17 00:00:00 2001
+From 8ceb530fef60f60cd505befdd9d5c0e5d74a46a2 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:20 -0600
 Subject: [PATCH 04/20] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.11.x/0004-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.11.x/0004-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 8ceb530fef60f60cd505befdd9d5c0e5d74a46a2 Mon Sep 17 00:00:00 2001
+From fb08bc0677ee97e6b50ceabb31af28c69c93aeae Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:20 -0600
 Subject: [PATCH 04/20] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.11.x/0005-vmbus-dynamically-enqueue-dequeue-a-channel-on-vmbus.patch
+++ b/kernel/patches-4.11.x/0005-vmbus-dynamically-enqueue-dequeue-a-channel-on-vmbus.patch
@@ -1,4 +1,4 @@
-From ab979cc7a97f66073e8e57b42dfb4f87ec7cd0ea Mon Sep 17 00:00:00 2001
+From bd47521c4b669ac4e95bc91889991e59b8795cf4 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:23 -0600
 Subject: [PATCH 05/20] vmbus: dynamically enqueue/dequeue a channel on

--- a/kernel/patches-4.11.x/0005-vmbus-dynamically-enqueue-dequeue-a-channel-on-vmbus.patch
+++ b/kernel/patches-4.11.x/0005-vmbus-dynamically-enqueue-dequeue-a-channel-on-vmbus.patch
@@ -1,4 +1,4 @@
-From bd47521c4b669ac4e95bc91889991e59b8795cf4 Mon Sep 17 00:00:00 2001
+From de71cb36c8f3ec3d742092050d5c78be74514f17 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:23 -0600
 Subject: [PATCH 05/20] vmbus: dynamically enqueue/dequeue a channel on

--- a/kernel/patches-4.11.x/0006-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
+++ b/kernel/patches-4.11.x/0006-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
@@ -1,4 +1,4 @@
-From a6d32d0ff83b21371756fd7146cd2a2ac2008592 Mon Sep 17 00:00:00 2001
+From e3a1ce89aaf58f3d8563163d0a2a5c7ac1730210 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:26 -0600
 Subject: [PATCH 06/20] hv_sock: implements Hyper-V transport for Virtual

--- a/kernel/patches-4.11.x/0006-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
+++ b/kernel/patches-4.11.x/0006-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
@@ -1,4 +1,4 @@
-From 773676aed6e042b7f0296d0e11fe6b9b6d0cac9c Mon Sep 17 00:00:00 2001
+From a6d32d0ff83b21371756fd7146cd2a2ac2008592 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:26 -0600
 Subject: [PATCH 06/20] hv_sock: implements Hyper-V transport for Virtual

--- a/kernel/patches-4.11.x/0007-VMCI-only-try-to-load-on-VMware-hypervisor.patch
+++ b/kernel/patches-4.11.x/0007-VMCI-only-try-to-load-on-VMware-hypervisor.patch
@@ -1,4 +1,4 @@
-From a8e8b701064574c36ea5a130904ab59beb9e3ad7 Mon Sep 17 00:00:00 2001
+From 575795d4704f3e555d2aeea059e5e33c986e3432 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:29 -0600
 Subject: [PATCH 07/20] VMCI: only try to load on VMware hypervisor

--- a/kernel/patches-4.11.x/0007-VMCI-only-try-to-load-on-VMware-hypervisor.patch
+++ b/kernel/patches-4.11.x/0007-VMCI-only-try-to-load-on-VMware-hypervisor.patch
@@ -1,4 +1,4 @@
-From 575795d4704f3e555d2aeea059e5e33c986e3432 Mon Sep 17 00:00:00 2001
+From e0b63af4b53c6f7cdf9d0420adb48abaff23da64 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:29 -0600
 Subject: [PATCH 07/20] VMCI: only try to load on VMware hypervisor

--- a/kernel/patches-4.11.x/0008-hv_sock-add-the-support-of-auto-loading.patch
+++ b/kernel/patches-4.11.x/0008-hv_sock-add-the-support-of-auto-loading.patch
@@ -1,4 +1,4 @@
-From 02541a42e2e39670e507d26735c887164cf5f897 Mon Sep 17 00:00:00 2001
+From 2be7d1fff049b681030b229ab286d0e0acb0b398 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:35 -0600
 Subject: [PATCH 08/20] hv_sock: add the support of auto-loading

--- a/kernel/patches-4.11.x/0008-hv_sock-add-the-support-of-auto-loading.patch
+++ b/kernel/patches-4.11.x/0008-hv_sock-add-the-support-of-auto-loading.patch
@@ -1,4 +1,4 @@
-From 2be7d1fff049b681030b229ab286d0e0acb0b398 Mon Sep 17 00:00:00 2001
+From 9e8ec387414694e64d9cd4994662fa7afae95bab Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:35 -0600
 Subject: [PATCH 08/20] hv_sock: add the support of auto-loading

--- a/kernel/patches-4.11.x/0009-tools-hv_sock-2-simple-test-cases.patch
+++ b/kernel/patches-4.11.x/0009-tools-hv_sock-2-simple-test-cases.patch
@@ -1,4 +1,4 @@
-From f64517f648f2017ebadf69cb96db8d7dd6d9659b Mon Sep 17 00:00:00 2001
+From e78bc87af93eee82f1d53214762663fdf6c46154 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 18:52:02 -0600
 Subject: [PATCH 09/20] tools: hv_sock: 2 simple test cases.

--- a/kernel/patches-4.11.x/0009-tools-hv_sock-2-simple-test-cases.patch
+++ b/kernel/patches-4.11.x/0009-tools-hv_sock-2-simple-test-cases.patch
@@ -1,4 +1,4 @@
-From e78bc87af93eee82f1d53214762663fdf6c46154 Mon Sep 17 00:00:00 2001
+From 957291f7871dd5fe30b62b3bab176d32a0ef54cc Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 18:52:02 -0600
 Subject: [PATCH 09/20] tools: hv_sock: 2 simple test cases.

--- a/kernel/patches-4.11.x/0010-vmbus-introduce-in-place-packet-iterator.patch
+++ b/kernel/patches-4.11.x/0010-vmbus-introduce-in-place-packet-iterator.patch
@@ -1,4 +1,4 @@
-From 503540281712b08a21b54fca22a719e6de126ec8 Mon Sep 17 00:00:00 2001
+From 7b2a7938fa2bf88da5e3cf23d56da221497de620 Mon Sep 17 00:00:00 2001
 From: stephen hemminger <stephen@networkplumber.org>
 Date: Mon, 27 Feb 2017 10:26:48 -0800
 Subject: [PATCH 10/20] vmbus: introduce in-place packet iterator

--- a/kernel/patches-4.11.x/0010-vmbus-introduce-in-place-packet-iterator.patch
+++ b/kernel/patches-4.11.x/0010-vmbus-introduce-in-place-packet-iterator.patch
@@ -1,4 +1,4 @@
-From 2aaa664f7216763e69f44ca30fbf0dba23b0bd89 Mon Sep 17 00:00:00 2001
+From 503540281712b08a21b54fca22a719e6de126ec8 Mon Sep 17 00:00:00 2001
 From: stephen hemminger <stephen@networkplumber.org>
 Date: Mon, 27 Feb 2017 10:26:48 -0800
 Subject: [PATCH 10/20] vmbus: introduce in-place packet iterator

--- a/kernel/patches-4.11.x/0011-hvsock-fix-a-race-in-hvs_stream_dequeue.patch
+++ b/kernel/patches-4.11.x/0011-hvsock-fix-a-race-in-hvs_stream_dequeue.patch
@@ -1,4 +1,4 @@
-From 909fa140cbebe7c0fc1f41a99ee3cd4021b8915f Mon Sep 17 00:00:00 2001
+From 3adb7780990ca958d74d22a84f8b77e7c284f2e3 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Tue, 16 May 2017 22:14:03 +0800
 Subject: [PATCH 11/20] hvsock: fix a race in hvs_stream_dequeue()

--- a/kernel/patches-4.11.x/0011-hvsock-fix-a-race-in-hvs_stream_dequeue.patch
+++ b/kernel/patches-4.11.x/0011-hvsock-fix-a-race-in-hvs_stream_dequeue.patch
@@ -1,4 +1,4 @@
-From 027de2c09c96f6cb0b2a7d7bfdcb3e4faf7e41f8 Mon Sep 17 00:00:00 2001
+From 909fa140cbebe7c0fc1f41a99ee3cd4021b8915f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Tue, 16 May 2017 22:14:03 +0800
 Subject: [PATCH 11/20] hvsock: fix a race in hvs_stream_dequeue()

--- a/kernel/patches-4.11.x/0012-hvsock-fix-vsock_dequeue-enqueue_accept-race.patch
+++ b/kernel/patches-4.11.x/0012-hvsock-fix-vsock_dequeue-enqueue_accept-race.patch
@@ -1,4 +1,4 @@
-From 873a75b242331c84f5c0c039178e2f4e694ebdbc Mon Sep 17 00:00:00 2001
+From eede177e637798f2fef330fd85d9f231f5342f11 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 19 May 2017 21:49:59 +0800
 Subject: [PATCH 12/20] hvsock: fix vsock_dequeue/enqueue_accept race

--- a/kernel/patches-4.11.x/0012-hvsock-fix-vsock_dequeue-enqueue_accept-race.patch
+++ b/kernel/patches-4.11.x/0012-hvsock-fix-vsock_dequeue-enqueue_accept-race.patch
@@ -1,4 +1,4 @@
-From ec13f59e3fcd78a31b8a377db813c750711c262c Mon Sep 17 00:00:00 2001
+From 873a75b242331c84f5c0c039178e2f4e694ebdbc Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 19 May 2017 21:49:59 +0800
 Subject: [PATCH 12/20] hvsock: fix vsock_dequeue/enqueue_accept race

--- a/kernel/patches-4.11.x/0013-Drivers-hv-vmbus-Fix-rescind-handling.patch
+++ b/kernel/patches-4.11.x/0013-Drivers-hv-vmbus-Fix-rescind-handling.patch
@@ -1,4 +1,4 @@
-From b0a431963f3fcd2742c2d12d670bbee5814b6ab6 Mon Sep 17 00:00:00 2001
+From a5fc9e6c5441686775934c2d3ee26d8a4ecad8c5 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Sun, 30 Apr 2017 16:21:18 -0700
 Subject: [PATCH 13/20] Drivers: hv: vmbus: Fix rescind handling

--- a/kernel/patches-4.11.x/0013-Drivers-hv-vmbus-Fix-rescind-handling.patch
+++ b/kernel/patches-4.11.x/0013-Drivers-hv-vmbus-Fix-rescind-handling.patch
@@ -1,4 +1,4 @@
-From a5fc9e6c5441686775934c2d3ee26d8a4ecad8c5 Mon Sep 17 00:00:00 2001
+From c50a745b628ba2fcfc88d4bcc42900f7fc4b440f Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Sun, 30 Apr 2017 16:21:18 -0700
 Subject: [PATCH 13/20] Drivers: hv: vmbus: Fix rescind handling

--- a/kernel/patches-4.11.x/0014-vmbus-fix-hv_percpu_channel_deq-enq-race.patch
+++ b/kernel/patches-4.11.x/0014-vmbus-fix-hv_percpu_channel_deq-enq-race.patch
@@ -1,4 +1,4 @@
-From 9425dfce5e61ecad4929ec71bae8848c078a6182 Mon Sep 17 00:00:00 2001
+From ecac53983428999d15a46af35f810297cf741b31 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 5 Jun 2017 16:13:18 +0800
 Subject: [PATCH 14/20] vmbus:  fix hv_percpu_channel_deq/enq race

--- a/kernel/patches-4.11.x/0014-vmbus-fix-hv_percpu_channel_deq-enq-race.patch
+++ b/kernel/patches-4.11.x/0014-vmbus-fix-hv_percpu_channel_deq-enq-race.patch
@@ -1,4 +1,4 @@
-From ecac53983428999d15a46af35f810297cf741b31 Mon Sep 17 00:00:00 2001
+From ad8629c03fb07e0fd2fc2df99eb1bd70f2b78b63 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 5 Jun 2017 16:13:18 +0800
 Subject: [PATCH 14/20] vmbus:  fix hv_percpu_channel_deq/enq race

--- a/kernel/patches-4.11.x/0015-vmbus-add-vmbus-onoffer-onoffer_rescind-sync.patch
+++ b/kernel/patches-4.11.x/0015-vmbus-add-vmbus-onoffer-onoffer_rescind-sync.patch
@@ -1,4 +1,4 @@
-From c0d2283fc1763beefa870ca0b2b3eeed1278e9b1 Mon Sep 17 00:00:00 2001
+From a2dc88ef9b0eb53dab732582c20674176199d5ac Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 5 Jun 2017 21:32:00 +0800
 Subject: [PATCH 15/20] vmbus: add vmbus onoffer/onoffer_rescind sync.

--- a/kernel/patches-4.11.x/0015-vmbus-add-vmbus-onoffer-onoffer_rescind-sync.patch
+++ b/kernel/patches-4.11.x/0015-vmbus-add-vmbus-onoffer-onoffer_rescind-sync.patch
@@ -1,4 +1,4 @@
-From 21d1da652810bdc3dd1c0ce62fbf3cb9bc6313b4 Mon Sep 17 00:00:00 2001
+From c0d2283fc1763beefa870ca0b2b3eeed1278e9b1 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 5 Jun 2017 21:32:00 +0800
 Subject: [PATCH 15/20] vmbus: add vmbus onoffer/onoffer_rescind sync.

--- a/kernel/patches-4.11.x/0016-hv-sock-a-temporary-workaround-for-the-pending_send_.patch
+++ b/kernel/patches-4.11.x/0016-hv-sock-a-temporary-workaround-for-the-pending_send_.patch
@@ -1,4 +1,4 @@
-From 042b1631de7a37dc79ca73ac9cee340fb0d72475 Mon Sep 17 00:00:00 2001
+From 49aed7c3a22494bd13b1d5a24b9b8ec4d73ecd93 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 21 Jun 2017 22:30:42 +0800
 Subject: [PATCH 16/20] hv-sock: a temporary workaround for the

--- a/kernel/patches-4.11.x/0016-hv-sock-a-temporary-workaround-for-the-pending_send_.patch
+++ b/kernel/patches-4.11.x/0016-hv-sock-a-temporary-workaround-for-the-pending_send_.patch
@@ -1,4 +1,4 @@
-From 49aed7c3a22494bd13b1d5a24b9b8ec4d73ecd93 Mon Sep 17 00:00:00 2001
+From 21fa752450c289169d9916ba0e7b7d936ccb96dc Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 21 Jun 2017 22:30:42 +0800
 Subject: [PATCH 16/20] hv-sock: a temporary workaround for the

--- a/kernel/patches-4.11.x/0017-vmbus-fix-the-missed-signaling-in-hv_signal_on_read.patch
+++ b/kernel/patches-4.11.x/0017-vmbus-fix-the-missed-signaling-in-hv_signal_on_read.patch
@@ -1,4 +1,4 @@
-From c9a2d11140ca97958406c9a3fc8d0590a16f0f13 Mon Sep 17 00:00:00 2001
+From 0c2f224de67ede9c376fe692c9d7f22c2eb5a51f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 28 Jun 2017 23:50:38 +0800
 Subject: [PATCH 17/20] vmbus: fix the missed signaling in hv_signal_on_read()

--- a/kernel/patches-4.11.x/0017-vmbus-fix-the-missed-signaling-in-hv_signal_on_read.patch
+++ b/kernel/patches-4.11.x/0017-vmbus-fix-the-missed-signaling-in-hv_signal_on_read.patch
@@ -1,4 +1,4 @@
-From 0c2f224de67ede9c376fe692c9d7f22c2eb5a51f Mon Sep 17 00:00:00 2001
+From b0b75fdcb4be0fe0998bc7405762d89022b601dc Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 28 Jun 2017 23:50:38 +0800
 Subject: [PATCH 17/20] vmbus: fix the missed signaling in hv_signal_on_read()

--- a/kernel/patches-4.11.x/0018-hv-sock-avoid-double-FINs-if-shutdown-is-called.patch
+++ b/kernel/patches-4.11.x/0018-hv-sock-avoid-double-FINs-if-shutdown-is-called.patch
@@ -1,4 +1,4 @@
-From 50733c200b645e604fc5e0e41be818250dc0bf50 Mon Sep 17 00:00:00 2001
+From 28c267f33d97e900b32b9d55ae0afabf11b9db7c Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 7 Jul 2017 09:15:29 +0800
 Subject: [PATCH 18/20] hv-sock: avoid double FINs if shutdown() is called

--- a/kernel/patches-4.11.x/0018-hv-sock-avoid-double-FINs-if-shutdown-is-called.patch
+++ b/kernel/patches-4.11.x/0018-hv-sock-avoid-double-FINs-if-shutdown-is-called.patch
@@ -1,4 +1,4 @@
-From 28c267f33d97e900b32b9d55ae0afabf11b9db7c Mon Sep 17 00:00:00 2001
+From 16104e3ed904c16f2e8adc1b883a4859b1e6ded5 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 7 Jul 2017 09:15:29 +0800
 Subject: [PATCH 18/20] hv-sock: avoid double FINs if shutdown() is called

--- a/kernel/patches-4.11.x/0019-Added-vsock-transport-support-to-9pfs.patch
+++ b/kernel/patches-4.11.x/0019-Added-vsock-transport-support-to-9pfs.patch
@@ -1,4 +1,4 @@
-From fe302afb2256b498f781741859cd3cda7f7fa7b3 Mon Sep 17 00:00:00 2001
+From 8f98c1cbe8efa9db62f256469d028cd3462c9433 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:50:36 -0700
 Subject: [PATCH 19/20] Added vsock transport support to 9pfs

--- a/kernel/patches-4.11.x/0019-Added-vsock-transport-support-to-9pfs.patch
+++ b/kernel/patches-4.11.x/0019-Added-vsock-transport-support-to-9pfs.patch
@@ -1,4 +1,4 @@
-From 8f98c1cbe8efa9db62f256469d028cd3462c9433 Mon Sep 17 00:00:00 2001
+From 9b03978a4be997d6ff3a8f9559c46fb8d389830b Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:50:36 -0700
 Subject: [PATCH 19/20] Added vsock transport support to 9pfs

--- a/kernel/patches-4.11.x/0020-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.11.x/0020-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 40f1e3dc27695385f68025e74cf103c6a1ce1a62 Mon Sep 17 00:00:00 2001
+From a0ffde86f87be4fc1b611c66ab8d0776915aa322 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 20/20] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.11.x/0020-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.11.x/0020-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From a0ffde86f87be4fc1b611c66ab8d0776915aa322 Mon Sep 17 00:00:00 2001
+From 1f1c253f7847a7a34c612e172bb4cf33461c7f82 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 20/20] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.4.x/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
+++ b/kernel/patches-4.4.x/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
@@ -1,4 +1,4 @@
-From 61c4b9d2e6ac6993fe3451ae8b56cb14f71e33ab Mon Sep 17 00:00:00 2001
+From 88df98a818ebf698a95796ef888422d2b13cf483 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 17 Dec 2015 16:53:43 +0800
 Subject: [PATCH 01/44] virtio: make find_vqs() checkpatch.pl-friendly

--- a/kernel/patches-4.4.x/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
+++ b/kernel/patches-4.4.x/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
@@ -1,4 +1,4 @@
-From c5945b252d54fdea8c6020485da6eaafa9a1a158 Mon Sep 17 00:00:00 2001
+From fabae8d94d2d811646b02ed0d65c9f0126cd8f78 Mon Sep 17 00:00:00 2001
 From: Julia Lawall <julia.lawall@lip6.fr>
 Date: Sat, 21 Nov 2015 18:39:17 +0100
 Subject: [PATCH 02/44] VSOCK: constify vmci_transport_notify_ops structures

--- a/kernel/patches-4.4.x/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
+++ b/kernel/patches-4.4.x/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
@@ -1,4 +1,4 @@
-From 63eb7067e48c11847a38efd91a5f419bf231bd7b Mon Sep 17 00:00:00 2001
+From 94cd028a956af62cd2fc047734f1374d4032e5dc Mon Sep 17 00:00:00 2001
 From: Claudio Imbrenda <imbrenda@linux.vnet.ibm.com>
 Date: Tue, 22 Mar 2016 17:05:52 +0100
 Subject: [PATCH 03/44] AF_VSOCK: Shrink the area influenced by prepare_to_wait

--- a/kernel/patches-4.4.x/0004-vsock-make-listener-child-lock-ordering-explicit.patch
+++ b/kernel/patches-4.4.x/0004-vsock-make-listener-child-lock-ordering-explicit.patch
@@ -1,4 +1,4 @@
-From d8b3974c5ea20dfb8fae8cc4467a131749a6901c Mon Sep 17 00:00:00 2001
+From e91c1503fdda5a8f59f1eb4c0afee6797cbffc1a Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 23 Jun 2016 16:28:58 +0100
 Subject: [PATCH 04/44] vsock: make listener child lock ordering explicit

--- a/kernel/patches-4.4.x/0005-VSOCK-transport-specific-vsock_transport-functions.patch
+++ b/kernel/patches-4.4.x/0005-VSOCK-transport-specific-vsock_transport-functions.patch
@@ -1,4 +1,4 @@
-From 6882f1a32034f3c02fdff2d99c9bbcc554068c8f Mon Sep 17 00:00:00 2001
+From fedde8b2157e61268bc5bd237eb1ed7ca3226099 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:30 +0100
 Subject: [PATCH 05/44] VSOCK: transport-specific vsock_transport functions

--- a/kernel/patches-4.4.x/0006-VSOCK-defer-sock-removal-to-transports.patch
+++ b/kernel/patches-4.4.x/0006-VSOCK-defer-sock-removal-to-transports.patch
@@ -1,4 +1,4 @@
-From 87bb91cdfafec2384948a51c4162ab46df55a717 Mon Sep 17 00:00:00 2001
+From f1a23b9f4963862546e0709d6877df62d8035c68 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:31 +0100
 Subject: [PATCH 06/44] VSOCK: defer sock removal to transports

--- a/kernel/patches-4.4.x/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
+++ b/kernel/patches-4.4.x/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
@@ -1,4 +1,4 @@
-From b7064324d23999fabaa168d9109df4f50a927f57 Mon Sep 17 00:00:00 2001
+From e525ff81b70f677e602a76a833e937bc5777d54a Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:32 +0100
 Subject: [PATCH 07/44] VSOCK: Introduce virtio_vsock_common.ko

--- a/kernel/patches-4.4.x/0008-VSOCK-Introduce-virtio_transport.ko.patch
+++ b/kernel/patches-4.4.x/0008-VSOCK-Introduce-virtio_transport.ko.patch
@@ -1,4 +1,4 @@
-From 437075b170a4322eea1f0910fe17893d0c5116fb Mon Sep 17 00:00:00 2001
+From fdeb1ac5f271137fe25610a41569a0045e9a3a2f Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:33 +0100
 Subject: [PATCH 08/44] VSOCK: Introduce virtio_transport.ko

--- a/kernel/patches-4.4.x/0009-VSOCK-Introduce-vhost_vsock.ko.patch
+++ b/kernel/patches-4.4.x/0009-VSOCK-Introduce-vhost_vsock.ko.patch
@@ -1,4 +1,4 @@
-From b9b5ed227cdabeea10dc94b087c8f4580649cdfc Mon Sep 17 00:00:00 2001
+From 509568336cfa46724780727b4eb7bcd9114e2730 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:34 +0100
 Subject: [PATCH 09/44] VSOCK: Introduce vhost_vsock.ko

--- a/kernel/patches-4.4.x/0010-VSOCK-Add-Makefile-and-Kconfig.patch
+++ b/kernel/patches-4.4.x/0010-VSOCK-Add-Makefile-and-Kconfig.patch
@@ -1,4 +1,4 @@
-From 939918468a20dd0a78e1bb4d0797eb4785c433ae Mon Sep 17 00:00:00 2001
+From d02917acf95d5c36372ba27f50eda30455684143 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:35 +0100
 Subject: [PATCH 10/44] VSOCK: Add Makefile and Kconfig

--- a/kernel/patches-4.4.x/0011-VSOCK-Use-kvfree.patch
+++ b/kernel/patches-4.4.x/0011-VSOCK-Use-kvfree.patch
@@ -1,4 +1,4 @@
-From c05b4c52e92d3c94f03e5007372408c9113eec6d Mon Sep 17 00:00:00 2001
+From 0e5985bf14d2c701c9f18188e0e5492b38f6c78d Mon Sep 17 00:00:00 2001
 From: Wei Yongjun <weiyj.lk@gmail.com>
 Date: Tue, 2 Aug 2016 13:50:42 +0000
 Subject: [PATCH 11/44] VSOCK: Use kvfree()

--- a/kernel/patches-4.4.x/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
+++ b/kernel/patches-4.4.x/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
@@ -1,4 +1,4 @@
-From f5bcc4ad4c86f00d51fd732291dd634278b491a3 Mon Sep 17 00:00:00 2001
+From 785d19437011614b013499edfef900d74b7d3529 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 4 Aug 2016 14:52:53 +0100
 Subject: [PATCH 12/44] vhost/vsock: fix vhost virtio_vsock_pkt use-after-free

--- a/kernel/patches-4.4.x/0013-virtio-vsock-fix-include-guard-typo.patch
+++ b/kernel/patches-4.4.x/0013-virtio-vsock-fix-include-guard-typo.patch
@@ -1,4 +1,4 @@
-From 3171e7a86fc6ade5f4587837221a4423c5900ffb Mon Sep 17 00:00:00 2001
+From ed83104bb1203ee84403ba7b905393469ffd96c0 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Fri, 5 Aug 2016 13:52:09 +0100
 Subject: [PATCH 13/44] virtio-vsock: fix include guard typo

--- a/kernel/patches-4.4.x/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
+++ b/kernel/patches-4.4.x/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
@@ -1,4 +1,4 @@
-From a21a2eb0101e4f68f852e9f259b34f4b37466589 Mon Sep 17 00:00:00 2001
+From 5cc8db483f9f98c5d8113ffa47e14c285af5789d Mon Sep 17 00:00:00 2001
 From: Gerard Garcia <ggarcia@deic.uab.cat>
 Date: Wed, 10 Aug 2016 17:24:34 +0200
 Subject: [PATCH 14/44] vhost/vsock: drop space available check for TX vq

--- a/kernel/patches-4.4.x/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/kernel/patches-4.4.x/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,4 +1,4 @@
-From d873deeedd06e8103a9ebe5244ba22d287a94bda Mon Sep 17 00:00:00 2001
+From 4f2fc0f9d3443887e7d92da9a8cef1ccddb29f79 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
 Subject: [PATCH 15/44] VSOCK: Only allow host network namespace to use

--- a/kernel/patches-4.4.x/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
+++ b/kernel/patches-4.4.x/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
@@ -1,4 +1,4 @@
-From 934e246ecf25ce2e1f10e0d3caed5da0be1200f9 Mon Sep 17 00:00:00 2001
+From 171ae7704c7307a33693c1655473bd21b72b0276 Mon Sep 17 00:00:00 2001
 From: Jake Oshins <jakeo@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:41 -0800
 Subject: [PATCH 16/44] drivers:hv: Define the channel type for Hyper-V PCI

--- a/kernel/patches-4.4.x/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
+++ b/kernel/patches-4.4.x/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
@@ -1,4 +1,4 @@
-From ac4de2acdfcc7d45000bfbd657dc0f2ffa7f7f25 Mon Sep 17 00:00:00 2001
+From 486b325b1e0c5d04d7ac935011359b41264d9942 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:43 -0800
 Subject: [PATCH 17/44] Drivers: hv: vmbus: Use uuid_le type consistently

--- a/kernel/patches-4.4.x/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
+++ b/kernel/patches-4.4.x/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
@@ -1,4 +1,4 @@
-From 32ec586052699938458ad07ac8dc50a168896b2e Mon Sep 17 00:00:00 2001
+From a76795ca769b5fb48de086391649980e3423df0f Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:44 -0800
 Subject: [PATCH 18/44] Drivers: hv: vmbus: Use uuid_le_cmp() for comparing

--- a/kernel/patches-4.4.x/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
+++ b/kernel/patches-4.4.x/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
@@ -1,4 +1,4 @@
-From 133a7d0168e517f9df046be8c83300d83049695f Mon Sep 17 00:00:00 2001
+From c680d5d098dc4c18ef963d0927ef988c62943e66 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:48 -0800
 Subject: [PATCH 19/44] Drivers: hv: vmbus: do sanity check of channel state in

--- a/kernel/patches-4.4.x/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
+++ b/kernel/patches-4.4.x/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
@@ -1,4 +1,4 @@
-From 963ac64008a410062a9a606a94e8c121e8fac98d Mon Sep 17 00:00:00 2001
+From d59095cbdb00a5e750f41d9e88d862c00d35a4f0 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:50 -0800
 Subject: [PATCH 20/44] Drivers: hv: vmbus: release relid on error in

--- a/kernel/patches-4.4.x/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
+++ b/kernel/patches-4.4.x/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
@@ -1,4 +1,4 @@
-From 62e4e442b00bff9d9d65c84a7bde38b139e0c45c Mon Sep 17 00:00:00 2001
+From ba7550d4292fff484a7625d387fc1e3d78041101 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:51 -0800
 Subject: [PATCH 21/44] Drivers: hv: vmbus: channge

--- a/kernel/patches-4.4.x/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
+++ b/kernel/patches-4.4.x/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
@@ -1,4 +1,4 @@
-From 74c01ca434a7fa426397d3c4c084676b0ed46aaa Mon Sep 17 00:00:00 2001
+From a67bdb6d67fa92c54632d1314dfb24d50c922c1a Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Mon, 14 Dec 2015 19:02:00 -0800
 Subject: [PATCH 22/44] Drivers: hv: remove code duplication between

--- a/kernel/patches-4.4.x/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
+++ b/kernel/patches-4.4.x/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
@@ -1,4 +1,4 @@
-From c6c2e2cd6f1c3c332b79d541023499b7517d73d0 Mon Sep 17 00:00:00 2001
+From 4a0b91ed04f1d56a05dbd7737eebb3d87476a23e Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Dec 2015 12:21:22 -0800
 Subject: [PATCH 23/44] Drivers: hv: vmbus: fix the building warning with

--- a/kernel/patches-4.4.x/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
+++ b/kernel/patches-4.4.x/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
@@ -1,4 +1,4 @@
-From 2b5bfe62a794308bc4fab6cc1bcc7522c293b247 Mon Sep 17 00:00:00 2001
+From 2abfe5200099e860218432a78921375035abfe89 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Tue, 15 Dec 2015 16:27:27 -0800
 Subject: [PATCH 24/44] Drivers: hv: vmbus: Treat Fibre Channel devices as

--- a/kernel/patches-4.4.x/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
+++ b/kernel/patches-4.4.x/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
@@ -1,4 +1,4 @@
-From e515e31524a6825304aa1e5c1f0284164c85460c Mon Sep 17 00:00:00 2001
+From c001362e0b769df18ae6de9f6cf78f0123870725 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Fri, 25 Dec 2015 20:00:30 -0800
 Subject: [PATCH 25/44] Drivers: hv: vmbus: Add vendor and device atttributes

--- a/kernel/patches-4.4.x/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
+++ b/kernel/patches-4.4.x/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
@@ -1,4 +1,4 @@
-From 5e6b154c8a7f1b33683ed7e2cdf6711ed003c834 Mon Sep 17 00:00:00 2001
+From 852c5d6c8c4c6027cd34c7034a751b64854091f5 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:37 -0800
 Subject: [PATCH 26/44] Drivers: hv: vmbus: add a helper function to set a

--- a/kernel/patches-4.4.x/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
+++ b/kernel/patches-4.4.x/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
@@ -1,4 +1,4 @@
-From 546d05baf3ec141f3c1e41785997ad788e5770b2 Mon Sep 17 00:00:00 2001
+From 56ceb6b4fdbd45fa464702c98d8eb9b28bf8e431 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:38 -0800
 Subject: [PATCH 27/44] Drivers: hv: vmbus: define the new offer type for

--- a/kernel/patches-4.4.x/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
+++ b/kernel/patches-4.4.x/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
@@ -1,4 +1,4 @@
-From 3baf2ff90d0f86fe92252d58e93fb2ca72fec28a Mon Sep 17 00:00:00 2001
+From e49651913b332152569808dc6b4fc7d8904eba11 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:39 -0800
 Subject: [PATCH 28/44] Drivers: hv: vmbus: vmbus_sendpacket_ctl: hvsock: avoid

--- a/kernel/patches-4.4.x/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
+++ b/kernel/patches-4.4.x/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
@@ -1,4 +1,4 @@
-From 0d13ce69d4eb9944f403f4789e7248b8345c696e Mon Sep 17 00:00:00 2001
+From 48171ec2bb0182d8862199d6aa91fb1a346a457d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:40 -0800
 Subject: [PATCH 29/44] Drivers: hv: vmbus: define a new VMBus message type for

--- a/kernel/patches-4.4.x/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
+++ b/kernel/patches-4.4.x/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
@@ -1,4 +1,4 @@
-From 7b89be011acfeb8a1d97604443620ebad4119ac5 Mon Sep 17 00:00:00 2001
+From 26d21149ad207ad26242a83370638a13749cf644 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:41 -0800
 Subject: [PATCH 30/44] Drivers: hv: vmbus: add a hvsock flag in struct

--- a/kernel/patches-4.4.x/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
+++ b/kernel/patches-4.4.x/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
@@ -1,4 +1,4 @@
-From 1c7e4192688e75b92757be973e4dec1c53753910 Mon Sep 17 00:00:00 2001
+From 298c9b07830f6b8947867b4747ac22322fbe2586 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:42 -0800
 Subject: [PATCH 31/44] Drivers: hv: vmbus: add a per-channel rescind callback

--- a/kernel/patches-4.4.x/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
+++ b/kernel/patches-4.4.x/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
@@ -1,4 +1,4 @@
-From a23e9018aef7706dfe9733ebacad7e5312e0e907 Mon Sep 17 00:00:00 2001
+From a057c3602ea4b7c0bfbd607d8b1ef1f9c9416e76 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:43 -0800
 Subject: [PATCH 32/44] Drivers: hv: vmbus: add an API

--- a/kernel/patches-4.4.x/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
+++ b/kernel/patches-4.4.x/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
@@ -1,4 +1,4 @@
-From 97dc15186b101ab8a4061d1892045adead6de0c4 Mon Sep 17 00:00:00 2001
+From b0161c9dccfb6004195a0825a6f10754287be108 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:45 -0800
 Subject: [PATCH 33/44] Drivers: hv: vmbus: Give control over how the ring

--- a/kernel/patches-4.4.x/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
+++ b/kernel/patches-4.4.x/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
@@ -1,4 +1,4 @@
-From 8e1cfc9a58801a1d75141aedaa26ee3250fb2ea3 Mon Sep 17 00:00:00 2001
+From 0cb1f746535b94073691230c6c888b88a926e056 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:16 -0800
 Subject: [PATCH 34/44] Drivers: hv: vmbus: avoid wait_for_completion() on

--- a/kernel/patches-4.4.x/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
+++ b/kernel/patches-4.4.x/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
@@ -1,4 +1,4 @@
-From c037111137ee2cd1fd1289af160e218d41665ce8 Mon Sep 17 00:00:00 2001
+From ce31567fc6100af796ca925dff6692c641191857 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:18 -0800
 Subject: [PATCH 35/44] Drivers: hv: vmbus: avoid unneeded compiler

--- a/kernel/patches-4.4.x/0036-kcm-Kernel-Connection-Multiplexor-module.patch
+++ b/kernel/patches-4.4.x/0036-kcm-Kernel-Connection-Multiplexor-module.patch
@@ -1,4 +1,4 @@
-From 4ee5930d8afb6edbd4da52f03fb11b40116e185e Mon Sep 17 00:00:00 2001
+From 9533f10cc6a48d7f2affae1a929fce40aef99b9c Mon Sep 17 00:00:00 2001
 From: Tom Herbert <tom@herbertland.com>
 Date: Mon, 7 Mar 2016 14:11:06 -0800
 Subject: [PATCH 36/44] kcm: Kernel Connection Multiplexor module

--- a/kernel/patches-4.4.x/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4.x/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From 5637934f2bac626756475bcfbd82dbf292f4faa8 Mon Sep 17 00:00:00 2001
+From bf754d67c2b1b9b5a3f3b07f992d74acbd1f53bc Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:51:09 -0700
 Subject: [PATCH 37/44] net: add the AF_KCM entries to family name tables

--- a/kernel/patches-4.4.x/0038-net-Add-Qualcomm-IPC-router.patch
+++ b/kernel/patches-4.4.x/0038-net-Add-Qualcomm-IPC-router.patch
@@ -1,4 +1,4 @@
-From 77c0cfd6d63b85ccb47b236114848af1bd542fbb Mon Sep 17 00:00:00 2001
+From db012a1c969a9e043904560a6413eacda9aa4963 Mon Sep 17 00:00:00 2001
 From: Courtney Cavin <courtney.cavin@sonymobile.com>
 Date: Wed, 27 Apr 2016 12:13:03 -0700
 Subject: [PATCH 38/44] net: Add Qualcomm IPC router

--- a/kernel/patches-4.4.x/0039-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.4.x/0039-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 553c4016a33f4392ddc57776e15fe9b941200fff Mon Sep 17 00:00:00 2001
+From 22558a29041769588d0653c97bb97b961b2747b3 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 15 May 2016 09:53:11 -0700
 Subject: [PATCH 39/44] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.4.x/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4.x/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From 7fc07c332b4cb17c519f4660fff5731659e8430d Mon Sep 17 00:00:00 2001
+From e4982ec384df123be9ed51a5f1b86475f90e13c7 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:53:08 -0700
 Subject: [PATCH 40/44] net: add the AF_HYPERV entries to family name tables

--- a/kernel/patches-4.4.x/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
+++ b/kernel/patches-4.4.x/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
@@ -1,4 +1,4 @@
-From 831750b0a264de15a495de720403b9385c3b6d1c Mon Sep 17 00:00:00 2001
+From 3d977da5bbe09b9b5210be7b0bc993361903a2d4 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 21 May 2016 16:55:50 +0800
 Subject: [PATCH 41/44] Drivers: hv: vmbus: fix the race when querying &

--- a/kernel/patches-4.4.x/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.4.x/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From e209cd27ed3958efc05e7bac7a23d64495705cb3 Mon Sep 17 00:00:00 2001
+From 973c574094d86d7c493f357ae1e92a01fdf44502 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 42/44] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.4.x/0043-fs-add-filp_clone_open-API.patch
+++ b/kernel/patches-4.4.x/0043-fs-add-filp_clone_open-API.patch
@@ -1,4 +1,4 @@
-From 441070052852e615194df40e83260611eeb34e77 Mon Sep 17 00:00:00 2001
+From 0c831954f862451e12e10dc30ef2f046f3231fe2 Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:49:38 -0800
 Subject: [PATCH 43/44] fs: add filp_clone_open API
@@ -29,10 +29,10 @@ index 71859c4d0b41..c0022708ff3a 100644
  /*
   * inode.c
 diff --git a/fs/open.c b/fs/open.c
-index 157b9940dd73..9d993f928ea0 100644
+index fbc5c7b230b3..94fe386e566d 100644
 --- a/fs/open.c
 +++ b/fs/open.c
-@@ -1001,6 +1001,26 @@ struct file *file_open_root(struct dentry *dentry, struct vfsmount *mnt,
+@@ -1007,6 +1007,26 @@ struct file *file_open_root(struct dentry *dentry, struct vfsmount *mnt,
  }
  EXPORT_SYMBOL(file_open_root);
  

--- a/kernel/patches-4.4.x/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
+++ b/kernel/patches-4.4.x/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
@@ -1,4 +1,4 @@
-From 5b697cfb94fa9fcd10963396780082538eea0609 Mon Sep 17 00:00:00 2001
+From 28dacef9de967effc1717fb24f268af74329506b Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:51:16 -0800
 Subject: [PATCH 44/44] binfmt_misc: add persistent opened binary handler for

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From f5aea11ed9d906ce3103f0d4430cca9155c93212 Mon Sep 17 00:00:00 2001
+From 9a6d5dd0603190ffe517152151484fbe15bce466 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/13] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 9a6d5dd0603190ffe517152151484fbe15bce466 Mon Sep 17 00:00:00 2001
+From a1cd1090b8a3434dc58789faefb315ed7768caa1 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/13] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From b5f856641ba6ed46018f839884f8cda0806ae2dc Mon Sep 17 00:00:00 2001
+From bf769cbfa80b2cab125b74f91a96fed762ac77c7 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/13] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From dc9fa7c0450759a36de276392de4f224106eb497 Mon Sep 17 00:00:00 2001
+From b5f856641ba6ed46018f839884f8cda0806ae2dc Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/13] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 32694adf09591557d2e5654e6c0fea7f3ed79002 Mon Sep 17 00:00:00 2001
+From 945dfc376d76f8d0cf2ac99fb3d1234a5114c774 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/13] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 1d169b4be370f2308ee7505b22e6f485bdc0cd9f Mon Sep 17 00:00:00 2001
+From 32694adf09591557d2e5654e6c0fea7f3ed79002 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/13] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 8583ce96f921d125fd63293b91badbd74ae7ea56 Mon Sep 17 00:00:00 2001
+From edc71eae7891daaa34c708a12fdc924bb02d12db Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/13] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 30311bc867ce9674e68b6b991be9fc1deecb500f Mon Sep 17 00:00:00 2001
+From 8583ce96f921d125fd63293b91badbd74ae7ea56 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/13] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 6e65be543a2f926a03d4e547430b4b36393cde4b Mon Sep 17 00:00:00 2001
+From 46b18570a955ac6deb66c7de265bf9b865479fbf Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/13] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 46b18570a955ac6deb66c7de265bf9b865479fbf Mon Sep 17 00:00:00 2001
+From 268a803b5bb6766d72d13882d3af768821c72eee Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/13] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From 34dca511a953918cc7fca48de98fa2e21e2cb9e0 Mon Sep 17 00:00:00 2001
+From 5d954a47c46273cfd9bbaf95e37d3a158ece5d1b Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/13] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From 7c2b9d64116a27cd32eae737fe43d3315256a93d Mon Sep 17 00:00:00 2001
+From 34dca511a953918cc7fca48de98fa2e21e2cb9e0 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/13] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From 8475deba8ff1b8d71f456d2601a839005b63e9ed Mon Sep 17 00:00:00 2001
+From 67173da6f5bc8f07183ca71a78494432772648a7 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/13] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From 67173da6f5bc8f07183ca71a78494432772648a7 Mon Sep 17 00:00:00 2001
+From 3733172d128268bf248f91c1d72bf14025523359 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/13] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From 557f78dbd9952f0c9a202a32fdc165c881d2af0f Mon Sep 17 00:00:00 2001
+From df9a902d0061fc83411d5d89135791a6cf3b780b Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/13] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From b1689718a4002d8c20ccfcbe6b5d053c589fa6e1 Mon Sep 17 00:00:00 2001
+From 557f78dbd9952f0c9a202a32fdc165c881d2af0f Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/13] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 63e1872a61c4c22dc2ac055286892a5a387a66d5 Mon Sep 17 00:00:00 2001
+From 7aedb1703f4d4a9095cfdaa627346f4854b40176 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/13] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 7aedb1703f4d4a9095cfdaa627346f4854b40176 Mon Sep 17 00:00:00 2001
+From e578aa3431b12c0ad3992e28b6dd9f64782e7863 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/13] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From 30a4d8677415cf73d821146f674d556fdd54547d Mon Sep 17 00:00:00 2001
+From 748a72b3cab42df4010c99ff98cd1f19674c3db1 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/13] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From 748a72b3cab42df4010c99ff98cd1f19674c3db1 Mon Sep 17 00:00:00 2001
+From 5cfe3272373ea36e7cb2646cef043c44de4a7a30 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/13] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 231d7886eb06926ead5821b250132afd5e67d30f Mon Sep 17 00:00:00 2001
+From 9a81697ede5abe7aadacc5e06a0e0ede26b5d473 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/13] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 9a81697ede5abe7aadacc5e06a0e0ede26b5d473 Mon Sep 17 00:00:00 2001
+From bbed3e70b5330fac78de35e01881263c46b1d145 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/13] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 8203566720f63d19f393de1bce5e27f343e282b5 Mon Sep 17 00:00:00 2001
+From 7a6cc7189e451ad4c7eca36eb7eb5e2cb4df57d0 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/13] vmbus: dynamically enqueue/dequeue the channel on

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 1eb8aed951c049eb4ee8f4bb9a06d0034168a1ca Mon Sep 17 00:00:00 2001
+From 8203566720f63d19f393de1bce5e27f343e282b5 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/13] vmbus: dynamically enqueue/dequeue the channel on

--- a/kernel/patches-4.9.x/0013-vmbus-fix-the-missed-signaling-in-hv_signal_on_read.patch
+++ b/kernel/patches-4.9.x/0013-vmbus-fix-the-missed-signaling-in-hv_signal_on_read.patch
@@ -1,4 +1,4 @@
-From 3ea66bc238f2c698a174263c090434f642283958 Mon Sep 17 00:00:00 2001
+From 52d8b3d83e5fc3a726d7dceb996a99a0e94fb95d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Thu, 6 Jul 2017 21:37:11 +0000
 Subject: [PATCH 13/13] vmbus: fix the missed signaling in hv_signal_on_read()

--- a/kernel/patches-4.9.x/0013-vmbus-fix-the-missed-signaling-in-hv_signal_on_read.patch
+++ b/kernel/patches-4.9.x/0013-vmbus-fix-the-missed-signaling-in-hv_signal_on_read.patch
@@ -1,4 +1,4 @@
-From 52d8b3d83e5fc3a726d7dceb996a99a0e94fb95d Mon Sep 17 00:00:00 2001
+From b93d0f588d709fd7b34a1457c9246cdede24048b Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Thu, 6 Jul 2017 21:37:11 +0000
 Subject: [PATCH 13/13] vmbus: fix the missed signaling in hv_signal_on_read()

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/010_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.36 AS ksrc
+FROM linuxkit/kernel:4.9.38 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/kernel-compile:1b396c221af673757703258159ddc8539843b02b@sha256:6b32d205bfc6407568324337b707d195d027328dbfec554428ea93e7b0a8299b AS build

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/010_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.9.x/test.sh
@@ -18,7 +18,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.36
+docker pull linuxkit/kernel:4.9.38
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.76
+  image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.11.9
+  image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.9.36
+  image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc


### PR DESCRIPTION
kernel images are already build and pushed. I've also included the intermediate 4.11.10/4.9.37 kernels (released last week) in a separate commit and build/pushed the images as well (for triaging and completeness).

![image](https://user-images.githubusercontent.com/3338098/28265081-e41a3e20-6ae5-11e7-8244-74fafa78c4fd.png)
