### PR TITLE
iPXE boot of arm64 on packet.net

### DIFF
--- a/docs/platform-packet.md
+++ b/docs/platform-packet.md
@@ -45,9 +45,18 @@ moby build linuxkit.yml
 PACKET_API_KEY=<API key> linuxkit run packet -serve :8080 -base-url http://9b828514.ngrok.io -project-id <Project ID> linuxkit
 ```
 
+To boot a `arm64` kernel on a Type 2a machine (`-machine
+baremetal_2a`) you currently need to un-compress both the kernel and
+the initrd before booting, e.g:
+```
+mv linuxkit-initrd.img linuxkit-initrd.img.gz && gzip -d linuxkit-initrd.img.gz
+mv linuxkit-kernel.img linuxkit-kernel.img.gz && gzip -d linuxkit-kernel.img.gz
+```
+
 **Note**: It may take several minutes to deploy a new server. If you
 are attached to the console, you should see the BIOS and the boot
 messages.
+
 
 
 ## Console

--- a/log.txt
+++ b/log.txt
@@ -1,0 +1,9 @@
+[2J[01;01H[=3h[2J[01;01H[2J[01;01H[=3h[2J[01;01H[2J[01;01H[=3h[2J[01;01H[2J[01;01H[=3h[2J[01;01H[2J[01;01H[=3h[2J[01;01H[0m[39m[49m[2J[01;01H[=3h[2J[01;01H[0m[39m[49m[2J[01;01H..PXE-E16: No offer received.
+Boot Failed. EFI Network
+[2J[01;01H[01;01HUEFI Interactive Shell v2.1
+EDK II
+UEFI v2.40 (BHYVE, 0x00010000)
+[1m[32m[49mMapping table[0m[39m[49m
+[04;01H[1m[32m[49mError. [0m[39m[49mNo mapping found
+[05;01HPress [1m[32m[49mESC[0m[39m[49m in 5 seconds to skip [1m[32m[49mstartup.nsh[0m[39m[49m or any other key to continue.[05;01HPress [1m[32m[49mESC[0m[39m[49m in 4 seconds to skip [1m[32m[49mstartup.nsh[0m[39m[49m or any other key to continue.[05;01HPress [1m[32m[49mESC[0m[39m[49m in 3 seconds to skip [1m[32m[49mstartup.nsh[0m[39m[49m or any other key to continue.[05;01HPress [1m[32m[49mESC[0m[39m[49m in 2 seconds to skip [1m[32m[49mstartup.nsh[0m[39m[49m or any other key to continue.[05;01HPress [1m[32m[49mESC[0m[39m[49m in 1 seconds to skip [1m[32m[49mstartup.nsh[0m[39m[49m or any other key to continue.
+[06;01H[1m[32m[49mShell> [0m[39m[49mtime="2017-08-08T23:15:51+01:00" level=fatal msg="Cannot run hyperkit: signal: killed" 

--- a/src/cmd/linuxkit/run_packet.go
+++ b/src/cmd/linuxkit/run_packet.go
@@ -128,9 +128,18 @@ func runPacket(args []string) {
 	userData := "#!ipxe\n\n"
 	userData += "dhcp\n"
 	userData += fmt.Sprintf("set base-url %s\n", url)
-	userData += fmt.Sprintf("set kernel-params ip=dhcp nomodeset ro serial console=ttyS1,115200 %s\n", cmdline)
-	userData += fmt.Sprintf("kernel ${base-url}/%s-kernel ${kernel-params}\n", name)
-	userData += fmt.Sprintf("initrd ${base-url}/%s-initrd.img\n", name)
+	if *machineFlag != "baremetal_2a" {
+		userData += fmt.Sprintf("set kernel-params ip=dhcp nomodeset ro serial console=ttyS1,115200 %s\n", cmdline)
+		userData += fmt.Sprintf("kernel ${base-url}/%s-kernel ${kernel-params}\n", name)
+		userData += fmt.Sprintf("initrd ${base-url}/%s-initrd.img\n", name)
+	} else {
+		// With EFI boot need to specify the initrd and root dev explicitly. See:
+		// http://ipxe.org/appnote/debian_preseed
+		// http://forum.ipxe.org/showthread.php?tid=7589
+		userData += fmt.Sprintf("initrd --name initrd ${base-url}/%s-initrd.img\n", name)
+		userData += fmt.Sprintf("set kernel-params ip=dhcp nomodeset ro %s\n", cmdline)
+		userData += fmt.Sprintf("kernel ${base-url}/%s-kernel initrd=initrd root=/dev/ram0 ${kernel-params}\n", name)
+	}
 	userData += "boot"
 	log.Debugf("Using userData of:\n%s\n", userData)
 

--- a/src/cmd/linuxkit/run_packet.go
+++ b/src/cmd/linuxkit/run_packet.go
@@ -172,7 +172,7 @@ func runPacket(args []string) {
 	}
 	log.Debugf("%s\n", string(b))
 
-	log.Printf("Machine booting...")
+	log.Printf("Booting %s...", dev.ID)
 
 	sshHost := "sos." + dev.Facility.Code + ".packet.net"
 	if *consoleFlag {


### PR DESCRIPTION
Boots uncompressed kernels/initrds.

Networking is not working yet due to missing driver and tty spews out:
```
[  267.047741] ttyS ttyS0: tty_port_close_start: tty->count = 1 port count = 2
```
every ten seconds.

![lamb](https://user-images.githubusercontent.com/3338098/29326456-7bf9cc74-81e3-11e7-8d17-2bb1f423873f.jpg)
