### PR TITLE
kubernetes: provide /etc/resolv.conf to kube and docker containers.

### DIFF
--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -13,6 +13,9 @@ onboot:
     image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: binfmt
     image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
   - name: format
@@ -32,8 +35,6 @@ services:
      - INSECURE=true
   - name: rngd
     image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
-  - name: dhcpcd
-    image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
   - name: ntpd
     image: linuxkit/openntpd:2874b66c9fa51fa5b4d11c8b50441eb94ee22a5a
   - name: sshd
@@ -48,6 +49,7 @@ services:
        options: ["rw","nosuid","noexec","nodev","relatime"]
     binds:
      - /dev:/dev
+     - /etc/resolv.conf:/etc/resolv.conf
      - /lib/modules:/lib/modules
      - /var:/var:rshared,rbind
      - /var/lib/kubeadm:/etc/kubernetes

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -62,7 +62,7 @@ services:
   - name: kubernetes-image-cache-control-plane
     image: linuxkitprojects/kubernetes-image-cache-control-plane:6fccda74ea301f9a62cdcfc2fe4952cff2c8c97b
   - name: kubelet
-    image: linuxkitprojects/kubernetes:d4d722823b1265a57355ae8a309d4953e293fd58
+    image: linuxkitprojects/kubernetes:8fca97c5faf0c6288aee82485d8c6539b84db256
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -13,6 +13,9 @@ onboot:
     image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
   - name: binfmt
     image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
     image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
   - name: format
@@ -32,8 +35,6 @@ services:
      - INSECURE=true
   - name: rngd
     image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
-  - name: dhcpcd
-    image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
   - name: ntpd
     image: linuxkit/openntpd:2874b66c9fa51fa5b4d11c8b50441eb94ee22a5a
   - name: sshd
@@ -48,6 +49,7 @@ services:
        options: ["rw","nosuid","noexec","nodev","relatime"]
     binds:
      - /dev:/dev
+     - /etc/resolv.conf:/etc/resolv.conf
      - /lib/modules:/lib/modules
      - /var:/var:rshared,rbind
      - /var/lib/kubeadm:/etc/kubernetes

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -60,7 +60,7 @@ services:
   - name: kubernetes-image-cache-common
     image: linuxkitprojects/kubernetes-image-cache-common:6fccda74ea301f9a62cdcfc2fe4952cff2c8c97b
   - name: kubelet
-    image: linuxkitprojects/kubernetes:d4d722823b1265a57355ae8a309d4953e293fd58
+    image: linuxkitprojects/kubernetes:8fca97c5faf0c6288aee82485d8c6539b84db256
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/projects/kubernetes/kubernetes/Dockerfile
+++ b/projects/kubernetes/kubernetes/Dockerfile
@@ -47,4 +47,4 @@ WORKDIR /
 ENTRYPOINT ["/usr/bin/kubelet.sh"]
 COPY --from=build /out /
 ENV KUBECONFIG "/etc/kubernetes/admin.conf"
-LABEL org.mobyproject.config='{"binds": ["/dev:/dev", "/var:/var:rshared,rbind", "/var/lib/kubeadm:/etc/kubernetes", "/etc/cni:/rootfs/etc/cni:rshared,rbind", "/opt/cni:/rootfs/opt/cni:rshared,rbind"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}], "capabilities": ["all"], "rootfsPropagation": "shared", "pid": "host"}'
+LABEL org.mobyproject.config='{"binds": ["/dev:/dev", "/etc/resolv.conf:/etc/resolv.conf", "/var:/var:rshared,rbind", "/var/lib/kubeadm:/etc/kubernetes", "/etc/cni:/rootfs/etc/cni:rshared,rbind", "/opt/cni:/rootfs/opt/cni:rshared,rbind"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}], "capabilities": ["all"], "rootfsPropagation": "shared", "pid": "host"}'


### PR DESCRIPTION
After #2289 we need to bind /etc/resolv.conf into the docker and kubelet
containers on both node and master.

Also since #2289 the metadata container requires /etc/resolv.conf to be
populated on the host, which means running DHCP earlier in oneshot onboot mode,
do so.

Signed-off-by: Ian Campbell <ijc@docker.com>
