### PR TITLE
Test dev existence getty

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -53,7 +53,7 @@ services:
     image: linuxkit/acpid:79e5c20de96e1633c9c40935b99dde45aefba37b
   # Enable getty for easier debugging
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
         - INSECURE=true
   # Run ntpd to keep time synchronised in the VM

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -18,7 +18,7 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/metadata:cec86f3e1c260c9eafefa80c262fceb40c182ddf
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:7c986fb7df33bea73b5c8097b46989e46f49d875
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -13,7 +13,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: redis

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/rngd", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -24,7 +24,7 @@ onboot:
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: tss

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:154913b72c6f1f33eb408609fca9963628e8c051
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/metadata:cec86f3e1c260c9eafefa80c262fceb40c182ddf
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: rngd

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -18,7 +18,7 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: rngd

--- a/pkg/getty/usr/bin/rungetty.sh
+++ b/pkg/getty/usr/bin/rungetty.sh
@@ -15,6 +15,12 @@ start_getty() {
 	term="linux"
 	[ "$speed" = "$1" ] && speed=115200
 
+	# does the device even exist?
+	if [ ! -c /dev/$tty ]; then
+		echo "getty: cmdline has console=$tty but /dev/$tty is not a character device; not starting getty for $tty" | tee /dev/console
+		return
+	fi
+
 	case "$tty" in
 	ttyS*|ttyAMA*|ttyUSB*|ttyMFD*)
 		line="-L"
@@ -35,7 +41,7 @@ start_getty() {
 
 	if ! grep -q -w "$tty" "$securetty"; then
 		# we could not find the tty in securetty, so start a getty but warn that root login will not work
-		echo "getty: cmdline has console=$tty but does not exist in $securetty; will not be able to log in as root on this tty $tty." > /dev/$tty
+		echo "getty: cmdline has console=$tty but does not exist in $securetty; will not be able to log in as root on this tty $tty." | tee /dev/$tty
 	fi
 	# respawn forever
 	infinite_loop setsid.getty -w /sbin/agetty $loginargs $line $speed $tty $term &

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -28,7 +28,7 @@ onboot:
       - /var/lib:/var/lib
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -28,7 +28,7 @@ onboot:
       - /var/lib:/var/lib
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
 trust:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/sysctl:154913b72c6f1f33eb408609fca9963628e8c051
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -30,7 +30,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:505a985d7bd7a90f15eca9cb4dc6ec92789d51a0
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
 files:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -23,7 +23,7 @@ onboot:
     image: linuxkit/metadata:cec86f3e1c260c9eafefa80c262fceb40c182ddf
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
   - name: qemu-ga

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -12,7 +12,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:2c841cdc34396e3fa8f25b62d112808f63f16df6
+    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
test that a given tty is a character device before trying to open getty on it.

Closes #2362 

**- How I did it**
```sh
	if [ ! -c /dev/$tty ]; then
		echo "getty: cmdline has console=$tty but /dev/$tty is not a character device; not starting getty for $tty" | tee /dev/console
		return
	fi
```

**- How to verify it**
Run it with a mixture of `console=` options that are and are not character devices and see that:

1. It starts for all char devices
2. It does _not_ start for missing or non-char devices
3. It puts an error message on console and in the log file that it is not starting it for that tty

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Only start getty for valid char-device ttys

**- A picture of a cute animal (not mandatory but encouraged)**
![hammerhead](http://r.ddmcdn.com/w_624/s_f/o_1/cx_0/cy_17/cw_624/ch_416/DSC/uploads/2014/05/hammerhead-sharks-pictures5.jpg)
