### PR TITLE
cmd: Use the main packet.net API repo again

### DIFF
--- a/src/cmd/linuxkit/run_packet.go
+++ b/src/cmd/linuxkit/run_packet.go
@@ -166,12 +166,11 @@ func runPacket(args []string) {
 		log.Debugf("%s\n", string(b))
 
 		req := packngo.DeviceUpdateRequest{
-			HostName:     hostname,
-			BillingCycle: dev.BillingCycle,
-			UserData:     userData,
-			Locked:       dev.Locked,
-			Tags:         dev.Tags,
-			AlwaysPXE:    *alwaysPXE,
+			HostName:  hostname,
+			UserData:  userData,
+			Locked:    dev.Locked,
+			Tags:      dev.Tags,
+			AlwaysPXE: *alwaysPXE,
 		}
 		dev, _, err = client.Devices.Update(*deviceFlag, &req)
 		if err != nil {

--- a/src/cmd/linuxkit/vendor.conf
+++ b/src/cmd/linuxkit/vendor.conf
@@ -12,7 +12,7 @@ github.com/gophercloud/gophercloud 2804b72cf099b41d2e25c8afcca786f9f962ddee
 github.com/jmespath/go-jmespath bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 github.com/mitchellh/go-ps 4fdf99ab29366514c69ccccddab5dc58b8d84062
 github.com/moby/hyperkit a82b409a87f12fa3306813410c37f4eed270efac
-github.com/packethost/packngo eacc1098296fb3d75607a13e2607474ce40f55b9 https://github.com/rn/packngo.git
+github.com/packethost/packngo 131798f2804a1b3e895ca98047d56f0d7e094e2a
 github.com/radu-matei/azure-sdk-for-go 3b12823551999669c9a325a32472508e0af7978e
 github.com/radu-matei/azure-vhd-utils e52754d5569d2a643a7775f72ff2a6cf524f4c25
 github.com/rn/iso9660wrap 4606f848a055435cdef85305960b0e1bb788d506

--- a/src/cmd/linuxkit/vendor/github.com/packethost/packngo/devices.go
+++ b/src/cmd/linuxkit/vendor/github.com/packethost/packngo/devices.go
@@ -67,7 +67,6 @@ type DeviceCreateRequest struct {
 type DeviceUpdateRequest struct {
 	HostName      string   `json:"hostname"`
 	Description   string   `json:"description"`
-	BillingCycle  string   `json:"billing_cycle"`
 	UserData      string   `json:"userdata"`
 	Locked        bool     `json:"locked"`
 	Tags          []string `json:"tags"`

--- a/src/cmd/linuxkit/vendor/github.com/packethost/packngo/ip.go
+++ b/src/cmd/linuxkit/vendor/github.com/packethost/packngo/ip.go
@@ -109,6 +109,7 @@ type IPReservationRequest struct {
 	Type     string `json:"type"`
 	Quantity int    `json:"quantity"`
 	Comments string `json:"comments"`
+	Facility string `json:"facility"`
 }
 
 // IPReservation represent an IP reservation for a single project
@@ -128,6 +129,7 @@ type IPReservation struct {
 	Created       string              `json:"created_at,omitempty"`
 	Updated       string              `json:"updated_at,omitempty"`
 	Href          string              `json:"href"`
+	Facility      Facility            `json:"facility,omitempty"`
 }
 
 type ipReservationRoot struct {


### PR DESCRIPTION
The local changes were merged, so switching back to the original
repository. A minor change in API was needed.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
![roo](https://user-images.githubusercontent.com/3338098/29452761-66eeea9e-83ff-11e7-907c-bee5342a0838.jpg)
