### PR TITLE
Allow specifying a set of metadata providers

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -10,7 +10,7 @@ init:
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata
-    image: linuxkit/metadata:cec86f3e1c260c9eafefa80c262fceb40c182ddf
+    image: linuxkit/metadata:0c29c3ac1e5d2ee591d9710eca987f7df3fb9ca6
   - name: sysctl
     image: linuxkit/sysctl:154913b72c6f1f33eb408609fca9963628e8c051
   - name: sysfs

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:cec86f3e1c260c9eafefa80c262fceb40c182ddf
+    image: linuxkit/metadata:0c29c3ac1e5d2ee591d9710eca987f7df3fb9ca6
 services:
   - name: rngd
     image: linuxkit/rngd:558e86a36242bb74353bc9287b715ddb8567357e

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:cec86f3e1c260c9eafefa80c262fceb40c182ddf
+    image: linuxkit/metadata:0c29c3ac1e5d2ee591d9710eca987f7df3fb9ca6
 services:
   - name: getty
     image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:cec86f3e1c260c9eafefa80c262fceb40c182ddf
+    image: linuxkit/metadata:0c29c3ac1e5d2ee591d9710eca987f7df3fb9ca6
 services:
   - name: getty
     image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec

--- a/pkg/metadata/main.go
+++ b/pkg/metadata/main.go
@@ -40,12 +40,26 @@ var netProviders []Provider
 // cdromProviders is a list of Providers offering metadata/userdata data via CDROM
 var cdromProviders []Provider
 
-func init() {
-	netProviders = []Provider{NewGCP(), NewVultr(), NewAWS()}
-	cdromProviders = ListCDROMs()
-}
-
 func main() {
+	providers := []string{"aws", "gcp", "vultr", "cdrom"}
+	if len(os.Args) > 1 {
+		providers = os.Args[1:]
+	}
+	for _, p := range providers {
+		switch p {
+		case "aws":
+			netProviders = append(netProviders, NewAWS())
+		case "gcp":
+			netProviders = append(netProviders, NewGCP())
+		case "vultr":
+			netProviders = append(netProviders, NewVultr())
+		case "cdrom":
+			cdromProviders = ListCDROMs()
+		default:
+			log.Fatalf("Unrecognised metadata provider: %s", p)
+		}
+	}
+
 	if err := os.MkdirAll(ConfigPath, 0755); err != nil {
 		log.Fatalf("Could not create %s: %s", ConfigPath, err)
 	}

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:cec86f3e1c260c9eafefa80c262fceb40c182ddf
+    image: linuxkit/metadata:0c29c3ac1e5d2ee591d9710eca987f7df3fb9ca6
 services:
   - name: rngd
     image: linuxkit/rngd:558e86a36242bb74353bc9287b715ddb8567357e

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:cec86f3e1c260c9eafefa80c262fceb40c182ddf
+    image: linuxkit/metadata:0c29c3ac1e5d2ee591d9710eca987f7df3fb9ca6
 services:
   - name: rngd
     image: mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -15,7 +15,7 @@ onboot:
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:cec86f3e1c260c9eafefa80c262fceb40c182ddf
+    image: linuxkit/metadata:0c29c3ac1e5d2ee591d9710eca987f7df3fb9ca6
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mounts

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -15,7 +15,7 @@ onboot:
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:cec86f3e1c260c9eafefa80c262fceb40c182ddf
+    image: linuxkit/metadata:0c29c3ac1e5d2ee591d9710eca987f7df3fb9ca6
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mounts

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -20,7 +20,7 @@ onboot:
     image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
     command: ["/usr/bin/mountie", "/var/lib/swarmd"]
   - name: metadata
-    image: linuxkit/metadata:cec86f3e1c260c9eafefa80c262fceb40c182ddf
+    image: linuxkit/metadata:0c29c3ac1e5d2ee591d9710eca987f7df3fb9ca6
 services:
   - name: getty
     image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec


### PR DESCRIPTION
run with `cmd: ["metadata", "aws"]` to just check for AWS metadata for example.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![elephant](https://user-images.githubusercontent.com/482364/29415736-ded2d498-835b-11e7-9228-98c814be4892.jpg)
