### PR TITLE
Make service start up containerd and services

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/vpnkit-expose-port:e2b49a6c56fbf876ea24f0a5ce4ccae5f940d1be # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
 services:
   - name: getty
     image: linuxkit/getty:97c5e2c8ebad23c2ed743366b475b5c15c42f70e

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -6,7 +6,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/pkg/containerd/cmd/service/main.go
+++ b/pkg/containerd/cmd/service/main.go
@@ -9,6 +9,12 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+const (
+	defaultSocket     = "/run/containerd/containerd.sock"
+	defaultPath       = "/containers/services"
+	defaultContainerd = "/usr/bin/containerd"
+)
+
 var (
 	defaultLogFormatter = &log.TextFormatter{}
 )
@@ -67,9 +73,9 @@ func main() {
 
 	switch args[0] {
 	case "start":
-		start(args[1:])
+		startCmd(args[1:])
 	case "system-init":
-		systemInit(args[1:])
+		systemInitCmd(args[1:])
 	default:
 		fmt.Printf("%q is not valid command.\n\n", args[0])
 		flag.Usage()

--- a/pkg/containerd/cmd/service/start.go
+++ b/pkg/containerd/cmd/service/start.go
@@ -15,7 +15,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func start(args []string) {
+func startCmd(args []string) {
 	invoked := filepath.Base(os.Args[0])
 	flags := flag.NewFlagSet("start", flag.ExitOnError)
 	flags.Usage = func() {
@@ -24,7 +24,8 @@ func start(args []string) {
 		flags.PrintDefaults()
 	}
 
-	sock := flags.String("sock", "/run/containerd/containerd.sock", "Path to containerd socket")
+	sock := flags.String("sock", defaultSocket, "Path to containerd socket")
+	path := flags.String("path", defaultPath, "Path to service configs")
 
 	dumpSpec := flags.String("dump-spec", "", "Dump container spec to file before start")
 
@@ -40,55 +41,65 @@ func start(args []string) {
 	}
 
 	service := args[0]
-	rootfs := filepath.Join("/containers/services", service, "rootfs")
+
 	log.Infof("Starting service: %q", service)
 	log := log.WithFields(log.Fields{
 		"service": service,
 	})
 
-	client, err := containerd.New(*sock)
+	id, pid, msg, err := start(service, *sock, *path, *dumpSpec)
 	if err != nil {
-		log.WithError(err).Fatal("creating containerd client")
+		log.WithError(err).Fatal(msg)
+	}
+
+	log.Debugf("Started %s pid %d", id, pid)
+}
+
+func start(service, sock, path, dumpSpec string) (string, uint32, string, error) {
+	rootfs := filepath.Join(path, service, "rootfs")
+
+	client, err := containerd.New(sock)
+	if err != nil {
+		return "", 0, "creating containerd client", err
 	}
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")
 
 	var spec *specs.Spec
-	specf, err := os.Open(filepath.Join("/containers/services", service, "config.json"))
+	specf, err := os.Open(filepath.Join(path, service, "config.json"))
 	if err != nil {
-		log.WithError(err).Fatal("failed to read service spec")
+		return "", 0, "failed to read service spec", err
 	}
 	if err := json.NewDecoder(specf).Decode(&spec); err != nil {
-		log.WithError(err).Fatal("failed to parse service spec")
+		return "", 0, "failed to parse service spec", err
 	}
-
-	log.Debugf("Rootfs is %s", rootfs)
 
 	spec.Root.Path = rootfs
 
-	if *dumpSpec != "" {
-		d, err := os.Create(*dumpSpec)
+	if dumpSpec != "" {
+		d, err := os.Create(dumpSpec)
 		if err != nil {
-			log.WithError(err).Fatal("failed to open file for spec dump")
+			return "", 0, "failed to open file for spec dump", err
 		}
 		enc := json.NewEncoder(d)
 		enc.SetIndent("", "    ")
 		if err := enc.Encode(&spec); err != nil {
-			log.WithError(err).Fatal("failed to write spec dump")
+			return "", 0, "failed to write spec dump", err
 		}
 
 	}
 
 	ctr, err := client.NewContainer(ctx, service, containerd.WithSpec(spec))
 	if err != nil {
-		log.WithError(err).Fatal("failed to create container")
+		return "", 0, "failed to create container", err
 	}
 
 	io := func() (*containerd.IO, error) {
 		logfile := filepath.Join("/var/log", service+".log")
 		// We just need this to exist.
-		if err := ioutil.WriteFile(logfile, []byte{}, 0666); err != nil {
-			log.WithError(err).Fatal("failed to touch logfile")
+		if err := ioutil.WriteFile(logfile, []byte{}, 0600); err != nil {
+			// if we cannot write to log, discard output
+			logfile = "/dev/null"
 		}
 		return &containerd.IO{
 			Stdin:    "/dev/null",
@@ -101,13 +112,13 @@ func start(args []string) {
 	task, err := ctr.NewTask(ctx, io)
 	if err != nil {
 		// Don't bother to destroy the container here.
-		log.WithError(err).Fatal("failed to create task")
+		return "", 0, "failed to create task", err
 	}
 
 	if err := task.Start(ctx); err != nil {
 		// Don't destroy the container here so it can be inspected for debugging.
-		log.WithError(err).Fatal("failed to start task")
+		return "", 0, "failed to start task", err
 	}
 
-	log.Debugf("Started %s pid %d", ctr.ID(), task.Pid())
+	return ctr.ID(), task.Pid(), "", nil
 }

--- a/pkg/containerd/etc/init.d/020-containerd
+++ b/pkg/containerd/etc/init.d/020-containerd
@@ -1,18 +1,6 @@
 #!/bin/sh
 
-# bring up containerd
-printf "\nStarting containerd\n"
-/usr/bin/containerd &
-
-# wait for socket to be there
-while [ ! -S /run/containerd/containerd.sock ]
-do
-	sleep 0.1
-done
-
 # start service containers
-
-service system-init
 
 if [ -d /containers/services ]
 then
@@ -20,6 +8,7 @@ then
 	do
 		/bin/mount --bind "$f/rootfs" "$f/rootfs"
 		mount -o remount,rw "$f/rootfs"
-		service start "$(basename $f)"
 	done
 fi
+
+service system-init

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
 services:
   - name: acpid
     image: linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: dhcpcd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:6df23ac196332cafb9c0f8e32f328e22d612267d

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -6,7 +6,7 @@ kernel:
 init:
   - linuxkit/init:a19363d2546205d4613a52371414f79c06d7070e
   - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
-  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/containerd:ff59f34e79369a6f2ce7c2a7b1cf0fcb226b31f4
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4b7b8bb024cebb1bbb9c8026d44d7cbc8e202c41


### PR DESCRIPTION
This moves most of the initialisation of containers to the
service init in the `service` command.

Still leaves remounting root file systems read only but this
will go away shortly. Another step closer to removing shell
scripts in base system.

Will add updating images shortly.

![owl](https://user-images.githubusercontent.com/482364/28616524-f5479dda-71f4-11e7-9bf5-f555c114c844.gif)
