### PR TITLE
tools/alpine: Make sure we use content trust for linuxkit/alpine

### DIFF
--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -2,21 +2,38 @@
 
 ORG?=linuxkit
 IMAGE=alpine
+DEPS=packages
 
-DOCKER_CONTENT_VAR=1
-PKG_DEPS=packages
-
-ARCH := $(shell uname -m)
-
-ifeq ($(ARCH), x86_64)
-BASE=alpine:3.6
-PKG_DEPS += packages.x86_64
+# The logic for content trust is a bit convoluted because:
+# - The arm64 base image is currently not signed so we need to pull it
+#   with content trust disabled. This is controlled by
+#   DOCKER_CONTENT_PULL.
+# - 'docker build' with the FROM image supplied as environment
+#   variable *and* with DOCKER_CONTENT_TRUST=1 currently does not work
+#   (https://github.com/moby/moby/issues/34199). We therefor build
+#   with DOCKER_CONTENT_TRUST explicitly set to 0. However, we pull
+#   the base image just before with content trust enabled (if
+#   supported, see above).
+# - By default we always pull and push the linuxkit/alpine image with
+#   content trust, unless explicitly disabled with NOTRUST. Once the
+#   above issues are resolved, this will be the only mechanism to control
+#   content trust.
+ifdef NOTRUST
+DOCKER_CONTENT_PULL=0
+else
+DOCKER_CONTENT_PULL=1
+export DOCKER_CONTENT_TRUST=1
 endif
 
+ARCH := $(shell uname -m)
+ifeq ($(ARCH), x86_64)
+BASE=alpine:3.6
+DEPS += packages.x86_64
+endif
 ifeq ($(ARCH), aarch64)
 BASE=arm64v8/alpine:3.6
-PKG_DEPS += packages.aarch64
-DOCKER_CONTENT_VAR=0
+DEPS += packages.aarch64
+DOCKER_CONTENT_PULL=0
 endif
 
 default: push
@@ -24,9 +41,9 @@ default: push
 show-tag:
 	@sed -n -e '1s/# \(.*\/.*:[0-9a-f]\{40\}\)/\1/p;q' versions.$(ARCH)
 
-iid: Dockerfile Makefile $(PKG_DEPS)
-	DOCKER_CONTENT_TRUST=$(DOCKER_CONTENT_VAR) docker pull $(BASE)
-	docker build --no-cache --build-arg BASE=$(BASE) --iidfile iid .
+iid: Dockerfile Makefile $(DEPS)
+	DOCKER_CONTENT_TRUST=$(DOCKER_CONTENT_PULL) docker pull $(BASE)
+	DOCKER_CONTENT_TRUST=0 docker build --no-cache --build-arg BASE=$(BASE) --iidfile iid .
 
 hash: Makefile iid
 	docker run --rm $(shell cat iid) sh -c 'echo Dockerfile /lib/apk/db/installed $$(find /mirror -name '*.apk' -type f) $$(find /go/bin -type f) | xargs cat | sha1sum' | sed 's/ .*//' > $@
@@ -36,9 +53,9 @@ versions.$(ARCH): Makefile hash iid
 	docker run --rm $(shell cat iid) find /mirror -name '*.apk' -exec basename '{}' .apk \; | sort | (echo '# automatically generated list of installed packages'; cat -) >> versions.$(ARCH)
 
 push: hash iid versions.$(ARCH)
-	DOCKER_CONTENT_TRUST=$(DOCKER_CONTENT_VAR) docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
+	docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(shell cat iid) $(ORG)/$(IMAGE):$(shell cat hash) && \
-		 DOCKER_CONTENT_TRUST=$(DOCKER_CONTENT_VAR) docker push $(ORG)/$(IMAGE):$(shell cat hash))
+		 docker push $(ORG)/$(IMAGE):$(shell cat hash))
 	rm -f iid
 
 tag: hash iid versions.$(ARCH)

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:f0bec4717a4b3f9d068d1b72626f3bf938d7365a
+# linuxkit/alpine:964e39653b32464f369e52099781b35642a253e5
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0


### PR DESCRIPTION
We should always pull and push linuxkit/alpine with content trust
irrespective of architecture, unless explicitly disabled.

Currently, we have to dance around various other issues on arm64,
which are now documented in the Makefile.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

![tiger](https://user-images.githubusercontent.com/3338098/28581442-1e36552e-715a-11e7-98d5-b910df74fe27.jpg)
