### PR TITLE
projects/kubernetes: fixup and bump to kube 1.7.2

### DIFF
--- a/projects/kubernetes/image-cache/Dockerfile
+++ b/projects/kubernetes/image-cache/Dockerfile
@@ -12,6 +12,8 @@ RUN apk add --no-cache --initdb -p /out \
 # Remove apk residuals. We have a read-only rootfs, so apk is of no use.
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
+RUN rmdir /out/var/run && ln -nfs /run /out/var/run
+
 FROM scratch
 WORKDIR /
 COPY --from=build /out /

--- a/projects/kubernetes/image-cache/Makefile
+++ b/projects/kubernetes/image-cache/Makefile
@@ -2,6 +2,9 @@ default: push
 
 COMMON_IMAGES := \
   kube-proxy-amd64\:v1.7.2@sha256\:d455480e81d60e0eff3415675278fe3daec6f56c79cd5b33a9b76548d8ab4365 \
+  k8s-dns-sidecar-amd64\:1.14.4@sha256\:97074c951046e37d3cbb98b82ae85ed15704a290cce66a8314e7f846404edde9 \
+  k8s-dns-kube-dns-amd64\:1.14.4@sha256\:40790881bbe9ef4ae4ff7fe8b892498eecb7fe6dcc22661402f271e03f7de344 \
+  k8s-dns-dnsmasq-nanny-amd64\:1.14.4@sha256\:aeeb994acbc505eabc7415187cd9edb38cbb5364dc1c2fc748154576464b3dc2 \
   pause-amd64\:3.0@sha256\:163ac025575b775d1c0f9bf0bdd0f086883171eb475b5068e7defa4ca9e76516
 
 CONTROL_PLANE_IMAGES := \

--- a/projects/kubernetes/image-cache/Makefile
+++ b/projects/kubernetes/image-cache/Makefile
@@ -1,13 +1,13 @@
 default: push
 
 COMMON_IMAGES := \
-  kube-proxy-amd64\:v1.6.7@sha256\:652ca0ef7cdf05341fafb590ced1b737126641829c70f5d23f9b714bc61c8607 \
+  kube-proxy-amd64\:v1.7.2@sha256\:d455480e81d60e0eff3415675278fe3daec6f56c79cd5b33a9b76548d8ab4365 \
   pause-amd64\:3.0@sha256\:163ac025575b775d1c0f9bf0bdd0f086883171eb475b5068e7defa4ca9e76516
 
 CONTROL_PLANE_IMAGES := \
-  kube-apiserver-amd64\:v1.6.7@sha256\:57e482529b95d32730d1bcd2e374199f27eab4abcf1ff49c5db2a7a7e2231cc8 \
-  kube-controller-manager-amd64\:v1.6.7@sha256\:884f609895fa715d66806681a6bf6f9851a911202ad3484b768fead8b7c78b39 \
-  kube-scheduler-amd64\:v1.6.7@sha256\:a1a498a0ca5ab23c228724d93c3f3d9457b31a046d9025471d98e1096422452c \
+  kube-apiserver-amd64\:v1.7.2@sha256\:a9ccc205760319696d2ef0641de4478ee90fb0b75fbe6c09b1d64058c8819f97 \
+  kube-controller-manager-amd64\:v1.7.2@sha256\:2b268ab9017fadb006ee994f48b7222375fe860dc7bd14bf501b98f0ddc2961b \
+  kube-scheduler-amd64\:v1.7.2@sha256\:b2e897138449e7a00508dc589b1d4b71e56498a4d949ff30eb07b1e9d665e439 \
   etcd-amd64\:3.0.17@sha256\:d83d3545e06fb035db8512e33bd44afb55dea007a3abd7b17742d3ac6d235940
 
 dl/%.tar:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -59,11 +59,11 @@ services:
     rootfsPropagation: shared
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: kubernetes-image-cache-common
-    image: linuxkitprojects/kubernetes-image-cache-common:6fccda74ea301f9a62cdcfc2fe4952cff2c8c97b
+    image: linuxkitprojects/kubernetes-image-cache-common:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
   - name: kubernetes-image-cache-control-plane
-    image: linuxkitprojects/kubernetes-image-cache-control-plane:6fccda74ea301f9a62cdcfc2fe4952cff2c8c97b
+    image: linuxkitprojects/kubernetes-image-cache-control-plane:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
   - name: kubelet
-    image: linuxkitprojects/kubernetes:8fca97c5faf0c6288aee82485d8c6539b84db256
+    image: linuxkitprojects/kubernetes:bbf14d70199babeea1f71f5b0bd70c1c1c9b5cd2
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -51,7 +51,7 @@ services:
      - /dev:/dev
      - /etc/resolv.conf:/etc/resolv.conf
      - /lib/modules:/lib/modules
-     - /run:/run:rshared,rbind
+     - /run:/run
      - /var:/var:rshared,rbind
      - /var/lib/kubeadm:/etc/kubernetes
      - /etc/cni:/etc/cni:rshared,rbind

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -51,6 +51,7 @@ services:
      - /dev:/dev
      - /etc/resolv.conf:/etc/resolv.conf
      - /lib/modules:/lib/modules
+     - /run:/run:rshared,rbind
      - /var:/var:rshared,rbind
      - /var/lib/kubeadm:/etc/kubernetes
      - /etc/cni:/etc/cni:rshared,rbind

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -30,7 +30,7 @@ onboot:
       - /var/lib:/var/lib
 services:
   - name: getty
-    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
+    image: linuxkit/getty:18c468293c583eb5f275a068b686d55969f1b736
     env:
      - INSECURE=true
   - name: rngd
@@ -38,7 +38,7 @@ services:
   - name: ntpd
     image: linuxkit/openntpd:2874b66c9fa51fa5b4d11c8b50441eb94ee22a5a
   - name: sshd
-    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
+    image: linuxkit/sshd:5dc5c3c4470c85f6c89f0e26b9d477ae4ff85a3c
   - name: docker
     image: docker:17.06.0-ce-dind
     capabilities:

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -51,7 +51,7 @@ services:
      - /dev:/dev
      - /etc/resolv.conf:/etc/resolv.conf
      - /lib/modules:/lib/modules
-     - /run:/run:rshared,rbind
+     - /run:/run
      - /var:/var:rshared,rbind
      - /var/lib/kubeadm:/etc/kubernetes
      - /etc/cni:/etc/cni:rshared,rbind

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -59,9 +59,9 @@ services:
     rootfsPropagation: shared
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: kubernetes-image-cache-common
-    image: linuxkitprojects/kubernetes-image-cache-common:6fccda74ea301f9a62cdcfc2fe4952cff2c8c97b
+    image: linuxkitprojects/kubernetes-image-cache-common:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
   - name: kubelet
-    image: linuxkitprojects/kubernetes:8fca97c5faf0c6288aee82485d8c6539b84db256
+    image: linuxkitprojects/kubernetes:bbf14d70199babeea1f71f5b0bd70c1c1c9b5cd2
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -51,6 +51,7 @@ services:
      - /dev:/dev
      - /etc/resolv.conf:/etc/resolv.conf
      - /lib/modules:/lib/modules
+     - /run:/run:rshared,rbind
      - /var:/var:rshared,rbind
      - /var/lib/kubeadm:/etc/kubernetes
      - /etc/cni:/etc/cni:rshared,rbind

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -30,7 +30,7 @@ onboot:
       - /var/lib:/var/lib
 services:
   - name: getty
-    image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02
+    image: linuxkit/getty:18c468293c583eb5f275a068b686d55969f1b736
     env:
      - INSECURE=true
   - name: rngd
@@ -38,7 +38,7 @@ services:
   - name: ntpd
     image: linuxkit/openntpd:2874b66c9fa51fa5b4d11c8b50441eb94ee22a5a
   - name: sshd
-    image: linuxkit/sshd:dc98a72c1d1285c30f2db176252f3ce2bf645d5b
+    image: linuxkit/sshd:5dc5c3c4470c85f6c89f0e26b9d477ae4ff85a3c
   - name: docker
     image: docker:17.06.0-ce-dind
     capabilities:

--- a/projects/kubernetes/kubernetes/Dockerfile
+++ b/projects/kubernetes/kubernetes/Dockerfile
@@ -30,6 +30,8 @@ RUN apk add --no-cache --initdb -p /out \
 # Remove apk residuals. We have a read-only rootfs, so apk is of no use.
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
+RUN rmdir /out/var/run && ln -nfs /run /out/var/run
+
 RUN curl -fSL -o /tmp/cni.tgz https://github.com/containernetworking/cni/releases/download/v0.5.2/cni-amd64-${cni_version}.tgz && \
     mkdir -p /out/opt/cni/bin /out/etc/cni/net.d && \
     tar -xzf /tmp/cni.tgz -C /out/opt/cni/bin
@@ -47,4 +49,4 @@ WORKDIR /
 ENTRYPOINT ["/usr/bin/kubelet.sh"]
 COPY --from=build /out /
 ENV KUBECONFIG "/etc/kubernetes/admin.conf"
-LABEL org.mobyproject.config='{"binds": ["/dev:/dev", "/etc/resolv.conf:/etc/resolv.conf", "/var:/var:rshared,rbind", "/var/lib/kubeadm:/etc/kubernetes", "/etc/cni:/rootfs/etc/cni:rshared,rbind", "/opt/cni:/rootfs/opt/cni:rshared,rbind"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}], "capabilities": ["all"], "rootfsPropagation": "shared", "pid": "host"}'
+LABEL org.mobyproject.config='{"binds": ["/dev:/dev", "/etc/resolv.conf:/etc/resolv.conf", "/run:/run", "/var:/var:rshared,rbind", "/var/lib/kubeadm:/etc/kubernetes", "/etc/cni:/rootfs/etc/cni:rshared,rbind", "/opt/cni:/rootfs/opt/cni:rshared,rbind"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}], "capabilities": ["all"], "rootfsPropagation": "shared", "pid": "host"}'

--- a/projects/kubernetes/kubernetes/Dockerfile
+++ b/projects/kubernetes/kubernetes/Dockerfile
@@ -2,7 +2,7 @@
 # XXX needs ebtables ethtool iproute2 libc6-compat socat
 FROM alpine:3.6 AS build
 
-ENV kubernetes_version v1.6.7
+ENV kubernetes_version v1.7.2
 ENV weave_version      v2.0.1
 ENV cni_version        v0.5.2
 


### PR DESCRIPTION
**- What I did**

- Updated `getty` and `sshd` which were lagging.
- Fixes up some fallout from the switch to a `tmpfs` on `/var` and in particular the change to `/var/run` being a symlink to `/run`.
- Updated to Kube 1.7.2
- Reintroduced k8s-dns images in the cache, since they are now used.

**- How I did it**

Emacs

**- How to verify it**

I like the sock shop demo for this.

**- Description for the changelog**
Kubernetes project is now based on Kube 1.7.2.

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://upload.wikimedia.org/wikipedia/en/d/d3/Leprous_Congregation_Cover.jpg "Leprous, The Congregation")](https://en.wikipedia.org/wiki/The_Congregation_(Leprous_album))
