### PR TITLE
Update to latest Hyperkit API

### DIFF
--- a/src/cmd/linuxkit/vendor.conf
+++ b/src/cmd/linuxkit/vendor.conf
@@ -11,7 +11,7 @@ github.com/googleapis/gax-go 8c5154c0fe5bf18cf649634d4c6df50897a32751
 github.com/gophercloud/gophercloud 2804b72cf099b41d2e25c8afcca786f9f962ddee
 github.com/jmespath/go-jmespath bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 github.com/mitchellh/go-ps 4fdf99ab29366514c69ccccddab5dc58b8d84062
-github.com/moby/hyperkit a82b409a87f12fa3306813410c37f4eed270efac
+github.com/moby/hyperkit 3e31617ae866c93925e2b3bc5d8006b60985e920
 github.com/packethost/packngo 131798f2804a1b3e895ca98047d56f0d7e094e2a
 github.com/radu-matei/azure-sdk-for-go 3b12823551999669c9a325a32472508e0af7978e
 github.com/radu-matei/azure-vhd-utils e52754d5569d2a643a7775f72ff2a6cf524f4c25


### PR DESCRIPTION
This adds support for the updated Hyperkit API, which is needed to
request a specific IP address in new versions of VPNKit / Docker for
Mac. IPs encoded in the UUID (the old method) will now be ignored by
VPNKit (from Docker for Mac 17.09-rc1 and later).

The protocol update in DfM also adds better error messages if Hyperkit fails to 
connect to VPNKit (e.g. if the IP or UUID is unavailable).

(more details in the commit message)