### PR TITLE
package.mk: Adjust the targe sequence to avoid early abort

### DIFF
--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -60,14 +60,14 @@ ifneq ($(DIRTY),)
 	$(error Your repository is not clean. Will not push package image)
 endif
 
-push: check-dirty tag
+push: tag check-dirty
 	docker pull $(TAG) || docker push $(TAG)
 ifneq ($(RELEASE),)
 	docker tag $(TAG) $(ORG)/$(IMAGE):$(RELEASE)
 	docker push $(ORG)/$(IMAGE):$(RELEASE)
 endif
 
-forcepush: check-dirty forcetag
+forcepush: forcetag check-dirty
 	docker push $(TAG)
 ifneq ($(RELEASE),)
 	docker tag $(TAG) $(ORG)/$(IMAGE):$(RELEASE)


### PR DESCRIPTION
Current package.mk will operate on the first dependence object
'check-dirty', which result in the make process abort earlier
with below message:
pkg/package.mk:60: *** Your repository is not clean. Will not push package image.  Stop.

This is not expected behavior since we have no chance to build
a docker image locally in case of the user has no intention to
push that image.

This patch adjust the dependece order for the those targets, thus
we can build the docker image locally but can't push that image
if we're in a dirty git repository.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
make the docker image build can succeed locally but the image can't be pushed for reason of dirty git repository 
**- How I did it**
change the dependence order for the target: build first, then check the git repo is dirty or not
**- How to verify it**
make a individual pkg like this `make ORG=mainline NOTRUST=1`
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/28714992-8c689492-73c8-11e7-9525-f3e192e90e93.jpg)
