### PR TITLE
Use a tmpfs for /var

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:e2b49a6c56fbf876ea24f0a5ce4ccae5f940d1be # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -21,7 +21,7 @@ onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib"]
   # create docker dir on mounted drive if it doesn't exist
   - name: mkdir-docker

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:e2b49a6c56fbf876ea24f0a5ce4ccae5f940d1be # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -16,7 +16,7 @@ onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 services:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 services:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -15,7 +15,7 @@ onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/external"]
   - name: swap
     image: linuxkit/swap:b6d447b55da3c28bdd8a3f4e30fb42c1fa0157bb

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/pkg/init/bin/rc.init
+++ b/pkg/init/bin/rc.init
@@ -12,6 +12,17 @@ mount -n -t tmpfs tmpfs /tmp -o nodev,nosuid,noexec,relatime,size=10%,mode=1777
 
 # mount tmpfs for /var. This may be overmounted with a persistent filesystem later
 mount -n -t tmpfs tmpfs /var -o nodev,nosuid,noexec,relatime,size=50%,mode=755
+# add standard directories in /var
+mkdir -m 755 /var/cache
+mkdir -m 555 /var/empty
+mkdir -m 755 /var/lib
+mkdir -m 755 /var/local
+mkdir -m 755 /var/lock
+mkdir -m 755 /var/log
+mkdir -m 755 /var/opt
+ln -s /run /var/run
+mkdir -m 755 /var/spool
+mkdir -m 1777 /var/tmp
 
 # mount devfs
 mount -n -t devtmpfs dev /dev -o nosuid,noexec,relatime,size=10m,nr_inodes=248418,mode=755

--- a/pkg/init/bin/rc.init
+++ b/pkg/init/bin/rc.init
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-# mount filesystems
+# mount proc filesystem
 mount -n -t proc proc /proc -o nodev,nosuid,noexec,relatime
 
+# remount rootfs as readonly
+mount -o remount,ro /
+
+# mount tmpfs for /tmp and /run
 mount -n -t tmpfs tmpfs /run -o nodev,nosuid,noexec,relatime,size=10%,mode=755
 mount -n -t tmpfs tmpfs /tmp -o nodev,nosuid,noexec,relatime,size=10%,mode=1777
+
+# mount tmpfs for /var. This may be overmounted with a persistent filesystem later
+mount -n -t tmpfs tmpfs /var -o nodev,nosuid,noexec,relatime,size=50%,mode=755
 
 # mount devfs
 mount -n -t devtmpfs dev /dev -o nosuid,noexec,relatime,size=10m,nr_inodes=248418,mode=755
@@ -100,14 +107,6 @@ ip link set lo up
 
 # for containerizing dhcpcd and other containers that need writable /etc/resolv.conf
 [ -L /etc/resolv.conf ] && mkdir -p $(dirname $(readlink -n /etc/resolv.conf)) && touch /etc/resolv.conf
-
-# remount rootfs as readonly
-mount -o remount,ro /
-
-# make /var writeable and shared
-mount -o bind /var /var
-mount -o remount,rw,nodev,nosuid,noexec,relatime /var /var
-mount --make-rshared /var
 
 # make / rshared
 mount --make-rshared /

--- a/pkg/mount/mountie.go
+++ b/pkg/mount/mountie.go
@@ -159,7 +159,7 @@ func main() {
 		log.Fatalf("Too many arguments")
 	}
 
-	err := os.MkdirAll(mountpoint, os.ModeDir)
+	err := os.MkdirAll(mountpoint, 0755)
 	if err != nil {
 		log.Fatalf("Unable to create mountpoint %s: %v", mountpoint, err)
 	}

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -19,7 +19,7 @@ onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -19,7 +19,7 @@ onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -12,7 +12,7 @@ onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/etcd"]
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -21,7 +21,7 @@ onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mounts
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/"]
   - name: var
     image: library/alpine:3.6

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -21,7 +21,7 @@ onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mounts
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/"]
   - name: var
     image: library/alpine:3.6

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/okernel:latest
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/okernel:latest
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -17,7 +17,7 @@ onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/swarmd"]
   - name: metadata
     image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: dhcpcd

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 services:

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 services:

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: check

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test-ns

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -16,7 +16,7 @@ onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
 onboot:

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -15,7 +15,7 @@ onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var"]
   - name: test
     image: linuxkit/test-containerd:325508d66a3a0afebe2fa0fd1a0325ae0c4d4613

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
   - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf

--- a/test/cases/040_packages/008_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/008_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/008_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/008_format_mount/000_auto/test.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
     command: ["/usr/bin/format"]
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/008_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/008_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/008_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/008_format_mount/001_by_label/test.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
     command: ["/usr/bin/format", "-label", "docker"]
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/008_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/008_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/008_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/008_format_mount/002_by_name/test.yml.in
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
     command: ["/usr/bin/format", "@DEVICE@"]
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "-device", "@DEVICE@1", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/008_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/008_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/008_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/008_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/008_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/008_format_mount/003_btrfs/test.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/008_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/008_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/008_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/008_format_mount/004_xfs/test.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
     command: ["/usr/bin/format", "-type", "xfs" ]
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/008_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/008_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/008_format_mount/010_multiple/test.yml
@@ -12,10 +12,10 @@ onboot:
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
     command: ["/usr/bin/format", "-label", "foo"]
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "-label", "foo", "/var/foo"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/008_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/008_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/009_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/009_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/009_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/009_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/009_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/009_extend/000_ext4/test-create.yml
@@ -8,7 +8,7 @@ onboot:
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/009_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/009_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: extend

--- a/test/cases/040_packages/009_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/009_extend/000_ext4/test.yml
@@ -8,7 +8,7 @@ onboot:
   - name: extend
     image: linuxkit/extend:1e81ffe40ad63887d6210228c2a791f28375ee0f
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/009_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/009_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: extend

--- a/test/cases/040_packages/009_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/009_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/009_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/009_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/009_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/009_extend/001_btrfs/test-create.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/009_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/009_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/009_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/009_extend/001_btrfs/test.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/extend:1e81ffe40ad63887d6210228c2a791f28375ee0f
     command: ["/usr/bin/extend", "-type", "btrfs"]
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/009_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/009_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/009_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/009_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/009_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/009_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: format

--- a/test/cases/040_packages/009_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/009_extend/002_xfs/test-create.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
     command: ["/usr/bin/format", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/009_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/009_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: extend

--- a/test/cases/040_packages/009_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/009_extend/002_xfs/test.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/extend:1e81ffe40ad63887d6210228c2a791f28375ee0f
     command: ["/usr/bin/extend", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/009_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/009_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: extend

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
 onboot:
   - name: sysctl

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4dcee04c04c900a5796dc719f8d16fea7e771059
+  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:241e4c119bb434ea468448bc0f69643b21e1039e
+  - linuxkit/init:e3e376881faced5a890b6ceb3e8e899cbfd04ecd
   - linuxkit/runc:842318b6ab524783554428c89a27d95af7bd2844
   - linuxkit/containerd:1ff17c0908bed91a7bff252fba2e3d360d05a3de
 onboot:


### PR DESCRIPTION
Previously we were cheating and remounting /var `rw` but this does not
work if the filesystem is really read only. Nount a tmpfs, which may
be overmounted later by a persistent filesystem.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

fix #2288 

![racoon](https://user-images.githubusercontent.com/482364/28716498-8dda1d1a-7395-11e7-9c99-aef94901bf7b.jpg)
