### PR TITLE
service: log stdout and stderr to separate files

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:fa4ab4ac78b83fe392e39b861b4114c3bb02d170 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
 services:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
 onboot:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
 onboot:

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
 onboot:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.43
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/pkg/init/cmd/service/start.go
+++ b/pkg/init/cmd/service/start.go
@@ -121,17 +121,21 @@ func start(service, sock, basePath, dumpSpec string) (string, uint32, string, er
 	}
 
 	io := func(id string) (containerd.IO, error) {
-		logfile := filepath.Join("/var/log", service+".log")
-		// We just need this to exist.
-		if err := ioutil.WriteFile(logfile, []byte{}, 0600); err != nil {
-			// if we cannot write to log, discard output
-			logfile = "/dev/null"
+		stdoutFile := filepath.Join("/var/log", service+".out.log")
+		stderrFile := filepath.Join("/var/log", service+".err.log")
+		// We just need this to exist. If we cannot write to the directory,
+		// we'll discard output instead.
+		if err := ioutil.WriteFile(stdoutFile, []byte{}, 0600); err != nil {
+			stdoutFile = "/dev/null"
+		}
+		if err := ioutil.WriteFile(stderrFile, []byte{}, 0600); err != nil {
+			stderrFile = "/dev/null"
 		}
 		return &cio{
 			containerd.IOConfig{
 				Stdin:    "/dev/null",
-				Stdout:   logfile,
-				Stderr:   logfile,
+				Stdout:   stdoutFile,
+				Stderr:   stderrFile,
 				Terminal: false,
 			},
 		}, nil

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:12348442d56c2ee9abf13ff38dff2e36b515bd1e # with runc, logwrite, startmemlogd
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f # with runc, logwrite, startmemlogd
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:059b2bb4b6efa5c58cf53fed4d0ea863521959fc
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
 onboot:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
 services:

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/004_config_4.12.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/004_config_4.12.x/test-kernel-config.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.87
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.12.12
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test-ctr.yml
+++ b/test/cases/040_packages/007_getty-containerd/test-ctr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test-wireguard.yml
+++ b/test/cases/040_packages/023_wireguard/test-wireguard.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.43
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:79973d34faf7d4654462f3408c5eb00befaf03b8
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
   - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
 onboot:

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d049e7b2074da5cd699a27defb47eb101142455d
+  - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
 onboot:
   - name: test-ns


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed a bug in `service` which fails to read data from the `stdout` of the container (in my case leading to the process blocking when the pipe filled up)

**- How I did it**

Previously we would pass the path `/var/log/service.log` for both stdout and stderr to containerd. containerd would construct a dict with the [paths as keys](https://github.com/containerd/containerd/blob/49437711c31c5f8ca8e1a5931be7284198497350/linux/shim/io.go#L51) and, due to the duplicate key, would only open one of the files and start one `io.Copy` instance. Writes to the other stream would be buffered by the pipe connected to containerd-shim and would eventually block.

If we modified containerd to open the file twice and start two `io.Copy` instances, we would end up with the two streams interleaved together. It seems cleaner to keep the streams separate; therefore this patch logs stdout to `/var/log/service.out.log` and stderr to `/var/log/service.err.log`.

**- How to verify it**

Create a service which writes to `stdout`: before this change, the write will not be logged. After this patch it will be logged to `/var/log/service.out.log`

**- Description for the changelog**

Change the log paths: write stdout to `/var/log/service.out.log` and stderr to `/var/log/service.err.log`

**- A picture of a cute animal (not mandatory but encouraged)**

![beaver sitting on logs](https://2.bp.blogspot.com/-TvayMc3oUEg/WQk7lyFCleI/AAAAAAAAQVo/FW2H3OOSzrMC-1pdeJDnNLj13l2QLzPeQCLcB/s1600/Beaver-sitting-on-logs-Isolated-illustration-on-a-white-background--Stock-Illustration.jpg)