### PR TITLE
getty: Detect if you are in a namespace

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -53,7 +53,7 @@ services:
     image: linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918
   # Enable getty for easier debugging
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
         - INSECURE=true
   # Run ntpd to keep time synchronised in the VM

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -53,7 +53,7 @@ services:
     image: linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918
   # Enable getty for easier debugging
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
         - INSECURE=true
   # Run ntpd to keep time synchronised in the VM

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -20,7 +20,7 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -20,7 +20,7 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
 trust:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:acd23f7c020e09799e03331e781f35965e19981f
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:acd23f7c020e09799e03331e781f35965e19981f
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -13,7 +13,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: redis

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -13,7 +13,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: redis

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -24,7 +24,7 @@ onboot:
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -24,7 +24,7 @@ onboot:
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:1b651a91f1c17f50357be9873b580ccf81668630
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: tss

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: rngd

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -20,7 +20,7 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: rngd

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -20,7 +20,7 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: rngd

--- a/pkg/getty/etc/profile.d/namespace.sh
+++ b/pkg/getty/etc/profile.d/namespace.sh
@@ -1,1 +1,0 @@
-export PS1="(ns: getty) $PS1"

--- a/pkg/getty/usr/bin/rungetty.sh
+++ b/pkg/getty/usr/bin/rungetty.sh
@@ -41,6 +41,14 @@ start_getty() {
 	infinite_loop setsid.getty -w /sbin/agetty $loginargs $line $speed $tty $term &
 }
 
+
+# check if we are namespaced, and, if so, indicate in the PS1
+if [ -z "$INIGETTY" ]; then
+	cat >/etc/profile.d/namespace.sh <<"EOF"
+export PS1="(ns: getty) $PS1"
+EOF
+fi
+
 # check if we have /etc/getty.shadow
 ROOTSHADOW=/hostroot/etc/getty.shadow
 if [ -f $ROOTSHADOW ]; then

--- a/pkg/getty/usr/bin/rungetty.sh
+++ b/pkg/getty/usr/bin/rungetty.sh
@@ -43,7 +43,7 @@ start_getty() {
 
 
 # check if we are namespaced, and, if so, indicate in the PS1
-if [ -z "$INIGETTY" ]; then
+if [ -z "$INITGETTY" ]; then
 	cat >/etc/profile.d/namespace.sh <<"EOF"
 export PS1="(ns: getty) $PS1"
 EOF

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -30,7 +30,7 @@ onboot:
       - /var/lib:/var/lib
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -30,7 +30,7 @@ onboot:
       - /var/lib:/var/lib
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -30,7 +30,7 @@ onboot:
       - /var/lib:/var/lib
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -30,7 +30,7 @@ onboot:
       - /var/lib:/var/lib
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
 trust:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:6cbeee0392b0670053ce2bf05a5a0d67ec2bce05
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -30,7 +30,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
 files:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -30,7 +30,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
 files:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -16,7 +16,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -16,7 +16,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -23,7 +23,7 @@ onboot:
     image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
     env:
      - INSECURE=true
   - name: qemu-ga

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -23,7 +23,7 @@ onboot:
     image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
     env:
      - INSECURE=true
   - name: qemu-ga

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -12,7 +12,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
+    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -12,7 +12,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+    image: linuxkit/getty:b4cdc4101eb41ce2b8aaf1ef0209445ebdc577b4
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)


### PR DESCRIPTION
This is an attempt at fixing #2213

If pid 1 isn't /sbin/init we're in a container
If we can see `containerd|runc` in the `pstree` then we're in the host
pid namespace but still in a container.
Otherwise, we're not in a namespace.

I"ve tested this with getty on `init`, in `services` with both a `host`
and `new` pid namespace and it seems to work as expected.

![](http://static.fjcdn.com/pictures/I+m+a+detective_3f6516_5349963.jpg)