### PR TITLE
qemu: Fix the networking issue in 'tap' mode on arm64

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -284,7 +284,7 @@ func runQemu(args []string) {
 		if len(publishFlags) != 0 {
 			log.Fatalf("Port publishing requires %q networking mode", qemuNetworkingUser)
 		}
-		netdevConfig = fmt.Sprintf("tap,ifname=%s,script=no,downscript=no", netMode[1])
+		netdevConfig = fmt.Sprintf("tap,id=t0,ifname=%s,script=no,downscript=no", netMode[1])
 	case qemuNetworkingBridge:
 		if len(netMode) != 2 {
 			log.Fatalf("Not enough arugments for %q networking mode", qemuNetworkingBridge)
@@ -571,13 +571,14 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 	if config.NetdevConfig == "" {
 		qemuArgs = append(qemuArgs, "-net", "none")
 	} else {
-		mac := retrieveMAC(config.StatePath)
-		qemuArgs = append(qemuArgs, "-net", "nic,model=virtio,macaddr="+mac.String())
+		// provide a network device first for the QEMU VM if '-networking' is specified,
+		qemuArgs = append(qemuArgs, "-device", "virtio-net-pci,netdev=t0")
 		forwardings, err := buildQemuForwardings(config.PublishedPorts, config.Containerized)
 		if err != nil {
 			log.Error(err)
 		}
-		qemuArgs = append(qemuArgs, "-net", config.NetdevConfig+forwardings)
+		// we perfer "-netdev" to the "-net" which is an old way to initialize a host nic
+		qemuArgs = append(qemuArgs, "-netdev", config.NetdevConfig+forwardings)
 	}
 
 	if config.GUI != true {


### PR DESCRIPTION
This PR is used to fix the issue #2488.

Currently we use '-net' the old way to initialize a host nic
interface, this method will not work on arm64 platform(#2488 issue),
so we use the '-netdev' method which will work on both arm64 and amd64.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the networking issue in 'tap' mode on arm64 platform
**- How I did it**
1. Add a new networking device 2. Add a networking interface in QEMU backed by the device created in step 1.
**- How to verify it**
Test it on both arm64 and amd64 platform after applied this patch, both system can enter into shell with valid network connection with outside world, eg, we can access the nginx service remotely from another machine.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/30257102-49acf7c8-96e2-11e7-96ff-54364a77c0e1.jpg)
