### PR TITLE
Update authors file with recent contributors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,7 @@ Gianluca Arbezzano <gianarb92@gmail.com>
 Hans van den Bogert <hansbogert@gmail.com>
 Ian Campbell <ian.campbell@docker.com>
 Ilya Dmitrichenko <errordeveloper@gmail.com>
+Istvan <l1x@users.noreply.github.com>
 Jason A. Donenfeld <Jason@zx2c4.com>
 Jeffrey Hogan <jeff.hogan1@gmail.com>
 Jeremy Yallop <yallop@docker.com>
@@ -44,6 +45,7 @@ Luke Hodkinson <furious.luke@gmail.com>
 Madhu Venugopal <madhu@docker.com>
 Magnus Skjegstad <magnus.skjegstad@docker.com>
 Marcus van Dam <marcus@marcusvandam.nl>
+marten <marten.cassel@gmail.com>
 Matt Bajor <matt.bajor@workday.com>
 Matt Bentley <matt.bentley@docker.com>
 Michel Courtine <michel.courtine@docker.com>


### PR DESCRIPTION
Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

![swallows](https://user-images.githubusercontent.com/3338098/29927292-cda4b080-8e5d-11e7-9c11-b390996185e0.jpg)
