### PR TITLE
aws: Fix panic when there is no console output

### DIFF
--- a/src/cmd/linuxkit/run_aws.go
+++ b/src/cmd/linuxkit/run_aws.go
@@ -167,12 +167,15 @@ func runAWS(args []string) {
 		log.Fatalf("Error getting output from instance %s: %s", *instanceID, err)
 	}
 
-	out, err := base64.StdEncoding.DecodeString(*output.Output)
-	if err != nil {
-		log.Fatalf("Error decoding output: %s", err)
+	if output.Output == nil {
+		log.Warn("No Console Output found")
+	} else {
+		out, err := base64.StdEncoding.DecodeString(*output.Output)
+		if err != nil {
+			log.Fatalf("Error decoding output: %s", err)
+		}
+		fmt.Printf(string(out) + "\n")
 	}
-	fmt.Printf(string(out) + "\n")
-
 	log.Infof("Terminating instance %s", *instanceID)
 	terminateParams := &ec2.TerminateInstancesInput{
 		InstanceIds: []*string{instanceID},


### PR DESCRIPTION
When an AWS machine is stopped and there is no console output the CLI
panics due to a nil pointer dereference. This commit checks that the
console output is not null before attempting to decode it.

Fixes: #2389

![](http://viralstories.in/wp-content/uploads/2014/11/car-1.gif)

Signed-off-by: Dave Tucker <dt@docker.com>