### PR TITLE
wireguard: version bump

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -38,8 +38,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20170706
-ENV WIREGUARD_SHA256=5763b9436265421a67f92cb82142042867fc87c573ecc18033d40c1476146c33
+ENV WIREGUARD_VERSION=0.0.20170726
+ENV WIREGUARD_SHA256=db91452b6b5ec28049721a520fe4fd0683825bad45b7383d12d7b819668201db
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # PGP keys: 589DA6B1 (greg@kroah.com) & 6092693E (autosigner@kernel.org) & 00411886 (torvalds@linux-foundation.org)


### PR DESCRIPTION
Simple version bump. Release notes [from the mailing list](https://lists.zx2c4.com/pipermail/wireguard/2017-July/001580.html):

-----

  * global: wireguard.io --> wireguard.com
  
  We have a new domain name -- WireGuard.com -- moving away from the .io, due to
  security concerns. Along with the new domain, we also have a commonly
  requested page for donations: https://www.wireguard.com/donations/ in addition
  to a Patreon page for those who are into that: https://www.patreon.com/zx2c4 .
  
  * ratelimiter: consistently use non-bh rcu
  * socket: style
  * wg-quick: usage typos
  * qemu: update default testing kernel
  * qemu: warn on all unseeded random usage when in debug mode
  * compat: work around odd kernels that backport kvfree
  * selftests: ensure that there isnt CPU lag when testing rate limiter
  
  The usual set of small fixes.
  
  * send: orphan skbs when buffering longterm
  
  This works around situations where some apps use the same socket for multiple
  interfaces. It's important in this case that indefinately queued packets don't
  eat away at the socket's send buffer; otherwise sending to other interfaces
  will be blocked.
  
  * device: support 4.13's extact newlink param
  
  We continue to support the newest kernels, in this case adjusting to recent
  changes in the upcoming 4.13 release.
  
  * global: use pointer to net_device
  
  This follows an upstream recommendation.
  
  * ratelimiter: use KMEM_CACHE macro
  * data: use KMEM_CACHE macro
  * data: simplify no-keypair failure case
  * send: use skb_queue_empty where appropriate
  
  Some nice cleanups from Samuel Holland, one of this summer's GSoC students.
  
  * blake2s: move compression loop to assembly
  * blake2s: fix up alignment issues
  
  Our BLAKE2s implementation now runs a bit faster, thanks to a commit and some
  additional suggestions from Samuel Neves, one of the BLAKE2 authors.
  
  * wg-quick: do not set explicit src route for v6 default route
  
  Clueless network operators were trying to use fec0::/10 as a global address,
  except that range doesn't have the scope. Previously I worked around this by
  adding an explicit `src ...` to the routing table for all v6, but this is
  actually undesirable in some caes, so it's better that network operators give
  out the correct IPs (likely in fc00::/7).
  
  * wg-quick: do not use grep
  
  This reduces the set of dependencies for wg-quick.
  
  * wg-quick: add explicit support for common DNS usage
  
  wg-quick supports a DNS = field for common usages of DNS. Folks doing
  complicated things or who don't want to use resolvconf can continue to use
  PostUp for this.
  
  * android: add port of wg-quick
  
  wg-quick now runs on Android using the ndc command to interact with Android's
  built-in network management daemons.
