### PR TITLE
Bump to containerd v1.0.0 alpha6

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:fa4ab4ac78b83fe392e39b861b4114c3bb02d170 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
 services:
   - name: getty
     image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: rngd1

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.43
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da as alpine
+FROM linuxkit/alpine:f4f5b333fa1a8433334fcae996d1637173144a72 as alpine
 RUN \
   apk add \
   btrfs-progs-dev \

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da AS build
+FROM linuxkit/alpine:f4f5b333fa1a8433334fcae996d1637173144a72 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -13,7 +13,7 @@ RUN go-compile.sh /go/src/cmd/init
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da AS mirror
+FROM linuxkit/alpine:f4f5b333fa1a8433334fcae996d1637173144a72 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:154913b72c6f1f33eb408609fca9963628e8c051

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/okernel:latest
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/scripts/update-component-sha.sh
+++ b/scripts/update-component-sha.sh
@@ -15,12 +15,12 @@ Available modes: --hash and --image
 
 Replace by hash:
 	$0 --hash <OLD> <NEW>
-	Example: $0 8675309abcdefg abcdef567899
+	Example: $0 --hash 8675309abcdefg abcdef567899
     	   Will replace all instances of 8675309abcdefg with abcdef567899
 
 Replace by image: $0 --image <IMAGE> <NEW>
 	$0 --image <IMAGE> <NEW>
-	Example: $0 linuxkit/foo abcdef567899
+	Example: $0 --image linuxkit/foo abcdef567899
 	   Will tag all instances of linuxkit/foo with abcdef567899
 
 By default, for convenience, if no mode is given (--image or --hash), the first method (--hash) is assumed. 

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
 services:
   - name: acpid
     image: linuxkit/acpid:79e5c20de96e1633c9c40935b99dde45aefba37b

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/004_config_4.12.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/004_config_4.12.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.83
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.8
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:2d20469b3746ac75f86ece7fe9b64cf80476add3
+    image: linuxkit/test-containerd:4f8a0405a48e544e3f7651dc79bfb6e07f3dc753
   - name: poweroff
     image: linuxkit/poweroff:1e9876c682c74d0602b7647c628bb0875fb13998
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test-wireguard.yml
+++ b/test/cases/040_packages/023_wireguard/test-wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.43
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: dhcpcd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:38cec1526acc8b1a2ce4b4ece78a810078c807e1

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.44
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:438d377802498afb3a6ed2a86175ab4beb07a31a
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:8e4aa6c09e9bceee8300a315c23e0333e187f5fa
+  - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da AS mirror
+FROM linuxkit/alpine:f4f5b333fa1a8433334fcae996d1637173144a72 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -44,7 +44,7 @@ RUN go get -u github.com/LK4D4/vndr
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.0.0-alpha4
+ENV CONTAINERD_COMMIT=v1.0.0-alpha6
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:d05028a6446eb1144f73dae6ae87167b956005a7-arm64
+# linuxkit/alpine:b39ee70ff7dc8a766a42e4c4b2822e87523de7d9-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da-amd64
+# linuxkit/alpine:f4f5b333fa1a8433334fcae996d1637173144a72-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -126,7 +126,7 @@ libltdl-2.4.6-r1
 libmagic-5.30-r0
 libmnl-1.0.4-r0
 libmount-2.28.2-r2
-libmspack-0.5_alpha-r0
+libmspack-0.5_alpha-r1
 libnfs-1.11.0-r0
 libnftnl-libs-1.0.7-r0
 libogg-1.3.2-r1


### PR DESCRIPTION
This carries all the changes from #2437 (bump to alpha5) and rolls in the bump to alpha6 (with no additional changes needed compared with #2437). This should fix the test regression which alpha5 had.