### PR TITLE
Add support for mount in runtime config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 PREFIX?=/usr/local/
 
 MOBY_REPO=https://github.com/moby/tool.git
-MOBY_COMMIT=0d58d332be0afc27be4402301f7c7950bd3ae189
+MOBY_COMMIT=69596e17ddb01fc3d3e75774bffeb760812b2f97
 MOBY_VERSION=0.0
 bin/moby: tmp_moby_bin.tar | bin
 	tar xf $<

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:fa4ab4ac78b83fe392e39b861b4114c3bb02d170 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 services:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.43
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/pkg/init/cmd/service/prepare.go
+++ b/pkg/init/cmd/service/prepare.go
@@ -266,27 +266,7 @@ func prepareProcess(pid int, runtime Runtime) error {
 
 // cleanup functions are best efforts only, mainly for rw onboot containers
 func cleanup(path string) {
-	// see if we are dealing with a read only or read write container
-	if _, err := os.Stat(filepath.Join(path, "lower")); err != nil {
-		cleanupRO(path)
-	} else {
-		cleanupRW(path)
-	}
-}
-
-func cleanupRO(path string) {
-	// remove the bind mount
+	// remove the root mount
 	rootfs := filepath.Join(path, "rootfs")
 	_ = unix.Unmount(rootfs, 0)
-}
-
-func cleanupRW(path string) {
-	// remove the overlay mount
-	rootfs := filepath.Join(path, "rootfs")
-	_ = os.RemoveAll(rootfs)
-	_ = unix.Unmount(rootfs, 0)
-	// remove the tmpfs
-	tmp := filepath.Join(path, "tmp")
-	_ = os.RemoveAll(tmp)
-	_ = unix.Unmount(tmp, 0)
 }

--- a/pkg/init/cmd/service/prepare.go
+++ b/pkg/init/cmd/service/prepare.go
@@ -7,9 +7,11 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"syscall"
+	"strings"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -21,9 +23,10 @@ const (
 
 // Runtime is the type of config processed at runtime, not used to build the OCI spec
 type Runtime struct {
-	Mkdir      []string    `yaml:"mkdir" json:"mkdir,omitempty"`
-	Interfaces []Interface `yaml:"interfaces" json:"interfaces,omitempty"`
-	BindNS     *Namespaces `yaml:"bindNS" json:"bindNS,omitempty"`
+	Mounts     []specs.Mount `yaml:"mounts" json:"mounts,omitempty"`
+	Mkdir      []string      `yaml:"mkdir" json:"mkdir,omitempty"`
+	Interfaces []Interface   `yaml:"interfaces" json:"interfaces,omitempty"`
+	BindNS     Namespaces    `yaml:"bindNS" json:"bindNS,omitempty"`
 }
 
 // Namespaces is the type for configuring paths to bind namespaces
@@ -61,12 +64,80 @@ func getRuntimeConfig(path string) Runtime {
 	return runtime
 }
 
+// parseMountOptions takes fstab style mount options and parses them for
+// use with a standard mount() syscall
+// taken from containerd, where it is not exported
+func parseMountOptions(options []string) (int, string) {
+	var (
+		flag int
+		data []string
+	)
+	flags := map[string]struct {
+		clear bool
+		flag  int
+	}{
+		"async":         {true, unix.MS_SYNCHRONOUS},
+		"atime":         {true, unix.MS_NOATIME},
+		"bind":          {false, unix.MS_BIND},
+		"defaults":      {false, 0},
+		"dev":           {true, unix.MS_NODEV},
+		"diratime":      {true, unix.MS_NODIRATIME},
+		"dirsync":       {false, unix.MS_DIRSYNC},
+		"exec":          {true, unix.MS_NOEXEC},
+		"mand":          {false, unix.MS_MANDLOCK},
+		"noatime":       {false, unix.MS_NOATIME},
+		"nodev":         {false, unix.MS_NODEV},
+		"nodiratime":    {false, unix.MS_NODIRATIME},
+		"noexec":        {false, unix.MS_NOEXEC},
+		"nomand":        {true, unix.MS_MANDLOCK},
+		"norelatime":    {true, unix.MS_RELATIME},
+		"nostrictatime": {true, unix.MS_STRICTATIME},
+		"nosuid":        {false, unix.MS_NOSUID},
+		"rbind":         {false, unix.MS_BIND | unix.MS_REC},
+		"relatime":      {false, unix.MS_RELATIME},
+		"remount":       {false, unix.MS_REMOUNT},
+		"ro":            {false, unix.MS_RDONLY},
+		"rw":            {true, unix.MS_RDONLY},
+		"strictatime":   {false, unix.MS_STRICTATIME},
+		"suid":          {true, unix.MS_NOSUID},
+		"sync":          {false, unix.MS_SYNCHRONOUS},
+	}
+	for _, o := range options {
+		// If the option does not exist in the flags table or the flag
+		// is not supported on the platform,
+		// then it is a data value for a specific fs type
+		if f, exists := flags[o]; exists && f.flag != 0 {
+			if f.clear {
+				flag &^= f.flag
+			} else {
+				flag |= f.flag
+			}
+		} else {
+			data = append(data, o)
+		}
+	}
+	return flag, strings.Join(data, ",")
+}
+
 // prepareFilesystem sets up the mounts, before the container is created
 func prepareFilesystem(path string, runtime Runtime) error {
 	// execute the runtime config that should be done up front
+	// we execute Mounts before Mkdir so you can make a directory under a mount
+	// but we do mkdir of the destination path in case missing
+	for _, mount := range runtime.Mounts {
+		const mode os.FileMode = 0755
+		err := os.MkdirAll(mount.Destination, mode)
+		if err != nil {
+			return fmt.Errorf("Cannot create directory for mount destination %s: %v", mount.Destination, err)
+		}
+		opts, data := parseMountOptions(mount.Options)
+		if err := unix.Mount(mount.Source, mount.Destination, mount.Type, uintptr(opts), data); err != nil {
+			return fmt.Errorf("Failed to mount %s: %v", mount.Source, err)
+		}
+	}
 	for _, dir := range runtime.Mkdir {
 		// in future we may need to change the structure to set mode, ownership
-		var mode os.FileMode = 0755
+		const mode os.FileMode = 0755
 		err := os.MkdirAll(dir, mode)
 		if err != nil {
 			return fmt.Errorf("Cannot create directory %s: %v", dir, err)
@@ -86,7 +157,7 @@ func prepareFilesystem(path string, runtime Runtime) error {
 func prepareRO(path string) error {
 	// make rootfs a mount point, as runc doesn't like it much otherwise
 	rootfs := filepath.Join(path, "rootfs")
-	if err := syscall.Mount(rootfs, rootfs, "", syscall.MS_BIND, ""); err != nil {
+	if err := unix.Mount(rootfs, rootfs, "", unix.MS_BIND, ""); err != nil {
 		return err
 	}
 	return nil
@@ -96,11 +167,11 @@ func prepareRW(path string) error {
 	// mount a tmpfs on tmp for upper and workdirs
 	// make it private as nothing else should be using this
 	tmp := filepath.Join(path, "tmp")
-	if err := syscall.Mount("tmpfs", tmp, "tmpfs", 0, "size=10%"); err != nil {
+	if err := unix.Mount("tmpfs", tmp, "tmpfs", 0, "size=10%"); err != nil {
 		return err
 	}
 	// make it private as nothing else should be using this
-	if err := syscall.Mount("", tmp, "", syscall.MS_REMOUNT|syscall.MS_PRIVATE, ""); err != nil {
+	if err := unix.Mount("", tmp, "", unix.MS_REMOUNT|unix.MS_PRIVATE, ""); err != nil {
 		return err
 	}
 	upper := filepath.Join(tmp, "upper")
@@ -115,7 +186,7 @@ func prepareRW(path string) error {
 	lower := filepath.Join(path, "lower")
 	rootfs := filepath.Join(path, "rootfs")
 	opt := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
-	if err := syscall.Mount("overlay", rootfs, "overlay", 0, opt); err != nil {
+	if err := unix.Mount("overlay", rootfs, "overlay", 0, opt); err != nil {
 		return err
 	}
 	return nil
@@ -138,7 +209,7 @@ func bindNS(ns string, path string, pid int) error {
 	if err := fi.Close(); err != nil {
 		return err
 	}
-	if err := syscall.Mount(fmt.Sprintf("/proc/%d/ns/%s", pid, ns), path, "", syscall.MS_BIND, ""); err != nil {
+	if err := unix.Mount(fmt.Sprintf("/proc/%d/ns/%s", pid, ns), path, "", unix.MS_BIND, ""); err != nil {
 		return fmt.Errorf("Failed to bind %s namespace at %s: %v", ns, path, err)
 	}
 	return nil
@@ -203,24 +274,22 @@ func prepareProcess(pid int, runtime Runtime) error {
 		}
 	}
 
-	if runtime.BindNS != nil {
-		binds := []struct {
-			ns   string
-			path string
-		}{
-			{"cgroup", runtime.BindNS.Cgroup},
-			{"ipc", runtime.BindNS.Ipc},
-			{"mnt", runtime.BindNS.Mnt},
-			{"net", runtime.BindNS.Net},
-			{"pid", runtime.BindNS.Pid},
-			{"user", runtime.BindNS.User},
-			{"uts", runtime.BindNS.Uts},
-		}
+	binds := []struct {
+		ns   string
+		path string
+	}{
+		{"cgroup", runtime.BindNS.Cgroup},
+		{"ipc", runtime.BindNS.Ipc},
+		{"mnt", runtime.BindNS.Mnt},
+		{"net", runtime.BindNS.Net},
+		{"pid", runtime.BindNS.Pid},
+		{"user", runtime.BindNS.User},
+		{"uts", runtime.BindNS.Uts},
+	}
 
-		for _, b := range binds {
-			if err := bindNS(b.ns, b.path, pid); err != nil {
-				return err
-			}
+	for _, b := range binds {
+		if err := bindNS(b.ns, b.path, pid); err != nil {
+			return err
 		}
 	}
 
@@ -240,16 +309,16 @@ func cleanup(path string) {
 func cleanupRO(path string) {
 	// remove the bind mount
 	rootfs := filepath.Join(path, "rootfs")
-	_ = syscall.Unmount(rootfs, 0)
+	_ = unix.Unmount(rootfs, 0)
 }
 
 func cleanupRW(path string) {
 	// remove the overlay mount
 	rootfs := filepath.Join(path, "rootfs")
 	_ = os.RemoveAll(rootfs)
-	_ = syscall.Unmount(rootfs, 0)
+	_ = unix.Unmount(rootfs, 0)
 	// remove the tmpfs
 	tmp := filepath.Join(path, "tmp")
 	_ = os.RemoveAll(tmp)
-	_ = syscall.Unmount(tmp, 0)
+	_ = unix.Unmount(tmp, 0)
 }

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/okernel:latest
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 services:

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/004_config_4.12.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/004_config_4.12.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test-wireguard.yml
+++ b/test/cases/040_packages/023_wireguard/test-wireguard.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.43
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:2122f8b7202b383c1be0a91a02122b0c078ca6ac
+  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
 onboot:


### PR DESCRIPTION
This could be used in LinuxKit now, as there are some examples, eg
https://github.com/linuxkit/linuxkit/blob/master/blueprints/docker-for-mac/base.yml#L33
which are creating containers to do a mount.

Also removed the ad hoc code to generate overlay mounts for writeable containers
with a runtime config which does the same thing.

See https://github.com/moby/tool/pull/145

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![cheetah](https://user-images.githubusercontent.com/482364/29569658-1ad45022-874c-11e7-9e01-06f5682ae9fd.jpg)
