### PR TITLE
Add apk to login (sshd & getty) containers

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -53,7 +53,7 @@ services:
     image: linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918
   # Enable getty for easier debugging
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
         - INSECURE=true
   # Run ntpd to keep time synchronised in the VM

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -18,7 +18,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: sshd
-    image: linuxkit/sshd:a00846032891f77f4f78b8a197e94e13a476a3ee
+    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -15,7 +15,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: sshd
-    image: linuxkit/sshd:a00846032891f77f4f78b8a197e94e13a476a3ee
+    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -20,7 +20,7 @@ onboot:
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -16,13 +16,13 @@ onboot:
     image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: rngd
     image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: sshd
-    image: linuxkit/sshd:a00846032891f77f4f78b8a197e94e13a476a3ee
+    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -15,7 +15,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: sshd
-    image: linuxkit/sshd:a00846032891f77f4f78b8a197e94e13a476a3ee
+    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -13,7 +13,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: redis

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: rngd
@@ -19,7 +19,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: sshd
-    image: linuxkit/sshd:a00846032891f77f4f78b8a197e94e13a476a3ee
+    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -24,7 +24,7 @@ onboot:
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -19,7 +19,7 @@ onboot:
     command: ["sh", "-c", "mkdir /host_var/vpnkit && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
 services:
   - name: sshd
-    image: linuxkit/sshd:a00846032891f77f4f78b8a197e94e13a476a3ee
+    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
   - name: vpnkit-forwarder
     image: linuxkit/vpnkit-forwarder:9c1545e7b093d1210118de7661d7346393ec195b
     binds:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -16,13 +16,13 @@ onboot:
     image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: rngd
     image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: sshd
-    image: linuxkit/sshd:a00846032891f77f4f78b8a197e94e13a476a3ee
+    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -20,7 +20,7 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: rngd

--- a/pkg/getty/Dockerfile
+++ b/pkg/getty/Dockerfile
@@ -1,15 +1,17 @@
-FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
+FROM linuxkit/alpine:a39a433162a873519910a07beeb3e8db22529956 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
+    apk-tools \
     busybox \
     ca-certificates \
     musl \
     tini \
     util-linux \
     && true
-RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
+
 #
 # We require a version of `setsid(1)` which supports the `-w`
 # option, which is not available in all implementations (e.g. the
@@ -29,4 +31,4 @@ COPY --from=mirror /out/ /
 COPY usr/ /usr/
 COPY etc/ /etc/
 CMD ["/usr/bin/rungetty.sh"]
-LABEL org.mobyproject.config='{"pid": "host", "net":"host", "binds": ["/run:/run", "/tmp:/tmp", "/etc:/hostroot/etc", "/usr/bin/ctr:/usr/bin/ctr", "/usr/bin/runc:/usr/bin/runc", "/var:/var","/containers:/containers","/dev:/dev","/sys:/sys"], "capabilities": ["all"]}'
+LABEL org.mobyproject.config='{"pid": "host", "net":"host", "binds": ["/run:/run", "/tmp:/tmp", "/etc:/hostroot/etc", "/usr/bin/ctr:/usr/bin/ctr", "/usr/bin/runc:/usr/bin/runc", "/containers:/containers","/dev:/dev","/sys:/sys"], "capabilities": ["all"]}'

--- a/pkg/sshd/Dockerfile
+++ b/pkg/sshd/Dockerfile
@@ -1,8 +1,9 @@
-FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
+FROM linuxkit/alpine:a39a433162a873519910a07beeb3e8db22529956 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
+    apk-tools \
     busybox \
     ca-certificates \
     musl \
@@ -10,7 +11,7 @@ RUN apk add --no-cache --initdb -p /out \
     tini \
     util-linux \
     && true
-RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 
 FROM scratch
 ENTRYPOINT []
@@ -20,4 +21,4 @@ COPY etc/ /etc/
 COPY usr/ /usr/
 RUN mkdir -p /etc/ssh /root/.ssh && chmod 0700 /root/.ssh
 CMD ["/sbin/tini", "/usr/bin/ssh.sh"]
-LABEL org.mobyproject.config='{"pid": "host", "binds": ["/root/.ssh:/root/.ssh", "/etc/resolv.conf:/etc/resolv.conf", "/run:/run", "/tmp:/tmp", "/etc:/hostroot/etc", "/usr/bin/ctr:/usr/bin/ctr", "/usr/bin/runc:/usr/bin/runc", "/var:/var","/containers:/containers","/dev:/dev","/sys:/sys"], "capabilities": ["all"]}'
+LABEL org.mobyproject.config='{"pid": "host", "binds": ["/root/.ssh:/root/.ssh", "/etc/resolv.conf:/etc/resolv.conf", "/run:/run", "/tmp:/tmp", "/etc:/hostroot/etc", "/usr/bin/ctr:/usr/bin/ctr", "/usr/bin/runc:/usr/bin/runc", "/containers:/containers","/dev:/dev","/sys:/sys"], "capabilities": ["all"]}'

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -27,7 +27,7 @@ onboot:
       - /var/lib:/var/lib
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: rngd
@@ -37,7 +37,7 @@ services:
   - name: ntpd
     image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: sshd
-    image: linuxkit/sshd:a00846032891f77f4f78b8a197e94e13a476a3ee
+    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
   - name: docker
     image: docker:17.06.0-ce-dind
     capabilities:

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -27,7 +27,7 @@ onboot:
       - /var/lib:/var/lib
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: rngd
@@ -37,7 +37,7 @@ services:
   - name: ntpd
     image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: sshd
-    image: linuxkit/sshd:a00846032891f77f4f78b8a197e94e13a476a3ee
+    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
   - name: docker
     image: docker:17.06.0-ce-dind
     capabilities:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -28,9 +28,9 @@ onboot:
      - /lib:/lib     # for ifconfig
 services:
   - name: sshd
-    image: linuxkit/sshd:a00846032891f77f4f78b8a197e94e13a476a3ee
+    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
 files:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -15,7 +15,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: sshd
-    image: linuxkit/sshd:a00846032891f77f4f78b8a197e94e13a476a3ee
+    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -16,7 +16,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: rngd

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -12,7 +12,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:9c32352b2a7b2f233de8741396afeb26b58f9a05
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)


### PR DESCRIPTION
**- What I did**

Made it possible to run `apk` commands (such as `apk add`) in the `getty` and `sshd` containers

Fixes #2206.

**- How I did it**

Added `apk-tools` to both images, used 00a2f2ac8caca2b10f0b61bfe0116892c5f2687d to provide an appropriate repositories config and stopped nuking the apk state.

I also dropped the bind mount of `/var` from both packages. Quoting the relevant bit of commit message:
>    Doing this requires that we not share `/var` with the login containers since we
>    want the apk database therein. Previously it was thought that the containers
>    might need some parts of `/var` for `ctr` to work (e.g. `/var/lib/containerd`)
>    but this is not the case now (if it ever was) based on my testing.

Although not strictly necessary, bumped the version of alpine base used by both images.

**- How to verify it**

Try `apk -U add strace` from a getty or sshd container.

**- Description for the changelog**
Login containers (sshd and getty) now have the `apk` installed enabling ad-hoc package installation.

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://upload.wikimedia.org/wikipedia/en/e/eb/TimesOfGrace.jpeg "Neurosis, Times of Grace")](https://en.wikipedia.org/wiki/Times_of_Grace_(album))
