### PR TITLE
qemu: restore persistent mac address support

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -571,13 +571,12 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 	if config.NetdevConfig == "" {
 		qemuArgs = append(qemuArgs, "-net", "none")
 	} else {
-		// provide a network device first for the QEMU VM if '-networking' is specified,
-		qemuArgs = append(qemuArgs, "-device", "virtio-net-pci,netdev=t0")
+		mac := retrieveMAC(config.StatePath)
+		qemuArgs = append(qemuArgs, "-device", "virtio-net-pci,netdev=t0,mac="+mac.String())
 		forwardings, err := buildQemuForwardings(config.PublishedPorts, config.Containerized)
 		if err != nil {
 			log.Error(err)
 		}
-		// we perfer "-netdev" to the "-net" which is an old way to initialize a host nic
 		qemuArgs = append(qemuArgs, "-netdev", config.NetdevConfig+forwardings)
 	}
 


### PR DESCRIPTION
If the state dir is preserved then the VM should come up with the same mac
address on subsequent reboots.

Fixes regression in #2498.

Rather than fixing the typo in the associated comments just remove them since
they don't really convey any useful information.

Signed-off-by: Ian Campbell <ijc@docker.com>
/cc @rn @arm64b