### PR TITLE
alpine: Use `docker build --iidfile`

### DIFF
--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -9,7 +9,7 @@ COPY Dockerfile /Dockerfile
 COPY packages* /tmp/
 
 # mirror packages
-RUN cat /tmp/packages.$(uname -m) >> /tmp/packages && \ 
+RUN cat /tmp/packages.$(uname -m) >> /tmp/packages && \
    mkdir -p /mirror/$(uname -m) && \
    apk fetch --recursive -o /mirror/$(uname -m) $(apk info; cat /tmp/packages)
 
@@ -30,7 +30,7 @@ RUN cp /mirror/$(uname -m)/APKINDEX.unsigned.tar.gz /mirror/$(uname -m)/APKINDEX
 RUN abuild-sign /mirror/$(uname -m)/APKINDEX.tar.gz
 
 # fetch OVMF for qemu EFI boot (this is not added as a package)
-RUN mkdir -p /usr/share/ovmf && \ 
+RUN mkdir -p /usr/share/ovmf && \
     if [ $(uname -m) = x86_64 ]; then \
        apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/community ovmf; \
     fi

--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -6,12 +6,14 @@ IMAGE=alpine
 DOCKER_CONTENT_VAR=1
 PKG_DEPS=packages
 
-ifeq ($(shell uname -m), x86_64)
+ARCH := $(shell uname -m)
+
+ifeq ($(ARCH), x86_64)
 BASE=alpine:3.6
 PKG_DEPS += packages.x86_64
 endif
 
-ifeq ($(shell uname -m), aarch64)
+ifeq ($(ARCH), aarch64)
 BASE=arm64v8/alpine:3.6
 PKG_DEPS += packages.aarch64
 DOCKER_CONTENT_VAR=0
@@ -20,27 +22,29 @@ endif
 default: push
 
 show-tag:
-	@sed -n -e '1s/# \(.*\/.*:[0-9a-f]\{40\}\)/\1/p;q' versions.$(shell uname -m)
+	@sed -n -e '1s/# \(.*\/.*:[0-9a-f]\{40\}\)/\1/p;q' versions.$(ARCH)
 
-hash: Dockerfile Makefile $(PKG_DEPS)
+iid: Dockerfile Makefile $(PKG_DEPS)
 	DOCKER_CONTENT_TRUST=$(DOCKER_CONTENT_VAR) docker pull $(BASE)
-	docker build --no-cache --build-arg BASE=$(BASE) -t $(IMAGE):build .
-	docker run --rm $(IMAGE):build sh -c 'echo Dockerfile /lib/apk/db/installed $$(find /mirror -name '*.apk' -type f) $$(find /go/bin -type f) | xargs cat | sha1sum' | sed 's/ .*//' > $@
+	docker build --no-cache --build-arg BASE=$(BASE) --iidfile iid .
 
-push: hash
+hash: Makefile iid
+	docker run --rm $(shell cat iid) sh -c 'echo Dockerfile /lib/apk/db/installed $$(find /mirror -name '*.apk' -type f) $$(find /go/bin -type f) | xargs cat | sha1sum' | sed 's/ .*//' > $@
+
+versions.$(ARCH): Makefile hash iid
+	echo "# $(ORG)/$(IMAGE):$(shell cat hash)" > versions.$(ARCH)
+	docker run --rm $(shell cat iid) find /mirror -name '*.apk' -exec basename '{}' .apk \; | sort | (echo '# automatically generated list of installed packages'; cat -) >> versions.$(ARCH)
+
+push: hash iid versions.$(ARCH)
 	DOCKER_CONTENT_TRUST=$(DOCKER_CONTENT_VAR) docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
-		(docker tag $(IMAGE):build $(ORG)/$(IMAGE):$(shell cat hash) && \
+		(docker tag $(shell cat iid) $(ORG)/$(IMAGE):$(shell cat hash) && \
 		 DOCKER_CONTENT_TRUST=$(DOCKER_CONTENT_VAR) docker push $(ORG)/$(IMAGE):$(shell cat hash))
-	echo "# $(ORG)/$(IMAGE):$(shell cat hash)" > versions.$(shell uname -m)
-	docker run --rm $(IMAGE):build find /mirror -name '*.apk' -exec basename '{}' .apk \; | sort | (echo '# automatically generated list of installed packages'; cat -) >> versions.$(shell uname -m)
-	docker rmi $(IMAGE):build
-	rm -f hash
+	rm -f iid
 
-tag: hash
+tag: hash iid versions.$(ARCH)
 	docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
-		docker tag $(IMAGE):build $(ORG)/$(IMAGE):$(shell cat hash)
-	docker rmi $(IMAGE):build
-	rm -f hash
+		docker tag $(shell cat iid) $(ORG)/$(IMAGE):$(shell cat hash)
+	rm -f iid
 
 clean:
-	rm -f hash
+	rm -f hash iid


### PR DESCRIPTION
This was added in 17.06 and allows us to avoid using `$(BASE):build` which is
not safe against parallel builds etc.

Having done this restructure the build to not always delete the built container
and to separate out the `hash` and `version` file rules so that they can be
included in both the `tag` and `push` targets.

Signed-off-by: Ian Campbell <ijc@docker.com>

This carries a change from https://github.com/linuxkit/linuxkit/pull/2258 which was dropped from there due to being off-topic.

**- What I did**

See above.

**- How I did it**

Used `docker build --no-cache --iidfile iid .` to build an `iid` file (which will contain `sha256:[0-9a-f]{64}`) and refactored the `hash` and `versions` generation into dedicated targets depending on that. Updated everything using `$(IMAGE):build` to use `$(shell cat iid)` instead. Updated the dependencies of the existing `tag` and `push` targets. It is no longer necessary to `docker rmi` anything.

**- How to verify it**

Check that `make -C tools/alpine tag` does something sensible.

**- Description for the changelog**
Internal detail not really worth mentioning

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://upload.wikimedia.org/wikipedia/en/5/53/Neurosis_-_Given_to_the_Rising.jpg "Neurosis, Given to the Rising")](https://en.wikipedia.org/wiki/Given_to_the_Rising)
