### PR TITLE
tools: Add openssl, attr-dev, and libtirpc-dev to the alpine base image

### DIFF
--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -3,6 +3,7 @@ alpine-baselayout
 alpine-keys
 apk-tools
 argp-standalone
+attr-dev
 autoconf
 automake
 bash
@@ -53,6 +54,7 @@ libcap-ng-dev
 libelf-dev
 libressl-dev
 libseccomp-dev
+libtirpc-dev
 libtool
 libunwind-dev
 linux-headers
@@ -63,6 +65,7 @@ ncurses-dev
 openntpd
 openrc
 openssh-server
+openssl
 openssl-dev
 patch
 python3

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:b39ee70ff7dc8a766a42e4c4b2822e87523de7d9-arm64
+# linuxkit/alpine:0cc5ef543ceaf8fdc4e257a491c1e4ffc83d7195-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -7,6 +7,7 @@ alsa-lib-1.1.3-r0
 apk-tools-2.7.2-r0
 argp-standalone-1.3-r2
 attr-2.4.47-r6
+attr-dev-2.4.47-r6
 autoconf-2.69-r0
 automake-1.15-r0
 bash-4.3.48-r1
@@ -36,6 +37,7 @@ dhcpcd-6.11.5-r1
 diffutils-3.5-r0
 dosfstools-4.1-r1
 e2fsprogs-1.43.4-r0
+e2fsprogs-dev-1.43.4-r0
 e2fsprogs-extra-1.43.4-r0
 e2fsprogs-libs-1.43.4-r0
 ebtables-2.0.10.4-r2
@@ -78,7 +80,9 @@ jsoncpp-1.8.0-r0
 keyutils-libs-1.5.9-r1
 kmod-23-r1
 krb5-conf-1.0-r1
+krb5-dev-1.14.3-r2
 krb5-libs-1.14.3-r2
+krb5-server-ldap-1.14.3-r2
 libacl-2.2.52-r3
 libaio-0.3.110-r0
 libarchive-3.3.1-r1
@@ -141,6 +145,7 @@ libssl1.0-1.0.2k-r0
 libstdc++-6.3.0-r4
 libtasn1-4.10-r2
 libtirpc-1.0.1-r1
+libtirpc-dev-1.0.1-r1
 libtool-2.4.6-r1
 libunistring-0.9.7-r0
 libunwind-1.2-r2
@@ -175,6 +180,7 @@ openntpd-6.0_p1-r3
 openrc-0.24.1-r2
 openssh-keygen-7.5_p1-r1
 openssh-server-7.5_p1-r1
+openssl-1.0.2k-r0
 openssl-dev-1.0.2k-r0
 opus-1.1.4-r0
 p11-kit-0.23.2-r1

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:f4f5b333fa1a8433334fcae996d1637173144a72-amd64
+# linuxkit/alpine:21f2d52a0e20a78a0a81bbf5bebc652a3ec21b01-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -7,6 +7,7 @@ alsa-lib-1.1.3-r0
 apk-tools-2.7.2-r0
 argp-standalone-1.3-r2
 attr-2.4.47-r6
+attr-dev-2.4.47-r6
 autoconf-2.69-r0
 automake-1.15-r0
 bash-4.3.48-r1
@@ -37,6 +38,7 @@ dhcpcd-6.11.5-r1
 diffutils-3.5-r0
 dosfstools-4.1-r1
 e2fsprogs-1.43.4-r0
+e2fsprogs-dev-1.43.4-r0
 e2fsprogs-extra-1.43.4-r0
 e2fsprogs-libs-1.43.4-r0
 ebtables-2.0.10.4-r2
@@ -81,7 +83,9 @@ jsoncpp-1.8.0-r0
 keyutils-libs-1.5.9-r1
 kmod-23-r1
 krb5-conf-1.0-r1
+krb5-dev-1.14.3-r2
 krb5-libs-1.14.3-r2
+krb5-server-ldap-1.14.3-r2
 lddtree-1.26-r0
 libacl-2.2.52-r3
 libaio-0.3.110-r0
@@ -147,6 +151,7 @@ libssl1.0-1.0.2k-r0
 libstdc++-6.3.0-r4
 libtasn1-4.10-r2
 libtirpc-1.0.1-r1
+libtirpc-dev-1.0.1-r1
 libtool-2.4.6-r1
 libunistring-0.9.7-r0
 libunwind-1.2-r2
@@ -183,6 +188,7 @@ openntpd-6.0_p1-r3
 openrc-0.24.1-r2
 openssh-keygen-7.5_p1-r1
 openssh-server-7.5_p1-r1
+openssl-1.0.2k-r0
 openssl-dev-1.0.2k-r0
 opus-1.1.4-r0
 ovmf-0.0.20161115-r1


### PR DESCRIPTION
- openssl is for the okernel project (see #2465)
- attr-dev and libtirpc-dev are require to configure ZFS to build the kernel modules

/cc @t-koulouris

![frogs](https://user-images.githubusercontent.com/3338098/29929862-a07eee8e-8e64-11e7-9821-00228e463511.jpg)
