### PR TITLE
Add script to clean up older images

### DIFF
--- a/scripts/cleanup-older-images.sh
+++ b/scripts/cleanup-older-images.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+set -e
+
+##
+#
+# script to remove all older linuxkit images
+# see usage() for usage and functionality
+#
+
+usage() {
+    cat >&2 <<EOF
+$0 [-n] <base> <versions>
+
+Prune any images that start with <base> except the <versions> most recent versions.
+[-n] = dry-run, but report what it would remove and leave.
+
+Examples:
+  $0 linuxkit 2
+        will remove all versions of any image starting with linuxkit except for the 2 most recent of each
+        would match "linuxkit/foo" and ALSO "linuxkitprojects/foo"
+
+  $0 linuxkit/ 2
+        will remove all versions of any image starting with linuxkit/ except for the 2 most recent of each
+        would match "linuxkit/foo" but NOT "linuxkitprojects/foo"
+
+  $0 linuxkit/sshd 3
+        will remove all versions of linuxkit/sshd except for the 3 most recent
+
+EOF
+}
+
+
+# backwards compatibility
+dryrun=false
+if [ "$1" = "-n" ]; then
+  dryrun=true
+  set -- "$2" "$3"
+fi
+
+# sufficient arguments
+if [ $# -ne 2 ] ; then
+    usage
+    exit 1
+fi
+
+imagebase="$1"
+versions="$2"
+unversions=$(( $versions + 1))
+
+# make sure the imagebase is good
+case "$imagebase" in
+  # has a slash in it
+  */*)
+    testimage="$imagebase*"
+    ;;
+    # no slash in it
+  *)
+    testimage="$imagebase*/*"
+    ;;
+esac
+
+# find all of our images
+IMAGELIST=$(docker image ls --filter=reference="$testimage"':*' --format '{{.Repository}} {{.Tag}} {{.CreatedAt}}')
+
+# find unique names for all images
+uniqueimages=$(echo "$IMAGELIST" | awk '{print $1}' | sort | uniq)
+
+# now go through each image, find the list
+for img in $uniqueimages; do
+  # get the unique list of each, and sort by date
+  sortedlist=$(echo "$IMAGELIST" | grep -w $img | sort -k 3,3 -r)
+  # now split
+  tokeep=$(echo "$sortedlist" | head -$versions | awk '{printf "%s:%s\t",$1,$2; $1=$2=""; print $0}')
+  todelete=$(echo "$sortedlist" | tail -n +$unversions | awk '{print $1":"$2}')
+  todeletedates=$(echo "$sortedlist" | tail -n +$unversions | awk '{printf "%s:%s\t",$1,$2; $1=$2=""; print $0}')
+
+  echo "$tokeep" | while read i; do
+    echo "KEEP\t$i"
+  done
+  if [ -n "$todeletedates" ]; then
+    echo "$todeletedates" | while read i; do
+      echo "DELETE\t$i"
+    done
+    if ! "$dryrun"; then
+      docker image rm $todelete
+    fi
+  fi
+done


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a script to `./scripts/` that will clean up all images that start with a particular name (namespace, part of namespace, namespace+repo, namespace+part of repo all valid) and how many recent versions to keep.

Per discussion on slack channel with @rn might be useful here.

E.g.

```
./scripts/cleanup-older-images.sh linuxkit/ 3
```

Will remove all images starting with `linuxkit/` except for the 3 most recent of each full repo name.

It sort of is `system prune -a` except that it adds:

* ability to limit to a particular set of images by namespace, namespace+repo, or part
* ability to keep a certain number of most recent

**- How I did it**
shell script wrapping docker, awk, etc. And, yes, no bash :-) .


**- How to verify it**
Run it and see. Includes an option `-n` where it will tell you what it will do but not delete any.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Tool to prune images more selectively.

**- A picture of a cute animal (not mandatory but encouraged)**
![wombat](http://www.factzoo.com/sites/all/img/montage/large-light-wombat.jpg)
