### PR TITLE
check-kernel-config: check for STRICT_MODULE_RWX too

### DIFF
--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76
+    image: linuxkit/test-kernel-config:9f0b6b012ad86f22d6ad488cdd870a37fa70bc75
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76
+    image: linuxkit/test-kernel-config:9f0b6b012ad86f22d6ad488cdd870a37fa70bc75
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/003_config_4.11.x/test-kernel-config.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:7e8bcae3e661f5b48c00cf2f15bbef19b35fac76
+    image: linuxkit/test-kernel-config:9f0b6b012ad86f22d6ad488cdd870a37fa70bc75
   - name: poweroff
     image: linuxkit/poweroff:bce51402e293da0b653923a43c3c7be6e0effa05
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/pkg/kernel-config/check-kernel-config.sh
+++ b/test/pkg/kernel-config/check-kernel-config.sh
@@ -73,6 +73,7 @@ fi
 
 if [ "$kernelMajor" -ge 4 -a "$kernelMinor" -ge 11 ]; then
   echo $UNZIPPED_CONFIG | grep -q CONFIG_STRICT_KERNEL_RWX=y || fail "CONFIG_STRICT_KERNEL_RWX=y"
+  echo $UNZIPPED_CONFIG | grep -q CONFIG_STRICT_MODULE_RWX=y || fail "CONFIG_STRICT_MODULE_RWX=y"
 fi
 
 # Negative cases


### PR DESCRIPTION
This is what CONFIG_DEBUG_SET_MODULE_RONX was renamed to; since we want
that one, presumably we want this one too.

Signed-off-by: Tycho Andersen <tycho@docker.com>