### PR TITLE
flag in init and background only if not in init

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -53,7 +53,7 @@ services:
     image: linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918
   # Enable getty for easier debugging
   - name: getty
-    image: linuxkit/getty:deb9332e786e72591bd9be200bcc9c7a534eb754
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
         - INSECURE=true
   # Run ntpd to keep time synchronised in the VM

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -20,7 +20,7 @@ onboot:
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
 services:
   - name: getty
-    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:b6ffbb669248e3369081a6c4427026aa968a2385
 services:
   - name: getty
-    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -13,7 +13,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
   - name: redis

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -24,7 +24,7 @@ onboot:
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
 services:
   - name: getty
-    image: linuxkit/getty:0bd92d5f906491c20e4177c57f965338fe5a8c5f
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
   - name: rngd

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -16,7 +16,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:deb9332e786e72591bd9be200bcc9c7a534eb754
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
   - name: rngd

--- a/pkg/getty/etc/init.d/001-getty
+++ b/pkg/getty/etc/init.d/001-getty
@@ -2,4 +2,6 @@
 
 # if we are here, then we need to debug a linuxkit build
 # so we always run in INSECURE mode
-INSECURE=true /usr/bin/rungetty.sh
+export INITGETTY=true
+export INSECURE=true
+/usr/bin/rungetty.sh

--- a/pkg/getty/usr/bin/rungetty.sh
+++ b/pkg/getty/usr/bin/rungetty.sh
@@ -56,5 +56,5 @@ for opt in $(cat /proc/cmdline); do
 	esac
 done
 
-# wait for all our child process to exit; tini will handle subreaping, if necessary
-wait
+# if we are in a container (not in root init) wait for all our child process to exit; tini will handle subreaping, if necessary
+[ -z "$INITGETTY" ] && wait

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -27,7 +27,7 @@ onboot:
       - /var/lib:/var/lib
 services:
   - name: getty
-    image: linuxkit/getty:deb9332e786e72591bd9be200bcc9c7a534eb754
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -27,7 +27,7 @@ onboot:
       - /var/lib:/var/lib
 services:
   - name: getty
-    image: linuxkit/getty:deb9332e786e72591bd9be200bcc9c7a534eb754
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -30,7 +30,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:89b2e91d7d1bf2f40220be0e3ed586e74746cceb
   - name: getty
-    image: linuxkit/getty:deb9332e786e72591bd9be200bcc9c7a534eb754
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
 files:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -16,7 +16,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:deb9332e786e72591bd9be200bcc9c7a534eb754
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
     env:
      - INSECURE=true
   - name: rngd

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -12,7 +12,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:deb9332e786e72591bd9be200bcc9c7a534eb754
+    image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

1. Add `INITGETTY=true` env var when running from `/etc/init.d/001-getty`
2. Only `wait` in `rungetty` if `INITGETTY` is true

`wait` was causing onboot to block. See [this](https://github.com/linuxkit/linuxkit/pull/2233#discussion_r127970030)

**- How I did it**
Typed

**- How to verify it**
Run in `services` and in `init`. Ensure everything starts when in `init`.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove block of `init` when getty is in `init` mode.

**- A picture of a cute animal (not mandatory but encouraged)**
![squid](https://upload.wikimedia.org/wikipedia/commons/d/dd/Loligo_vulgaris.jpg)

No, a squid is _not_ cute, but it is the first animal that came to mind.

