### PR TITLE
pkg: Add forcepush target

### DIFF
--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -1,4 +1,4 @@
-.PHONY: image tag show-tag
+.PHONY: image tag forcetag show-tag check-dirty push forcepush
 default: push
 
 ORG?=linuxkit
@@ -55,11 +55,20 @@ tag: $(BASE_DEPS) $(DEPS)
 forcetag: $(BASE_DEPS) $(DEPS)
 	docker build $(LABELS) $(NET_OPT) -t $(TAG) $(SOURCE)
 
-push: tag
+check-dirty:
 ifneq ($(DIRTY),)
-	$(error Your repository is not clean. Will not push package image.)
+	$(error Your repository is not clean. Will not push package image)
 endif
+
+push: check-dirty tag
 	docker pull $(TAG) || docker push $(TAG)
+ifneq ($(RELEASE),)
+	docker tag $(TAG) $(ORG)/$(IMAGE):$(RELEASE)
+	docker push $(ORG)/$(IMAGE):$(RELEASE)
+endif
+
+forcepush: check-dirty forcetag
+	docker push $(TAG)
 ifneq ($(RELEASE),)
 	docker tag $(TAG) $(ORG)/$(IMAGE):$(RELEASE)
 	docker push $(ORG)/$(IMAGE):$(RELEASE)


### PR DESCRIPTION
This is like the `push` target but omits the pulls and depends on forcetag
instead. With the git commit now being embedded into the image this is now a
necessary part of rebasing a PR for which images have already been pushed.

Also adds PHONY targets for existing forcetag and push targets which were
missing.

NB $(error) appends a "." to omit the final one from the error message

Signed-off-by: Ian Campbell <ijc@docker.com>