### PR TITLE
Unpack filesystem for BIOS ISO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 PREFIX?=/usr/local/
 
 MOBY_REPO=https://github.com/moby/tool.git
-MOBY_COMMIT=14a4d923aef7cf5a8a6f162b128315d9e0f7884e
+MOBY_COMMIT=b9de5ff4c64e01d8fbaa495776890a82e9647f20
 MOBY_VERSION=0.0
 bin/moby: tmp_moby_bin.tar | bin
 	tar xf $<

--- a/tools/mkimage-iso-bios/make-iso
+++ b/tools/mkimage-iso-bios/make-iso
@@ -5,22 +5,17 @@ set -e
 mkdir -p /tmp/iso
 cd /tmp/iso
 
-# input is a tarball of kernel and initrd.img on stdin
+# input is a tarball of filesystem on stdin with kernel in /boot
 # output is an iso on stdout
 
 # extract. BSD tar auto recognises compression, unlike GNU tar
 # only if stdin is a tty, if so need files volume mounted...
 [ -t 0 ] || bsdtar xzf -
 
-INITRD="$(find . -name '*.img')"
-KERNEL="$(find . -name kernel -or -name '*bzImage')"
-CMDLINE="$*"
-
-[ "$KERNEL" = "kernel" ] || mv "$KERNEL" kernel
-[ "$INITRD" = "initrd.img" ] || mv "$INITRD" initrd.img
-
-# clean up subdirectories
-find . -mindepth 1 -maxdepth 1 -type d | xargs rm -rf
+CMDLINE="$(cat boot/cmdline)"
+# if no root= root device specified, assume /dev/sr0 ie first CD drive
+echo "${CMDLINE}" | grep -q 'root=' || CMDLINE="${CMDLINE} root=/dev/sr0"
+rm boot/cmdline
 
 mkdir -p isolinux
 cp /usr/share/syslinux/isolinux.bin ./isolinux/
@@ -28,8 +23,7 @@ cp /usr/share/syslinux/ldlinux.c32 ./isolinux/
 
 CFG="DEFAULT linux
 LABEL linux
-    KERNEL /kernel
-    INITRD /initrd.img
+    KERNEL /boot/kernel
     APPEND ${CMDLINE}
 "
 
@@ -39,6 +33,7 @@ genisoimage -o ../linuxkit-bios.iso -l -J -R \
                 -c isolinux/boot.cat  \
                 -b isolinux/isolinux.bin \
                    -no-emul-boot -boot-load-size 4 -boot-info-table \
+		-joliet-long -input-charset utf8 \
                 -V LinuxKit .
 
 isohybrid ../linuxkit-bios.iso


### PR DESCRIPTION
Now that LinuxKit works on a truly immutable filesystem, for an
ISO it makes sense to use the ISO filesystem rather than using
an initrd. Only major difference is you may need to specify the
device for the root filesystem in the kernel command line, but
we set a sane default of `/dev/sr0` if unspecified.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![cat-mummy](https://user-images.githubusercontent.com/482364/28875552-d383f75e-778d-11e7-8ca9-9c99f238ff75.jpg)
