### PR TITLE
[OpenStack] Inherit env vars for push, and make run more consistent with other providers

### DIFF
--- a/docs/platform-openstack.md
+++ b/docs/platform-openstack.md
@@ -1,13 +1,25 @@
 # LinuxKit with OpenStack
 
-LinuxKit interacts with OpenStack through its native APIs and requires access
-to both an OpenStack Keystone server for authentication and an OpenStack image
-service (Glance) in order to host the LinuxKit images.
+LinuxKit interacts with OpenStack through its native APIs and requires access and provides basic support for pushing images and launching virtual instances.
 
-Supported (tested) versions of the relevant OpenStack APIs:
+Supported (tested) versions of the relevant OpenStack APIs are:
 
 - Keystone v3
 - Glance v2
+- Nova v2
+- Neutron v2
+
+## Authentication
+
+LinuxKit's support for OpenStack handles two ways of providing the endpoint and authentication details.  You can either set the standard set of environment variables and the commands detailed below will inherit those, or you can explicitly provide them on the command-line as options to `push` and `run`.  The examples below use the latter, but if you prefer the former then you'll need to set the following:
+
+```shell
+OS_USERNAME="admin"
+OS_PASSWORD="xxx"
+OS_TENANT_NAME="linuxkit"
+OS_AUTH_URL="https://keystone.com:5000/v3"
+OS_USER_DOMAIN_NAME=default
+```
 
 ## Push
 
@@ -20,27 +32,52 @@ Supported (tested) versions of the relevant OpenStack APIs:
 - **qcow2** (Qemu disk image)
 - **iso** (ISO9660 compatible CD-ROM image)
 
-A compatible image needs to have the correct extension (must match
-one from above) in order to be supported by the `linuxkit push openstack` 
-command. The `openstack` backend will use the filename extension to determine
-the image type, and use the filename as a label for the new image. 
+A compatible image needs to have the correct extension (must match one from above) in order to be supported by the `linuxkit push openstack` command. The `openstack` backend will use the filename extension to determine the image type, and use the filename as a label for the new image.
 
-### Usage
+Images generated with Moby can be uploaded into OpenStack's image service with `linuxkit push openstack`, plus a few options.  For example:
 
-The `openstack` backend uses the password authentication method in order to
-retrieve a token that can be used to interact with the various components of
-OpenStack.  Example usage:
-
-```
+```shell
 ./linuxkit push openstack \
--authurl=http://keystone.com:5000/v3 \
--username=admin \
--password=XXXXXXXXXXX \
--project=linuxkit \
-./linuxkit.iso 
+  -authurl=https://keystone.example.com:5000/v3 \
+  -username=admin \
+  -password=XXXXXXXXXXX \
+  -project=linuxkit \
+  -img-name=LinuxKitTest
+  ./linuxkit.iso
 ```
 
-### Execution Flow
-1. Authenticate with OpenStack's identity service
-2. Create a "queued" image in Glance and retrieve its UUID
-3. Use this new image ID to upload the LinuxKit image
+If successful, this will return the image's UUID.  If you've set your environment variables up as described above, this command can then be simplified:
+
+```shell
+./linuxkit push openstack \
+  -img-name "LinuxKitTest" \
+  ~/Desktop/linuxkitmage.qcow2
+```
+
+## Run
+
+Virtual machines can be launched using `linuxkit run openstack`.  As an example:
+
+```shell
+linuxkit run openstack \
+  -authurl https://keystone.example.com:5000/v3 \
+  -username=admin \
+  -password=xxx \
+  -project=linuxkit \
+  -network c5d02c5f-c625-4539-8aed-1dab3aa85a0a \
+  LinuxKitTest
+```
+
+This will create a new instance with the same name as the image, and if successful will return the newly-created instance's UUID.  You can then check the boot logs as follows, e.g:
+
+```shell
+$ openstack console log show 7cdd4d53-78b3-47c7-9a77-ba8a3f60548d
+[..]
+linuxkit-fa163ec840c9 login: root (automatic login)
+
+Welcome to LinuxKit!
+
+NOTE: This system is namespaced.
+The namespace you are currently in may not be the root.
+[..]
+```

--- a/src/cmd/linuxkit/push_openstack.go
+++ b/src/cmd/linuxkit/push_openstack.go
@@ -25,13 +25,12 @@ func pushOpenstack(args []string) {
 		fmt.Printf("Options:\n\n")
 		flags.PrintDefaults()
 	}
-	authurl := flags.String("authurl", "", "The URL of the OpenStack identity service, i.e https://keystone.example.com:5000/v3")
-	usernameFlag := flags.String("username", "", "Username with permissions to upload image")
-	passwordFlag := flags.String("password", "", "Password for the Username")
-	projectName := flags.String("project", "", "Name of the Project (aka Tenant) to be used")
-	userDomainFlag := flags.String("domain", "Default", "Domain name")
-
+	authurlFlag := flags.String("authurl", "", "The URL of the OpenStack identity service, i.e https://keystone.example.com:5000/v3")
 	imageName := flags.String("img-name", "", "A unique name for the image, if blank the filename will be used")
+	passwordFlag := flags.String("password", "", "Password for the specified username")
+	projectNameFlag := flags.String("project", "", "Name of the Project (aka Tenant) to be used")
+	userDomainFlag := flags.String("domain", "Default", "Domain name")
+	usernameFlag := flags.String("username", "", "Username with permissions to upload image")
 
 	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
@@ -47,12 +46,18 @@ func pushOpenstack(args []string) {
 	// Check that the file both exists, and can be read
 	checkFile(filePath)
 
+	authurl := getStringValue(authurlVar, *authurlFlag, "")
+	password := getStringValue(passwordVar, *passwordFlag, "")
+	projectName := getStringValue(projectNameVar, *projectNameFlag, "")
+	userDomain := getStringValue(userDomainVar, *userDomainFlag, "")
+	username := getStringValue(usernameVar, *usernameFlag, "")
+
 	authOpts := gophercloud.AuthOptions{
-		IdentityEndpoint: *authurl,
-		Username:         *usernameFlag,
-		Password:         *passwordFlag,
-		DomainName:       *userDomainFlag,
-		TenantName:       *projectName,
+		DomainName:       userDomain,
+		IdentityEndpoint: authurl,
+		Password:         password,
+		TenantName:       projectName,
+		Username:         username,
 	}
 	provider, err := openstack.AuthenticatedClient(authOpts)
 	if err != nil {


### PR DESCRIPTION
**- What I did**

* Update `push` support to inherit relevant environment information, where available;
* Change `run` support so that it's consistent with other providers, notably GCP and AWS.  It now takes the name of the image as the first argument without requiring much else;
* Update documentation to cover support for new features and changed options.

**- How to verify it**

Workflow now looks like:

```shell
$ bin/linuxkit push openstack -img-name "LinuxKitImage" ~/Desktop/linuxkitmage.qcow2 
Uploading file /Users/nick/Desktop/linuxkitmage.qcow2 with Image ID c5b4d9e8-38fb-4728-bc66-c9670201aac7
Image uploaded successfully!
$ bin/linuxkit run openstack -network c5d02c5f-c625-4539-8aed-1dab3aa85a0a -flavor dc1.1x1 LinuxKitImage
Server created, UUID is 40b620ab-bbf8-4931-b428-f4a94a93a229
```

**- Description for the changelog**

Updates for OpenStack push and run support to improve behaviour and consistency, plus documentation.

**- A picture of a cute animal (not mandatory but encouraged)**

![noidea2](https://user-images.githubusercontent.com/436656/28896119-140ffed6-77d3-11e7-8503-9862ed5705a2.gif)