### PR TITLE
wireguard: version bump

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -38,8 +38,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20170726
-ENV WIREGUARD_SHA256=db91452b6b5ec28049721a520fe4fd0683825bad45b7383d12d7b819668201db
+ENV WIREGUARD_VERSION=0.0.20170810
+ENV WIREGUARD_SHA256=ab96230390625aad6f4816fa23aef6e9f7fee130f083d838919129ff12089bf7
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # PGP keys: 589DA6B1 (greg@kroah.com) & 6092693E (autosigner@kernel.org) & 00411886 (torvalds@linux-foundation.org)


### PR DESCRIPTION
This is a simple version bump. However, you should wait until https://github.com/alpinelinux/aports/pull/2123 is merged before merging this, because the bump needs the latest wireguard-tools package.

Changelog:
  
  * android: fix readme
  * contrib: move Android tools to wireguard-android repo
  
  All the Android tools have been moved to an Android-specific repo,
  which, in addition to having all the wg-quick CLI things, will also
  have a nice UI that Samuel, one of our GSoC students, has been
  working on. Stay tuned, exciting things coming.
  
  * socket: move print function from compat
  * compat: work around odd kernels that backport kv[mz]alloc
  * compat: get rid of warnings on frankenkernels
  * compat: support grsecurity with our compat padata implementation
  * netns: work around linux 3.10 issues
  
  The usual set of compat fixups for weird kernels. With regards to
  Grsecurity, we make a change that _should_ make this part of the
  compat layer work with Grsecurity, but unfortunately I really have
  no way of knowing, since I don't actually have access to their
  source code. I assume, though, if this doesn't work, I'll receive
  more complaints and will take another stab in the dark. The general
  situation saddens me, as I really liked that project and wish I
  could still play with it.
  
  * recieve: cleanup variable usage
  * receive: single line if style
  * recieve: pskb_trim already checks length
  * receive: move lastminute guard into timer event
  * selftest: more checking in ratelimiter
  * blake2s: satisfy sparse
  * routingtable: unbloat BUG()
  * timers: rename confusingly named functions and variables
  * noise: infer initiator or not from handshake state
  
  Usual set of code quality cleanups.
  
  * tools: stricter userspace ipc parsing
  * netns: explictly test reply to sender routing
  * timers: do not send out double keepalive
  
  Some logic fixes and a more expansive test suite.
  
  * hashtables: allow up to 2^20 peers per interface
  * hashtables: if we have an index match, don't search further ever
  
  This allows for nearly 1 million peers per interface, which should be
  more than enough. If needed later, this number could easily be increased
  beyond this. We also increase the size of the hashtables to accommodate
  this upper bound. In the future, it might be smart to dynamically expand
  the hashtable instead of this hard coded compromise value between small
  systems and large systems. Ongoing work includes figuring out the most
  optimal scheme for these hashtables and for the insertion to mask their
  order from timing inference.