### PR TITLE
init: mkdir /etc/ssl/certs as required by the metadata package

### DIFF
--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -17,6 +17,9 @@ FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 
+# Add /etc/ssl/certs so it can be bind-mounted into metadata package
+RUN mkdir -p /out/etc/ssl/certs
+
 # Remove apk residuals. We have a read-only rootfs, so apk is of no use.
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 


### PR DESCRIPTION
**- What I did**

Fixed the `metadata` package (as used by the `blueprints/docker-for-mac` example)

**- How I did it**

I ensured the directory `/etc/ssl/certs` exists by creating it in the `init` package. The [Dockerfile](https://github.com/linuxkit/linuxkit/blob/498d5a1966fdf5f03908cf96c39df9390ebc8c85/pkg/metadata/Dockerfile#L18) of the `metadata` package contains a `bind` for `/etc/ssl/certs`

**- How to verify it**

Run the commands:
```
  cd blueprints/docker-for-mac
  moby build -name docker-for-mac base.yml docker-17.06-ce.yml
  linuxkit run hyperkit -networking=vpnkit -vsock-ports=2376 -disk size=500M docker-for-mac
```

Without this fix the console will have an error:
```
Welcome to LinuxKit

                        ##         .
                  ## ## ##        ==
               ## ## ## ## ##    ===
           /"""""""""""""""""\___/ ===
          {                       /  ===-
           \______ O           __/
             \    \         __/
              \____\_______/

container_linux.go:265: starting container process caused "process_linux.go:348: container init caused \"rootfs_linux.go:57: mounting \\\"/etc/ssl/certs\\\" to rootfs \\\"/containers/onboot/000-metadata/rootfs\\\" at \\\"/etc/ssl/certs\\\" caused \\\"stat /etc/ssl/certs: no such file or directory\\\"\""
```

With this fix (and hashes updated -- not included in this PR) the console will now say:
```
Welcome to LinuxKit

                        ##         .
                  ## ## ##        ==
               ## ## ## ## ##    ===
           /"""""""""""""""""\___/ ===
          {                       /  ===-
           \______ O           __/
             \    \         __/
              \____\_______/

2017/08/21 16:44:39 No metadata/userdata found. Bye
```
