### PR TITLE
tools: Support iso-efi generation for both arm64 and amd64

### DIFF
--- a/tools/mkimage-iso-efi/Dockerfile
+++ b/tools/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,51 @@
-FROM linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630
+FROM linuxkit/alpine:8b53d842a47fce43464e15f65ee2f68b82542330 AS grub-build
+
+RUN apk add \
+  automake \
+  make \
+  bison \
+  gettext \
+  flex \
+  gcc \
+  git \
+  libtool \
+  libc-dev \
+  linux-headers \
+  python3 \
+  autoconf
+
+# because python is not available
+RUN ln -s python3 /usr/bin/python
+
+ENV GRUB_MODULES="part_gpt fat ext2 iso9660 gzio linux acpi normal cpio crypto disk boot crc64 gpt \
+search_disk_uuid tftp verify xzio xfs video hfs hfspluscomp hfsplus"
+ENV GRUB_COMMIT=6782f6d431d22b4e9ab14e94d263795c7991e160
+
+COPY patches/* /patches/
+RUN mkdir /grub-lib && \
+  set -e && \
+  git clone https://github.com/coreos/grub.git && \
+  cd grub && \
+  git checkout -b grub-build ${GRUB_COMMIT} && \
+  for patch in /patches/*.patch; do \
+    echo "Applying $patch"; \
+    patch -p1 < "$patch"; \
+  done && \
+  ./autogen.sh && \
+  ./configure --libdir=/grub-lib --with-platform=efi CFLAGS="-Os -Wno-unused-value" && \
+  make -j "$(getconf _NPROCESSORS_ONLN)" && \
+  make install && \
+# create the grub core image
+  case $(uname -m) in \
+  x86_64) \
+    ./grub-mkimage -O x86_64-efi -d /grub-lib/grub/x86_64-efi -o /grub-lib/BOOTX64.EFI -p /EFI/BOOT ${GRUB_MODULES}; \
+    ;; \
+  aarch64) \
+    ./grub-mkimage -O arm64-efi -d /grub-lib/grub/arm64-efi -o /grub-lib/BOOTAA64.EFI -p /EFI/BOOT ${GRUB_MODULES}; \
+    ;; \
+  esac
+
+FROM linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630 AS make-img
 
 RUN \
   apk update && apk upgrade && \
@@ -6,11 +53,11 @@ RUN \
   dosfstools \
   libarchive-tools \
   binutils \
-  gummiboot \
   mtools \
   xorriso \
   && true
 
 COPY . .
+COPY --from=grub-build /grub-lib/BOOT*.EFI /usr/local/share/
 
 ENTRYPOINT [ "/make-efi" ]

--- a/tools/mkimage-iso-efi/Makefile
+++ b/tools/mkimage-iso-efi/Makefile
@@ -1,4 +1,5 @@
 IMAGE=mkimage-iso-efi
 DEPS=make-efi
+NETWORK=1
 
 include ../../pkg/package.mk

--- a/tools/mkimage-iso-efi/make-efi
+++ b/tools/mkimage-iso-efi/make-efi
@@ -2,6 +2,19 @@
 
 set -e
 
+# get the GRUB2 boot file name
+ARCH=`uname -m`
+case $ARCH in
+x86_64)
+  BOOTFILE=BOOTX64.EFI
+  ROOTDEV=/dev/sr0
+  ;;
+aarch64)
+  BOOTFILE=BOOTAA64.EFI
+  ROOTDEV=/dev/vda
+  ;;
+esac
+
 mkdir -p /tmp/efi
 cd /tmp/efi
 
@@ -13,39 +26,38 @@ cd /tmp/efi
 [ -t 0 ] || bsdtar xzf -
 
 CMDLINE="$(cat boot/cmdline)"
-# if no root= root device specified, assume /dev/sr0 ie first CD drive
-echo "${CMDLINE}" | grep -q 'root=' || CMDLINE="${CMDLINE} root=/dev/sr0"
+# if no root= root device specified, assume /dev/{sr0, vda} ie first CD drive
+# need to detect the root device automatically in the future
+echo "${CMDLINE}" | grep -q 'root=' || CMDLINE="${CMDLINE} root=${ROOTDEV}"
 rm boot/cmdline
 
-# Create a EFI boot file with kernel. From:
-# https://github.com/haraldh/mkrescue-uefi/blob/master/mkrescue-uefi.sh
-cp /usr/lib/gummiboot/linuxx64.efi.stub .
-echo "${CMDLINE}" > cmdline.txt
+cp /usr/local/share/$BOOTFILE .
 
-objcopy \
-	--add-section .osrel=/etc/os-release --change-section-vma .osrel=0x20000 \
-	--add-section .cmdline=./cmdline.txt --change-section-vma .cmdline=0x30000 \
-	--add-section .linux=./boot/kernel --change-section-vma .linux=0x40000 \
-	./linuxx64.efi.stub \
-	linuxkit.efi
+CFG="set timeout=0
+set gfxpayload=text
+menuentry 'LinuxKit ISO Image' {
+	linux /boot/kernel ${CMDLINE} text
+}
+"
 
-rm cmdline.txt
+mkdir -p EFI/BOOT
+printf "$CFG" > EFI/BOOT/grub.cfg
 
 # create a ISO with a EFI boot partition
 # Stuff it into a FAT filesystem, making it as small as possible.  511KiB
 # headroom seems to be enough; (x+31)/32*32 rounds up to multiple of 32.
-mkfs.vfat -v -C boot/efi.raw \
-        $(( ($(stat -c %s "linuxkit.efi") / 1024 + 511) \
+mkfs.vfat -v -C boot.img \
+        $(( ($(stat -c %s "${BOOTFILE}") / 1024 + 511) \
 		/ 32 * 32 )) > /dev/null
 echo "mtools_skip_check=1" >> /etc/mtools.conf && \
-mmd -i boot/efi.raw ::/EFI
-mmd -i boot/efi.raw ::/EFI/BOOT
-mcopy -i boot/efi.raw linuxkit.efi ::/EFI/BOOT/BOOTX64.EFI
+mmd -i boot.img ::/EFI
+mmd -i boot.img ::/EFI/BOOT
+mcopy -i boot.img $BOOTFILE ::/EFI/BOOT/
 
-rm linuxkit.efi linuxx64.efi.stub
+rm $BOOTFILE
 
 xorriso -as mkisofs \
-	-R -e boot/efi.raw -no-emul-boot -o linuxkit-efi.iso .
+	-R -e boot.img -hide boot.img -hide boot.catalog -no-emul-boot -o linuxkit-efi.iso .
 
 cat linuxkit-efi.iso
 

--- a/tools/mkimage-iso-efi/patches/0001-TPM-build-issue-fixing.patch
+++ b/tools/mkimage-iso-efi/patches/0001-TPM-build-issue-fixing.patch
@@ -1,0 +1,72 @@
+From 617b08377dbaa9ea3876b5585fe0ba36286fbed6 Mon Sep 17 00:00:00 2001
+From: Dennis Chen <dennis.chen@arm.com>
+Date: Thu, 17 Aug 2017 05:47:55 +0000
+Subject: [PATCH] TPM: build issue fixing
+
+Fix the build issue on arm64 and amd64.
+
+Signed-off-by: Dennis Chen <dennis.chen@arm.com>
+---
+ grub-core/kern/efi/tpm.c | 12 ++++++------
+ include/grub/efi/tpm.h   |  4 ++--
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/grub-core/kern/efi/tpm.c b/grub-core/kern/efi/tpm.c
+index c9fb3c1..ed40f98 100644
+--- a/grub-core/kern/efi/tpm.c
++++ b/grub-core/kern/efi/tpm.c
+@@ -175,7 +175,7 @@ grub_tpm1_log_event(grub_efi_handle_t tpm_handle, unsigned char *buf,
+ 		    grub_size_t size, grub_uint8_t pcr,
+ 		    const char *description)
+ {
+-  Event *event;
++  TCG_PCR_EVENT *event;
+   grub_efi_status_t status;
+   grub_efi_tpm_protocol_t *tpm;
+   grub_efi_physical_address_t lastevent;
+@@ -188,15 +188,15 @@ grub_tpm1_log_event(grub_efi_handle_t tpm_handle, unsigned char *buf,
+   if (!grub_tpm_present(tpm))
+     return 0;
+ 
+-  event = grub_zalloc(sizeof (Event) + grub_strlen(description) + 1);
++  event = grub_zalloc(sizeof (TCG_PCR_EVENT) + grub_strlen(description) + 1);
+   if (!event)
+     return grub_error (GRUB_ERR_OUT_OF_MEMORY,
+ 		       N_("cannot allocate TPM event buffer"));
+ 
+-  event->pcrindex = pcr;
+-  event->eventtype = EV_IPL;
+-  event->eventsize = grub_strlen(description) + 1;
+-  grub_memcpy(event->event, description, event->eventsize);
++  event->PCRIndex = pcr;
++  event->EventType = EV_IPL;
++  event->EventSize = grub_strlen(description) + 1;
++  grub_memcpy(event->Event, description, event->EventSize);
+ 
+   algorithm = TCG_ALG_SHA;
+   status = efi_call_7 (tpm->log_extend_event, tpm, buf, (grub_uint64_t) size,
+diff --git a/include/grub/efi/tpm.h b/include/grub/efi/tpm.h
+index e2aff4a..fb3bb0e 100644
+--- a/include/grub/efi/tpm.h
++++ b/include/grub/efi/tpm.h
+@@ -69,7 +69,7 @@ struct grub_efi_tpm_protocol
+ 					    grub_efi_uint32_t TpmOutputParameterBlockSize,
+ 					    grub_efi_uint8_t *TpmOutputParameterBlock);
+   grub_efi_status_t (*log_extend_event) (struct grub_efi_tpm_protocol *this,
+-					 grub_efi_physical_address_t HashData,
++					 grub_efi_uint8_t *HashData,
+ 					 grub_efi_uint64_t HashDataLen,
+ 					 grub_efi_uint32_t AlgorithmId,
+ 					 TCG_PCR_EVENT *TCGLogData,
+@@ -129,7 +129,7 @@ struct grub_efi_tpm2_protocol
+ 				      grub_efi_boolean_t *EventLogTruncated);
+   grub_efi_status_t (*hash_log_extend_event) (struct grub_efi_tpm2_protocol *this,
+ 					      grub_efi_uint64_t Flags,
+-					      grub_efi_physical_address_t *DataToHash,
++					      grub_efi_uint8_t *DataToHash,
+ 					      grub_efi_uint64_t DataToHashLen,
+ 					      EFI_TCG2_EVENT *EfiTcgEvent);
+   grub_efi_status_t (*submit_command) (struct grub_efi_tpm2_protocol *this,
+-- 
+2.7.4
+

--- a/tools/mkimage-iso-efi/patches/0002-video-Allow-to-set-pure-text-mode-in-case-of-EFI.patch
+++ b/tools/mkimage-iso-efi/patches/0002-video-Allow-to-set-pure-text-mode-in-case-of-EFI.patch
@@ -1,0 +1,33 @@
+From ac7afa666cb2b7b133b6e27bcf22c9cd90a2936a Mon Sep 17 00:00:00 2001
+From: Dennis Chen <dennis.chen@arm.com>
+Date: Wed, 6 Sep 2017 09:06:54 +0000
+Subject: [PATCH] video: Allow to set pure 'text' mode in case of EFI
+
+Current code doesn't accept a pure text mode when booting
+from UEFI firmware on i386 platform, this will result in
+below error message even we already have 'set gfxpayload=text'
+configured: "no suitable video mode found". This often happens
+when we boot a VM which UEFI firmware doesn't include 'suitable'
+video modes.
+
+Signed-off-by: Dennis Chen <dennis.chen@arm.com>
+---
+ grub-core/loader/i386/linux.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/loader/i386/linux.c b/grub-core/loader/i386/linux.c
+index 5fdfea3..8cf1086 100644
+--- a/grub-core/loader/i386/linux.c
++++ b/grub-core/loader/i386/linux.c
+@@ -49,7 +49,7 @@ GRUB_MOD_LICENSE ("GPLv3+");
+ #include <grub/efi/efi.h>
+ #define HAS_VGA_TEXT 0
+ #define DEFAULT_VIDEO_MODE "auto"
+-#define ACCEPTS_PURE_TEXT 0
++#define ACCEPTS_PURE_TEXT 1
+ #elif defined (GRUB_MACHINE_IEEE1275)
+ #include <grub/ieee1275/ieee1275.h>
+ #define HAS_VGA_TEXT 0
+-- 
+2.7.4
+


### PR DESCRIPTION
This patch uses coreos grub2 instead of the built-in gummiboot
tool with Alpine distribution.

Coreos grub2 has the security feature such as TPM and kernel
verification, so we can setup a trust chain when loading
modules with grub2.

GNU grub2[1] also has the plan to add those security related
features, they have a 'verifiers' branch to do that, but
there're some build issue need to fix,so this patch use
coreos as an alternative.

This patch is used to address the #2359 #2375.

Thanks Avi Deitcher <avi@deitcher.net> for the contribution
to build the GRUB2 from ubuntu 16.04 to alpine base image.

Change Log:
1. Remove the comments raised by @rn
2. Resolve the trust build issue raised by @rn 
3. Using the `/dev/vda` as the device name point by kernel command line `root=` on arm64, `/dev/sr0` on amd64. As next plan, we can adapt a more flexible method to get the dev name of the CDROM.
4. Build the grub2 in Alpine system

[1] https://git.savannah.gnu.org/git/grub.git

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Support iso-efi format image generation
**- How I did it**
Build a grub2 core image with help of ubuntu, then use that core image to construct the bootable iso image within Alpine distribution
**- How to verify it**
`tools/mkimage-iso-efi/make ORG=m0824`
Change the `src/moby/output.go` in moby tool git repos to point to the new built `mkimage-iso-efi` image.
`bin/moby build -output iso-efi linuxkit.yml`
`bin/linuxkit run qemu -uefi -fw "/path/to/ovmf/ovmf.fd" -iso linuxkit-efi.iso`
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/29599191-b0fab9e2-8800-11e7-840f-3c70c8921b10.jpg)
