### PR TITLE
Use ISO for kubernetes

### DIFF
--- a/projects/kubernetes/Makefile
+++ b/projects/kubernetes/Makefile
@@ -13,10 +13,10 @@ push-container-images:
 build-vm-images: kube-master-initrd.img kube-node-initrd.img
 
 kube-master-initrd.img: kube-master.yml
-	../../bin/moby build -name kube-master kube-master.yml
+	moby build -name kube-master kube-master.yml
 
 kube-node-initrd.img: kube-node.yml
-	../../bin/moby build -name kube-node kube-node.yml
+	moby build -name kube-node kube-node.yml
 
 clean:
 	rm -f -r \

--- a/projects/kubernetes/Makefile
+++ b/projects/kubernetes/Makefile
@@ -10,15 +10,15 @@ push-container-images:
 	$(MAKE) -C kubernetes push
 	$(MAKE) -C image-cache push
 
-build-vm-images: kube-master-initrd.img kube-node-initrd.img
+build-vm-images: kube-master.iso kube-node.iso
 
-kube-master-initrd.img: kube-master.yml
-	moby build -name kube-master kube-master.yml
+kube-master.iso: kube-master.yml
+	moby build -name kube-master -output iso-efi -output iso-bios kube-master.yml
 
-kube-node-initrd.img: kube-node.yml
-	moby build -name kube-node kube-node.yml
+kube-node.iso: kube-node.yml
+	moby build -name kube-node -output iso-efi -output iso-bios kube-node.yml
 
 clean:
 	rm -f -r \
-	  kube-*-kernel kube-*-cmdline kube-*-state kube-*-initrd.img
+	  kube-*-kernel kube-*-cmdline kube-*-state kube-*-initrd.img *.iso
 	$(MAKE) -C image-cache clean

--- a/projects/kubernetes/boot.sh
+++ b/projects/kubernetes/boot.sh
@@ -1,10 +1,20 @@
-#!/bin/bash -eu
+#!/bin/sh
+
+set -e
+
 : ${KUBE_PORT_BASE:=2222}
 : ${KUBE_VCPUS:=2}
-: ${KUBE_MEM:=4096}
+: ${KUBE_MEM:=1024}
 : ${KUBE_DISK:=4G}
 : ${KUBE_NETWORKING:=default}
 : ${KUBE_RUN_ARGS:=}
+: ${KUBE_EFI:=}
+
+[ "$(uname -s)" = "Darwin" ] && KUBE_EFI=1
+
+suffix=".iso"
+[ -n "${KUBE_EFI}" ] && suffix="-efi.iso" && uefi="--uefi"
+
 if [ $# -eq 0 ] ; then
     img="kube-master"
     data=""
@@ -36,4 +46,4 @@ else
 fi
 set -x
 rm -rf "${state}"
-linuxkit run ${KUBE_RUN_ARGS} -networking ${KUBE_NETWORKING} -cpus ${KUBE_VCPUS} -mem ${KUBE_MEM} -state "${state}" -disk size=${KUBE_DISK} -data "${data}" "${img}"
+linuxkit run ${KUBE_RUN_ARGS} -networking ${KUBE_NETWORKING} -cpus ${KUBE_VCPUS} -mem ${KUBE_MEM} -state "${state}" -disk size=${KUBE_DISK} -data "${data}" ${uefi} "${img}${suffix}"

--- a/projects/kubernetes/boot.sh
+++ b/projects/kubernetes/boot.sh
@@ -36,4 +36,4 @@ else
 fi
 set -x
 rm -rf "${state}"
-../../bin/linuxkit run ${KUBE_RUN_ARGS} -networking ${KUBE_NETWORKING} -cpus ${KUBE_VCPUS} -mem ${KUBE_MEM} -state "${state}" -disk size=${KUBE_DISK} -data "${data}" "${img}"
+linuxkit run ${KUBE_RUN_ARGS} -networking ${KUBE_NETWORKING} -cpus ${KUBE_VCPUS} -mem ${KUBE_MEM} -state "${state}" -disk size=${KUBE_DISK} -data "${data}" "${img}"


### PR DESCRIPTION
Because Kubernetes is 1.5GB, ISO makes sense as the files do not take up memory, so you can boot a 1GB machine rather than a 4GB one.

Also cherry pick a patch of Ian's, and de-bashify the script.

![img_20170809_003915](https://user-images.githubusercontent.com/482364/29121266-c628d688-7d05-11e7-8af9-ceccd0e4ff68.jpg)
