### PR TITLE
Fix AWS push

### DIFF
--- a/src/cmd/linuxkit/push_aws.go
+++ b/src/cmd/linuxkit/push_aws.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,9 +68,9 @@ func pushAWS(args []string) {
 		name = filepath.Base(name)
 	}
 
-	content, err := ioutil.ReadAll(f)
+	fi, err := f.Stat()
 	if err != nil {
-		log.Fatalf("Error reading file: %v", err)
+		log.Fatalf("Error reading file information: %v", err)
 	}
 
 	dst := name + filepath.Ext(path)
@@ -79,7 +78,7 @@ func pushAWS(args []string) {
 		Bucket:        aws.String(bucket),
 		Key:           aws.String(dst),
 		Body:          f,
-		ContentLength: aws.Int64(int64(len(content))),
+		ContentLength: aws.Int64(fi.Size()),
 		ContentType:   aws.String("application/octet-stream"),
 	}
 	log.Debugf("PutObject:\n%v", putParams)


### PR DESCRIPTION
**- What I did**
The AWS push cannot work on machines with little amount of RAM (i.e. 4GB) if you want to push a 1GB image. We (me and @pyaillet) replaced the loading of image with only using file information. 

**- How I did it**
Replaced ioutil.readAll with file Stat

**- How to verify it**
Push a 1GB image in a machine with 4GB of RAM or less.

**- Description for the changelog**
Reduce amount of RAM used by AWS push

**- And of course, a picture of a cute animal**
![20170610_204838-effects](https://user-images.githubusercontent.com/1011902/28961148-963dadc0-7901-11e7-82b3-2dfa1486947a.jpg)


