### PR TITLE
cmd: On KVM/aarch64 add gic_version=host

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -504,10 +504,8 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 
 	if config.KVM {
 		qemuArgs = append(qemuArgs, "-enable-kvm")
-		// Remove the hardcode of virtual machine type for x86, since we will
-		// support aarch64 in future
 		if config.Arch == "aarch64" {
-			qemuArgs = append(qemuArgs, "-machine", "virt")
+			qemuArgs = append(qemuArgs, "-machine", "virt,gic_version=host")
 		} else {
 			qemuArgs = append(qemuArgs, "-machine", "q35,accel=kvm:tcg")
 		}


### PR DESCRIPTION
This picks the correct GIC version to be emulated.
Without it you get an error on Thunder-X (and possibly others):

KVM_SET_DEVICE_ATTR failed: No such device

See also https://bugzilla.redhat.com/show_bug.cgi?id=1375571#c6

Fixes #2360

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

![baby-hermit](https://user-images.githubusercontent.com/3338098/30219417-ddcf003a-94b3-11e7-8892-4ded6ef6c75b.jpg)
