### PR TITLE
Add script to update tag for all image matches

### DIFF
--- a/scripts/update-component-sha.sh
+++ b/scripts/update-component-sha.sh
@@ -1,10 +1,67 @@
 #!/bin/sh
 set -e
-if [ $# -ne 2 ] ; then
-    echo "Need <OLD> and <NEW> as arguments" >&2
+
+##
+#
+# script to replace hashes in config files
+# see usage() for usage and functionality
+#
+
+function usage() {
+    cat >&2 <<EOF
+$0 --<mode> <how-to-find> <new-hash>
+
+Available modes: --hash and --image
+
+Replace by hash:
+	$0 --hash <OLD> <NEW>
+	Example: $0 8675309abcdefg abcdef567899
+    	   Will replace all instances of 8675309abcdefg with abcdef567899
+
+Replace by image: $0 --image <IMAGE> <NEW>
+	$0 --image <IMAGE> <NEW>
+	Example: $0 linuxkit/foo abcdef567899
+	   Will tag all instances of linuxkit/foo with abcdef567899
+
+By default, for convenience, if no mode is given (--image or --hash), the first method (--hash) is assumed. 
+Thus the following are equivalent:
+	$0 <OLD> <NEW>
+	$0 --hash <OLD> <NEW>
+
+EOF
+}
+
+
+# backwards compatibility
+if [ $# -eq 2 ]; then
+  set -- "--hash" "$1" "$2"
+fi
+
+# sufficient arguments
+if [ $# -ne 3 ] ; then
+    usage
     exit 1
 fi
-old=$1
-new=$2
 
-git grep -l "$old" | xargs sed -i -e "s,$old,$new,g"
+
+# which mode?
+case "$1" in
+    --hash)
+        old=$2
+        new=$3
+
+        git grep -w -l "\b$old\b" | xargs sed -i.bak -e "s,$old,$new,g"
+        ;;
+    --image)
+        image=$2
+        hash=$3
+        git grep -E -l "\b$image:" | xargs sed -i.bak -e "s,$image:[[:xdigit:]]"'\{40\}'",$image:$hash,g"
+        ;;
+    *)
+        echo "Unknown mode $1"
+        usage
+        exit 1
+        ;;
+esac
+
+find . -name '*.bak' | xargs rm


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a script that updates all instances of an image with a given tag. The existing script replaces tag `<OLD>` with `<NEW>`. This changes the hash for any occurrence of `<IMAGE>` to `<NEW>`, no matter what the old one was.

Existing is fine, but often I find the need to just "change them all."

**- How I did it**
Typing.

**- How to verify it**
Run it, see the changes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Script to support changing tag for all occurrences of an image.


**- A picture of a cute animal (not mandatory but encouraged)**
![monster](http://www.behindthevoiceactors.com/_img/chars/randy-disney-infinity-6.42.jpg)

