### PR TITLE
pkg/getty: Add ARM 'ttyAMA0' console into securetty

### DIFF
--- a/pkg/getty/etc/securetty
+++ b/pkg/getty/etc/securetty
@@ -28,6 +28,8 @@ hvsi1
 # ARM "AMBA" serial ports
 ttyAM0
 ttyAM1
+ttyAMA0
+ttyAMA1
 
 # s390 and s390x ports in LPAR mode
 ttysclp0


### PR DESCRIPTION
We need to add 'ttyAMA0' console used on ARM64 platform into
securetty file to make it's possible to log into the system
as root. Also it will dismiss the below warning message before
login:
"getty: cmdline has console=ttyAMA0 but does not exist in
/etc/securetty; will not be able to log in as root on this tty ttyAMA0."

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
 Dismiss the console warning message before login.
**- How I did it**
Add the 'ttyAMA0' used on ARM64 into /etc/securetty
**- How to verify it**
The warning message is disappeared after this patch applied. 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/28772428-c9abd948-7618-11e7-8bb2-c370766b19f7.jpg)
