### PR TITLE
Do an extra chmod after chown

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:fa4ab4ac78b83fe392e39b861b4114c3bb02d170 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
 onboot:

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
 services:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
 onboot:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
 onboot:

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
 onboot:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/okernel:latest
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
 services:

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.79
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test-ns

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/cases/040_packages/008_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/008_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/008_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/008_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/008_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/008_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/008_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: format

--- a/test/cases/040_packages/008_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/008_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: format

--- a/test/cases/040_packages/009_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/009_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: format

--- a/test/cases/040_packages/009_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/009_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: extend

--- a/test/cases/040_packages/009_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/009_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/009_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/009_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/009_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/009_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: format

--- a/test/cases/040_packages/009_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/009_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: extend

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
 onboot:
   - name: sysctl

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.40
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:906e174b3f2e07f97d6fd693a2e8518e98dafa58
+  - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
   - linuxkit/runc:2d645aca4eee8d0d1f121177f1b696244219d250
   - linuxkit/containerd:f69bc5b8ec0392e2d34d3fd3bfdb7266ef6d4ed4
 onboot:


### PR DESCRIPTION
Chown clears suid bits even for root on Linux.

Also move a few functions to x/sys/unix from syscall, to be
more arm64 friendly.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

Fixes issue with suid binaries losing their suid flags.

![sudo make me a sandwich](https://user-images.githubusercontent.com/482364/29028750-2b097e3e-7b7d-11e7-9245-fa76a105d327.jpg)
