### PR TITLE
Add wireguard to sshd and getty

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -18,7 +18,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: sshd
-    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
+    image: linuxkit/sshd:9e9186dd5989ae9c604eba77e306b0e67500b55c
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -15,7 +15,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: sshd
-    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
+    image: linuxkit/sshd:9e9186dd5989ae9c604eba77e306b0e67500b55c
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -20,7 +20,7 @@ onboot:
     command: ["/mount.sh", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
+    image: linuxkit/getty:1b651a91f1c17f50357be9873b580ccf81668630
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -16,13 +16,13 @@ onboot:
     image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
 services:
   - name: getty
-    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
+    image: linuxkit/getty:1b651a91f1c17f50357be9873b580ccf81668630
     env:
      - INSECURE=true
   - name: rngd
     image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: sshd
-    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
+    image: linuxkit/sshd:9e9186dd5989ae9c604eba77e306b0e67500b55c
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
+    image: linuxkit/getty:1b651a91f1c17f50357be9873b580ccf81668630
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
+    image: linuxkit/getty:1b651a91f1c17f50357be9873b580ccf81668630
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
 services:
   - name: getty
-    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
+    image: linuxkit/getty:1b651a91f1c17f50357be9873b580ccf81668630
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -15,7 +15,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: sshd
-    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
+    image: linuxkit/sshd:9e9186dd5989ae9c604eba77e306b0e67500b55c
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -13,7 +13,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
+    image: linuxkit/getty:1b651a91f1c17f50357be9873b580ccf81668630
     env:
      - INSECURE=true
   - name: redis

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
+    image: linuxkit/getty:1b651a91f1c17f50357be9873b580ccf81668630
     env:
      - INSECURE=true
   - name: rngd
@@ -19,7 +19,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41
   - name: sshd
-    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
+    image: linuxkit/sshd:9e9186dd5989ae9c604eba77e306b0e67500b55c
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -24,7 +24,7 @@ onboot:
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
+    image: linuxkit/getty:1b651a91f1c17f50357be9873b580ccf81668630
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
 services:
   - name: getty
-    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
+    image: linuxkit/getty:1b651a91f1c17f50357be9873b580ccf81668630
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -19,7 +19,7 @@ onboot:
     command: ["sh", "-c", "mkdir /host_var/vpnkit && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
 services:
   - name: sshd
-    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
+    image: linuxkit/sshd:9e9186dd5989ae9c604eba77e306b0e67500b55c
   - name: vpnkit-forwarder
     image: linuxkit/vpnkit-forwarder:9c1545e7b093d1210118de7661d7346393ec195b
     binds:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -16,13 +16,13 @@ onboot:
     image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
 services:
   - name: getty
-    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
+    image: linuxkit/getty:1b651a91f1c17f50357be9873b580ccf81668630
     env:
      - INSECURE=true
   - name: rngd
     image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
   - name: sshd
-    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
+    image: linuxkit/sshd:9e9186dd5989ae9c604eba77e306b0e67500b55c
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/pkg/getty/Dockerfile
+++ b/pkg/getty/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:a39a433162a873519910a07beeb3e8db22529956 AS mirror
+FROM linuxkit/alpine:4248059c38452217ff63853869df36034a890401 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -9,6 +9,7 @@ RUN apk add --no-cache --initdb -p /out \
     musl \
     tini \
     util-linux \
+    wireguard-tools \
     && true
 RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 

--- a/pkg/sshd/Dockerfile
+++ b/pkg/sshd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:a39a433162a873519910a07beeb3e8db22529956 AS mirror
+FROM linuxkit/alpine:4248059c38452217ff63853869df36034a890401 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -10,6 +10,7 @@ RUN apk add --no-cache --initdb -p /out \
     openssh-server \
     tini \
     util-linux \
+    wireguard-tools \
     && true
 RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 


### PR DESCRIPTION
WireGuard is on the same level as iproute2, which is also in sshd and getty. If WireGuard is going to become an important component of LinuxKit, it should be available for people to play with in these containers. Adding the tools adds hardly any increase and size, and will make developing LinuxKit+WireGuard considerably smoother. This is also needed to use these in reproducable/networkless configurations, since /mirrors is not available after boot.

Suggested by @rn and @justincormack.