### PR TITLE
Fixed commands and resolv.conf in docker example

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -38,6 +38,7 @@ services:
      - type: cgroup
        options: ["rw","nosuid","noexec","nodev","relatime"]
     binds:
+     - /etc/resolv.conf:/etc/resolv.conf
      - /var/lib/docker:/var/lib/docker
      - /lib/modules:/lib/modules
      - /etc/docker/daemon.json:/etc/docker/daemon.json

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -34,11 +34,12 @@ services:
      - type: cgroup
        options: ["rw","nosuid","noexec","nodev","relatime"]
     binds:
+     - /etc/resolv.conf:/etc/resolv.conf
      - /var/lib/docker:/var/lib/docker
      - /lib/modules:/lib/modules
      - /var/run:/var/run
      - /var/html:/var/html
-    command: ["/usr/bin/docker-init", "/usr/bin/dockerd"]
+    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: compose
     image: linuxkitprojects/compose:0535e78608f57702745dfd56fbe78d28d237e469
     binds:

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -34,11 +34,12 @@ services:
      - type: cgroup
        options: ["rw","nosuid","noexec","nodev","relatime"]
     binds:
+     - /etc/resolv.conf:/etc/resolv.conf
      - /var/lib/docker:/var/lib/docker
      - /lib/modules:/lib/modules
      - /var/run:/var/run
      - /var/html:/var/html
-    command: ["/usr/bin/docker-init", "/usr/bin/dockerd"]
+    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: compose
     image: linuxkitprojects/compose:0535e78608f57702745dfd56fbe78d28d237e469
     binds:


### PR DESCRIPTION
Signed-off-by: Matt Bentley <matt.bentley@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed command for docker to run and added a bind mount for resolv.conf because DNS is great - remembering all of those IPs is really hard.  Fixed for both the docker example and the static & dynamic compose project examples

**- How I did it**
vim :)

**- How to verify it**
moby build foo.yml
linuxkit run foo

**- Description for the changelog**
Updated commands as the path for docker changed and added resolv.conf to bind mounts

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/414445/28691134-cd6b3f42-72e9-11e7-89eb-24d359b6dc5f.png)
