### PR TITLE
cmd/qemu: Better handling of arch and console for aarch64

### DIFF
--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.40
-  cmdline: "console=tty0 console=ttyS0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
   - linuxkit/runc:90e45f13e1d0a0983f36ef854621e3eac91cf541

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.40
-  cmdline: "console=tty0 console=ttyS0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
   - linuxkit/runc:90e45f13e1d0a0983f36ef854621e3eac91cf541

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.40
-  cmdline: "console=tty0 console=ttyS0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
   - linuxkit/runc:90e45f13e1d0a0983f36ef854621e3eac91cf541

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -2,7 +2,7 @@
 # connect: nc localhost 6379
 kernel:
   image: linuxkit/kernel:4.9.40
-  cmdline: "console=tty0 console=ttyS0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
   - linuxkit/runc:90e45f13e1d0a0983f36ef854621e3eac91cf541

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.40
-  cmdline: "console=tty0 console=ttyS0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
   - linuxkit/runc:90e45f13e1d0a0983f36ef854621e3eac91cf541

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.40
-  cmdline: "console=tty0 console=ttyS0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
   - linuxkit/runc:90e45f13e1d0a0983f36ef854621e3eac91cf541

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.40
-  cmdline: "console=tty0 console=ttyS0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
   - linuxkit/runc:90e45f13e1d0a0983f36ef854621e3eac91cf541


### PR DESCRIPTION
- When executing on aarch64, use it as the defaul arch
- When selecting aarch64 on a non aarch64 system set the
  CPU flag to a default value (not 'host').
- On aarch64, rewrite ttyS0 to ttyAMA0. This is a bit skanky
  but allows us to re-use execiting YAML files.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

Can now boot a arm64 kernel on my mac with:
```
linuxkit run qemu -arch aarch64 linuxkit
```

![turtle-beach](https://user-images.githubusercontent.com/3338098/28970262-cfc157b8-791f-11e7-93ce-f633131e375a.jpg)
