### PR TITLE
Support multiple CDROMS in metadata

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -10,7 +10,7 @@ init:
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata
-    image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
+    image: linuxkit/metadata:c3871ac5838e052ddb33248ceb95f86e4569aec4
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
+    image: linuxkit/metadata:c3871ac5838e052ddb33248ceb95f86e4569aec4
 services:
   - name: rngd
     image: linuxkit/rngd:6565ae49f6be29d4e64614a4df3978b972956ebf

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
+    image: linuxkit/metadata:c3871ac5838e052ddb33248ceb95f86e4569aec4
 services:
   - name: getty
     image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
+    image: linuxkit/metadata:c3871ac5838e052ddb33248ceb95f86e4569aec4
 services:
   - name: getty
     image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02

--- a/pkg/metadata/Dockerfile
+++ b/pkg/metadata/Dockerfile
@@ -6,10 +6,13 @@ ENV GOPATH=/go PATH=$PATH:/go/bin
 COPY .  /go/src/metadata/
 RUN go-compile.sh /go/src/metadata
 
+RUN mkdir -p out/tmp out/var out/dev out/etc
+
 FROM scratch
 ENTRYPOINT []
 CMD []
 WORKDIR /
 COPY --from=mirror /go/bin/metadata /usr/bin/metadata
+COPY --from=mirror /out/ /
 CMD ["/usr/bin/metadata"]
-LABEL org.mobyproject.config='{"binds": ["/dev:/dev", "/var:/var", "/etc/resolv.conf:/etc/resolv.conf"], "capabilities": ["CAP_SYS_ADMIN"]}'
+LABEL org.mobyproject.config='{"binds": ["/dev:/dev", "/var:/var", "/etc/resolv.conf:/etc/resolv.conf"], "tmpfs": ["/tmp"], "readonly": true, "capabilities": ["CAP_SYS_ADMIN"]}'

--- a/pkg/metadata/provider_cdrom.go
+++ b/pkg/metadata/provider_cdrom.go
@@ -3,39 +3,73 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
+	"path/filepath"
+	"syscall"
 )
 
 const (
 	configFile = "config"
+	cdromDevs  = "/dev/sr[0-9]*"
 )
 
 // ProviderCDROM is the type implementing the Provider interface for CDROMs
 // It looks for a file called 'configFile' in the root
 type ProviderCDROM struct {
+	device     string
+	mountPoint string
+	err        error
+	data       []byte
+}
+
+// ListCDROMs lists all the cdroms in the system
+func ListCDROMs() []Provider {
+	cdroms, err := filepath.Glob(cdromDevs)
+	if err != nil {
+		// Glob can only error on invalid pattern
+		panic(fmt.Sprintf("Invalid glob pattern: %s", cdromDevs))
+	}
+	providers := []Provider{}
+	for _, device := range cdroms {
+		providers = append(providers, NewCDROM(device))
+	}
+	return providers
 }
 
 // NewCDROM returns a new ProviderCDROM
-func NewCDROM() *ProviderCDROM {
-	return &ProviderCDROM{}
+func NewCDROM(device string) *ProviderCDROM {
+	mountPoint, err := ioutil.TempDir("", "cd")
+	p := ProviderCDROM{device, mountPoint, err, []byte{}}
+	if err == nil {
+		if p.err = p.mount(); p.err == nil {
+			p.data, p.err = ioutil.ReadFile(path.Join(p.mountPoint, configFile))
+			p.unmount()
+		}
+	}
+	return &p
 }
 
 func (p *ProviderCDROM) String() string {
-	return "CDROM"
+	return "CDROM " + p.device
 }
 
 // Probe checks if the CD has the right file
 func (p *ProviderCDROM) Probe() bool {
-	_, err := os.Stat(path.Join(MountPoint, configFile))
-	return (!os.IsNotExist(err))
+	return len(p.data) != 0
 }
 
 // Extract gets both the CDROM specific and generic userdata
 func (p *ProviderCDROM) Extract() ([]byte, error) {
-	data, err := ioutil.ReadFile(path.Join(MountPoint, configFile))
-	if err != nil {
-		return nil, fmt.Errorf("CDROM: Error reading file: %s", err)
-	}
-	return data, nil
+	return p.data, p.err
+}
+
+// mount mounts a CDROM/DVD device under mountPoint
+func (p *ProviderCDROM) mount() error {
+	// We may need to poll a little for device ready
+	return syscall.Mount(p.device, p.mountPoint, "iso9660", syscall.MS_RDONLY, "")
+}
+
+// unmount removes the mount
+func (p *ProviderCDROM) unmount() {
+	_ = syscall.Unmount(p.mountPoint, 0)
 }

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
+    image: linuxkit/metadata:c3871ac5838e052ddb33248ceb95f86e4569aec4
 services:
   - name: rngd
     image: linuxkit/rngd:6565ae49f6be29d4e64614a4df3978b972956ebf

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
+    image: linuxkit/metadata:c3871ac5838e052ddb33248ceb95f86e4569aec4
 services:
   - name: rngd
     image: mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -17,7 +17,7 @@ onboot:
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
+    image: linuxkit/metadata:c3871ac5838e052ddb33248ceb95f86e4569aec4
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mounts

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -17,7 +17,7 @@ onboot:
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
+    image: linuxkit/metadata:c3871ac5838e052ddb33248ceb95f86e4569aec4
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mounts

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -20,7 +20,7 @@ onboot:
     image: linuxkit/mount:a738ccad4e3e009b7c5f541226e9232a6287fa5d
     command: ["/usr/bin/mountie", "/var/lib/swarmd"]
   - name: metadata
-    image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
+    image: linuxkit/metadata:c3871ac5838e052ddb33248ceb95f86e4569aec4
 services:
   - name: getty
     image: linuxkit/getty:58620cff1b0bf8b5d144d087602115e996f18a02


### PR DESCRIPTION
This checks if any CDROM in the system has metadata. Useful if
you boot off CDROM and also have a metadata CDROM.

Also switch the metadata container to read only, as it is only
writing to bind mounted in directories, and /tmp.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![dog-with-disc](https://user-images.githubusercontent.com/482364/28923621-90427550-7856-11e7-8c4f-23802d01fa57.jpg)
