### PR TITLE
save qemu pid in state directory

### DIFF
--- a/test/cases/040_packages/003_containerd/test.sh
+++ b/test/cases/040_packages/003_containerd/test.sh
@@ -10,7 +10,7 @@ set -e
 . "${RT_PROJECT_ROOT}/_lib/lib.sh"
 
 clean_up() {
-	find . -iname "test-containerd*" -not -iname "*.yml" -exec rm -rf {} \;
+	find . -depth -iname "test-containerd*" -not -iname "*.yml" -exec rm -rf {} \;
 }
 trap clean_up EXIT
 

--- a/test/cases/040_packages/007_getty-containerd/test.sh
+++ b/test/cases/040_packages/007_getty-containerd/test.sh
@@ -12,7 +12,7 @@ set -e
 NAME=test-ctr
 
 clean_up() {
-	find . -iname "test-ctr*" -not -iname "*.yml" -exec rm -rf {} \;
+	find . -depth -iname "test-ctr*" -not -iname "*.yml" -exec rm -rf {} \;
 }
 trap clean_up EXIT
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Made it so qemu stores pidfile within state directory the same way hyperkit does

**- How I did it**

* Unconditionally create state directory as its required no matter what for our pidfile
* pass `-pidfile $STATE_DIR/qemu.pid` to qemu to create pid file

**- How to verify it**

`./bin/linuxkit run linuxkit` (or any image) and `cat linuxkit-state/qemu.pid` (replace linuxkit-state if you specified `-state` to linuxkit)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Save qemu pid to file within state directory


**- A picture of a cute animal (not mandatory but encouraged)**
![](http://17909.cdx.c.ooyala.com/1mNWM4ODE61G9Op_KFHu8jiQwnZibPHN/promo305904731)