### PR TITLE
Update LCOW to latest OpenGCS rev

### DIFF
--- a/blueprints/lcow.yml
+++ b/blueprints/lcow.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
   tar: none
 init:
-  - linuxkit/init-lcow:227221c5f344b59c841fd57d0a9decbc50f1bb5e
+  - linuxkit/init-lcow:cd057e6320c5f76f8126430ac7978f54a7d6b5bd
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 trust:
   org:

--- a/pkg/init-lcow/Dockerfile
+++ b/pkg/init-lcow/Dockerfile
@@ -9,7 +9,7 @@ RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
 FROM linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630 AS build
 ENV OPENGCS_REPO=https://github.com/Microsoft/opengcs
-ENV OPENGCS_COMMIT=2dad06f038530dc305fb139a281507f1002e7e51
+ENV OPENGCS_COMMIT=34a64c3608036509e36bf9a211579a411f4d10da
 RUN apk add --no-cache build-base curl git go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin
 RUN git clone $OPENGCS_REPO /go/src/github.com/Microsoft/opengcs && \


### PR DESCRIPTION
Note when testing on Windows Build 16278 with todays docker master (server:`15b8d04`, client: `65202d6`) this will pull images but silently fails when running. This does **not** seem to be a regression with LinuxKit as the images from the previous update fail the same way (even when build with older `moby`). This is likely an issue with the Windows build and/or the docker master version used...

I suggest to merge this anyway as the OpenGCS changes picked up here contain a number of fixes.

![hedgehog](https://user-images.githubusercontent.com/3338098/29889357-ce25f9b2-8dbb-11e7-98b9-97c23e6f4f10.jpg)
