### PR TITLE
Create a multi-arch alpine base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,16 @@ bin/rtf: tmp_rtf_bin.tar | bin
 tmp_rtf_bin.tar: Makefile
 	docker run --rm --log-driver=none -e http_proxy=$(http_proxy) -e https_proxy=$(https_proxy) $(CROSS) $(GO_COMPILE) --clone-path github.com/linuxkit/rtf --clone https://github.com/linuxkit/rtf.git --commit $(RTF_COMMIT) --package github.com/linuxkit/rtf --ldflags "-X $(RTF_CMD).GitCommit=$(RTF_COMMIT) -X $(RTF_CMD).Version=$(RTF_VERSION)" -o bin/rtf > $@
 
+# Manifest tool for multi-arch images
+MT_COMMIT=186e7752e8032756bb263b830451f44e5176864f
+MT_REPO=https://github.com/rn/manifest-tool
+bin/manifest-tool: tmp_mt_bin.tar | bin
+	tar xf $<
+	rm $<
+	touch $@
+
+tmp_mt_bin.tar: Makefile
+	docker run --rm --log-driver=none -e http_proxy=$(http_proxy) -e https_proxy=$(https_proxy) $(CROSS) $(GO_COMPILE) --clone-path github.com/estesp/manifest-tool --clone $(MT_REPO) --commit $(MT_COMMIT) --package github.com/estesp/manifest-tool --ldflags "-X main.gitCommit=$(MT_COMMIT)" -o bin/manifest-tool > $@
 
 LINUXKIT_DEPS=$(wildcard src/cmd/linuxkit/*.go) Makefile src/cmd/linuxkit/vendor.conf
 bin/linuxkit: tmp_linuxkit_bin.tar
@@ -55,11 +65,11 @@ tmp_linuxkit_bin.tar: $(LINUXKIT_DEPS)
 .PHONY: test-cross
 test-cross:
 	$(MAKE) clean
-	$(MAKE) -j 3 GOOS=darwin tmp_moby_bin.tar tmp_rtf_bin.tar tmp_linuxkit_bin.tar
+	$(MAKE) -j 3 GOOS=darwin tmp_moby_bin.tar tmp_rtf_bin.tar tmp_mt_bin.tar tmp_linuxkit_bin.tar
 	$(MAKE) clean
-	$(MAKE) -j 3 GOOS=windows tmp_moby_bin.tar tmp_rtf_bin.tar tmp_linuxkit_bin.tar
+	$(MAKE) -j 3 GOOS=windows tmp_moby_bin.tar tmp_rtf_bin.tar tmp_mt_bin.tar tmp_linuxkit_bin.tar
 	$(MAKE) clean
-	$(MAKE) -j 3 GOOS=linux tmp_moby_bin.tar tmp_rtf_bin.tar tmp_linuxkit_bin.tar
+	$(MAKE) -j 3 GOOS=linux tmp_moby_bin.tar tmp_rtf_bin.tar tmp_mt_bin.tar tmp_linuxkit_bin.tar
 	$(MAKE) clean
 
 

--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -29,10 +29,12 @@ ARCH := $(shell uname -m)
 ifeq ($(ARCH), x86_64)
 BASE=alpine:3.6
 DEPS += packages.x86_64
+SUFFIX=-amd64
 endif
 ifeq ($(ARCH), aarch64)
 BASE=arm64v8/alpine:3.6
 DEPS += packages.aarch64
+SUFFIX=-arm64
 DOCKER_CONTENT_PULL=0
 endif
 
@@ -46,7 +48,7 @@ iid: Dockerfile Makefile $(DEPS)
 	DOCKER_CONTENT_TRUST=0 docker build --no-cache --build-arg BASE=$(BASE) --iidfile iid .
 
 hash: Makefile iid
-	docker run --rm $(shell cat iid) sh -c 'echo Dockerfile /lib/apk/db/installed $$(find /mirror -name '*.apk' -type f) $$(find /go/bin -type f) | xargs cat | sha1sum' | sed 's/ .*//' > $@
+	docker run --rm $(shell cat iid) sh -c 'echo Dockerfile /lib/apk/db/installed $$(find /mirror -name '*.apk' -type f) $$(find /go/bin -type f) | xargs cat | sha1sum' | sed 's/ .*//' | sed 's/$$/$(SUFFIX)/'> $@
 
 versions.$(ARCH): Makefile hash iid
 	echo "# $(ORG)/$(IMAGE):$(shell cat hash)" > versions.$(ARCH)
@@ -56,6 +58,7 @@ push: hash iid versions.$(ARCH)
 	docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(shell cat iid) $(ORG)/$(IMAGE):$(shell cat hash) && \
 		 docker push $(ORG)/$(IMAGE):$(shell cat hash))
+	./push-manifest.sh $(ORG) $(IMAGE)
 	rm -f iid
 
 tag: hash iid versions.$(ARCH)

--- a/tools/alpine/push-manifest.sh
+++ b/tools/alpine/push-manifest.sh
@@ -1,0 +1,71 @@
+#! /bin/sh
+
+# This script creates a multiarch manifest for the 'linuxkit/alpine'
+# image, pushes and signs it. The manifest is pushed with the tag of
+# the amd64 images (which is the suffix removed). On macOS we use the
+# credentials helper to extract the Hub credentials. We need to
+# manually sign the manifest using 'notary'.
+#
+# This script is specific to 'linuxkit/alpine'. For normal packages we
+# use a different scheme.
+#
+# This should all be replaced with 'docker manifest' once it lands.
+
+ORG=$1
+IMAGE=$2
+
+IMG_X86_64=$(head -1 versions.x86_64 | sed 's,[#| ]*,,')
+IMG_ARM64=$(head -1 versions.aarch64 | sed 's,[#| ]*,,')
+IMG_MANIFEST=$(echo "$IMG_X86_64" | sed 's,\-.*$,,')
+IMG_TAG=$(echo "$IMG_MANIFEST" | sed 's,.*:,,')
+
+YAML=$(mktemp)
+cat <<EOF > "$YAML"
+image: $IMG_MANIFEST
+manifests:
+  - image: $IMG_ARM64
+    platform:
+      architecture: arm64
+      os: linux
+  - image: $IMG_X86_64
+    platform:
+      architecture: amd64
+      os: linux
+EOF
+
+# work out additional arguments. Specifically, on Darwin the hub
+# credentials are stored on the keychain and we need to extract them
+# from there
+case $(uname -s) in
+    Darwin)
+        CRED=$(echo "https://index.docker.io/v1/" | /Applications/Docker.app/Contents/Resources/bin/docker-credential-osxkeychain.bin get)
+        USER=$(echo "$CRED" | jq -r '.Username')
+        PASS=$(echo "$CRED" | jq -r '.Secret')
+        USERPASS="$USER\n$PASS"
+        MT_ARGS="--username $USER --password $PASS"
+        ;;
+    Linux)
+        MT_ARGS=
+        USERPASS=$(cat ~/.docker/config.json | jq -r '.auths."https://index.docker.io/v1/".auth' | base64 -d - | sed 's,:,\\n,')
+        ;;
+    *)
+        echo "Unsupported platform"
+        exit 1
+        ;;
+esac
+
+# Push manifest list
+OUT=$(manifest-tool $MT_ARGS push from-spec "$YAML")
+rm "$YAML"
+echo "$OUT"
+SHA256=$(echo "$OUT" | cut -d' ' -f2 | cut -d':' -f2)
+LEN=$(echo "$OUT" | cut -d' ' -f3)
+
+# Sign manifest (TODO: Use $USERPASS and pass them into notary)
+notary -s https://notary.docker.io \
+       -d ~/.docker/trust addhash \
+       -p docker.io/"$ORG"/"$IMAGE" \
+       "$IMG_TAG" "$LEN" --sha256 "$SHA256" \
+       -r targets/releases
+
+echo "New multi-arch image: $ORG/$IMAGE:$IMG_TAG"

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:964e39653b32464f369e52099781b35642a253e5
+# linuxkit/alpine:6ddb2bad487a429f9995dd4844290c934325d2ab-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -87,14 +87,14 @@ libattr-2.4.47-r6
 libblkid-2.28.2-r2
 libburn-1.4.6-r0
 libbz2-1.0.6-r5
+libc-dev-0.7.1-r0
+libc-utils-0.7.1-r0
 libcap-2.25-r1
 libcap-ng-0.7.8-r0
 libcap-ng-dev-0.7.8-r0
-libc-dev-0.7.1-r0
 libcom_err-1.43.4-r0
 libcrypto1.0-1.0.2k-r0
 libcurl-7.54.0-r0
-libc-utils-0.7.1-r0
 libdrm-2.4.80-r0
 libedit-20170329.3.1-r2
 libelf-0.8.13-r2
@@ -125,10 +125,10 @@ libogg-1.3.2-r1
 libpcap-1.8.1-r0
 libpng-1.6.29-r1
 libressl-2.5.4-r0
+libressl-dev-2.5.4-r0
 libressl2.5-libcrypto-2.5.4-r0
 libressl2.5-libssl-2.5.4-r0
 libressl2.5-libtls-2.5.4-r0
-libressl-dev-2.5.4-r0
 libsasl-2.1.26-r10
 libseccomp-2.3.2-r0
 libseccomp-dev-2.3.2-r0
@@ -217,7 +217,7 @@ util-linux-dev-2.28.2-r2
 vde2-libs-2.3.2-r7
 vim-8.0.0595-r0
 wayland-1.13.0-r0
-wireguard-tools-0.0.20170629-r0
+wireguard-tools-0.0.20170726-r0
 xfsprogs-4.5.0-r0
 xfsprogs-extra-4.5.0-r0
 xfsprogs-libs-4.5.0-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:c23813875499d85163dc358fc6370c9de650df57
+# linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0


### PR DESCRIPTION
- Add a modified version of the `manifest-tool` to the top-level Makefile
- Append `-amd64` and `-arm64` to the architecture specific base images
- After pushing the image use `push-manifest.sh`, which:
  - Extracts the current hashes from the `version.*` files
  - Creates a `manifest-tool` YAML file
  - Push the manifest list to hub using the hash of the `x86_64` images (without the `-amd64`)
  - Sign the manifest using `notary`
- Note, the build requires a modified version of `manifest-tool` and `jq` to be installed. On macOS it also requires the `docker-credential-osxkeychain.bin` which is installed with Docker for Mac, and on Linux it requires `base64` (though that is currently not used).

There now is signed a multi-arch image on hub as: `linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630`

Next step is to add support for multi-arch images to `package.mk`, then rebuild the various packages and tools as well as the kernel package. I think that has to be done in one PR and can't be done incrementally.

wip: #2292

/cc @ijc @arm64b @justincormack @riyazdf I've tried to implement the `mirror` apprach suggested by @ijc [here](https://github.com/linuxkit/linuxkit/issues/2292#issuecomment-317997094) but one can't `apk fetch --arch $arch` at the moment.

![sleep](https://user-images.githubusercontent.com/3338098/28834437-200bb2ce-76da-11e7-8ede-bdc9d3ad8b8e.jpg)
