### PR TITLE
wireguard: bump to new snapshot with better RTS semantics

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -37,8 +37,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20170810
-ENV WIREGUARD_SHA256=ab96230390625aad6f4816fa23aef6e9f7fee130f083d838919129ff12089bf7
+ENV WIREGUARD_VERSION=0.0.20170907
+ENV WIREGUARD_SHA256=a1ee12d60662607e4c5a19f84b5115e56f083e2600053882e161537f12d963fd
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # PGP keys: 589DA6B1 (greg@kroah.com) & 6092693E (autosigner@kernel.org) & 00411886 (torvalds@linux-foundation.org)


### PR DESCRIPTION
  This follows an extensive discussion on the mailing list.
  
  We store the destination IP of incoming packets as the source IP of
  outgoing packets. When we send outgoing packets, we then ask the routing
  table for which interface to use and which source address, given our
  inputs of the destination address and a suggested source address. This
  all is good and fine, since it means we'll successfully reply using the
  correct source address, correlating with the destination address for
  incoming packets. However, what happens when default routes change? Or
  when interface IP addresses change?
  
  Prior to this snapshot, after getting the response from the routing table
  of the source address, destination address, and interface, we would then
  make sure that the source address actually belonged to the outbound
  interface. If it didn't, we'd reset our source address to zero and
  re-ask the routing table, in which case the routing table would then
  give us the default IP address for sending that packet. This worked
  mostly fine for most purposes, but there was a problem: what if
  WireGuard legitimately accepted an inbound packet on a default interface
  using an IP of another interface? In this case, falling back to asking
  for the default source IP was not a good strategy, since it'd nearly
  always mean we'd fail to reply using the right source.
  
  So, this snapshot changes the algorithm slightly. Rather than falling back
  to using the default IP if the preferred source IP doesn't belong to the
  outbound interface, we have two checks: we make sure that the source IP
  address belongs to _some_ interface on the system, no matter which one
  (so long as it's within the network namespace), and we check whether or
  not the interface of an incoming packet matches the returned interface
  for the outbound traffic. If both these conditions are true, then we
  proceed with using this source IP address. If not, we fall back to the
  default IP address.