### PR TITLE
[WIP] Grand multi-arch conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: default
 VERSION="0.0" # dummy for now
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:a1e3cd3a54b1ad683b555655282272d0eb27ee40
+GO_COMPILE=linuxkit/go-compile:7cac05c5588b3dd6a7f7bdb34fc1da90257394c7
 
 MOBY?=bin/moby
 LINUXKIT?=bin/linuxkit

--- a/scripts/push-manifest.sh
+++ b/scripts/push-manifest.sh
@@ -1,40 +1,20 @@
 #! /bin/sh
 
-# This script creates a multiarch manifest for the 'linuxkit/alpine'
-# image, pushes and signs it. The manifest is pushed with the tag of
-# the amd64 images (which is the suffix removed). On macOS we use the
-# credentials helper to extract the Hub credentials. We need to
-# manually sign the manifest using 'notary'.
+# This script pushes a multiarch manifest for packages and signs it.
+# 
+# The TARGET must be of the form <org>/<image>:<tag> and this is what
+# the manifest is pushed to. It assumes that there is are images of
+# the form <org>/<image>:<tag>-<arch> already on hub.
 #
-# This script is specific to 'linuxkit/alpine'. For normal packages we
-# use a different scheme.
-#
-# This should all be replaced with 'docker manifest' once it lands.
+# If TRUST is not set, the manifest will not be signed.
 
-ORG=$1
-IMAGE=$2
+TARGET=$1
+TRUST=$2
 
 NOTARY_DELEGATION_PASSPHRASE="$DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE"
 
-IMG_X86_64=$(head -1 versions.x86_64 | sed 's,[#| ]*,,')
-IMG_ARM64=$(head -1 versions.aarch64 | sed 's,[#| ]*,,')
-# Extract the TAG from the x86_64 name and build the manifest target name
-TAG=$(echo "$IMG_X86_64" | sed 's,\-.*$,,' | cut -d':' -f2)
-TARGET="$ORG/$IMAGE:$TAG"
-
-YAML=$(mktemp)
-cat <<EOF > "$YAML"
-image: $TARGET
-manifests:
-  - image: $IMG_ARM64
-    platform:
-      architecture: arm64
-      os: linux
-  - image: $IMG_X86_64
-    platform:
-      architecture: amd64
-      os: linux
-EOF
+REPO=$(echo "$TARGET" | cut -d':' -f1)
+TAG=$(echo "$TARGET" | cut -d':' -f2)
 
 # Work out credentials. On macOS they are needed for manifest-tool and
 # we need them for notary on all platforms.
@@ -59,9 +39,17 @@ case $(uname -s) in
 esac
 
 # Push manifest list
-OUT=$(manifest-tool $MT_ARGS push from-spec "$YAML")
-rm "$YAML"
+OUT=$(manifest-tool $MT_ARGS push from-args \
+                    --ignore-missing \
+                    --platforms linux/amd64,linux/arm64 \
+                    --template "$TARGET"-ARCH \
+                    --target "$TARGET")
+
 echo "$OUT"
+if [ -z ${TRUST+x} ]; then
+    echo "Not signing $TARGET"
+    exit 0
+fi
 
 # Extract sha256 and length from the manifest-tool output
 SHA256=$(echo "$OUT" | cut -d' ' -f2 | cut -d':' -f2)
@@ -70,8 +58,8 @@ LEN=$(echo "$OUT" | cut -d' ' -f3)
 # Sign manifest (TODO: Use $USER and $PASS and pass them into notary)
 notary -s https://notary.docker.io \
        -d ~/.docker/trust addhash \
-       -p docker.io/"$ORG"/"$IMAGE" \
+       -p docker.io/"$REPO" \
        "$TAG" "$LEN" --sha256 "$SHA256" \
        -r targets/releases
 
-echo "New multi-arch image: $ORG/$IMAGE:$IMG_TAG"
+echo "New multi-arch image: $REPO:$TAG"

--- a/tools/go-compile/Dockerfile
+++ b/tools/go-compile/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:3744607156e6b67e3e7d083b15be9e7722215e73 AS mirror
+FROM linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \


### PR DESCRIPTION
This is WIP to get some early feedback before embarking on converting everything to multi-arch images.

This adds a script to push and sign manifest (similar to the one used for `linuxkit/alpine`), adds it to the generic package building makefile.

It then converts the the `linuxkit/go-compile` package to a multi-arch images and uses it in the top-level Makefile file to build the tools.

This works! and bootstraps the mechanism to convert all the other packages. It would be good to get some  early feedback on the integration before embarking on the grand conversion.

If the approach is ok, I'll close this and finish the work before submitting a proper PR

@justincormack PTAL