### PR TITLE
Update linuxkit kernel to 4.12.9

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+        image: linuxkit/kernel:4.12.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=ttyS1"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -1,8 +1,8 @@
 kernel:
-  image: linuxkit/kernel:4.9.38
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:7d97282aebe36040fcdd3378a95562d440d34a9d
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=tty0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.46
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.43
+  image: linuxkit/kernel:4.12.9
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412


### PR DESCRIPTION
**- Update linuxkit kernel to 4.12.9**

Updated all linuxkit kernel versions to 4.12.9 from older ones. Also updated the `linuxkit/init` hash in `examples/tpm.yml`