### PR TITLE
Improve wireguard example

### DIFF
--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -12,30 +12,43 @@ onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
-  - name: wg
-    image: linuxkit/ip:4ce3b47fef3a9d5c78ae45e2946c9fdf95af2fa5
+  - name: wg0
+    image: linuxkit/ip:b084fd2ada446015e00e43a441bb0ae41ff8b227
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
-    command: ["sh", "-c", "ip link set dev wg0 up; ip address add dev wg0 192.168.2.1 peer 192.168.2.2; wg setconf wg0 /etc/wireguard/wg0.conf; wg show wg0"]
+    command: ["sh", "-c", "ip link set dev wg0 up; ip address add dev wg0 192.168.2.1/24; wg setconf wg0 /etc/wireguard/wg0.conf; wg show wg0"]
     runtime:
       interfaces:
         - name: wg0
           add: wireguard
           createInRoot: true
       bindNS:
-          net: /run/netns/wg
+          net: /run/netns/wg0
+  - name: wg1
+    image: linuxkit/ip:b084fd2ada446015e00e43a441bb0ae41ff8b227
+    net: new
+    binds:
+      - /etc/wireguard:/etc/wireguard
+    command: ["sh", "-c", "ip link set dev wg1 up; ip address add dev wg1 192.168.2.2/24; wg setconf wg1 /etc/wireguard/wg1.conf; wg show wg1"]
+    runtime:
+      interfaces:
+        - name: wg1
+          add: wireguard
+          createInRoot: true
+      bindNS:
+          net: /run/netns/wg1
 services:
   - name: getty
     image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
     env:
      - INSECURE=true
-    net: /run/netns/wg
+    net: /run/netns/wg1
   - name: rngd
     image: linuxkit/rngd:558e86a36242bb74353bc9287b715ddb8567357e
   - name: nginx
     image: nginx:alpine
-    net: /run/netns/wg
+    net: /run/netns/wg0
     capabilities:
      - CAP_NET_BIND_SERVICE
      - CAP_CHOWN
@@ -46,11 +59,21 @@ files:
   - path: etc/wireguard/wg0.conf
     contents: |
       [Interface] 
-      PrivateKey = yAnz5TF+lXXJte14tji3zlMNq+hd2rYUIgJBgB3fBmk= 
+      PrivateKey = KG7EKkHDkp7THfW5mOXcZzo3RbGAjq+ARMfJGFm5G1s=
       ListenPort = 51820
       [Peer] 
-      PublicKey = xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg= 
+      PublicKey = ZP7h1OjA1oIAmsAvMKujp2RAAC/f0kY814b3Xq6j/0Y=
       AllowedIPs = 0.0.0.0/0
+      Endpoint = 127.0.0.1:51821
+  - path: etc/wireguard/wg1.conf
+    contents: |
+      [Interface]
+      PrivateKey = SCGCKDuTm4PMOw+LXdK/2s8mxnv145QHOohKRq3vc2A=
+      ListenPort = 51821
+      [Peer]
+      PublicKey = AcS5t3PC5nL/oj0sYhc3yFpDlRaXoJ0mfEq6iq0rFF4=
+      AllowedIPs = 0.0.0.0/0
+      Endpoint = 127.0.0.1:51820
 trust:
   org:
     - linuxkit

--- a/pkg/ip/Dockerfile
+++ b/pkg/ip/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630 AS mirror
+FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/test/cases/040_packages/023_wireguard/check.sh
+++ b/test/cases/040_packages/023_wireguard/check.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+function success {
+	printf "wireguard test suite PASSED\n" >&1
+	exit 0
+}
+
+function failed {
+	printf "wireguard test suite FAILED\n" >&1
+	exit 1
+}
+
+if [ "$1" = "shutdown" ]
+then
+	[ -f /tmp/ok ] && success
+	failed
+	exit 0
+fi
+
+# Nginx may not be up immediately as service startup is async
+for s in $(seq 1 10)
+do
+	wget -O - http://192.168.2.1/ && echo "success" > /tmp/ok && halt
+	sleep 1
+done
+
+halt

--- a/test/cases/040_packages/023_wireguard/test-wireguard.yml
+++ b/test/cases/040_packages/023_wireguard/test-wireguard.yml
@@ -1,0 +1,90 @@
+kernel:
+  image: linuxkit/kernel:4.9.43
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
+  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
+onboot:
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+  - name: wg0
+    image: linuxkit/ip:b084fd2ada446015e00e43a441bb0ae41ff8b227
+    net: new
+    binds:
+      - /etc/wireguard:/etc/wireguard
+    command: ["sh", "-c", "ip link set dev wg0 up; ip address add dev wg0 192.168.2.1/24; wg setconf wg0 /etc/wireguard/wg0.conf; wg show wg0"]
+    runtime:
+      interfaces:
+        - name: wg0
+          add: wireguard
+          createInRoot: true
+      bindNS:
+          net: /run/netns/wg0
+  - name: wg1
+    image: linuxkit/ip:b084fd2ada446015e00e43a441bb0ae41ff8b227
+    net: new
+    binds:
+      - /etc/wireguard:/etc/wireguard
+    command: ["sh", "-c", "ip link set dev wg1 up; ip address add dev wg1 192.168.2.2/24; wg setconf wg1 /etc/wireguard/wg1.conf; wg show wg1"]
+    runtime:
+      interfaces:
+        - name: wg1
+          add: wireguard
+          createInRoot: true
+      bindNS:
+          net: /run/netns/wg1
+onshutdown:
+  - name: test2
+    image: alpine:3.6
+    binds:
+      - /tmp:/tmp
+      - /check.sh:/check.sh
+    command: ["sh", "./check.sh", "shutdown"]
+services:
+  - name: nginx
+    image: nginx:alpine
+    net: /run/netns/wg0
+    capabilities:
+     - CAP_NET_BIND_SERVICE
+     - CAP_CHOWN
+     - CAP_SETUID
+     - CAP_SETGID
+     - CAP_DAC_OVERRIDE
+  - name: test
+    image: alpine:3.6
+    net: /run/netns/wg1
+    pid: host
+    capabilities:
+      - CAP_KILL
+    binds:
+      - /tmp:/tmp
+      - /check.sh:/check.sh
+    command: ["sh", "./check.sh"]
+files:
+  - path: etc/wireguard/wg0.conf
+    contents: |
+      [Interface] 
+      PrivateKey = KG7EKkHDkp7THfW5mOXcZzo3RbGAjq+ARMfJGFm5G1s=
+      ListenPort = 51820
+      [Peer] 
+      PublicKey = ZP7h1OjA1oIAmsAvMKujp2RAAC/f0kY814b3Xq6j/0Y=
+      AllowedIPs = 0.0.0.0/0
+      Endpoint = 127.0.0.1:51821
+  - path: etc/wireguard/wg1.conf
+    contents: |
+      [Interface]
+      PrivateKey = SCGCKDuTm4PMOw+LXdK/2s8mxnv145QHOohKRq3vc2A=
+      ListenPort = 51821
+      [Peer]
+      PublicKey = AcS5t3PC5nL/oj0sYhc3yFpDlRaXoJ0mfEq6iq0rFF4=
+      AllowedIPs = 0.0.0.0/0
+      Endpoint = 127.0.0.1:51820
+  - path: check.sh
+    source: ./check.sh
+trust:
+  org:
+    - linuxkit
+    - library

--- a/test/cases/040_packages/023_wireguard/test.sh
+++ b/test/cases/040_packages/023_wireguard/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# SUMMARY: Check that wireguard works
+# LABELS:
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	find . -depth -iname "test-wireguard*" -not -iname "*.yml" -exec rm -rf {} \;
+}
+trap clean_up EXIT
+
+# Test code goes here
+moby build -output kernel+initrd test-wireguard.yml
+RESULT="$(linuxkit run test-wireguard)"
+echo "${RESULT}"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0


### PR DESCRIPTION
- fix version mismatch with current kernel
- change test to create two connected wireguard interfaces, one running nginx and one in the getty, so you can see the communication between them
- add a test based on the example

![three_headed_puppy-600x399](https://user-images.githubusercontent.com/482364/29565378-92ec50fa-873d-11e7-9538-f47967383360.jpg)

cc @zx2c4 @riyazdf 