### PR TITLE
Kubernetes improvements

### DIFF
--- a/projects/kubernetes/image-cache/Makefile
+++ b/projects/kubernetes/image-cache/Makefile
@@ -1,16 +1,16 @@
 default: push
 
 COMMON_IMAGES := \
-  kube-proxy-amd64\:v1.7.2@sha256\:d455480e81d60e0eff3415675278fe3daec6f56c79cd5b33a9b76548d8ab4365 \
+  kube-proxy-amd64\:v1.7.4@sha256\:5373a1c294c9ffb2e842d74d3df8fcc5bed68c02af3fb3611c2fd71a411a68fe \
   k8s-dns-sidecar-amd64\:1.14.4@sha256\:97074c951046e37d3cbb98b82ae85ed15704a290cce66a8314e7f846404edde9 \
   k8s-dns-kube-dns-amd64\:1.14.4@sha256\:40790881bbe9ef4ae4ff7fe8b892498eecb7fe6dcc22661402f271e03f7de344 \
   k8s-dns-dnsmasq-nanny-amd64\:1.14.4@sha256\:aeeb994acbc505eabc7415187cd9edb38cbb5364dc1c2fc748154576464b3dc2 \
   pause-amd64\:3.0@sha256\:163ac025575b775d1c0f9bf0bdd0f086883171eb475b5068e7defa4ca9e76516
 
 CONTROL_PLANE_IMAGES := \
-  kube-apiserver-amd64\:v1.7.2@sha256\:a9ccc205760319696d2ef0641de4478ee90fb0b75fbe6c09b1d64058c8819f97 \
-  kube-controller-manager-amd64\:v1.7.2@sha256\:2b268ab9017fadb006ee994f48b7222375fe860dc7bd14bf501b98f0ddc2961b \
-  kube-scheduler-amd64\:v1.7.2@sha256\:b2e897138449e7a00508dc589b1d4b71e56498a4d949ff30eb07b1e9d665e439 \
+  kube-apiserver-amd64\:v1.7.4@sha256\:f880371b4cee1a810d7caf4c8a2c0b8fa169879545b06a537e4ea6bcdfbbe1f6 \
+  kube-controller-manager-amd64\:v1.7.4@sha256\:7e31b7f71a8c1904c8b38c1681666ef551d0598fbbb4142522b05074ae0c9fd1 \
+  kube-scheduler-amd64\:v1.7.4@sha256\:3712116f370e21938e6a55e0f73dc02a4a6f4830a33304127105ed89451ee527 \
   etcd-amd64\:3.0.17@sha256\:d83d3545e06fb035db8512e33bd44afb55dea007a3abd7b17742d3ac6d235940
 
 dl/%.tar:

--- a/projects/kubernetes/image-cache/Makefile.pkg
+++ b/projects/kubernetes/image-cache/Makefile.pkg
@@ -3,6 +3,7 @@ IMAGE=kubernetes-image-cache-$(CACHE)
 NOTRUST=1
 SOURCE=$(BUILDDIR)
 DEPS=$(BUILDDIR)/Dockerfile
+ARCHES=x86_64
 
 $(BUILDDIR)/Dockerfile: Dockerfile
 	cp $< $@

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -54,11 +54,11 @@ services:
     runtime:
       mkdir: ["/var/lib/kubeadm", "/var/lib/cni/etc", "/var/lib/cni/opt"]
   - name: kubernetes-image-cache-common
-    image: linuxkitprojects/kubernetes-image-cache-common:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
+    image: linuxkitprojects/kubernetes-image-cache-common:0d818c5b1a7a0a0aa52c2a52e23de784d7fd5e25
   - name: kubernetes-image-cache-control-plane
-    image: linuxkitprojects/kubernetes-image-cache-control-plane:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
+    image: linuxkitprojects/kubernetes-image-cache-control-plane:0d818c5b1a7a0a0aa52c2a52e23de784d7fd5e25
   - name: kubelet
-    image: linuxkitprojects/kubernetes:bbf14d70199babeea1f71f5b0bd70c1c1c9b5cd2
+    image: linuxkitprojects/kubernetes:c4a6ae5121df50471ad244b9fc153ff5eb674fb2
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -47,24 +47,20 @@ services:
      - /run:/run
      - /var:/var:rshared,rbind
      - /var/lib/kubeadm:/etc/kubernetes
-     - /etc/cni:/etc/cni:rshared,rbind
-     - /opt/cni:/opt/cni:rshared,rbind
+     - /var/lib/cni/etc:/etc/cni:rshared,rbind
+     - /var/lib/cni/opt:/opt/cni:rshared,rbind
     rootfsPropagation: shared
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
     runtime:
-      mkdir: ["/var/lib/kubeadm"]
+      mkdir: ["/var/lib/kubeadm", "/var/lib/cni/etc", "/var/lib/cni/opt"]
   - name: kubernetes-image-cache-common
     image: linuxkitprojects/kubernetes-image-cache-common:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
   - name: kubernetes-image-cache-control-plane
     image: linuxkitprojects/kubernetes-image-cache-control-plane:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
   - name: kubelet
     image: linuxkitprojects/kubernetes:bbf14d70199babeea1f71f5b0bd70c1c1c9b5cd2
-    runtime:
-      mkdir: ["/var/lib/kubeadm"]
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub
     mode: "0600"
     optional: true
-  - {path: etc/cni, directory: true}
-  - {path: opt/cni, directory: true}

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -47,22 +47,18 @@ services:
      - /run:/run
      - /var:/var:rshared,rbind
      - /var/lib/kubeadm:/etc/kubernetes
-     - /etc/cni:/etc/cni:rshared,rbind
-     - /opt/cni:/opt/cni:rshared,rbind
+     - /var/lib/cni/etc:/etc/cni:rshared,rbind
+     - /var/lib/cni/opt:/opt/cni:rshared,rbind
     rootfsPropagation: shared
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
     runtime:
-      mkdir: ["/var/lib/kubeadm"]
+      mkdir: ["/var/lib/kubeadm", "/var/lib/cni/etc", "/var/lib/cni/opt"]
   - name: kubernetes-image-cache-common
     image: linuxkitprojects/kubernetes-image-cache-common:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
   - name: kubelet
     image: linuxkitprojects/kubernetes:bbf14d70199babeea1f71f5b0bd70c1c1c9b5cd2
-    runtime:
-      mkdir: ["/var/lib/kubeadm"]
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub
     mode: "0600"
     optional: true
-  - {path: etc/cni, directory: true}
-  - {path: opt/cni, directory: true}

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -54,9 +54,9 @@ services:
     runtime:
       mkdir: ["/var/lib/kubeadm", "/var/lib/cni/etc", "/var/lib/cni/opt"]
   - name: kubernetes-image-cache-common
-    image: linuxkitprojects/kubernetes-image-cache-common:ba16b1f8cfe4f415a5946d521e59f67eaeecd9ce
+    image: linuxkitprojects/kubernetes-image-cache-common:0d818c5b1a7a0a0aa52c2a52e23de784d7fd5e25
   - name: kubelet
-    image: linuxkitprojects/kubernetes:bbf14d70199babeea1f71f5b0bd70c1c1c9b5cd2
+    image: linuxkitprojects/kubernetes:c4a6ae5121df50471ad244b9fc153ff5eb674fb2
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/projects/kubernetes/kubernetes/Dockerfile
+++ b/projects/kubernetes/kubernetes/Dockerfile
@@ -1,6 +1,4 @@
-#FROM linuxkit/alpine:9bcf61f605ef0ce36cc94d59b8eac307862de6e1 AS build
-# XXX needs ebtables ethtool iproute2 libc6-compat socat
-FROM alpine:3.6 AS build
+FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da AS build
 
 ENV kubernetes_version v1.7.2
 ENV weave_version      v2.0.1

--- a/projects/kubernetes/kubernetes/Dockerfile
+++ b/projects/kubernetes/kubernetes/Dockerfile
@@ -1,6 +1,6 @@
 FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da AS build
 
-ENV kubernetes_version v1.7.2
+ENV kubernetes_version v1.7.4
 ENV weave_version      v2.0.1
 ENV cni_version        v0.5.2
 

--- a/projects/kubernetes/kubernetes/Dockerfile
+++ b/projects/kubernetes/kubernetes/Dockerfile
@@ -33,7 +33,7 @@ RUN rmdir /out/var/run && ln -nfs /run /out/var/run
 RUN curl -fSL -o /tmp/cni.tgz https://github.com/containernetworking/cni/releases/download/v0.5.2/cni-amd64-${cni_version}.tgz && \
     mkdir -p /out/opt/cni/bin /out/etc/cni/net.d && \
     tar -xzf /tmp/cni.tgz -C /out/opt/cni/bin
-RUN curl -fSL -o /out/etc/weave.yaml https://cloud.weave.works/k8s/v1.6/net?v=${weave_version} 
+RUN curl -fSL -o /out/etc/weave.yaml https://cloud.weave.works/k8s/v1.7/net?v=${weave_version} 
 RUN curl -fSL -o /out/usr/bin/kubelet https://dl.k8s.io/${kubernetes_version}/bin/linux/amd64/kubelet && chmod 0755 /out/usr/bin/kubelet
 RUN curl -fSL -o /out/usr/bin/kubeadm https://dl.k8s.io/${kubernetes_version}/bin/linux/amd64/kubeadm && chmod 0755 /out/usr/bin/kubeadm
 RUN curl -fSL -o /out/usr/bin/kubectl https://dl.k8s.io/${kubernetes_version}/bin/linux/amd64/kubectl && chmod 0755 /out/usr/bin/kubectl

--- a/projects/kubernetes/kubernetes/Dockerfile
+++ b/projects/kubernetes/kubernetes/Dockerfile
@@ -49,4 +49,4 @@ WORKDIR /
 ENTRYPOINT ["/usr/bin/kubelet.sh"]
 COPY --from=build /out /
 ENV KUBECONFIG "/etc/kubernetes/admin.conf"
-LABEL org.mobyproject.config='{"binds": ["/dev:/dev", "/etc/resolv.conf:/etc/resolv.conf", "/run:/run", "/var:/var:rshared,rbind", "/var/lib/kubeadm:/etc/kubernetes", "/etc/cni:/rootfs/etc/cni:rshared,rbind", "/opt/cni:/rootfs/opt/cni:rshared,rbind"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}], "capabilities": ["all"], "rootfsPropagation": "shared", "pid": "host"}'
+LABEL org.mobyproject.config='{"binds": ["/dev:/dev", "/etc/resolv.conf:/etc/resolv.conf", "/run:/run", "/var:/var:rshared,rbind", "/var/lib/kubeadm:/etc/kubernetes", "/var/lib/cni/etc:/rootfs/etc/cni:rshared,rbind", "/var/lib/cni/opt:/rootfs/opt/cni:rshared,rbind"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}], "capabilities": ["all"], "rootfsPropagation": "shared", "pid": "host", "runtime": {"mkdir": ["/var/lib/kubeadm", "/var/lib/cni/etc", "/var/lib/cni/opt"]}}'

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -2,5 +2,6 @@ ORG?=linuxkitprojects
 IMAGE=kubernetes
 NETWORK=1
 NOTRUST=1
+ARCHES=x86_64
 
 include ../../../pkg/package.mk


### PR DESCRIPTION
- fix persistence/writeability of CNI paths, as the were bound to read only paths
- use standard LinuxKit base image now it has all the requirements
- update Weave yaml to k8s 1.7.x
- only build on amd64 - there are no prebuild arm64 images yet
- upgrade to 1.7.4

![goats-on-camel](https://user-images.githubusercontent.com/482364/29530446-bb843372-869b-11e7-9f12-a52fdf574274.jpg)
