### PR TITLE
Update to tip of manifest-tool and opengcs/LCOW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ tmp_rtf_bin.tar: Makefile
 	docker run --rm --log-driver=none -e http_proxy=$(http_proxy) -e https_proxy=$(https_proxy) $(CROSS) $(GO_COMPILE) --clone-path github.com/linuxkit/rtf --clone https://github.com/linuxkit/rtf.git --commit $(RTF_COMMIT) --package github.com/linuxkit/rtf --ldflags "-X $(RTF_CMD).GitCommit=$(RTF_COMMIT) -X $(RTF_CMD).Version=$(RTF_VERSION)" -o bin/rtf > $@
 
 # Manifest tool for multi-arch images
-MT_COMMIT=186e7752e8032756bb263b830451f44e5176864f
-MT_REPO=https://github.com/rn/manifest-tool
+MT_COMMIT=bfbd11963b8e0eb5f6e400afaebeaf39820b4e90
+MT_REPO=https://github.com/estesp/manifest-tool
 bin/manifest-tool: tmp_mt_bin.tar | bin
 	tar xf $<
 	rm $<

--- a/blueprints/lcow.yml
+++ b/blueprints/lcow.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
   tar: none
 init:
-  - linuxkit/init-lcow:73860235d61b9c039728931555c03cb6f575b5e0
+  - linuxkit/init-lcow:5ee2626d038fef97c6b52f1ea7f436cc3da125b8
   - linuxkit/runc:90e45f13e1d0a0983f36ef854621e3eac91cf541
 trust:
   org:

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -20,8 +20,10 @@ Before you can build packages you need:
 - Docker version 17.06 or newer. If you are on a Mac you also need
   `docker-credential-osxkeychain.bin`, which comes with Docker for Mac.
 - `make`, `notary`, `base64`, `jq`, and `expect`
-- A custom copy of `manifest-tool` which you can build with `make
-  bin/manifest-tool`. `manifest-tool` must be in your path.
+- A *recent* version of `manifest-tool` which you can build with `make
+  bin/manifest-tool`, or `go get github.com:estesp/manifest-tool`, or
+  via the LinuxKit homebrew tap with `brew install --HEAD
+  manifest-tool`. `manifest-tool` must be in your path.
 
 Further, when building packages you need to be logged into hub with
 `docker login` as some of the tooling extracts your hub credentials

--- a/pkg/init-lcow/Dockerfile
+++ b/pkg/init-lcow/Dockerfile
@@ -9,7 +9,7 @@ RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
 FROM linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630 AS build
 ENV OPENGCS_REPO=https://github.com/Microsoft/opengcs
-ENV OPENGCS_COMMIT=e248b10d8dae94ffaa59fae15245b4e7b6c56fbb
+ENV OPENGCS_COMMIT=285d650c8f3aa754af537871cddc273b6c5c6d58
 RUN apk add --no-cache build-base curl git go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin
 RUN git clone $OPENGCS_REPO /go/src/github.com/Microsoft/opengcs && \
@@ -21,9 +21,7 @@ RUN mkdir /out && \
     cp -r /go/src/github.com/Microsoft/opengcs/service/bin /out/bin && \
     mkdir /out/sbin && \
     curl -fSL "https://raw.githubusercontent.com/mirror/busybox/38d966943f5288bb1f2e7219f50a92753c730b14/examples/udhcp/simple.script" -o /out/sbin/udhcpc_config.script && \
-    chmod ugo+rx /out/sbin/udhcpc_config.script && \
-    mkdir -p /out/root/integration && \
-    cp /go/src/github.com/Microsoft/opengcs/kernelconfig/4.11/prebuildSandbox.vhdx /out/root/integration/prebuildSandbox.vhdx
+    chmod ugo+rx /out/sbin/udhcpc_config.script
 
 FROM scratch
 ENTRYPOINT []


### PR DESCRIPTION
- PR to manifest-tool to get the length for notary has been merged. Use official version now and update docs that `go get` now also works
- Update `opengcs` to latest and then update the LCOW blueprint
![dog-rabbit](https://user-images.githubusercontent.com/3338098/28978792-5613afb8-793f-11e7-928b-1fb12140a0c1.jpg)
