### PR TITLE
allow passing arguments directly to qemu

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -40,6 +40,7 @@ type QemuConfig struct {
 	Containerized  bool
 	QemuBinPath    string
 	QemuImgPath    string
+	QemuArgs       []string
 	PublishedPorts []string
 	NetdevConfig   string
 	UUID           uuid.UUID
@@ -71,6 +72,15 @@ func envOverrideBool(env string, b *bool) {
 	}
 }
 
+func envOverrideString(env string, s *string) {
+	val := os.Getenv(env)
+	if val == "" {
+		return
+	}
+
+	*s = val
+}
+
 func generateMAC() net.HardwareAddr {
 	mac := make([]byte, 6)
 	n, err := rand.Read(mac)
@@ -99,6 +109,9 @@ func runQemu(args []string) {
 		fmt.Printf("setuid network helper and appropriate host configuration, see\n")
 		fmt.Printf("http://wiki.qemu.org/Features/HelperNetworking.\n")
 	}
+
+	// Arguments to pass to qemu
+	qemuDirectArgs := flags.String("args", "", "Arguments to pass directly to qemu")
 
 	// Display flags
 	enableGUI := flags.Bool("gui", false, "Set qemu to use video output instead of stdio")
@@ -145,6 +158,7 @@ func runQemu(args []string) {
 
 	// These envvars override the corresponding command line
 	// options. So this must remain after the `flags.Parse` above.
+	envOverrideString("LINUXKIT_QEMU_ARGS", qemuDirectArgs)
 	envOverrideBool("LINUXKIT_QEMU_KVM", enableKVM)
 	envOverrideBool("LINUXKIT_QEMU_CONTAINERIZED", qemuContainerized)
 
@@ -289,6 +303,7 @@ func runQemu(args []string) {
 		Memory:         *mem,
 		KVM:            *enableKVM,
 		Containerized:  *qemuContainerized,
+		QemuArgs:       strings.Split(*qemuDirectArgs, " "),
 		PublishedPorts: publishFlags,
 		NetdevConfig:   netdevConfig,
 		UUID:           vmUUID,
@@ -457,8 +472,10 @@ func runQemuContainer(config QemuConfig) error {
 }
 
 func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
-	// Iterate through the flags and build arguments
+	// Iterate through the flags and build arguments appending to arguments passed via QEMU_OPTIONS
 	var qemuArgs []string
+
+	qemuArgs = append(qemuArgs, config.QemuArgs...)
 	qemuArgs = append(qemuArgs, "-device", "virtio-rng-pci")
 	qemuArgs = append(qemuArgs, "-smp", config.CPUs)
 	qemuArgs = append(qemuArgs, "-m", config.Memory)

--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -40,7 +40,7 @@ type QemuConfig struct {
 	Containerized  bool
 	QemuBinPath    string
 	QemuImgPath    string
-	QemuArgs       []string
+	QemuOptions    []string
 	PublishedPorts []string
 	NetdevConfig   string
 	UUID           uuid.UUID
@@ -111,7 +111,7 @@ func runQemu(args []string) {
 	}
 
 	// Arguments to pass to qemu
-	qemuDirectArgs := flags.String("args", "", "Arguments to pass directly to qemu")
+	qemuDirectOptions := flags.String("qemuOptions", "", "Options to pass directly to qemu")
 
 	// Display flags
 	enableGUI := flags.Bool("gui", false, "Set qemu to use video output instead of stdio")
@@ -158,9 +158,9 @@ func runQemu(args []string) {
 
 	// These envvars override the corresponding command line
 	// options. So this must remain after the `flags.Parse` above.
-	envOverrideString("LINUXKIT_QEMU_ARGS", qemuDirectArgs)
 	envOverrideBool("LINUXKIT_QEMU_KVM", enableKVM)
 	envOverrideBool("LINUXKIT_QEMU_CONTAINERIZED", qemuContainerized)
+	envOverrideString("LINUXKIT_QEMU_OPTIONS", qemuDirectOptions)
 
 	if len(remArgs) == 0 {
 		fmt.Println("Please specify the path to the image to boot")
@@ -303,7 +303,7 @@ func runQemu(args []string) {
 		Memory:         *mem,
 		KVM:            *enableKVM,
 		Containerized:  *qemuContainerized,
-		QemuArgs:       strings.Split(*qemuDirectArgs, " "),
+		QemuOptions:    strings.Split(*qemuDirectOptions, " "),
 		PublishedPorts: publishFlags,
 		NetdevConfig:   netdevConfig,
 		UUID:           vmUUID,
@@ -475,7 +475,7 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 	// Iterate through the flags and build arguments appending to arguments passed via QEMU_OPTIONS
 	var qemuArgs []string
 
-	qemuArgs = append(qemuArgs, config.QemuArgs...)
+	qemuArgs = append(qemuArgs, config.QemuOptions...)
 	qemuArgs = append(qemuArgs, "-device", "virtio-rng-pci")
 	qemuArgs = append(qemuArgs, "-smp", config.CPUs)
 	qemuArgs = append(qemuArgs, "-m", config.Memory)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a `-args` and overriding `LINUXKIT_QEMU_ARGS` environment variable to the qemu runner

**- How I did it**

mimicked current flag/environment handling to add this, and append the flags within `buildQemuCmdline`

**- How to verify it**

see addition of `-args` in `linuxkit run qemu -help`. simplest validation being to run linuxkit image doing `-args "-badflag"` or with `LINUXKIT_QEMU_ARGS=-badflag` and qemu will fail nothing the bad flag being added as the arguments being sent to it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

* allow passing custom additional arguments directly to qemu

**- A picture of a cute animal (not mandatory but encouraged)**

![](http://www.cutestpaw.com/wp-content/uploads/2014/01/Augusta-has-reached-one-million-views.jpg)