### PR TITLE
correct the calculation of wireguard header overhead

### DIFF
--- a/reports/sig-security/2017-07-19.md
+++ b/reports/sig-security/2017-07-19.md
@@ -40,7 +40,7 @@ Previous meeting notes: [2017-07-05](2017-07-05.md)
       packet
   - Kernel networking stack is the one allocating the packet buffers,
     WireGuard doesn't allocate anything on top of this
-  - WireGuard overhead = UDP header + WireGuard = 60 bytes
+  - WireGuard overhead: ipv4 header (20 bytes) + udp header (8 bytes) + wireguard header (4 byte type, 4 byte keyid, 8 byte nonce, 16 byte authtag = 32 bytes) = 60 bytes
   - performance
     - fast, no copies across \*space
     - ChaChaPoly is fast


### PR DESCRIPTION
Thanks to Jason Donenfeld for the correction.

Signed-off-by: Tycho Andersen <tycho@docker.com>