### PR TITLE
docker-for-mac: supply the daemon.json via metadata

### DIFF
--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -39,7 +39,7 @@ linuxkit run hyperkit -networking=vpnkit -vsock-ports=2376 -disk size=500M -data
 In another terminal you should now be able to access docker via the socket `guest.00000947` in the state directory (`docker-for-mac-state/` by default):
 
 ```
-$ docker -H unix://docker-for-mac-state/guest.00000947 ps
+$ docker -H unix://docker-for-mac-state/guest.00000948 ps
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ```
 

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -33,7 +33,7 @@ $ moby build -name docker-for-mac base.yml docker-ce.yml
 To run the VM with a 500M disk:
 
 ```
-linuxkit run hyperkit -networking=vpnkit -vsock-ports=2376 -disk size=500M docker-for-mac
+linuxkit run hyperkit -networking=vpnkit -vsock-ports=2376 -disk size=500M -data ./metadata.json docker-for-mac
 ```
 
 In another terminal you should now be able to access docker via the socket `guest.00000947` in the state directory (`docker-for-mac-state/` by default):

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -24,12 +24,6 @@ onboot:
   - name: mount
     image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
     command: ["/usr/bin/mountie", "/var/lib"]
-  # create docker dir on mounted drive if it doesn't exist
-  - name: mkdir-docker
-    image: alpine:3.6
-    binds:
-        - /var/lib:/host_var_lib
-    command: ["sh", "-c", "mkdir -p /host_var_lib/docker"]
   # mount-vpnkit mounts the 9p share used by vpnkit to coordinate port forwarding
   - name: mount-vpnkit
     image: alpine:3.6

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -7,6 +7,7 @@ init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
+  - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata

--- a/blueprints/docker-for-mac/docker-ce.yml
+++ b/blueprints/docker-for-mac/docker-ce.yml
@@ -23,11 +23,6 @@ services:
             "--swarm-default-advertise-addr=eth0",
             "--userland-proxy-path", "/usr/bin/vpnkit-expose-port",
             "--storage-driver", "overlay2" ]
-
-files:
-    - path: /var/config/docker/daemon.json
-      contents: '{ "debug": true }'
-
 trust:
     org:
         - library

--- a/blueprints/docker-for-mac/docker-ce.yml
+++ b/blueprints/docker-for-mac/docker-ce.yml
@@ -23,6 +23,8 @@ services:
             "--swarm-default-advertise-addr=eth0",
             "--userland-proxy-path", "/usr/bin/vpnkit-expose-port",
             "--storage-driver", "overlay2" ]
+    runtime:
+      mkdir: ["/var/lib/docker"]
 trust:
     org:
         - library

--- a/blueprints/docker-for-mac/metadata.json
+++ b/blueprints/docker-for-mac/metadata.json
@@ -1,0 +1,8 @@
+{
+  "docker": {
+    "daemon.json": {
+      "perm": "0644",
+      "content": "{ \"debug\": true }"
+    }
+  }
+}


### PR DESCRIPTION
**- What I did**

Fixed a bug in `blueprints/docker-for-mac` which prevented the Docker daemon from starting if you follow the instructions in the `README.md`

**- How I did it**

The Docker daemon needs a `daemon.json` file. Previously a default trivial file was supplied by a `files` declaration in the `.yml` which wrote it to `/var/config/docker/daemon.json` -- a path which is really owned by the `metadata` package. This trick used to work but doesn't work any more -- the `/var/config` directory is empty and the daemon doesn't start. We may have been relying on undefined behaviour?

This patch tweaks the `README.md` to supply the `daemon.json` via the `metadata` package which is the mechanism a real deployment is expected to use. It also adds the `ca-certificates` package to make the `metadata` package start properly, as described in #2443 

**- How to verify it**

Follow the instructions in the `README.md`
```
cd blueprints/docker-for-mac
moby build -name docker-for-mac base.yml docker-17.06-ce.yml
linuxkit run hyperkit -networking=vpnkit -vsock-ports=2376 -disk size=500M -data ./metadata.json docker-for-mac
```

and observe that the `docker-dfm` task is running:
```
ctr t ls
TASK                    PID     STATUS    
vsudd                   1003    RUNNING
acpid                   697     RUNNING
docker-dfm              738     RUNNING
getty                   789     RUNNING
host-timesync-daemon    837     RUNNING
ntpd                    878     RUNNING
trim-after-delete       918     RUNNING
vpnkit-forwarder        959     RUNNING
```
