### PR TITLE
Wireguard tools as package

### DIFF
--- a/docs/wireguard.md
+++ b/docs/wireguard.md
@@ -18,7 +18,7 @@ A full technical paper from NDSS 2017 is available [here](https://www.wireguard.
 The default kernels build WireGuard in as a module.
 
 ### Userspace Tools
-The userspace tools are part of `tools/alpine`.
+The userspace tools are now a package part of `tools/alpine`, which can be installed via `apk add wireguard-tools`.
 
 ## Quickstart
 To give WireGuard a spin, the [official quick start](https://www.wireguard.com/quickstart/) is a good way to get going.  For containers,

--- a/pkg/getty/Dockerfile
+++ b/pkg/getty/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache --initdb -p /out \
     musl \
     tini \
     util-linux \
+    wireguard-tools \
     && true
 RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 

--- a/pkg/sshd/Dockerfile
+++ b/pkg/sshd/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache --initdb -p /out \
     openssh-server \
     tini \
     util-linux \
+    wireguard-tools \
     && true
 RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -11,6 +11,9 @@ COPY packages /tmp/
 RUN mkdir -p /mirror/$(uname -m) && \
    apk fetch --recursive -o /mirror/$(uname -m) $(apk info; cat /tmp/packages)
 
+# add the tools for WireGuard, since the kernel module is now included, but from edge/testing
+RUN apk fetch --recursive -o /mirror/$(uname -m) -X http://dl-cdn.alpinelinux.org/alpine/edge/testing -U wireguard-tools
+
 # install abuild for signing
 RUN apk add --no-cache abuild
 
@@ -26,9 +29,6 @@ RUN abuild-sign /mirror/$(uname -m)/APKINDEX.tar.gz
 
 # fetch OVMF for qemu EFI boot (this is not added as a package)
 RUN apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/community ovmf
-
-# add the tools for WireGuard, since the kernel module is now included
-RUN apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/testing -U wireguard-tools
 
 # set this as our repo but keep a copy of the upstream for downstream use
 RUN mv /etc/apk/repositories /etc/apk/repositories.upstream && echo "/mirror" > /etc/apk/repositories && apk update


### PR DESCRIPTION
As discussed with @rn, wireguard-tools should be a *package available from* tools/alpine. Then, it can be included in sshd and getty, since it's on the same level as iproute2, and wireguard is going to be an essential feature of linuxkit, so it's important for folks to get acquainted with it.

The hashes in getty and sshd need to be updated, so after you've built them and have a tag, please mention it here so I can update the PR.