### PR TITLE
Update moby to support metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 
 PREFIX?=/usr/local/
 
-MOBY_COMMIT=a824287800b1871fde9859f5b2bd9009eaefa990
+MOBY_COMMIT=4105b7ea313b04bfd930aa45b8a091e8e3a1b2ac
 MOBY_VERSION=0.0
 bin/moby: tmp_moby_bin.tar | bin
 	tar xf $<

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -49,6 +49,8 @@ files:
 
       [metrics]
       address = ":13337"
+  - path: etc/linuxkit-config
+    metadata: yaml
 trust:
   org:
     - linuxkit


### PR DESCRIPTION
Add the yaml config to the default `linuxkit.yml`. You can check
this with `cat /proc/1/root/etc/linuxkit-config`.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![little-egret 2c-nwt-cley 2c-nick-goodrum 2c-18-january-2015- small](https://user-images.githubusercontent.com/482364/28274494-facca7b6-6b08-11e7-8546-4b489bcaef43.JPG)
