### PR TITLE
Remove user/references to linuxkit/kernel-compile

### DIFF
--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -56,7 +56,9 @@ modules:
 
 ```
 FROM linuxkit/kernel:4.9.33 AS ksrc
-FROM linuxkit/kernel-compile:1b396c221af673757703258159ddc8539843b02b@sha256:6b32d205bfc6407568324337b707d195d027328dbfec554428ea93e7b0a8299b AS build
+FROM linuxkit/alpine:<hash> AS build
+RUN apk add build-base
+
 COPY --from=ksrc /kernel-dev.tar /
 RUN tar xf kernel-dev.tar
 

--- a/test/cases/020_kernel/010_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.9.x/Dockerfile
@@ -6,7 +6,9 @@
 FROM linuxkit/kernel:4.9.46 AS ksrc
 
 # Extract headers and compile module
-FROM linuxkit/kernel-compile:1b396c221af673757703258159ddc8539843b02b@sha256:6b32d205bfc6407568324337b707d195d027328dbfec554428ea93e7b0a8299b AS build
+FROM linuxkit/alpine:f4f5b333fa1a8433334fcae996d1637173144a72 AS build
+RUN apk add build-base
+
 COPY --from=ksrc /kernel-dev.tar /
 RUN tar xf kernel-dev.tar
 


### PR DESCRIPTION
It is no longer maintained and we should use the alpine base directly. This updates the test which used it and the documentation for compiling kernel modules

related to #2333

![croc](https://user-images.githubusercontent.com/3338098/29928470-03a78498-8e61-11e7-89ef-6bcc4582b510.jpg)
