### PR TITLE
Remove binfmt from most examples

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -11,8 +11,6 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs
     image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
-  - name: binfmt
-    image: linuxkit/binfmt:257b5174a8e33bc62d5448cc026d72cae3713628
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -9,8 +9,6 @@ init:
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
-  - name: binfmt
-    image: linuxkit/binfmt:257b5174a8e33bc62d5448cc026d72cae3713628
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -14,8 +14,6 @@ onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
-  - name: binfmt
-    image: linuxkit/binfmt:257b5174a8e33bc62d5448cc026d72cae3713628
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -14,8 +14,6 @@ onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
-  - name: binfmt
-    image: linuxkit/binfmt:257b5174a8e33bc62d5448cc026d72cae3713628
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -10,8 +10,6 @@ init:
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
-  - name: binfmt
-    image: linuxkit/binfmt:257b5174a8e33bc62d5448cc026d72cae3713628
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -30,13 +28,6 @@ files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/ca-certificates
-    - linuxkit/sysctl
-    - linuxkit/binfmt
-    - linuxkit/dhcpcd
-    - linuxkit/rngd
+  org:
+    - linuxkit
+    - library

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -11,8 +11,6 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs
     image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
-  - name: binfmt
-    image: linuxkit/binfmt:257b5174a8e33bc62d5448cc026d72cae3713628
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -11,8 +11,6 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs
     image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
-  - name: binfmt
-    image: linuxkit/binfmt:257b5174a8e33bc62d5448cc026d72cae3713628
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -10,8 +10,6 @@ init:
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
-  - name: binfmt
-    image: linuxkit/binfmt:257b5174a8e33bc62d5448cc026d72cae3713628
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -30,13 +28,6 @@ files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'
 trust:
-  image:
-    - linuxkit/kernel
-    - linuxkit/init
-    - linuxkit/runc
-    - linuxkit/containerd
-    - linuxkit/ca-certificates
-    - linuxkit/sysctl
-    - linuxkit/binfmt
-    - linuxkit/dhcpcd
-    - linuxkit/rngd
+  org:
+    - linuxkit
+    - library

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -9,8 +9,6 @@ init:
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
-  - name: binfmt
-    image: linuxkit/binfmt:257b5174a8e33bc62d5448cc026d72cae3713628
   - name: dhcpcd
     image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -52,5 +50,4 @@ files:
 trust:
   org:
     - linuxkit
-  image:
-    - nginx:alpine
+    - library

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -11,8 +11,6 @@ onboot:
     image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
   - name: sysfs
     image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
-  - name: binfmt
-    image: linuxkit/binfmt:257b5174a8e33bc62d5448cc026d72cae3713628
   - name: format
     image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
   - name: mount


### PR DESCRIPTION
It is not in any wa=y a required container, and now that arm64
and other architecture machines are widely available we should
start to deprecate it, as it has many issues, eg requires patches
to qemu for Go support, will mislabel images etc.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![pixel-cat](https://user-images.githubusercontent.com/482364/28925745-ae6e4994-785d-11e7-97e1-1b55c807c7c1.gif)
