### PR TITLE
new pkg/modprobe from linuxkit/alpine base onto scratch

### DIFF
--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -38,6 +38,15 @@ In summary, LinuxKit offers a choice of the following kernels:
 - [linuxkit/kernel-fedora](https://hub.docker.com/r/linuxkit/kernel-fedora/): Selected Fedora kernels.
 
 
+## Loading kernel modules
+
+Most kernel modules are autoloaded with `mdev` but if you need to `modprobe` a module manually you can use the `modprobe` package in the `onboot` section like this:
+```
+  - name: modprobe
+    image: linuxkit/modprobe:<hash>
+    command: ["modprobe", "-a", "iscsi_tcp", "dm_multipath"]
+```
+
 ## Compiling external kernel modules
 
 This section describes how to build external (out-of-tree) kernel

--- a/pkg/modprobe/Dockerfile
+++ b/pkg/modprobe/Dockerfile
@@ -1,0 +1,13 @@
+FROM linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630 AS mirror
+
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    busybox
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+FROM scratch
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=mirror /out/ /
+LABEL org.mobyproject.config='{"binds": ["/lib/modules:/lib/modules", "/sys:/sys"], "capabilities": ["CAP_SYS_MODULE"]}'

--- a/pkg/modprobe/Makefile
+++ b/pkg/modprobe/Makefile
@@ -1,0 +1,3 @@
+IMAGE=modprobe
+
+include ../package.mk


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Created a minimal pkg/modprobe package which is based on scratch, with only the linuxkit/alpine /bin/busybox, and /bin/busybox -> /sbin/modprobe symlinked. This also includes the required capabilities and bind mounts for loading modules.

**- How I did it**
I followed the established pattern for the other included LinuxKit packages

**- How to verify it**

1. Build Linuxkit packages, and use as follows -
```
  - name: modprobe
    image: linuxkit/modprobe:HASH
    command: ["modprobe", "-a", "iscsi_tcp", "dm_multipath"]
```
(substituting the module you need to load in the above)

2. Create and boot your LinuxKit image
3. Run `lsmod` to verify the specified module has been installed

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
added minimal pkg/modprobe


**- A picture of a cute animal (not mandatory but encouraged)**
![maddie](https://user-images.githubusercontent.com/4591181/30398827-9f736bd8-9886-11e7-865a-792b469665bc.png)
