### PR TITLE
swarmd: refresh versions

### DIFF
--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -45,7 +45,7 @@ services:
       - /var:/var
       - /var/lib/swarmd:/weavedb
   - name: swarmd
-    image: linuxkitprojects/swarmd:1cd4c061cc7327750d2a12c267db6d4d9e26b1d3
+    image: linuxkitprojects/swarmd:cce587b5e67b7d3e088a2e527dafc5ad3edb6502
     command: ["/usr/bin/swarmd", "--containerd-addr=/run/containerd/containerd.sock", "--log-level=debug", "--state-dir=/var/lib/swarmd"]
     capabilities:
      - all

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -35,7 +35,7 @@ services:
   - name: ntpd
     image: linuxkit/openntpd:19370f5d9bec84eb91073b7196b732f1301d9c90
   - name: weave
-    image: weaveworks/weave@sha256:05172329b6ff72099db7bb891ac311b89948a3064ca9b8641c6b4abe38548677 # Must match swarmd/Dockerfile
+    image: weaveworks/weave:2.0.1@sha256:2d70caac7db33365482cc923d40ff8d3ec1238ae7fe06a00b3dde310d09f226e # Must match swarmd/Dockerfile
     command: ["/bin/sh", "/home/weave/weaver-wrapper"]
     capabilities:
      - all

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -23,7 +23,7 @@ onboot:
     image: linuxkit/metadata:428093dd1c4178e8ba1952af44b46c0fd16f8e79
 services:
   - name: getty
-    image: linuxkit/getty:9f27c1272b6d128c9a09745e916f151d09cb0d27
+    image: linuxkit/getty:08b704915af0ce90f8f40df5d41d4c1aa14ef83a
     env:
      - INSECURE=true
   - name: qemu-ga

--- a/projects/swarmd/swarmd/Dockerfile
+++ b/projects/swarmd/swarmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM weaveworks/weave@sha256:05172329b6ff72099db7bb891ac311b89948a3064ca9b8641c6b4abe38548677 AS weave
+FROM weaveworks/weave:2.0.1@sha256:2d70caac7db33365482cc923d40ff8d3ec1238ae7fe06a00b3dde310d09f226e AS weave
 
 # Nothing to do in here, just for COPY --from=weave below
 

--- a/projects/swarmd/swarmd/Dockerfile
+++ b/projects/swarmd/swarmd/Dockerfile
@@ -40,9 +40,9 @@ RUN mkdir -p /out/usr/bin/ /out/etc  /out/opt/cni/bin /out/etc/cni/net.d
 # Swarmd
 
 # https://github.com/ijc/swarmkit/tree/containerd-wip
-ENV SWARMKIT_REPO=https://github.com/ijc25/swarmkit
+ENV SWARMKIT_REPO=https://github.com/ijc/swarmkit
 ENV SWARMKIT_BRANCH=containerd-wip
-ENV SWARMKIT_COMMIT=4a484ccb498bee117fe6167d5a5e7ea0f6d4f2e9
+ENV SWARMKIT_COMMIT=8a09c038f1ba8f227a28b7f48ccc92a04edb85f5
 
 RUN mkdir -p $GOPATH/src/github.com/docker && \
   cd $GOPATH/src/github.com/docker && \


### PR DESCRIPTION
**- What I did**

Refreshed the getty, weave and swarmd packages in projects/swarmd to current versions. In particular the swarmd package is now up to date with containerd v1.0.0-alpha1.

**- How I did it**

emacs again.

**- How to verify it**

Run the swarmd project.

**- Description for the changelog**
swarmd project has been updated to be compatible with containerd v1.0.0-alpha1

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://f4.bcbits.com/img/a2993129801_2.jpg "Corsair, Corsair")](https://shadowkingdomrecords.bandcamp.com/album/corsair)
