### PR TITLE
Bump to containerd v1.0.0-alpha4 and runc v1.0.0-rc4

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -5,8 +5,8 @@ kernel:
 init:
   - linuxkit/vpnkit-expose-port:fa4ab4ac78b83fe392e39b861b4114c3bb02d170 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata

--- a/blueprints/lcow.yml
+++ b/blueprints/lcow.yml
@@ -4,7 +4,7 @@ kernel:
   tar: none
 init:
   - linuxkit/init-lcow:5506c381816e067c3c8978948352b3bf2025e909
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 trust:
   org:
     - linuxkit

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
 services:
   - name: getty
     image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -5,8 +5,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:4a9e5f80a774bbea494d49324428a22c6f018865 as alpine
+FROM linuxkit/alpine:6ed3b299f5243acb6459b4993549c5045e4ad7f4 as alpine
 RUN \
   apk add \
   btrfs-progs-dev \

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:4a9e5f80a774bbea494d49324428a22c6f018865 as alpine
+FROM linuxkit/alpine:6ed3b299f5243acb6459b4993549c5045e4ad7f4 as alpine
 RUN \
   apk add \
   bash \
@@ -11,7 +11,7 @@ RUN \
   make \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin
-ENV RUNC_COMMIT=45bde006ca8c90e089894508708bcf0e2cdf9e13
+ENV RUNC_COMMIT=v1.0.0-rc4
 RUN mkdir -p $GOPATH/src/github.com/opencontainers && \
   cd $GOPATH/src/github.com/opencontainers && \
   git clone https://github.com/opencontainers/runc.git

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:154913b72c6f1f33eb408609fca9963628e8c051

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:1e9876c682c74d0602b7647c628bb0875fb13998

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:1e9876c682c74d0602b7647c628bb0875fb13998

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:1e9876c682c74d0602b7647c628bb0875fb13998

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:1e9876c682c74d0602b7647c628bb0875fb13998

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:1e9876c682c74d0602b7647c628bb0875fb13998

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:1e9876c682c74d0602b7647c628bb0875fb13998

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:1e9876c682c74d0602b7647c628bb0875fb13998

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
 services:
   - name: acpid
     image: linuxkit/acpid:79e5c20de96e1633c9c40935b99dde45aefba37b

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:d58766bb6c0def3df9e6ffc645ee11677f127faa

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:d58766bb6c0def3df9e6ffc645ee11677f127faa

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:8e93e61e46ebcb302761eca0180e4c7f43e60bcf

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:472eeba777d056c5f98fe074aa0f581c67ccc7ff

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
     command: ["/usr/bin/mountie", "/var"]
   - name: test
-    image: linuxkit/test-containerd:cde0f791f5a9f7123b05ec16532693e17774a585
+    image: linuxkit/test-containerd:deb892aa3abe9425b2615d67b4e3a522b346e630
   - name: poweroff
     image: linuxkit/poweroff:1e9876c682c74d0602b7647c628bb0875fb13998
 trust:

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:deb892aa3abe9425b2615d67b4e3a522b346e630
+    image: linuxkit/test-containerd:1918b152cbfc10d73004797ac38beb14d6239187
   - name: poweroff
     image: linuxkit/poweroff:1e9876c682c74d0602b7647c628bb0875fb13998
 trust:

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mount
     image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
-    command: ["/usr/bin/mountie", "/var"]
+    command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
     image: linuxkit/test-containerd:deb892aa3abe9425b2615d67b4e3a522b346e630
   - name: poweroff

--- a/test/cases/040_packages/003_containerd/test.sh
+++ b/test/cases/040_packages/003_containerd/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # SUMMARY: Run containerd test
-# LABELS: skip
+# LABELS:
 # REPEAT:
 
 set -e

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: extend
     image: linuxkit/extend:468cc677e35503a265235767d5f488253f51cfd6

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: modprobe
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: modprobe
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: extend
     image: linuxkit/extend:468cc677e35503a265235767d5f488253f51cfd6

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: modprobe
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:194193fb42cc999b8abe9c5966ed05dbef2a63c1

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:1e9876c682c74d0602b7647c628bb0875fb13998

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:154913b72c6f1f33eb408609fca9963628e8c051

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:38cec1526acc8b1a2ce4b4ece78a810078c807e1

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -5,8 +5,8 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c7d651da1a5e308c757bc61ce6a41804ea843426
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
-  - linuxkit/containerd:d136569c66ce041853d762b7032456419e580efe
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
+  - linuxkit/containerd:09a21d6606a4011efebacff62a88b956ecac01be
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -35,4 +35,4 @@ WORKDIR $GOPATH/src/github.com/containerd/containerd
 ADD run.sh ./run.sh
 
 ENTRYPOINT ["/bin/sh", "run.sh"]
-LABEL org.mobyproject.config='{"net": "host", "capabilities": ["all"], "tmpfs": ["/tmp:exec"], "binds": ["/dev:/dev", "/var:/var", "/etc/resolv.conf:/etc/resolv.conf", "/usr/bin/runc:/usr/bin/runc", "/usr/bin/containerd:/usr/bin/containerd", "/usr/bin/containerd-shim:/usr/bin/containerd-shim"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}],}'
+LABEL org.mobyproject.config='{"capabilities": ["all"], "tmpfs": ["/tmp:exec"], "binds": ["/var:/var", "/etc/resolv.conf:/etc/resolv.conf", "/usr/bin/runc:/usr/bin/runc", "/usr/bin/containerd:/usr/bin/containerd", "/usr/bin/containerd-shim:/usr/bin/containerd-shim"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}],}'

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -2,6 +2,7 @@ FROM linuxkit/alpine:6ed3b299f5243acb6459b4993549c5045e4ad7f4 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)
+# xfsprogs is required for xfs test (mkfs.xfs)
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
     busybox \
@@ -15,6 +16,7 @@ RUN apk add --no-cache --initdb -p /out \
     make \
     musl \
     util-linux \
+    xfsprogs \
     tzdata
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 RUN cp /out/usr/share/zoneinfo/UTC /out/etc/localtime
@@ -35,4 +37,4 @@ WORKDIR $GOPATH/src/github.com/containerd/containerd
 ADD run.sh ./run.sh
 
 ENTRYPOINT ["/bin/sh", "run.sh"]
-LABEL org.mobyproject.config='{"capabilities": ["all"], "tmpfs": ["/tmp:exec"], "binds": ["/var:/var", "/etc/resolv.conf:/etc/resolv.conf", "/usr/bin/runc:/usr/bin/runc", "/usr/bin/containerd:/usr/bin/containerd", "/usr/bin/containerd-shim:/usr/bin/containerd-shim"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}],}'
+LABEL org.mobyproject.config='{"capabilities": ["all"], "tmpfs": ["/tmp"], "binds": ["/dev:/dev", "/var/lib:/var/lib", "/etc/resolv.conf:/etc/resolv.conf", "/usr/bin/runc:/usr/bin/runc", "/usr/bin/containerd:/usr/bin/containerd", "/usr/bin/containerd-shim:/usr/bin/containerd-shim"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}],}'

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -19,15 +19,19 @@ RUN apk add --no-cache --initdb -p /out \
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 RUN cp /out/usr/share/zoneinfo/UTC /out/etc/localtime
 
-FROM scratch
-COPY --from=mirror /out/ /
-ENV GOPATH=/go
+RUN apk add git
+ENV GOPATH=/out/go
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git
 WORKDIR $GOPATH/src/github.com/containerd/containerd
 # CONTAINERD_COMMIT is defined in linuxkit/alpine
 RUN git checkout $CONTAINERD_COMMIT
+
+FROM scratch
+COPY --from=mirror /out/ /
+ENV GOPATH=/go
+WORKDIR $GOPATH/src/github.com/containerd/containerd
 ADD run.sh ./run.sh
 
 ENTRYPOINT ["/bin/sh", "run.sh"]

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630 AS mirror
+FROM linuxkit/alpine:6ed3b299f5243acb6459b4993549c5045e4ad7f4 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/containerd/run.sh
+++ b/test/pkg/containerd/run.sh
@@ -5,6 +5,10 @@ function failed {
 	exit 1
 }
 
+# Get these into the logs.
+git describe HEAD
+git rev-parse HEAD
+
 # unset -race (does not work on alpine; see golang/go#14481)
 export TESTFLAGS=
 make root-test || failed

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
-  - linuxkit/runc:dfc0437161843bc0dfeb334cda7ffd6a18b76bcd
+  - linuxkit/runc:838259153885c0c40460379d6cdb7baebaf3fa36
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -51,6 +51,7 @@ COPY --from=mirror /Dockerfile /Dockerfile
 
 RUN apk update && apk upgrade -a
 
-# Update `FROM` in `test/pkg/containerd/Dockerfile` when changing this.
+# Update `FROM` in both `pkg/containerd/Dockerfile` and
+# `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.0.0-alpha3
+ENV CONTAINERD_COMMIT=v1.0.0-alpha4

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:304ee372743f6221c3ffe901a67763b3a7fb2aa6-arm64
+# linuxkit/alpine:38032f77c1bebafebe9eb72906de38fb12078a79-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -55,7 +55,7 @@ gettext-0.19.8.1-r1
 gettext-asprintf-0.19.8.1-r1
 gettext-dev-0.19.8.1-r1
 gettext-libs-0.19.8.1-r1
-git-2.13.0-r0
+git-2.13.5-r0
 glib-2.52.1-r0
 gmp-6.1.2-r0
 gmp-dev-6.1.2-r0
@@ -161,10 +161,10 @@ mtools-4.0.18-r1
 musl-1.1.16-r13
 musl-dev-1.1.16-r13
 musl-utils-1.1.16-r13
-ncurses-dev-6.0-r7
-ncurses-libs-6.0-r7
-ncurses-terminfo-6.0-r7
-ncurses-terminfo-base-6.0-r7
+ncurses-dev-6.0-r8
+ncurses-libs-6.0-r8
+ncurses-terminfo-6.0-r8
+ncurses-terminfo-base-6.0-r8
 nettle-3.3-r0
 npth-1.2-r0
 oniguruma-6.2.0-r0
@@ -200,7 +200,7 @@ sfdisk-2.28.2-r2
 slang-2.3.1-r0
 slang-dev-2.3.1-r0
 snappy-1.1.4-r1
-spice-server-0.13.3-r1
+spice-server-0.13.3-r2
 sqlite-libs-3.18.0-r0
 squashfs-tools-4.3-r3
 strace-4.16-r1
@@ -217,7 +217,7 @@ util-linux-dev-2.28.2-r2
 vde2-libs-2.3.2-r7
 vim-8.0.0595-r0
 wayland-1.13.0-r0
-wireguard-tools-0.0.20170726-r0
+wireguard-tools-0.0.20170810-r0
 xfsprogs-4.5.0-r0
 xfsprogs-extra-4.5.0-r0
 xfsprogs-libs-4.5.0-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:4a9e5f80a774bbea494d49324428a22c6f018865-amd64
+# linuxkit/alpine:6ed3b299f5243acb6459b4993549c5045e4ad7f4-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -57,7 +57,7 @@ gettext-0.19.8.1-r1
 gettext-asprintf-0.19.8.1-r1
 gettext-dev-0.19.8.1-r1
 gettext-libs-0.19.8.1-r1
-git-2.13.0-r0
+git-2.13.5-r0
 glib-2.52.1-r0
 gmp-6.1.2-r0
 gmp-dev-6.1.2-r0
@@ -168,10 +168,10 @@ mtools-4.0.18-r1
 musl-1.1.16-r13
 musl-dev-1.1.16-r13
 musl-utils-1.1.16-r13
-ncurses-dev-6.0-r7
-ncurses-libs-6.0-r7
-ncurses-terminfo-6.0-r7
-ncurses-terminfo-base-6.0-r7
+ncurses-dev-6.0-r8
+ncurses-libs-6.0-r8
+ncurses-terminfo-6.0-r8
+ncurses-terminfo-base-6.0-r8
 nettle-3.3-r0
 npth-1.2-r0
 oniguruma-6.2.0-r0
@@ -208,7 +208,7 @@ sfdisk-2.28.2-r2
 slang-2.3.1-r0
 slang-dev-2.3.1-r0
 snappy-1.1.4-r1
-spice-server-0.13.3-r1
+spice-server-0.13.3-r2
 sqlite-libs-3.18.0-r0
 squashfs-tools-4.3-r3
 strace-4.16-r1
@@ -226,7 +226,7 @@ util-linux-dev-2.28.2-r2
 vde2-libs-2.3.2-r7
 vim-8.0.0595-r0
 wayland-1.13.0-r0
-wireguard-tools-0.0.20170726-r0
+wireguard-tools-0.0.20170810-r0
 xfsprogs-4.5.0-r0
 xfsprogs-extra-4.5.0-r0
 xfsprogs-libs-4.5.0-r0


### PR DESCRIPTION
Updates to the latest releases of runc and containerd.

Also a few fixes found during #2328 investigations so the containerd test is now actually testing the thing we wanted.

fix #2328