### PR TITLE
[WIP] kubernetes: use cri-containerd to use containerd as runtime

### DIFF
--- a/projects/kubernetes/cri-containerd/Dockerfile
+++ b/projects/kubernetes/cri-containerd/Dockerfile
@@ -12,8 +12,8 @@ RUN \
 ENV GOPATH=/go PATH=$PATH:/go/bin
 
 ENV CRI_CONTAINERD_URL https://github.com/kubernetes-incubator/cri-containerd.git
-#ENV CRI_CONTAINERD_BRANCH ...
-ENV CRI_CONTAINERD_COMMIT 86a0f6a59b0d61381d60473680f1b6283fbfd8f9
+ENV CRI_CONTAINERD_BRANCH pull/113/head
+ENV CRI_CONTAINERD_COMMIT 32e03134186077f0dc4ef48767542a7165d181b0
 RUN mkdir -p $GOPATH/src/github.com/kubernetes-incubator && \
     cd $GOPATH/src/github.com/kubernetes-incubator && \
     git clone $CRI_CONTAINERD_URL cri-containerd

--- a/projects/kubernetes/cri-containerd/Dockerfile
+++ b/projects/kubernetes/cri-containerd/Dockerfile
@@ -1,0 +1,44 @@
+FROM linuxkit/alpine:4a9e5f80a774bbea494d49324428a22c6f018865 AS build
+
+RUN \
+  apk add \
+  bash \
+  gcc \
+  git \
+  go \
+  libc-dev \
+  make \
+  && true
+ENV GOPATH=/go PATH=$PATH:/go/bin
+
+ENV CRI_CONTAINERD_URL https://github.com/kubernetes-incubator/cri-containerd.git
+#ENV CRI_CONTAINERD_BRANCH ...
+ENV CRI_CONTAINERD_COMMIT 86a0f6a59b0d61381d60473680f1b6283fbfd8f9
+RUN mkdir -p $GOPATH/src/github.com/kubernetes-incubator && \
+    cd $GOPATH/src/github.com/kubernetes-incubator && \
+    git clone $CRI_CONTAINERD_URL cri-containerd
+WORKDIR $GOPATH/src/github.com/kubernetes-incubator/cri-containerd
+RUN set -e; \
+    if [ -n "$CRI_CONTAINERD_BRANCH" ] ; then \
+        git fetch origin "$CRI_CONTAINERD_BRANCH"; \
+    fi; \
+    git checkout $CRI_CONTAINERD_COMMIT
+RUN make static-binaries
+
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    busybox \
+    ca-certificates \
+    && true
+# Remove apk residuals. We have a read-only rootfs, so apk is of no use.
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+RUN make DESTDIR=/out install
+
+FROM scratch
+WORKDIR /
+
+ENTRYPOINT ["cri-containerd", "-v", "2", "--alsologtostderr"]
+COPY --from=build /out /
+LABEL org.mobyproject.config='{"binds": ["/etc/resolv.conf:/etc/resolv.conf", "/run:/run", "/tmp:/tmp", "/var:/var:rshared,rbind", "/var/lib/kubeadm:/etc/kubernetes", "/etc/cni:/etc/cni:rshared,rbind", "/opt/cni:/opt/cni:rshared,rbind", "/run/containerd/containerd.sock:/run/containerd/containerd.sock"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}], "capabilities": ["all"], "rootfsPropagation": "shared", "pid": "host"}'

--- a/projects/kubernetes/cri-containerd/Makefile
+++ b/projects/kubernetes/cri-containerd/Makefile
@@ -1,0 +1,6 @@
+ORG?=linuxkitprojects
+IMAGE=cri-containerd
+NETWORK=1
+NOTRUST=1
+
+include ../../../pkg/package.mk

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -23,7 +23,7 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/"]
   - name: var
     image: library/alpine:3.6
-    command: ["mkdir", "/var/lib/kubeadm"]
+    command: ["mkdir", "/var/lib/kubeadm", "/var/lib/etcd"]
     binds:
       - /var/lib:/var/lib
 services:
@@ -37,32 +37,17 @@ services:
     image: linuxkit/openntpd:0d7befc79842849d0b88d6c3b64200e340d7cf67
   - name: sshd
     image: linuxkit/sshd:505a985d7bd7a90f15eca9cb4dc6ec92789d51a0
-  - name: docker
-    image: docker:17.06.0-ce-dind
-    capabilities:
-     - all
-    pid: host
-    mounts:
-     - type: cgroup
-       options: ["rw","nosuid","noexec","nodev","relatime"]
-    binds:
-     - /dev:/dev
-     - /etc/resolv.conf:/etc/resolv.conf
-     - /lib/modules:/lib/modules
-     - /run:/run
-     - /var:/var:rshared,rbind
-     - /var/lib/kubeadm:/etc/kubernetes
-     - /etc/cni:/etc/cni:rshared,rbind
-     - /opt/cni:/opt/cni:rshared,rbind
-    rootfsPropagation: shared
-    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
-  - name: kubernetes-image-cache-common
-    image: linuxkitprojects/kubernetes-image-cache-common:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
-  - name: kubernetes-image-cache-control-plane
-    image: linuxkitprojects/kubernetes-image-cache-control-plane:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
+  - name: cri-containerd
+    image: linuxkitprojects/cri-containerd:79948ac40f7d5573b95eeb0045257eae8b94d6d8
+  #- name: kubernetes-image-cache-common
+  #  image: linuxkitprojects/kubernetes-image-cache-common:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
+  #- name: kubernetes-image-cache-control-plane
+  #  image: linuxkitprojects/kubernetes-image-cache-control-plane:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
   - name: kubelet
-    image: linuxkitprojects/kubernetes:bbf14d70199babeea1f71f5b0bd70c1c1c9b5cd2
+    image: linuxkitprojects/kubernetes:edd56f0d58abced32da781e58c9e4c1c3a6b6009
 files:
+  - path: /etc/kubernetes
+    symlink: "/var/lib/kubeadm"
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub
     mode: "0600"

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -23,7 +23,7 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/"]
   - name: var
     image: library/alpine:3.6
-    command: ["mkdir", "/var/lib/kubeadm"]
+    command: ["mkdir", "/var/lib/kubeadm", "/var/lib/etcd"]
     binds:
       - /var/lib:/var/lib
 services:
@@ -37,30 +37,15 @@ services:
     image: linuxkit/openntpd:0d7befc79842849d0b88d6c3b64200e340d7cf67
   - name: sshd
     image: linuxkit/sshd:505a985d7bd7a90f15eca9cb4dc6ec92789d51a0
-  - name: docker
-    image: docker:17.06.0-ce-dind
-    capabilities:
-     - all
-    pid: host
-    mounts:
-     - type: cgroup
-       options: ["rw","nosuid","noexec","nodev","relatime"]
-    binds:
-     - /dev:/dev
-     - /etc/resolv.conf:/etc/resolv.conf
-     - /lib/modules:/lib/modules
-     - /run:/run
-     - /var:/var:rshared,rbind
-     - /var/lib/kubeadm:/etc/kubernetes
-     - /etc/cni:/etc/cni:rshared,rbind
-     - /opt/cni:/opt/cni:rshared,rbind
-    rootfsPropagation: shared
-    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
-  - name: kubernetes-image-cache-common
-    image: linuxkitprojects/kubernetes-image-cache-common:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
+  - name: cri-containerd
+    image: linuxkitprojects/cri-containerd:79948ac40f7d5573b95eeb0045257eae8b94d6d8
+  #- name: kubernetes-image-cache-common
+  #  image: linuxkitprojects/kubernetes-image-cache-common:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
   - name: kubelet
-    image: linuxkitprojects/kubernetes:bbf14d70199babeea1f71f5b0bd70c1c1c9b5cd2
+    image: linuxkitprojects/kubernetes:edd56f0d58abced32da781e58c9e4c1c3a6b6009
 files:
+  - path: /etc/kubernetes
+    symlink: "/var/lib/kubeadm"
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub
     mode: "0600"

--- a/projects/kubernetes/kubernetes/kubelet.sh
+++ b/projects/kubernetes/kubernetes/kubelet.sh
@@ -2,6 +2,8 @@
 mount --bind /opt/cni /rootfs/opt/cni
 mount --bind /etc/cni /rootfs/etc/cni
 until kubelet --kubeconfig=/var/lib/kubeadm/kubelet.conf \
+	      --container-runtime=remote \
+	      --container-runtime-endpoint=unix:///var/run/cri-containerd.sock \
 	      --require-kubeconfig=true \
 	      --pod-manifest-path=/var/lib/kubeadm/manifests \
 	      --allow-privileged=true \


### PR DESCRIPTION
**- What I did**

Switched `project/kubernetes` to using [cri-containerd](https://github.com/kubernetes-incubator/cri-containerd/) as the runtime. This cri implementation drivers containerd v1.0.0 directly.

**- How I did it**

Mainly it is just a case of packaging cri-containerd, configuring kubelet and making a adjustments to the images.

This PR is a WIP for a variety of reasons:
* It is based on cri-containerd targeting v1.0.0-alpha3, current cri-containerd targets a version between alpha2 and alpha3. I have a local [update to alpha3](https://github.com/Ijc/cri-containerd/tree/containerd-v1.0.0-alpha3) which is pretty trivial but alpha3 lacks some fixes (such as https://github.com/containerd/containerd/pull/1279) from the cri-containerd maintainers. I'm not sure how critical these are in practice. The fixes are in alpha4 (if noone beats me to it I'll make a PR on cri-containerd after I've bumped linuxkit to alpha4 in a separate PR here).
* The system isn't quite functional! Currently it seems to fail to pull the weave image. I haven't fully investigated. The system, is trying to pull `weaveworks/weave-kube:2.0.1` (which comes from the `weave.yaml`), whereas containerd requires one to ask for `docker.io/weaveworks/weave-kube:2.0.1` I've not yet investigated who (if anyone) is responsible for the imposition of a default registry in the new configuration.
* The image cache images are not ported and are commented out for now. Images will be downloaded at runtime instead (not the end of the world, but not ideal).
* I'm unsure if we should just make this transition or if we should continue to support both configurations (and if so how I would do that)

**- How to verify it**

You should be able to boot and run an image and run `kubeadm-init.sh` and it should bring up most pods except networking. It's not yet possible to run a workload (or rather I've not tried because networking isn't up).

**- Description for the changelog**
Kubernetes project now uses cri-containerd by default.

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://user-images.githubusercontent.com/12985729/29215542-57f73674-7ea3-11e7-9f8f-4fa4a0469e67.jpeg "Vae Solis, Throw the Horns")](https://www.metal-archives.com/albums/Vae_Solis/Throw_the_Horns/36469)

