### PR TITLE
Add some more tools to base image and only clone containerd once

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:fa4ab4ac78b83fe392e39b861b4114c3bb02d170 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 services:
   - name: getty
     image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: rngd1

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.43
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6ed3b299f5243acb6459b4993549c5045e4ad7f4 as alpine
+FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da as alpine
 RUN \
   apk add \
   btrfs-progs-dev \
@@ -10,13 +10,8 @@ RUN \
   make \
   tzdata \
   && true
-ENV GOPATH=/go PATH=$PATH:/go/bin
-# CONTAINERD_REPO and CONTAINERD_COMMIT are defined in linuxkit/alpine
-RUN mkdir -p $GOPATH/src/github.com/containerd && \
-  cd $GOPATH/src/github.com/containerd && \
-  git clone $CONTAINERD_REPO
+
 WORKDIR $GOPATH/src/github.com/containerd/containerd
-RUN git checkout $CONTAINERD_COMMIT
 RUN make binaries EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS="-extldflags \\\"-fno-PIC -static\\\""
 RUN cp bin/containerd bin/ctr bin/containerd-shim /usr/bin/
 

--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -1,5 +1,4 @@
 IMAGE=containerd
-NETWORK=1
 DEPS=$(wildcard cmd/service/*.go) etc/containerd/config.toml
 
 include ../package.mk

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:0fd732eb9e99c4db0953ae8de23d95de340ab847 AS build
+FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -10,19 +10,10 @@ ENV GOPATH=/go PATH=$PATH:/go/bin
 COPY cmd /go/src/cmd
 RUN go-compile.sh /go/src/cmd/init
 
-# checkout containerd for vendoring
-ENV GOPATH=/go PATH=$PATH:/go/bin
-# CONTAINERD_REPO and CONTAINERD_COMMIT are defined in linuxkit/alpine
-RUN mkdir -p $GOPATH/src/github.com/containerd && \
-  cd $GOPATH/src/github.com/containerd && \
-  git clone $CONTAINERD_REPO
-WORKDIR $GOPATH/src/github.com/containerd/containerd
-RUN git checkout $CONTAINERD_COMMIT
-
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:6ed3b299f5243acb6459b4993549c5045e4ad7f4 AS mirror
+FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/init/Makefile
+++ b/pkg/init/Makefile
@@ -1,5 +1,4 @@
 IMAGE=init
-NETWORK=1
 DEPS=usermode-helper.c $(wildcard etc/*) $(wildcard etc/init.d/*) $(shell find cmd -type f)
 
 include ../package.mk

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:154913b72c6f1f33eb408609fca9963628e8c051

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/okernel:latest
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 services:
   - name: acpid
     image: linuxkit/acpid:79e5c20de96e1633c9c40935b99dde45aefba37b

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:1918b152cbfc10d73004797ac38beb14d6239187
+    image: linuxkit/test-containerd:2d20469b3746ac75f86ece7fe9b64cf80476add3
   - name: poweroff
     image: linuxkit/poweroff:1e9876c682c74d0602b7647c628bb0875fb13998
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: sysctl

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:38cec1526acc8b1a2ce4b4ece78a810078c807e1

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:09d549199c7615fee56567c70d8263585dfa02f7
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:fc35653f832f053bfb1ce1ed84d2bb7a277e9c18
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6ed3b299f5243acb6459b4993549c5045e4ad7f4 AS mirror
+FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)
@@ -21,17 +21,9 @@ RUN apk add --no-cache --initdb -p /out \
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 RUN cp /out/usr/share/zoneinfo/UTC /out/etc/localtime
 
-RUN apk add git
-ENV GOPATH=/out/go
-RUN mkdir -p $GOPATH/src/github.com/containerd && \
-  cd $GOPATH/src/github.com/containerd && \
-  git clone https://github.com/containerd/containerd.git
-WORKDIR $GOPATH/src/github.com/containerd/containerd
-# CONTAINERD_COMMIT is defined in linuxkit/alpine
-RUN git checkout $CONTAINERD_COMMIT
-
 FROM scratch
 COPY --from=mirror /out/ /
+COPY --from=mirror /go/src/github.com/containerd/containerd /go/src/github.com/containerd/containerd/
 ENV GOPATH=/go
 WORKDIR $GOPATH/src/github.com/containerd/containerd
 ADD run.sh ./run.sh

--- a/test/pkg/containerd/Makefile
+++ b/test/pkg/containerd/Makefile
@@ -1,5 +1,4 @@
 IMAGE=test-containerd
 DEPS=run.sh
-NETWORK=1
 
 include ../../../pkg/package.mk

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -40,6 +40,17 @@ RUN go get -u github.com/golang/lint/golint
 RUN go get -u github.com/gordonklaus/ineffassign
 RUN go get -u github.com/LK4D4/vndr
 
+# checkout containerd
+# Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
+# `test/pkg/containerd/Dockerfile` when changing this.
+ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
+ENV CONTAINERD_COMMIT=v1.0.0-alpha4
+RUN mkdir -p $GOPATH/src/github.com/containerd && \
+  cd $GOPATH/src/github.com/containerd && \
+  git clone https://github.com/containerd/containerd.git && \
+  cd $GOPATH/src/github.com/containerd/containerd && \
+  git checkout $CONTAINERD_COMMIT
+
 FROM $BASE
 
 COPY --from=mirror /etc/apk/repositories /etc/apk/repositories
@@ -48,10 +59,8 @@ COPY --from=mirror /etc/apk/keys /etc/apk/keys/
 COPY --from=mirror /mirror /mirror/
 COPY --from=mirror /go/bin /go/bin/
 COPY --from=mirror /Dockerfile /Dockerfile
+COPY --from=mirror /go/src/github.com/containerd/containerd /go/src/github.com/containerd/containerd/
 
 RUN apk update && apk upgrade -a
 
-# Update `FROM` in both `pkg/containerd/Dockerfile` and
-# `test/pkg/containerd/Dockerfile` when changing this.
-ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.0.0-alpha4
+ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -25,6 +25,7 @@ diffutils
 dosfstools
 e2fsprogs
 e2fsprogs-extra
+ebtables
 elfutils-dev
 ethtool
 expect
@@ -45,9 +46,10 @@ iptables
 jq
 kmod
 libarchive-tools
-libcap-ng-dev
 libc-dev
 libc-utils
+libc6-compat
+libcap-ng-dev
 libelf-dev
 libressl-dev
 libseccomp-dev
@@ -75,6 +77,7 @@ sed
 sfdisk
 sgdisk
 slang-dev
+socat
 squashfs-tools
 strace
 swig
@@ -86,9 +89,9 @@ util-linux
 util-linux-dev
 vim
 xfsprogs
+xfsprogs-extra
 xorriso
 xz
 xz-dev
 zfs
-xfsprogs-extra
 zlib-dev

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:c327d338176ccc28a0d51ef145040463d13975dd-arm64
+# linuxkit/alpine:d05028a6446eb1144f73dae6ae87167b956005a7-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -38,6 +38,7 @@ dosfstools-4.1-r1
 e2fsprogs-1.43.4-r0
 e2fsprogs-extra-1.43.4-r0
 e2fsprogs-libs-1.43.4-r0
+ebtables-2.0.10.4-r2
 elfutils-dev-0.168-r1
 elfutils-libelf-0.168-r1
 ethtool-4.10-r0
@@ -90,6 +91,7 @@ libburn-1.4.6-r0
 libbz2-1.0.6-r5
 libc-dev-0.7.1-r0
 libc-utils-0.7.1-r0
+libc6-compat-1.1.16-r13
 libcap-2.25-r1
 libcap-ng-0.7.8-r0
 libcap-ng-dev-0.7.8-r0
@@ -178,7 +180,7 @@ opus-1.1.4-r0
 p11-kit-0.23.2-r1
 patch-2.7.5-r1
 pax-utils-1.2.2-r0
-pcre-8.40-r2
+pcre-8.41-r0
 perl-5.24.1-r2
 pinentry-1.0.0-r0
 pixman-0.34.0-r0
@@ -202,6 +204,7 @@ sgdisk-1.0.1-r1
 slang-2.3.1-r0
 slang-dev-2.3.1-r0
 snappy-1.1.4-r1
+socat-1.7.3.2-r1
 spice-server-0.13.3-r2
 sqlite-libs-3.18.0-r0
 squashfs-tools-4.3-r3

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:0fd732eb9e99c4db0953ae8de23d95de340ab847-amd64
+# linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -39,6 +39,7 @@ dosfstools-4.1-r1
 e2fsprogs-1.43.4-r0
 e2fsprogs-extra-1.43.4-r0
 e2fsprogs-libs-1.43.4-r0
+ebtables-2.0.10.4-r2
 elfutils-dev-0.168-r1
 elfutils-libelf-0.168-r1
 ethtool-4.10-r0
@@ -94,6 +95,7 @@ libburn-1.4.6-r0
 libbz2-1.0.6-r5
 libc-dev-0.7.1-r0
 libc-utils-0.7.1-r0
+libc6-compat-1.1.16-r13
 libcap-2.25-r1
 libcap-ng-0.7.8-r0
 libcap-ng-dev-0.7.8-r0
@@ -187,7 +189,7 @@ ovmf-0.0.20161115-r1
 p11-kit-0.23.2-r1
 patch-2.7.5-r1
 pax-utils-1.2.2-r0
-pcre-8.40-r2
+pcre-8.41-r0
 perl-5.24.1-r2
 pinentry-1.0.0-r0
 pixman-0.34.0-r0
@@ -210,6 +212,7 @@ sgdisk-1.0.1-r1
 slang-2.3.1-r0
 slang-dev-2.3.1-r0
 snappy-1.1.4-r1
+socat-1.7.3.2-r1
 spice-server-0.13.3-r2
 sqlite-libs-3.18.0-r0
 squashfs-tools-4.3-r3


### PR DESCRIPTION
Add the extra tools into base image that Kubernetes is using; currently it clones from upstream Alpine instead of our base image.

As discussed in comments in #2413 it is better to just clone `containerd` once in the base, not the three times it was being cloned.
