### PR TITLE
Various OVMF related fixes

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -18,7 +18,7 @@ import (
 )
 
 // QemuImg is the version of qemu container
-const QemuImg = "linuxkit/qemu:bc5e096d3b440509954aa9341db3ff4d3d615344"
+const QemuImg = "linuxkit/qemu:8c07b24790ac5162dfc129791f8afeace159ca20"
 
 // QemuConfig contains the config for Qemu
 type QemuConfig struct {

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -29,12 +29,6 @@ RUN apk index --rewrite-arch $(uname -m) -o /mirror/$(uname -m)/APKINDEX.unsigne
 RUN cp /mirror/$(uname -m)/APKINDEX.unsigned.tar.gz /mirror/$(uname -m)/APKINDEX.tar.gz
 RUN abuild-sign /mirror/$(uname -m)/APKINDEX.tar.gz
 
-# fetch OVMF for qemu EFI boot (this is not added as a package)
-RUN mkdir -p /usr/share/ovmf && \
-    if [ $(uname -m) = x86_64 ]; then \
-       apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/community ovmf; \
-    fi
-
 # set this as our repo but keep a copy of the upstream for downstream use
 RUN mv /etc/apk/repositories /etc/apk/repositories.upstream && echo "/mirror" > /etc/apk/repositories && apk update
 
@@ -53,7 +47,6 @@ COPY --from=mirror /etc/apk/repositories.upstream /etc/apk/repositories.upstream
 COPY --from=mirror /etc/apk/keys /etc/apk/keys/
 COPY --from=mirror /mirror /mirror/
 COPY --from=mirror /go/bin /go/bin/
-COPY --from=mirror /usr/share/ovmf/ /usr/share/ovmf/
 COPY --from=mirror /Dockerfile /Dockerfile
 
 RUN apk update && apk upgrade -a

--- a/tools/alpine/packages.x86_64
+++ b/tools/alpine/packages.x86_64
@@ -1,2 +1,3 @@
 open-vm-tools
+ovmf
 syslinux

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:34af9cb1990debd17fae6d4198c62ce3910d9908
+# linuxkit/alpine:77c8dfc5860012c869a19d7a2c68e701469692c8
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -182,6 +182,7 @@ openssh-keygen-7.5_p1-r1
 openssh-server-7.5_p1-r1
 openssl-dev-1.0.2k-r0
 opus-1.1.4-r0
+ovmf-0.0.20161115-r1
 p11-kit-0.23.2-r1
 patch-2.7.5-r1
 pax-utils-1.2.2-r0

--- a/tools/qemu/Dockerfile
+++ b/tools/qemu/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS mirror
+FROM linuxkit/alpine:77c8dfc5860012c869a19d7a2c68e701469692c8 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
@@ -7,19 +7,10 @@ RUN apk add --no-cache --initdb -p /out \
     qemu-img && \
     case $(uname -m) in \
     x86_64) \
-        apk add --no-cache --initdb -p /out qemu-system-x86_64; \
+        apk add --no-cache --initdb -p /out qemu-system-x86_64 ovmf; \
         ;; \
     aarch64) \
         apk add --no-cache --initdb -p /out qemu-system-aarch64; \
-        ;; \
-    esac
-
-RUN case $(uname -m) in \
-    x86_64) \
-        mkdir -p /out/usr/share/ovmf \
-        && cp /usr/share/ovmf/bios.bin /out/usr/share/ovmf/bios.bin; \
-        ;; \
-    aarch64) \
         ;; \
     esac
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache


### PR DESCRIPTION
- Add the `ovmf` package to the mirror instead of installing it to the `linuxkit/alpine` rootfs. This has the added benefit of the version of the package being recorded.
- Install the `ovmf` package in `tools/qemu`.
- Update the `linuxkit run qemu` code to use the new image
- While working on this, I also noticed that, when run in containerised mode, we would always bind mount the FW into the container. Clearly we'd want to use the FW in the container by default. Now, it only bind mounts the FW if the location specified via `-fw` is not the default.

Note that when run on Docker for Mac in containerised mode qemu currently segfaults when using the efi boot. I doubt this is a regression introduced by theses changes and the EFI image boots fine on Hyper-V.

![bluebird](https://user-images.githubusercontent.com/3338098/28630047-17cdb958-7221-11e7-9a58-2986aaddb82a.jpg)
