### PR TITLE
metadata: avoid printing large chunks of configuration json to the console

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -10,7 +10,7 @@ init:
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata
-    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
+    image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
+    image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
 services:
   - name: rngd
     image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
+    image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
 services:
   - name: getty
     image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
+    image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
 services:
   - name: getty
     image: linuxkit/getty:0a2955f3d7a10a0e71972791c3ba6400118f327e

--- a/pkg/metadata/main.go
+++ b/pkg/metadata/main.go
@@ -173,11 +173,11 @@ func processUserData(data []byte) error {
 			switch fi := i.(type) {
 			case map[string]interface{}:
 				if _, ok := fi["perm"]; !ok {
-					log.Printf("No permission provided %s:%s", f, fi)
+					log.Printf("No permission provided %s", f)
 					continue
 				}
 				if _, ok := fi["content"]; !ok {
-					log.Printf("No content provided %s:%s", f, fi)
+					log.Printf("No content provided %s", f)
 					continue
 				}
 				c = fi["content"].(string)

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
+    image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
 services:
   - name: rngd
     image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
+    image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
 services:
   - name: rngd
     image: mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -14,7 +14,7 @@ onboot:
   - name: binfmt
     image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: metadata
-    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
+    image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
   - name: format
     image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mounts

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -14,7 +14,7 @@ onboot:
   - name: binfmt
     image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
   - name: metadata
-    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
+    image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
   - name: format
     image: linuxkit/format:84a997e69051a1bf05b7c1926ab785bb07932954
   - name: mounts

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -20,7 +20,7 @@ onboot:
     image: linuxkit/mount:ac8939c4102f97c084d9ddfd445c1908fce6d768
     command: ["/mount.sh", "/var/lib/swarmd"]
   - name: metadata
-    image: linuxkit/metadata:f122f1b4e873f1d08cd67bd9105385fd923af0cb
+    image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
 services:
   - name: getty
     image: linuxkit/getty:9f27c1272b6d128c9a09745e916f151d09cb0d27


### PR DESCRIPTION

**- What I did**

I prevented large chunks of configuration .json (some of which could be secret) from being logged to the console.

**- How I did it**

I suppressed printing the .json value when there is no `perm` or `content` attribute i.e. when the node is a directory.

**- How to verify it**

Using configuration .json like:
```json
{
  "etc": {
    "ssl": {
      "certs": {
        "ca-certificates.crt": {
          "perm": "0644",
          "content": "large amount of certificate text"
        }
      }
    }
  }
}
```
Without this patch, I see on the console:
```
2017/07/20 10:03:04 CDROM: Probe succeeded
2017/07/20 10:03:04 No permission provided ssl:map[certs:map[ca-certificates.crt:map[perm:0644 content:large amount of certificate text]]]
 - 000-metadata
```
With this patch, I see on the console:
```
2017/07/20 09:54:18 CDROM: Probe succeeded
2017/07/20 09:54:18 No permission provided ssl
 - 000-metadata
```
