### PR TITLE
qemu: Specify the firmware file format explicitly

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -537,7 +537,7 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 	}
 
 	if config.UEFI {
-		qemuArgs = append(qemuArgs, "-pflash", config.FWPath)
+		qemuArgs = append(qemuArgs, "-drive", "if=pflash,format=raw,file="+config.FWPath)
 	}
 
 	// build kernel boot config from kernel/initrd/cmdline


### PR DESCRIPTION
Currently we depend on the qemu to detect the firmware file format
automatically, which is dangerous. This patch specify the 'raw'
format explicitly to remove the kind of restrictions.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
specify the firmware file format explicitly
**- How I did it**
Using the qemu command line "-drive if=pflash,format=raw,file=/usr/share/ovmf/OVMF.fd" instead of "-pflash file=" 
**- How to verify it**
After the patch applied, below warning message will be removed:

WARNING: Image format was not specified for '/usr/share/ovmf/OVMF.fd' and probing guessed raw.
         Automatically detecting the format is dangerous for raw images, write operations on block 0 will be restricted.
         Specify the 'raw' format explicitly to remove the restrictions.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/29406560-ff3b29d4-8373-11e7-81f5-68154e763d85.jpg)
