### PR TITLE
aws: Honour the zone variable when creating an instance

### DIFF
--- a/src/cmd/linuxkit/run_aws.go
+++ b/src/cmd/linuxkit/run_aws.go
@@ -88,6 +88,9 @@ func runAWS(args []string) {
 		InstanceType: aws.String(machine),
 		MinCount:     aws.Int64(1),
 		MaxCount:     aws.Int64(1),
+		Placement: &ec2.Placement{
+			AvailabilityZone: aws.String(zone),
+		},
 	}
 	runResult, err := compute.RunInstances(params)
 	if err != nil {


### PR DESCRIPTION
Instances were being created in a different AZ to the one specified in
the zone variable. This could lead to situations where the disks and the
instance were in different AZs and would result in an error.

This commit adds placement information to the API call used to create
the instance.

Fixes: #2388

![](http://www.pe.com/wp-content/uploads/migration/nry/nryf5b-b88466366z.120150723115133000g74b0911.10.jpg?w=535)

Signed-off-by: Dave Tucker <dt@docker.com>