### PR TITLE
Add support for building ZFS kernel modules

### DIFF
--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -307,3 +307,39 @@ nsenter -m/proc/1/ns/mnt ash
 
 Alternatively, you can add the `kernel-perf` package as stage in a
 multi-stage build to add it to a custom package.
+
+
+## ZFS
+
+The kernel build Makefile has support for building the ZFS kernel
+modules. Note, the modules are currently not distributed as standard
+LinuxKit packages and if you wish to use them you have to compile them
+yourself:
+
+```sh
+cd kernel
+make ORG=<foo> NOTRUST=1 push_zfs_4.9.x # or different kernel version
+```
+
+will build and push a `zfs-kmod-4.9.<version>` image to Docker Hub
+under the `ORG` specified. This package contains the all the standard
+kernel modules from the kernel specified plus the `spl` and `zfs`
+kernel modules, with `depmod` run over them, so they can be
+`modprobe`ed. To use the modules do something like this in your YAML
+file:
+
+```
+kernel:
+  image: linuxkit/kernel:4.9.47
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+init:
+  - <foo>/zfs-kmod:4.9.47
+  ...
+```
+
+Then, you also need to make sure the Alpine `zfs` utilities are
+available in the container where your want to run `zfs` commands. The
+Alpine `zfs` utilities are available in `linuxkit/alpine` and the
+version of the kernel module should match the version of the
+tools. The container where you run the `zfs` tools might also need
+`CAP_SYS_MODULE` to be able to load the kernel modules.

--- a/kernel/Dockerfile.zfs
+++ b/kernel/Dockerfile.zfs
@@ -1,0 +1,59 @@
+ARG IMAGE
+FROM ${IMAGE} AS ksrc
+FROM linuxkit/alpine:349a817bdd6b293ca623ab97acf5377ccdeac7d2 AS build
+RUN apk add \
+    attr-dev \
+    autoconf \
+    automake \
+    build-base \
+    file \
+    git \
+    libtirpc-dev \ 
+    libtool \
+    util-linux-dev \
+    zlib-dev
+
+COPY --from=ksrc /kernel-dev.tar /
+RUN tar xf kernel-dev.tar
+
+# Also extract the kernel modules
+COPY --from=ksrc /kernel.tar /
+RUN tar xf kernel.tar
+
+# Note: ZFS and SPL commits must match. It's unclear how much the user
+# space tools must match the kernel module version. The current zfs
+# package on Alpine is 0.6.5.9. We pick 0.6.5.10 because it has
+# support for 4.12 based kernels.
+ENV VERSION=0.6.5.10
+
+ENV SPL_REPO=https://github.com/zfsonlinux/spl.git
+ENV SPL_COMMIT=spl-${VERSION}
+RUN git clone ${SPL_REPO} && \
+    cd spl && \
+    git checkout ${SPL_COMMIT}
+
+ENV ZFS_REPO=https://github.com/zfsonlinux/zfs.git
+ENV ZFS_COMMIT=zfs-${VERSION}
+RUN git clone ${ZFS_REPO} && \
+    cd zfs && \
+    git checkout ${ZFS_COMMIT}
+
+WORKDIR /spl
+RUN ./autogen.sh && \
+    ./configure && \
+    cd module && \
+    make && \
+    make install
+
+WORKDIR /zfs
+RUN ./autogen.sh && \
+    ./configure --with-spl=/spl && \
+    cd module && \
+    make -j "$(getconf _NPROCESSORS_ONLN)" && \
+    make install
+
+FROM scratch
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=build /lib/modules/ /lib/modules/

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -16,6 +16,7 @@
 ORG?=linuxkit
 IMAGE:=kernel
 IMAGE_PERF:=kernel-perf
+IMAGE_ZFS:=zfs-kmod
 
 # You can specify an extra options for the Makefile. This will:
 # - append a kernel_config$(EXTRA) to the kernel config for your kernel/arch
@@ -118,11 +119,13 @@ push: push_$(2)$(3)
 show-tags: show-tag_$(2)$(3)
 fetch: sources/linux-$(1).tar.xz
 
-ifneq ($(2), 4.4.x)
 # 'docker build' with the FROM image supplied as --build-arg
 # *and* with DOCKER_CONTENT_TRUST=1 currently does not work
 # (https://github.com/moby/moby/issues/34199). So, we pull the image
 # with DCT and then build with DOCKER_CONTENT_TRUST explicitly set to 0.
+
+ifneq ($(2), 4.4.x)
+# perf does not build out of the box for 4.4.x and 4.4.x is not that relevant anymore to work on a fix
 build_perf_$(2)$(3): build_$(2)$(3)
 	docker pull $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG)$(SUFFIX) || \
 		(docker pull $(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) && \
@@ -141,6 +144,26 @@ push_perf_$(2)$(3): build_perf_$(2)$(3)
 
 build: build_perf_$(2)$(3)
 push: push_perf_$(2)$(3)
+endif
+
+ifneq ($(3), -dbg)
+# ZFS does not compile against -dbg kernels because CONFIG_DEBUG_LOCK_ALLOC
+# is incompatible with CDDL, apparently (this is ./configure check)
+build_zfs_$(2)$(3): build_$(2)$(3)
+	docker pull $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) || \
+		(docker pull $(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) && \
+		 DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile.zfs \
+			--build-arg IMAGE=$(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) \
+			--no-cache $(LABEL) -t $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) .)
+
+push_zfs_$(2)$(3): build_zfs_$(2)$(3)
+	@if [ x"$(DIRTY)" != x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+	docker pull $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) || \
+		(docker push $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) && \
+		 docker tag $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) $(ORG)/$(IMAGE_ZFS):$(1)$(3)$(SUFFIX) && \
+		 docker push $(ORG)/$(IMAGE_ZFS):$(1)$(3)$(SUFFIX) && \
+		 $(PUSH_MANIFEST) $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG) $(DOCKER_CONTENT_TRUST) && \
+		 $(PUSH_MANIFEST) $(ORG)/$(IMAGE_ZFS):$(1)$(3) $(DOCKER_CONTENT_TRUST))
 endif
 
 endef


### PR DESCRIPTION
This adds support for building the ZFS kernel modules. The modules can be build as a separate package with tags matching the kernel build version. The modules can be added to a linuxkit image by adding the `zfs-kmod` package to the `init` section of a YAML file.

The `zfs-kmod` package also contains the standard kernel modules with `depmod` run over all of them so that `modprobe` should work.

The kernel modules do not compile for debug kernels due to CDDL incompatibility, apparently (the ZFS `./configure` script complains about `CONFIG_DEBUG_LOCK_ALLOC`)

Note, the `zfs-kmod` package is not build as the standard kernel build and is *not* hosted under the `linuxkit` Hub org due licensing uncertainty. Potential users will have to build the package themselves. `./docs/kernels.md` contains some notes.

/cc @matjohn2 (re #2333)

![piglet](https://user-images.githubusercontent.com/3338098/29937959-18d71a54-8e7f-11e7-8e8e-d6ca1fadd9fa.jpg)
