### PR TITLE
wireguard: use custom wg-quick

### DIFF
--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.43
+  image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6d11a1f9d299d3425e78cce80dfba8b236d20412
@@ -13,11 +13,11 @@ onboot:
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:b084fd2ada446015e00e43a441bb0ae41ff8b227
+    image: linuxkit/ip:044287be54a62d1590dcd4d22543c1a1031479e6
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
-    command: ["sh", "-c", "ip link set dev wg0 up; ip address add dev wg0 192.168.2.1/24; wg setconf wg0 /etc/wireguard/wg0.conf; wg show wg0"]
+    command: ["/usr/bin/lk-wg-config", "configure", "/etc/wireguard/wg0.conf"]
     runtime:
       interfaces:
         - name: wg0
@@ -26,11 +26,11 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:b084fd2ada446015e00e43a441bb0ae41ff8b227
+    image: linuxkit/ip:044287be54a62d1590dcd4d22543c1a1031479e6
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
-    command: ["sh", "-c", "ip link set dev wg1 up; ip address add dev wg1 192.168.2.2/24; wg setconf wg1 /etc/wireguard/wg1.conf; wg show wg1"]
+    command: ["/usr/bin/lk-wg-config", "configure", "/etc/wireguard/wg1.conf"]
     runtime:
       interfaces:
         - name: wg1
@@ -40,7 +40,7 @@ onboot:
           net: /run/netns/wg1
 services:
   - name: getty
-    image: linuxkit/getty:797cb79e0a229fcd16ebf44a0da74bcec03968ec
+    image: linuxkit/getty:48870d0f92c65fecd6ddb18004d68d85f9b9cde3
     env:
      - INSECURE=true
     net: /run/netns/wg1
@@ -58,7 +58,9 @@ services:
 files:
   - path: etc/wireguard/wg0.conf
     contents: |
-      [Interface] 
+      [Interface]
+      Address = 192.168.2.1/24
+      DNS = 192.168.2.2
       PrivateKey = KG7EKkHDkp7THfW5mOXcZzo3RbGAjq+ARMfJGFm5G1s=
       ListenPort = 51820
       [Peer] 
@@ -68,6 +70,7 @@ files:
   - path: etc/wireguard/wg1.conf
     contents: |
       [Interface]
+      Address = 192.168.2.2/24
       PrivateKey = SCGCKDuTm4PMOw+LXdK/2s8mxnv145QHOohKRq3vc2A=
       ListenPort = 51821
       [Peer]

--- a/pkg/getty/Dockerfile
+++ b/pkg/getty/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630 AS mirror
+FROM linuxkit/alpine:1e67b8fdba849ed2f7e8537c13b7f280639623d6 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/ip/Dockerfile
+++ b/pkg/ip/Dockerfile
@@ -1,5 +1,6 @@
-FROM linuxkit/alpine:a120ad6aead3fe583eaa20e9b75a05ac1b3487da AS mirror
+FROM linuxkit/alpine:1e67b8fdba849ed2f7e8537c13b7f280639623d6 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add curl
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
     bash \
@@ -7,6 +8,9 @@ RUN apk add --no-cache --initdb -p /out \
     iproute2 \
     musl \
     wireguard-tools
+
+# We grab our version of wg-quick, called lk-wg-config.sh
+RUN curl -sSL -o /out/usr/bin/lk-wg-config https://gist.githubusercontent.com/zx2c4/3624de869ab7eaef3de5ea8f2b867be9/raw/de72b018f4f4548858ce6aae2898b34db0474221/lk-wg-config.sh && chmod 755 /out/usr/bin/lk-wg-config
 
 # Remove apk residuals
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache

--- a/pkg/ip/Makefile
+++ b/pkg/ip/Makefile
@@ -1,3 +1,4 @@
 IMAGE=ip
+NETWORK=1
 
 include ../package.mk

--- a/test/cases/040_packages/023_wireguard/test-wireguard.yml
+++ b/test/cases/040_packages/023_wireguard/test-wireguard.yml
@@ -11,11 +11,11 @@ onboot:
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:b084fd2ada446015e00e43a441bb0ae41ff8b227
+    image: linuxkit/ip:044287be54a62d1590dcd4d22543c1a1031479e6
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
-    command: ["sh", "-c", "ip link set dev wg0 up; ip address add dev wg0 192.168.2.1/24; wg setconf wg0 /etc/wireguard/wg0.conf; wg show wg0"]
+    command: ["/usr/bin/lk-wg-config", "configure", "/etc/wireguard/wg0.conf"]
     runtime:
       interfaces:
         - name: wg0
@@ -24,11 +24,11 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:b084fd2ada446015e00e43a441bb0ae41ff8b227
+    image: linuxkit/ip:044287be54a62d1590dcd4d22543c1a1031479e6
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
-    command: ["sh", "-c", "ip link set dev wg1 up; ip address add dev wg1 192.168.2.2/24; wg setconf wg1 /etc/wireguard/wg1.conf; wg show wg1"]
+    command: ["/usr/bin/lk-wg-config", "configure", "/etc/wireguard/wg1.conf"]
     runtime:
       interfaces:
         - name: wg1
@@ -66,7 +66,8 @@ services:
 files:
   - path: etc/wireguard/wg0.conf
     contents: |
-      [Interface] 
+      [Interface]
+      Address = 192.168.2.1/24
       PrivateKey = KG7EKkHDkp7THfW5mOXcZzo3RbGAjq+ARMfJGFm5G1s=
       ListenPort = 51820
       [Peer] 
@@ -76,6 +77,7 @@ files:
   - path: etc/wireguard/wg1.conf
     contents: |
       [Interface]
+      Address = 192.168.2.2/24
       PrivateKey = SCGCKDuTm4PMOw+LXdK/2s8mxnv145QHOohKRq3vc2A=
       ListenPort = 51821
       [Peer]


### PR DESCRIPTION
This makes things in general much cleaner. This is a reworking of #2457 from @justincormack , which avoids putting GPLd code directly in this repo, while also fixing up a few other small things.

Currently untested, but I wanted to get your feedback on the idea.

Note that downloading custom scripts and tarballs and whatnot via curl is already quite common throughout LinuxKit:

```
test/pkg/ltp/Dockerfile:RUN curl -fsSL -o ltp-full-${LTP_VERSION}.tar.xz ${LTP_SOURCE}
projects/clear-containers/kernel/Dockerfile:RUN curl -fsSL -o linux-${KERNEL_VERSION}.tar.xz ${KERNEL_SOURCE}
projects/selinux/kernel/Dockerfile:RUN curl -fsSL -o linux-${KERNEL_VERSION}.tar.xz ${KERNEL_SOURCE}
projects/landlock/kernel-landlock/Dockerfile:RUN curl -fsSL -o linux-${KERNEL_VERSION}.tar.xz ${KERNEL_SOURCE}
projects/shiftfs/Dockerfile:RUN curl -fsSL -o linux-${KERNEL_VERSION}.tar.xz ${KERNEL_SOURCE}
projects/ima-namespace/kernel/Dockerfile:RUN curl -fsSL -o linux-${KERNEL_VERSION}.tar.xz ${KERNEL_SOURCE}
projects/kernel-config/Dockerfile:RUN curl -fsSL -o linux-${KERNEL_VERSION}.tar.xz ${KERNEL_SOURCE}
projects/memorizer/kernel-memorizer/Dockerfile:RUN curl -fsSLO ${KERNEL_SHA256_SUMS} && \
projects/ebpf/ebpf.build/Dockerfile:RUN curl -sSL -O https://fedorahosted.org/releases/e/l/elfutils/0.165/elfutils-$ELFUTILS_VERSION.tar.bz2
projects/kubernetes/kubernetes/Dockerfile:RUN curl -fSL -o /tmp/cni.tgz https://github.com/containernetworking/cni/releases/download/v0.5.2/cni-amd64-${cni_version}.tgz && \
projects/kubernetes/kubernetes/Dockerfile:RUN curl -fSL -o /out/etc/weave.yaml https://cloud.weave.works/k8s/v1.7/net?v=${weave_version} 
projects/kubernetes/kubernetes/Dockerfile:RUN curl -fSL -o /out/usr/bin/kubelet https://dl.k8s.io/${kubernetes_version}/bin/linux/amd64/kubelet && chmod 0755 /out/usr/bin/kubelet
projects/kubernetes/kubernetes/Dockerfile:RUN curl -fSL -o /out/usr/bin/kubeadm https://dl.k8s.io/${kubernetes_version}/bin/linux/amd64/kubeadm && chmod 0755 /out/usr/bin/kubeadm
projects/kubernetes/kubernetes/Dockerfile:RUN curl -fSL -o /out/usr/bin/kubectl https://dl.k8s.io/${kubernetes_version}/bin/linux/amd64/kubectl && chmod 0755 /out/usr/bin/kubectl
kernel/Dockerfile:RUN curl -fsSLO ${KERNEL_SHA256_SUMS} && \
kernel/Dockerfile:RUN curl -sSL -o /wireguard.tar.xz "${WIREGUARD_URL}" && \
```