### PR TITLE
Updated document with the right LinuxKit command for pushing VHD to Azure Platform

### DIFF
--- a/docs/platform-azure.md
+++ b/docs/platform-azure.md
@@ -34,7 +34,7 @@ This will output a `azure.vhd` image.
 To deploy the `azure.vhd` image on Azure, invoke the following command:
 
 ```
-linuxkit run azure --resource-group <resource-group-name> --storage-account <storage-account-name> --location westeurope <path-to-your-azure.vhd>
+linuxkit run azure -resourceGroupName <resource-group-name> -accountName <storage-account-name> -location westeurope <path-to-your-azure.vhd>
 ```
 
 Sample output of the command:


### PR DESCRIPTION
The document showed the incorrect sub-command options for LinuxKit run azure  which needs to be updated and hence fixed it.

**- What I did**

Modified the incorrect Linuxkit run command for Azure.



**- How I did it**

linuxkit run azure -resourceGroupName <resource-group-name> -accountName <storage-account-name> -location westeurope <path-to-your-azure.vhd>

**- How to verify it**

$git clone https://github.com/linuxkit/linuxkit
$cd linuxkit
$make
$cp -rf bin/moby /usr/local/bin/
$cp -rf bin/linuxkit /usr/local/bin/
$cd linuxkit/examples/azure
$moby build -o vhd azure.yml
$ linuxkit run azure --resourceGroupName mylinuxkitresource --accountName mylinuxkitstorage -location eastasia azure.vhd

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![63bb616a33fc209cd3a48795c981f46d--mini-husky-alaskan-klee-kai](https://user-images.githubusercontent.com/313480/28771515-c44ff46a-7600-11e7-948f-8f7b8883970a.jpg)