### PR TITLE
Update to latest alpine base for go-compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: default
 VERSION="0.0" # dummy for now
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:f68574b165475cff908190e0f1e86cbbb1884f86
+GO_COMPILE=linuxkit/go-compile:a1e3cd3a54b1ad683b555655282272d0eb27ee40
 
 MOBY?=bin/moby
 LINUXKIT?=bin/linuxkit

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -19,20 +19,20 @@ To update all dependencies:
 
 ```
 docker run -it --rm \
--v $(PWD):/go/src/github.com/linuxkit/linuxkit \
+-v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:f68574b165475cff908190e0f1e86cbbb1884f86
+linuxkit/go-compile:a1e3cd3a54b1ad683b555655282272d0eb27ee40
 ```
 
 To update a single dependency:
 
 ```
 docker run -it --rm \
--v $(PWD):/go/src/github.com/linuxkit/linuxkit \
+-v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:f68574b165475cff908190e0f1e86cbbb1884f86 \
+linuxkit/go-compile:a1e3cd3a54b1ad683b555655282272d0eb27ee40
 github.com/docker/docker
 ```
 

--- a/tools/go-compile/Dockerfile
+++ b/tools/go-compile/Dockerfile
@@ -1,4 +1,5 @@
-FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
+FROM linuxkit/alpine:3744607156e6b67e3e7d083b15be9e7722215e73 AS mirror
+
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \


### PR DESCRIPTION
I noticed that running the runes in docs/vendoring.md made a bunch of files
which are omitted by modern vndr come back, presumably due to the old version
of vndr referenced there. So update the go-compile package to the current
version everywhere.

Also correct the use of `make` variable syntax (`$(PWD)`) where shell syntax
command substitution for `pwd` was desired.

Signed-off-by: Ian Campbell <ijc@docker.com>
