### PR TITLE
Remove bashism in script

### DIFF
--- a/scripts/update-component-sha.sh
+++ b/scripts/update-component-sha.sh
@@ -7,7 +7,7 @@ set -e
 # see usage() for usage and functionality
 #
 
-function usage() {
+usage() {
     cat >&2 <<EOF
 $0 --<mode> <how-to-find> <new-hash>
 


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed a bashism from [update-component-sha.sh](./scripts/update-component-sha.sh) per https://github.com/linuxkit/linuxkit/issues/2284#issuecomment-317685142 

**- How I did it**
Removed the duplicate word `function`

**- How to verify it**
Run it in different modes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove bashism from script.

**- A picture of a cute animal (not mandatory but encouraged)**
![ostrich](http://thewowimages.com/wowimages/funny_animals-6.jpg)
