### PR TITLE
containerd: add `exec` subcommand to `service`

### DIFF
--- a/pkg/containerd/cmd/service/exec.go
+++ b/pkg/containerd/cmd/service/exec.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/containerd/console"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/namespaces"
+	"golang.org/x/sys/unix"
+)
+
+type resizer interface {
+	Resize(ctx context.Context, w, h uint32) error
+}
+
+type killer interface {
+	Kill(context.Context, syscall.Signal) error
+}
+
+func exec(args []string) {
+	invoked := filepath.Base(os.Args[0])
+	flags := flag.NewFlagSet("exec", flag.ExitOnError)
+	flags.Usage = func() {
+		fmt.Printf("USAGE: %s exec [--tty] [service] [command] [args...]\n\n", invoked)
+		fmt.Printf("Options:\n")
+		flags.PrintDefaults()
+	}
+
+	sock := flags.String("sock", "/run/containerd/containerd.sock", "Path to containerd socket")
+	tty := flags.Bool("tty", false, "allocate a TTY")
+
+	if err := flags.Parse(args); err != nil {
+		log.Fatal("Unable to parse args")
+	}
+	args = flags.Args()
+
+	if len(args) < 1 {
+		fmt.Println("Please specify the service")
+		flags.Usage()
+		os.Exit(1)
+	}
+
+	if len(args) < 2 {
+		fmt.Println("Please specify the command to run")
+		flags.Usage()
+		os.Exit(1)
+	}
+
+	service := args[0]
+	args = args[1:]
+	execid := fmt.Sprintf("exec%d", os.Getpid())
+	log := log.WithFields(log.Fields{
+		"service": service,
+	})
+
+	client, err := containerd.New(*sock)
+	if err != nil {
+		log.WithError(err).Fatal("creating containerd client")
+	}
+
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+
+	container, err := client.LoadContainer(ctx, service)
+	if err != nil {
+		log.WithError(err).Fatal("loading container")
+	}
+	spec, err := container.Spec()
+	if err != nil {
+		log.WithError(err).Fatal("loading spec")
+	}
+	task, err := container.Task(ctx, nil)
+	if err != nil {
+		log.WithError(err).Fatal("getting task")
+	}
+
+	pspec := spec.Process
+	pspec.Terminal = *tty
+	pspec.Args = args
+
+	io := containerd.Stdio
+	if *tty {
+		io = containerd.StdioTerminal
+	}
+
+	process, err := task.Exec(ctx, execid, pspec, io)
+	if err != nil {
+		log.WithError(err).Fatal("exec failed")
+	}
+	defer process.Delete(ctx)
+
+	statusC := make(chan uint32, 1)
+	go func() {
+		status, err := process.Wait(ctx)
+		if err != nil {
+			log.WithError(err).Error("wait process")
+		}
+		statusC <- status
+	}()
+	var con console.Console
+	if *tty {
+		con = console.Current()
+		defer con.Reset()
+		if err := con.SetRaw(); err != nil {
+			log.WithError(err).Fatal("setting console raw")
+		}
+	}
+	if err := process.Start(ctx); err != nil {
+		log.WithError(err).Fatal("starting process")
+	}
+	if *tty {
+		if err := handleConsoleResize(ctx, process, con); err != nil {
+			log.WithError(err).Fatal("resizing console")
+		}
+	} else {
+		sigc := forwardAllSignals(ctx, process)
+		defer stopCatch(sigc)
+	}
+	status := <-statusC
+	if status != 0 {
+		log.Errorf("Exited with code %d", int(status))
+	}
+}
+
+func forwardAllSignals(ctx context.Context, task killer) chan os.Signal {
+	sigc := make(chan os.Signal, 128)
+	signal.Notify(sigc)
+	go func() {
+		for s := range sigc {
+			log.Debug("forwarding signal ", s)
+			if err := task.Kill(ctx, s.(syscall.Signal)); err != nil {
+				log.WithError(err).Errorf("forward signal %s", s)
+			}
+		}
+	}()
+	return sigc
+}
+
+func stopCatch(sigc chan os.Signal) {
+	signal.Stop(sigc)
+	close(sigc)
+}
+
+func handleConsoleResize(ctx context.Context, task resizer, con console.Console) error {
+	// do an initial resize of the console
+	size, err := con.Size()
+	if err != nil {
+		return err
+	}
+	if err := task.Resize(ctx, uint32(size.Width), uint32(size.Height)); err != nil {
+		log.WithError(err).Error("resize pty")
+	}
+	s := make(chan os.Signal, 16)
+	signal.Notify(s, unix.SIGWINCH)
+	go func() {
+		for range s {
+			size, err := con.Size()
+			if err != nil {
+				log.WithError(err).Error("get pty size")
+				continue
+			}
+			if err := task.Resize(ctx, uint32(size.Width), uint32(size.Height)); err != nil {
+				log.WithError(err).Error("resize pty")
+			}
+		}
+	}()
+	return nil
+}

--- a/pkg/containerd/cmd/service/main.go
+++ b/pkg/containerd/cmd/service/main.go
@@ -31,6 +31,7 @@ func main() {
 		fmt.Printf("Commands:\n")
 		fmt.Printf("  system-init Prepare the system at start of day\n")
 		fmt.Printf("  start       Start a service\n")
+		fmt.Printf("  exec        Execute a command in a service\n")
 		fmt.Printf("  help        Print this message\n")
 		fmt.Printf("\n")
 		fmt.Printf("Run '%s COMMAND --help' for more information on the command\n", filepath.Base(os.Args[0]))
@@ -70,6 +71,8 @@ func main() {
 		start(args[1:])
 	case "system-init":
 		systemInit(args[1:])
+	case "exec":
+		exec(args[1:])
 	default:
 		fmt.Printf("%q is not valid command.\n\n", args[0])
 		flag.Usage()


### PR DESCRIPTION
**- What I did**

This replaces `ctr exec --tty --exec-id mumble <service>`.

Several helpers cribbed from ctr source.

Signed-off-by: Ian Campbell <ijc@docker.com>

**- How I did it**

Mostly stole code from `ctr`.

**- How to verify it**

Right now:
```
(ns: getty) linuxkit-525400123456:~# nsenter -m/proc/1/ns/mnt service exec --tty nginx ps aux
PID   USER     TIME   COMMAND
    1 root       0:00 nginx: master process nginx -g daemon off;
    5 nginx      0:00 nginx: worker process
   15 root       0:00 ps aux
```

If there is support for this idea I think it makes sense to bind `service` into the `getty` and `sshd` containers.

**- Description for the changelog**
`service exec` is a convenient way to enter a container namespace.

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://upload.wikimedia.org/wikipedia/en/e/eb/Rocket_from_the_Crypt_-_Scream%2C_Dracula%2C_Scream%21_cover.jpg "Rocket from the Crypt, Scream Dracula Scream")](https://en.wikipedia.org/wiki/Scream,_Dracula,_Scream!)
