### PR TITLE
Add onshutdown support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 
 PREFIX?=/usr/local/
 
-MOBY_COMMIT=4105b7ea313b04bfd930aa45b8a091e8e3a1b2ac
+MOBY_COMMIT=a261a33812ec2ba6650dc0b16353f537ade66355
 MOBY_VERSION=0.0
 bin/moby: tmp_moby_bin.tar | bin
 	tar xf $<

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,8 +4,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:e2b49a6c56fbf876ea24f0a5ce4ccae5f940d1be # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   # support metadata for optional config in /var/config

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 services:
   - name: getty

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,8 +4,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -14,6 +14,10 @@ onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+onshutdown:
+  - name: shutdown
+    image: busybox:latest
+    command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
     image: linuxkit/getty:deb9332e786e72591bd9be200bcc9c7a534eb754

--- a/pkg/init/bin/rc.init
+++ b/pkg/init/bin/rc.init
@@ -119,7 +119,7 @@ ulimit -n 1048576
 ulimit -p unlimited
 
 # execute other init processes
-INITS="$(find /etc/init.d -type f | sort)"
+INITS="$(find /etc/init.d -type f 2>/dev/null | sort)"
 for f in $INITS
 do
 	$f

--- a/pkg/init/bin/rc.shutdown
+++ b/pkg/init/bin/rc.shutdown
@@ -1,13 +1,20 @@
 #!/bin/sh
 
-[ "$1" = "reboot" ] && exec /sbin/reboot
+# execute other shutdown processes
+SHUTS="$(find /etc/shutdown.d -type f 2>/dev/null | sort)"
+for f in $SHUTS
+do
+        $f
+done
 
-# poweroff
-
+# kill all processes and unmount filesystems
 /usr/sbin/killall5 -15
 /bin/sleep 5
 /usr/sbin/killall5 -9
 /sbin/swapoff -a
 /bin/echo "Unmounting filesystems"
 /bin/umount -a -r
+
+# shutdown or reboot
+[ "$1" = "reboot" ] && exec /sbin/reboot -f
 /sbin/poweroff -f

--- a/pkg/runc/etc/shutdown.d/010-onshutdown
+++ b/pkg/runc/etc/shutdown.d/010-onshutdown
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# start onshutdown containers, run to completion
+
+if [ -d /containers/onshutdown ]
+then
+	for f in $(find /containers/onshutdown -mindepth 1 -maxdepth 1 | sort)
+	do
+		base="$(basename $f)"
+		/bin/mount --bind "$f/rootfs" "$f/rootfs"
+		mount -o remount,rw "$f/rootfs"
+		/usr/bin/runc run --bundle "$f" "$(basename $f)"
+		printf " - $base\n"
+	done
+fi

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - samoht/fdd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: sysctl

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/okernel:latest
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/projects/wireguard/wireguard.yml
+++ b/projects/wireguard/wireguard.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel-wireguard:4.9.15-2ca28b7589b673373a33274023ca870a3a77e081
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:4e9a83e890e6477dcd25029fc4f1ced61d0642f4
   - linuxkit/wireguard-utils:26fe3d38455f2d441549e3c54bdec1b26ac819b8

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 services:
   - name: acpid

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/010_tcp4_veth/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/011_tcp4_veth_reverse/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/020_tcp6_veth/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/021_tcp6_veth_reverse/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/030_tcp4_loopback/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/040_tcp6_loopback/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/050_udp4_veth/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/051_udp4_veth_reverse/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/060_udp6_veth/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/061_udp6_veth_reverse/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/070_udp4_loopback/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/000_4.4.x/080_udp6_loopback/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.77
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/010_tcp4_veth/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/011_tcp4_veth_reverse/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/020_tcp6_veth/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/021_tcp6_veth_reverse/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/030_tcp4_loopback/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/040_tcp6_loopback/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/050_udp4_veth/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/051_udp4_veth_reverse/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/060_udp6_veth/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/061_udp6_veth_reverse/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/070_udp4_loopback/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/001_4.9.x/080_udp6_loopback/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/010_tcp4_veth/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/011_tcp4_veth_reverse/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/020_tcp6_veth/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/021_tcp6_veth_reverse/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/030_tcp4_loopback/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/040_tcp6_loopback/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/050_udp4_veth/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/051_udp4_veth_reverse/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/060_udp6_veth/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/061_udp6_veth_reverse/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/070_udp4_loopback/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
+++ b/test/cases/020_kernel/110_netns/003_4.11.x/080_udp6_loopback/test-netns.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.11.11
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test-netns
     image: linuxkit/test-netns:3e02fb2730ad29a732eb2d4c711cb890169ed776

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:a63b8ee4c5de335afc32ba850e0af319b25b96c0

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: ltp

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,8 +4,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 onboot:
   - name: dhcpcd


### PR DESCRIPTION
Fix #1988 

This is a list of images to run on a clean shutdown. Note that you must not rely on these
being run at all, as machines may be be powered off or shut down without having time to run
these scripts. If you add anything here you should test both in the case where they are
run and when they are not. Most systems are likely to be "crash only" and not have any setup here,
but you can attempt to deregister cleanly from a network service here, rather than relying
on timeouts, for example.

![img_20170718_091423](https://user-images.githubusercontent.com/482364/28319059-b4e4eaf8-6bc4-11e7-8e6b-478abe7d9828.jpg)
