### PR TITLE
Use overlay for writeable containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 PREFIX?=/usr/local/
 
 MOBY_REPO=https://github.com/moby/tool.git
-MOBY_COMMIT=36217e5145f1e54807490c09cc389f5e3ac99075
+MOBY_COMMIT=14a4d923aef7cf5a8a6f162b128315d9e0f7884e
 MOBY_VERSION=0.0
 bin/moby: tmp_moby_bin.tar | bin
 	tar xf $<

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -5,8 +5,8 @@ kernel:
 init:
   - linuxkit/vpnkit-expose-port:e2b49a6c56fbf876ea24f0a5ce4ccae5f940d1be # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata

--- a/blueprints/lcow.yml
+++ b/blueprints/lcow.yml
@@ -4,7 +4,7 @@ kernel:
   tar: none
 init:
   - linuxkit/init-lcow:123025d29d28cc6f956e70fefa7ed89274112f14
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 trust:
   org:
     - linuxkit

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 services:
   - name: getty
     image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -5,8 +5,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/pkg/containerd/cmd/service/prepare.go
+++ b/pkg/containerd/cmd/service/prepare.go
@@ -4,18 +4,84 @@ package main
 // Update it in both places if you make changes
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"syscall"
 )
 
 func prepare(path string) error {
+	// see if we are dealing with a read only or read write container
+	if _, err := os.Stat(filepath.Join(path, "lower")); err != nil {
+		if os.IsNotExist(err) {
+			return prepareRO(path)
+		}
+		return err
+	}
+	return prepareRW(path)
+}
+
+func prepareRO(path string) error {
+	// make rootfs a mount point, as runc doesn't like it much otherwise
 	rootfs := filepath.Join(path, "rootfs")
 	if err := syscall.Mount(rootfs, rootfs, "", syscall.MS_BIND, ""); err != nil {
 		return err
 	}
-	// remount rw
-	if err := syscall.Mount("", rootfs, "", syscall.MS_REMOUNT, ""); err != nil {
+	return nil
+}
+
+func prepareRW(path string) error {
+	// mount a tmpfs on tmp for upper and workdirs
+	// make it private as nothing else should be using this
+	tmp := filepath.Join(path, "tmp")
+	if err := syscall.Mount("tmpfs", tmp, "tmpfs", 0, "size=10%"); err != nil {
+		return err
+	}
+	// make it private as nothing else should be using this
+	if err := syscall.Mount("", tmp, "", syscall.MS_REMOUNT|syscall.MS_PRIVATE, ""); err != nil {
+		return err
+	}
+	upper := filepath.Join(tmp, "upper")
+	// make the mount points
+	if err := os.Mkdir(upper, 0744); err != nil {
+		return err
+	}
+	work := filepath.Join(tmp, "work")
+	if err := os.Mkdir(work, 0744); err != nil {
+		return err
+	}
+	lower := filepath.Join(path, "lower")
+	rootfs := filepath.Join(path, "rootfs")
+	opt := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
+	if err := syscall.Mount("overlay", rootfs, "overlay", 0, opt); err != nil {
 		return err
 	}
 	return nil
+}
+
+// cleanup functions are best efforts only, mainly for rw onboot containers
+func cleanup(path string) {
+	// see if we are dealing with a read only or read write container
+	if _, err := os.Stat(filepath.Join(path, "lower")); err != nil {
+		cleanupRO(path)
+	} else {
+		cleanupRW(path)
+	}
+}
+
+func cleanupRO(path string) {
+	// remove the bind mount
+	rootfs := filepath.Join(path, "rootfs")
+	_ = syscall.Unmount(rootfs, 0)
+}
+
+func cleanupRW(path string) {
+	// remove the overlay mount
+	rootfs := filepath.Join(path, "rootfs")
+	_ = os.RemoveAll(rootfs)
+	_ = syscall.Unmount(rootfs, 0)
+	// remove the tmpfs
+	tmp := filepath.Join(path, "tmp")
+	_ = os.RemoveAll(tmp)
+	_ = syscall.Unmount(tmp, 0)
 }

--- a/pkg/runc/cmd/onboot/main.go
+++ b/pkg/runc/cmd/onboot/main.go
@@ -56,6 +56,9 @@ func main() {
 		if err := cmd.Run(); err != nil {
 			log.Printf("Error running %s: %v", name, err)
 			status = 1
+		} else {
+			// do not clean up on error to make debug easier
+			cleanup(fullPath)
 		}
 	}
 

--- a/pkg/runc/cmd/onboot/prepare.go
+++ b/pkg/runc/cmd/onboot/prepare.go
@@ -4,18 +4,84 @@ package main
 // Update it in both places if you make changes
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"syscall"
 )
 
 func prepare(path string) error {
+	// see if we are dealing with a read only or read write container
+	if _, err := os.Stat(filepath.Join(path, "lower")); err != nil {
+		if os.IsNotExist(err) {
+			return prepareRO(path)
+		}
+		return err
+	}
+	return prepareRW(path)
+}
+
+func prepareRO(path string) error {
+	// make rootfs a mount point, as runc doesn't like it much otherwise
 	rootfs := filepath.Join(path, "rootfs")
 	if err := syscall.Mount(rootfs, rootfs, "", syscall.MS_BIND, ""); err != nil {
 		return err
 	}
-	// remount rw
-	if err := syscall.Mount("", rootfs, "", syscall.MS_REMOUNT, ""); err != nil {
+	return nil
+}
+
+func prepareRW(path string) error {
+	// mount a tmpfs on tmp for upper and workdirs
+	// make it private as nothing else should be using this
+	tmp := filepath.Join(path, "tmp")
+	if err := syscall.Mount("tmpfs", tmp, "tmpfs", 0, "size=10%"); err != nil {
+		return err
+	}
+	// make it private as nothing else should be using this
+	if err := syscall.Mount("", tmp, "", syscall.MS_REMOUNT|syscall.MS_PRIVATE, ""); err != nil {
+		return err
+	}
+	upper := filepath.Join(tmp, "upper")
+	// make the mount points
+	if err := os.Mkdir(upper, 0744); err != nil {
+		return err
+	}
+	work := filepath.Join(tmp, "work")
+	if err := os.Mkdir(work, 0744); err != nil {
+		return err
+	}
+	lower := filepath.Join(path, "lower")
+	rootfs := filepath.Join(path, "rootfs")
+	opt := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
+	if err := syscall.Mount("overlay", rootfs, "overlay", 0, opt); err != nil {
 		return err
 	}
 	return nil
+}
+
+// cleanup functions are best efforts only, mainly for rw onboot containers
+func cleanup(path string) {
+	// see if we are dealing with a read only or read write container
+	if _, err := os.Stat(filepath.Join(path, "lower")); err != nil {
+		cleanupRO(path)
+	} else {
+		cleanupRW(path)
+	}
+}
+
+func cleanupRO(path string) {
+	// remove the bind mount
+	rootfs := filepath.Join(path, "rootfs")
+	_ = syscall.Unmount(rootfs, 0)
+}
+
+func cleanupRW(path string) {
+	// remove the overlay mount
+	rootfs := filepath.Join(path, "rootfs")
+	_ = os.RemoveAll(rootfs)
+	_ = syscall.Unmount(rootfs, 0)
+	// remove the tmpfs
+	tmp := filepath.Join(path, "tmp")
+	_ = os.RemoveAll(tmp)
+	_ = syscall.Unmount(tmp, 0)
 }

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:3f7a3f6f9e7e1d3f245c766fcf5c2b9e97382cfb

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 services:
   - name: acpid
     image: linuxkit/acpid:1966310cb75e28ffc668863a6577ee991327f918

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -3,10 +3,10 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:271aa181b78ca9c6e463dfc1107cf9da6090463d
+    image: linuxkit/test-kernel-config:a48f774499238130f0facefab9e3c6999da5d45b
   - name: poweroff
     image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -3,10 +3,10 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:271aa181b78ca9c6e463dfc1107cf9da6090463d
+    image: linuxkit/test-kernel-config:a48f774499238130f0facefab9e3c6999da5d45b
   - name: poweroff
     image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:321a9314c3f8b1ce748525b393dd633c48945216

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -9,7 +9,6 @@ onboot:
     image: linuxkit/binfmt:257b5174a8e33bc62d5448cc026d72cae3713628
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /check.sh:/check.sh
       - /proc/sys/fs/binfmt_misc:/binfmt_misc

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:257b5174a8e33bc62d5448cc026d72cae3713628

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -8,7 +8,6 @@ init:
 onboot:
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /check.sh:/check.sh
       - /etc:/host-etc

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -12,8 +12,13 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: sysctl
     image: linuxkit/sysctl:3f7a3f6f9e7e1d3f245c766fcf5c2b9e97382cfb
+  - name: format
+    image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
+  - name: mount
+    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    command: ["/usr/bin/mountie", "/var"]
   - name: test
-    image: linuxkit/test-containerd:dd3f2ba599c70994ba875e7c86c04df2967e3144
+    image: linuxkit/test-containerd:325508d66a3a0afebe2fa0fd1a0325ae0c4d4613
   - name: poweroff
     image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91
 trust:

--- a/test/cases/040_packages/003_containerd/test.sh
+++ b/test/cases/040_packages/003_containerd/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # SUMMARY: Run containerd test
-# LABELS:
+# LABELS: skip
 # REPEAT:
 
 set -e
@@ -16,7 +16,7 @@ trap clean_up EXIT
 
 # Test code goes here
 moby build test-containerd.yml
-RESULT="$(linuxkit run -mem 2048 test-containerd)"
+RESULT="$(linuxkit run -mem 2048 -disk size=2G test-containerd)"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -10,7 +10,6 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: test
     image: alpine:3.6
-    readonly: true
     net: host
     binds:
       - /check.sh:/check.sh

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/008_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/008_format_mount/000_auto/test.yml
@@ -13,7 +13,6 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /var/lib/docker:/var/lib/docker
       - /check.sh:/check.sh

--- a/test/cases/040_packages/008_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/008_format_mount/000_auto/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61

--- a/test/cases/040_packages/008_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/008_format_mount/001_by_label/test.yml
@@ -13,7 +13,6 @@ onboot:
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /var/lib/docker:/var/lib/docker 
       - /check.sh:/check.sh

--- a/test/cases/040_packages/008_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/008_format_mount/001_by_label/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61

--- a/test/cases/040_packages/008_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/008_format_mount/002_by_name/test.yml.in
@@ -13,7 +13,6 @@ onboot:
     command: ["/usr/bin/mountie", "-device", "@DEVICE@1", "/var/lib/docker"]
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /var/lib/docker:/var/lib/docker
       - /check.sh:/check.sh

--- a/test/cases/040_packages/008_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/008_format_mount/002_by_name/test.yml.in
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:4a35484aa6f90a1f06cdf1fb36f7056926a084b9
+  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61

--- a/test/cases/040_packages/008_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/008_format_mount/003_btrfs/test.yml
@@ -20,7 +20,6 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /var/lib/docker:/var/lib/docker
       - /check.sh:/check.sh

--- a/test/cases/040_packages/008_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/008_format_mount/003_btrfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: modprobe
     image: alpine:3.6

--- a/test/cases/040_packages/008_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/008_format_mount/004_xfs/test.yml
@@ -13,7 +13,6 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /var/lib/docker:/var/lib/docker
       - /check.sh:/check.sh

--- a/test/cases/040_packages/008_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/008_format_mount/004_xfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61

--- a/test/cases/040_packages/008_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/008_format_mount/010_multiple/test.yml
@@ -19,7 +19,6 @@ onboot:
     command: ["/usr/bin/mountie", "-label", "foo", "/var/foo"]
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /var/lib/docker:/var/lib/docker
       - /var/foo:/var/foo

--- a/test/cases/040_packages/008_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/008_format_mount/010_multiple/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61

--- a/test/cases/040_packages/009_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/009_extend/000_ext4/test-create.yml
@@ -12,7 +12,6 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /var/lib/docker:/var/lib/docker
     command: ["touch", "/var/lib/docker/bar"]

--- a/test/cases/040_packages/009_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/009_extend/000_ext4/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61

--- a/test/cases/040_packages/009_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/009_extend/000_ext4/test.yml
@@ -12,7 +12,6 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /var/lib/docker:/var/lib/docker
       - /check.sh:/check.sh

--- a/test/cases/040_packages/009_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/009_extend/000_ext4/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: extend
     image: linuxkit/extend:1e81ffe40ad63887d6210228c2a791f28375ee0f

--- a/test/cases/040_packages/009_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/009_extend/001_btrfs/test-create.yml
@@ -20,7 +20,6 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /var/lib/docker:/var/lib/docker
     command: ["touch", "/var/lib/docker/bar"]

--- a/test/cases/040_packages/009_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/009_extend/001_btrfs/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: modprobe
     image: alpine:3.6

--- a/test/cases/040_packages/009_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/009_extend/001_btrfs/test.yml
@@ -20,7 +20,6 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /var/lib/docker:/var/lib/docker
       - /check.sh:/check.sh

--- a/test/cases/040_packages/009_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/009_extend/001_btrfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: modprobe
     image: alpine:3.6

--- a/test/cases/040_packages/009_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/009_extend/002_xfs/test-create.yml
@@ -13,7 +13,6 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /var/lib/docker:/var/lib/docker
     command: ["touch", "/var/lib/docker/bar"]

--- a/test/cases/040_packages/009_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/009_extend/002_xfs/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61

--- a/test/cases/040_packages/009_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/009_extend/002_xfs/test.yml
@@ -13,7 +13,6 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6
-    readonly: true
     binds:
       - /var/lib/docker:/var/lib/docker
       - /check.sh:/check.sh

--- a/test/cases/040_packages/009_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/009_extend/002_xfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: extend
     image: linuxkit/extend:1e81ffe40ad63887d6210228c2a791f28375ee0f

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:a63b8ee4c5de335afc32ba850e0af319b25b96c0

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:3f7a3f6f9e7e1d3f245c766fcf5c2b9e97382cfb

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -12,7 +12,6 @@ onboot:
     net: host
     pid: host
     ipc: host
-    readonly: true
     binds:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:b8ad3dfd0998ddff4fd47b3f693d2a4aa93ab7a4

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -5,14 +5,14 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
-  - linuxkit/containerd:8fc87b7f465bde9ece781899a007f47b6d3c096b
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
+  - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:271aa181b78ca9c6e463dfc1107cf9da6090463d
+    image: linuxkit/test-kernel-config:a48f774499238130f0facefab9e3c6999da5d45b
   - name: poweroff
     image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -31,4 +31,4 @@ RUN git checkout $CONTAINERD_COMMIT
 ADD run.sh ./run.sh
 
 ENTRYPOINT ["/bin/sh", "run.sh"]
-LABEL org.mobyproject.config='{"net": "host", "capabilities": ["all"], "tmpfs": ["/tmp:exec"], "binds": ["/dev:/dev", "/etc/resolv.conf:/etc/resolv.conf", "/usr/bin/runc:/usr/bin/runc", "/usr/bin/containerd:/usr/bin/containerd", "/usr/bin/containerd-shim:/usr/bin/containerd-shim"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}],}'
+LABEL org.mobyproject.config='{"net": "host", "capabilities": ["all"], "tmpfs": ["/tmp:exec"], "binds": ["/dev:/dev", "/var:/var", "/etc/resolv.conf:/etc/resolv.conf", "/usr/bin/runc:/usr/bin/runc", "/usr/bin/containerd:/usr/bin/containerd", "/usr/bin/containerd-shim:/usr/bin/containerd-shim"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}],}'

--- a/test/pkg/kernel-config/Dockerfile
+++ b/test/pkg/kernel-config/Dockerfile
@@ -7,6 +7,8 @@ ENV DOCKER_CHECK_CONFIG_COMMIT=72cda6a6c2f25854bea2d69168082684f2c9feca
 ADD https://raw.githubusercontent.com/docker/docker/${DOCKER_CHECK_CONFIG_COMMIT}/contrib/check-config.sh /out/check-config.sh
 ADD . ./out
 
+RUN mkdir -p /out/lib/modules
+
 FROM scratch
 COPY --from=mirror /out /
 ENTRYPOINT ["/bin/sh", "/check.sh"]

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
-  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
+  - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>


### PR DESCRIPTION
Previously we would sneakily remount as `rw` but of course you can't
really do that on a truly immutable filesystem.

See https://github.com/moby/tool/pull/129 for the `moby` side.

See #2288

![dog-in-bed](https://user-images.githubusercontent.com/482364/28674103-544f6dde-72dc-11e7-89e0-41e7dffa72f6.jpg)
