### PR TITLE
wireguard: add tools to alpine as package not into filesystem

### DIFF
--- a/docs/wireguard.md
+++ b/docs/wireguard.md
@@ -18,7 +18,7 @@ A full technical paper from NDSS 2017 is available [here](https://www.wireguard.
 The default kernels build WireGuard in as a module.
 
 ### Userspace Tools
-The userspace tools are part of `tools/alpine`.
+The userspace tools are now a package available in `tools/alpine`, which can be installed via `apk add wireguard-tools`.
 
 ## Quickstart
 To give WireGuard a spin, the [official quick start](https://www.wireguard.com/quickstart/) is a good way to get going.  For containers,

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -11,6 +11,9 @@ COPY packages /tmp/
 RUN mkdir -p /mirror/$(uname -m) && \
    apk fetch --recursive -o /mirror/$(uname -m) $(apk info; cat /tmp/packages)
 
+# add the tools for WireGuard, since the kernel module is now included, but from edge/testing
+RUN apk fetch --recursive -o /mirror/$(uname -m) -X http://dl-cdn.alpinelinux.org/alpine/edge/testing -U wireguard-tools
+
 # install abuild for signing
 RUN apk add --no-cache abuild
 
@@ -26,9 +29,6 @@ RUN abuild-sign /mirror/$(uname -m)/APKINDEX.tar.gz
 
 # fetch OVMF for qemu EFI boot (this is not added as a package)
 RUN apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/community ovmf
-
-# add the tools for WireGuard, since the kernel module is now included
-RUN apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/testing -U wireguard-tools
 
 # set this as our repo but keep a copy of the upstream for downstream use
 RUN mv /etc/apk/repositories /etc/apk/repositories.upstream && echo "/mirror" > /etc/apk/repositories && apk update


### PR DESCRIPTION
As discussed with @rn, wireguard-tools should be a package available from tools/alpine. Then, it can be included in sshd and getty, since it's on the same level as iproute2, and wireguard is going to be an essential feature of linuxkit, so it's important for folks to get acquainted with it.

This PR takes the first step of making it into a package.

From @rn, it works:

```
make ORG=rneugeba  tag
docker run --rm -ti rneugeba/alpine:5ca5d83ef72f74bdc2a7b96bc17d58031a42306d /bin/sh
/ # apk search wireguard
wireguard-tools-0.0.20170629-r0
```