### PR TITLE
kernel update to 4.12.13/4.9.50/4.4.88

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -1,6 +1,6 @@
 # This is a blueprint for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:fa4ab4ac78b83fe392e39b861b4114c3bb02d170 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -330,7 +330,7 @@ file:
 
 ```
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - <foo>/zfs-kmod:4.9.47

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=tty0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -172,11 +172,11 @@ endef
 # Build Targets
 # Debug targets only for latest stable and LTS stable
 #
-$(eval $(call kernel,4.12.12,4.12.x,$(EXTRA)))
-$(eval $(call kernel,4.12.12,4.12.x,-dbg))
-$(eval $(call kernel,4.9.49,4.9.x,$(EXTRA)))
-$(eval $(call kernel,4.9.49,4.9.x,-dbg))
-$(eval $(call kernel,4.4.87,4.4.x,$(EXTRA)))
+$(eval $(call kernel,4.12.13,4.12.x,$(EXTRA)))
+$(eval $(call kernel,4.12.13,4.12.x,-dbg))
+$(eval $(call kernel,4.9.50,4.9.x,$(EXTRA)))
+$(eval $(call kernel,4.9.50,4.9.x,-dbg))
+$(eval $(call kernel,4.4.88,4.4.x,$(EXTRA)))
 
 # Target for kernel config
 kconfig: | sources

--- a/kernel/kernel_config-4.12.x-aarch64
+++ b/kernel/kernel_config-4.12.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.12.12 Kernel Configuration
+# Linux/arm64 4.12.13 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/kernel_config-4.12.x-x86_64
+++ b/kernel/kernel_config-4.12.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.12.12 Kernel Configuration
+# Linux/x86 4.12.13 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/kernel_config-4.4.x-aarch64
+++ b/kernel/kernel_config-4.4.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.4.87 Kernel Configuration
+# Linux/arm64 4.4.88 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/kernel_config-4.4.x-x86_64
+++ b/kernel/kernel_config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.87 Kernel Configuration
+# Linux/x86 4.4.88 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/kernel_config-4.9.x-aarch64
+++ b/kernel/kernel_config-4.9.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.9.49 Kernel Configuration
+# Linux/arm64 4.9.50 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/kernel_config-4.9.x-x86_64
+++ b/kernel/kernel_config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.49 Kernel Configuration
+# Linux/x86 4.9.50 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.12.x/0001-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
+++ b/kernel/patches-4.12.x/0001-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
@@ -1,4 +1,4 @@
-From 39f8854c3df42f891054229688cc797df101436c Mon Sep 17 00:00:00 2001
+From d34b8dad5cbb125d4d0260e439ea0d02cd93b7f8 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 26 Jul 2017 12:31:50 -0600
 Subject: [PATCH 01/15] vmbus: vmbus_open(): reset onchannel_callback on error

--- a/kernel/patches-4.12.x/0002-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.12.x/0002-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 782e0fdf4c9b91b6c62e316d6a59e34240198cd5 Mon Sep 17 00:00:00 2001
+From 02167ba1cbb35d954c029846f753b1c38daf0c4e Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 26 Jul 2017 12:31:53 -0600
 Subject: [PATCH 02/15] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.12.x/0003-vmbus-dynamically-enqueue-dequeue-a-channel-on-vmbus.patch
+++ b/kernel/patches-4.12.x/0003-vmbus-dynamically-enqueue-dequeue-a-channel-on-vmbus.patch
@@ -1,4 +1,4 @@
-From 4b35ca75f7c705804407411b1ab13dc3d0e95551 Mon Sep 17 00:00:00 2001
+From a021d948658c20f25abb7f4ae5fce42bdbe2869b Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:23 -0600
 Subject: [PATCH 03/15] vmbus: dynamically enqueue/dequeue a channel on

--- a/kernel/patches-4.12.x/0004-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
+++ b/kernel/patches-4.12.x/0004-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
@@ -1,4 +1,4 @@
-From cc1423bdb6d3e096a13363deb8aaa38cb2ba02bc Mon Sep 17 00:00:00 2001
+From 1c7e06eb20a24ff9f8ef3058458cb2df485afe8b Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 26 Jul 2017 12:31:56 -0600
 Subject: [PATCH 04/15] hv_sock: implements Hyper-V transport for Virtual

--- a/kernel/patches-4.12.x/0005-VMCI-only-try-to-load-on-VMware-hypervisor.patch
+++ b/kernel/patches-4.12.x/0005-VMCI-only-try-to-load-on-VMware-hypervisor.patch
@@ -1,4 +1,4 @@
-From ac93019a1a44459202922c3557a98c62ce00dbcc Mon Sep 17 00:00:00 2001
+From f8cbe9d1fd7c7eb028a65b2a2eb0945d056b8522 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 26 Jul 2017 12:31:58 -0600
 Subject: [PATCH 05/15] VMCI: only try to load on VMware hypervisor

--- a/kernel/patches-4.12.x/0006-hv_sock-add-the-support-of-auto-loading.patch
+++ b/kernel/patches-4.12.x/0006-hv_sock-add-the-support-of-auto-loading.patch
@@ -1,4 +1,4 @@
-From d701c3561cf4ed5857e3cb02410360c3072d3052 Mon Sep 17 00:00:00 2001
+From c242464f783f61a4859d8f900ee5fa088ac001a6 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 26 Jul 2017 12:32:00 -0600
 Subject: [PATCH 06/15] hv_sock: add the support of auto-loading

--- a/kernel/patches-4.12.x/0007-hv_sock-fix-a-race-in-hvs_stream_dequeue.patch
+++ b/kernel/patches-4.12.x/0007-hv_sock-fix-a-race-in-hvs_stream_dequeue.patch
@@ -1,4 +1,4 @@
-From b19e3edacd88eede6671e10c4b84f65d8acca0a3 Mon Sep 17 00:00:00 2001
+From 0a248a2bce10f2b4552a1c2f33f25a350d8ebe66 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 26 Jul 2017 12:32:03 -0600
 Subject: [PATCH 07/15] hv_sock: fix a race in hvs_stream_dequeue()

--- a/kernel/patches-4.12.x/0008-vsock-fix-vsock_dequeue-enqueue_accept-race.patch
+++ b/kernel/patches-4.12.x/0008-vsock-fix-vsock_dequeue-enqueue_accept-race.patch
@@ -1,4 +1,4 @@
-From 849bfb3316d581b22a5c67be40dcb74b9e25f19d Mon Sep 17 00:00:00 2001
+From 7c7818b98fe1d107a54ef5336b6d919d920d5b3a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 26 Jul 2017 12:32:06 -0600
 Subject: [PATCH 08/15] vsock: fix vsock_dequeue/enqueue_accept race

--- a/kernel/patches-4.12.x/0009-Drivers-hv-vmbus-Fix-rescind-handling.patch
+++ b/kernel/patches-4.12.x/0009-Drivers-hv-vmbus-Fix-rescind-handling.patch
@@ -1,4 +1,4 @@
-From 18512d7b4c53d60572e316f027220fb6f06b28dd Mon Sep 17 00:00:00 2001
+From 75c1cf1fd1506de61867f3a53e38a27d8a904513 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Sun, 30 Apr 2017 16:21:18 -0700
 Subject: [PATCH 09/15] Drivers: hv: vmbus: Fix rescind handling

--- a/kernel/patches-4.12.x/0010-vmbus-fix-hv_percpu_channel_deq-enq-race.patch
+++ b/kernel/patches-4.12.x/0010-vmbus-fix-hv_percpu_channel_deq-enq-race.patch
@@ -1,4 +1,4 @@
-From f7dfc5988ca168d551d2bf86cf9c402af63435c7 Mon Sep 17 00:00:00 2001
+From 87521124dac07e6a31aae1650646e70dfc9c4722 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 5 Jun 2017 16:13:18 +0800
 Subject: [PATCH 10/15] vmbus: fix hv_percpu_channel_deq/enq race

--- a/kernel/patches-4.12.x/0011-vmbus-add-vmbus-onoffer-onoffer_rescind-sync.patch
+++ b/kernel/patches-4.12.x/0011-vmbus-add-vmbus-onoffer-onoffer_rescind-sync.patch
@@ -1,4 +1,4 @@
-From 43d8d2d8ce9ecfc0fbfffd2a5cfbc316a772b711 Mon Sep 17 00:00:00 2001
+From 5427bcb5e34615568731ff5633e7ab4cf0446a5f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 5 Jun 2017 21:32:00 +0800
 Subject: [PATCH 11/15] vmbus: add vmbus onoffer/onoffer_rescind sync.

--- a/kernel/patches-4.12.x/0012-vmbus-fix-the-missed-signaling-in-hv_signal_on_read.patch
+++ b/kernel/patches-4.12.x/0012-vmbus-fix-the-missed-signaling-in-hv_signal_on_read.patch
@@ -1,4 +1,4 @@
-From 91785bc2831cab9878cfa709b87773978572dcbe Mon Sep 17 00:00:00 2001
+From af7743fa98a12e9cafdc85daf2ed58e6f8d22c36 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 28 Jun 2017 23:50:38 +0800
 Subject: [PATCH 12/15] vmbus: fix the missed signaling in hv_signal_on_read()

--- a/kernel/patches-4.12.x/0013-hv_sock-avoid-double-FINs-if-shutdown-is-called.patch
+++ b/kernel/patches-4.12.x/0013-hv_sock-avoid-double-FINs-if-shutdown-is-called.patch
@@ -1,4 +1,4 @@
-From 34d883a2479aa8661daefeec280f29ca08c737f4 Mon Sep 17 00:00:00 2001
+From b203b317bfe37f32d1c34e388b50900cec44d941 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 26 Jul 2017 12:32:08 -0600
 Subject: [PATCH 13/15] hv_sock: avoid double FINs if shutdown() is called

--- a/kernel/patches-4.12.x/0014-Added-vsock-transport-support-to-9pfs.patch
+++ b/kernel/patches-4.12.x/0014-Added-vsock-transport-support-to-9pfs.patch
@@ -1,4 +1,4 @@
-From ce64649631d12c3c1a6d80752ea56cc85f3a4bcb Mon Sep 17 00:00:00 2001
+From 44570fbde0c9eceb4c9e890bb084197a7f186c84 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:50:36 -0700
 Subject: [PATCH 14/15] Added vsock transport support to 9pfs

--- a/kernel/patches-4.12.x/0015-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.12.x/0015-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 2903caeac4e3f172e63faaf854fdecc17793d308 Mon Sep 17 00:00:00 2001
+From 6654360f103281d1390fd9a8c4770096c8bfa584 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 15/15] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.4.x/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
+++ b/kernel/patches-4.4.x/0001-virtio-make-find_vqs-checkpatch.pl-friendly.patch
@@ -1,4 +1,4 @@
-From 34a405262b5c1d952b0d58bfa050907038becd8e Mon Sep 17 00:00:00 2001
+From 120fe8dcda24a448b6b59c2d46adf10e831a6ebb Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 17 Dec 2015 16:53:43 +0800
 Subject: [PATCH 01/44] virtio: make find_vqs() checkpatch.pl-friendly

--- a/kernel/patches-4.4.x/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
+++ b/kernel/patches-4.4.x/0002-VSOCK-constify-vmci_transport_notify_ops-structures.patch
@@ -1,4 +1,4 @@
-From 8a5f9db0bb9385e482f93204052fa1fa8efe93c2 Mon Sep 17 00:00:00 2001
+From 53d55d7616a6f0149c18487c3b70b6b79641a53d Mon Sep 17 00:00:00 2001
 From: Julia Lawall <julia.lawall@lip6.fr>
 Date: Sat, 21 Nov 2015 18:39:17 +0100
 Subject: [PATCH 02/44] VSOCK: constify vmci_transport_notify_ops structures

--- a/kernel/patches-4.4.x/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
+++ b/kernel/patches-4.4.x/0003-AF_VSOCK-Shrink-the-area-influenced-by-prepare_to_wa.patch
@@ -1,4 +1,4 @@
-From 8d5e0d160ed34646d67581d0cbd44ccc659df912 Mon Sep 17 00:00:00 2001
+From 470636b821fd0891db72cf1d19e96c07fcf7f698 Mon Sep 17 00:00:00 2001
 From: Claudio Imbrenda <imbrenda@linux.vnet.ibm.com>
 Date: Tue, 22 Mar 2016 17:05:52 +0100
 Subject: [PATCH 03/44] AF_VSOCK: Shrink the area influenced by prepare_to_wait

--- a/kernel/patches-4.4.x/0004-vsock-make-listener-child-lock-ordering-explicit.patch
+++ b/kernel/patches-4.4.x/0004-vsock-make-listener-child-lock-ordering-explicit.patch
@@ -1,4 +1,4 @@
-From 32ca1a04aa3d05a5ff3b6433598b8f2ceb6f7c9c Mon Sep 17 00:00:00 2001
+From d0d86b04fb0f329beb935359fb8fe94d30a231b8 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 23 Jun 2016 16:28:58 +0100
 Subject: [PATCH 04/44] vsock: make listener child lock ordering explicit

--- a/kernel/patches-4.4.x/0005-VSOCK-transport-specific-vsock_transport-functions.patch
+++ b/kernel/patches-4.4.x/0005-VSOCK-transport-specific-vsock_transport-functions.patch
@@ -1,4 +1,4 @@
-From 6141d8fea865c4ce43b2d9a929b374aa47bdd42d Mon Sep 17 00:00:00 2001
+From 5294d286da1bb65ee310adaa6e4c70f886c6f15d Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:30 +0100
 Subject: [PATCH 05/44] VSOCK: transport-specific vsock_transport functions

--- a/kernel/patches-4.4.x/0006-VSOCK-defer-sock-removal-to-transports.patch
+++ b/kernel/patches-4.4.x/0006-VSOCK-defer-sock-removal-to-transports.patch
@@ -1,4 +1,4 @@
-From 52b62613c0e408cc9e2c5aacde07d0027b6d95c5 Mon Sep 17 00:00:00 2001
+From 568806a444490c2466d2c085250c098615bb063b Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:31 +0100
 Subject: [PATCH 06/44] VSOCK: defer sock removal to transports

--- a/kernel/patches-4.4.x/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
+++ b/kernel/patches-4.4.x/0007-VSOCK-Introduce-virtio_vsock_common.ko.patch
@@ -1,4 +1,4 @@
-From 9b5062776073af12447a27f7f11f864f37283080 Mon Sep 17 00:00:00 2001
+From a8f313c7d0a7fc95dbb575a48817a7b88ffde250 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:32 +0100
 Subject: [PATCH 07/44] VSOCK: Introduce virtio_vsock_common.ko

--- a/kernel/patches-4.4.x/0008-VSOCK-Introduce-virtio_transport.ko.patch
+++ b/kernel/patches-4.4.x/0008-VSOCK-Introduce-virtio_transport.ko.patch
@@ -1,4 +1,4 @@
-From a45478c44817a0fc03013ac9d9976438101bb8ac Mon Sep 17 00:00:00 2001
+From 8d22cd606d60c767e283ecfba9f365d9770f785c Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:33 +0100
 Subject: [PATCH 08/44] VSOCK: Introduce virtio_transport.ko

--- a/kernel/patches-4.4.x/0009-VSOCK-Introduce-vhost_vsock.ko.patch
+++ b/kernel/patches-4.4.x/0009-VSOCK-Introduce-vhost_vsock.ko.patch
@@ -1,4 +1,4 @@
-From c4359ab810299fa1535db8c70c0034f8e7755f59 Mon Sep 17 00:00:00 2001
+From 235577957357662232d628b14fc49dcf75e54367 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:34 +0100
 Subject: [PATCH 09/44] VSOCK: Introduce vhost_vsock.ko

--- a/kernel/patches-4.4.x/0010-VSOCK-Add-Makefile-and-Kconfig.patch
+++ b/kernel/patches-4.4.x/0010-VSOCK-Add-Makefile-and-Kconfig.patch
@@ -1,4 +1,4 @@
-From 1451188428327bf00a2f6f722e11059d684c52bb Mon Sep 17 00:00:00 2001
+From 2d81646733af16e0125e8de023c7a813317adb08 Mon Sep 17 00:00:00 2001
 From: Asias He <asias@redhat.com>
 Date: Thu, 28 Jul 2016 15:36:35 +0100
 Subject: [PATCH 10/44] VSOCK: Add Makefile and Kconfig

--- a/kernel/patches-4.4.x/0011-VSOCK-Use-kvfree.patch
+++ b/kernel/patches-4.4.x/0011-VSOCK-Use-kvfree.patch
@@ -1,4 +1,4 @@
-From 79659047f205acf0f1c05d8197703d948e25cf45 Mon Sep 17 00:00:00 2001
+From f20d320f713743ce93efdb093524bd8a621c570e Mon Sep 17 00:00:00 2001
 From: Wei Yongjun <weiyj.lk@gmail.com>
 Date: Tue, 2 Aug 2016 13:50:42 +0000
 Subject: [PATCH 11/44] VSOCK: Use kvfree()

--- a/kernel/patches-4.4.x/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
+++ b/kernel/patches-4.4.x/0012-vhost-vsock-fix-vhost-virtio_vsock_pkt-use-after-fre.patch
@@ -1,4 +1,4 @@
-From 83f5e8787ae4311e2f7a60cb915925b67e863aa5 Mon Sep 17 00:00:00 2001
+From 70a904bee26f95db969254b7c915b4f6355caf23 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Thu, 4 Aug 2016 14:52:53 +0100
 Subject: [PATCH 12/44] vhost/vsock: fix vhost virtio_vsock_pkt use-after-free

--- a/kernel/patches-4.4.x/0013-virtio-vsock-fix-include-guard-typo.patch
+++ b/kernel/patches-4.4.x/0013-virtio-vsock-fix-include-guard-typo.patch
@@ -1,4 +1,4 @@
-From a2f71099dfab23914e8c703dae3f3516aa481f43 Mon Sep 17 00:00:00 2001
+From a00eca4b669c1657ea55f27431f2752bd25fd325 Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Fri, 5 Aug 2016 13:52:09 +0100
 Subject: [PATCH 13/44] virtio-vsock: fix include guard typo

--- a/kernel/patches-4.4.x/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
+++ b/kernel/patches-4.4.x/0014-vhost-vsock-drop-space-available-check-for-TX-vq.patch
@@ -1,4 +1,4 @@
-From a8fb0a2bdb46c39803a34352676ba4556e3a43b7 Mon Sep 17 00:00:00 2001
+From 68e98076f26d2cf91ef60c07ff944addc017267c Mon Sep 17 00:00:00 2001
 From: Gerard Garcia <ggarcia@deic.uab.cat>
 Date: Wed, 10 Aug 2016 17:24:34 +0200
 Subject: [PATCH 14/44] vhost/vsock: drop space available check for TX vq

--- a/kernel/patches-4.4.x/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
+++ b/kernel/patches-4.4.x/0015-VSOCK-Only-allow-host-network-namespace-to-use-AF_VS.patch
@@ -1,4 +1,4 @@
-From 5e02dd4ba4ee5d9bb10c29bb2df4197ca0bd967e Mon Sep 17 00:00:00 2001
+From eef93cbf2d004565b332cb3c69b61daa1f154750 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ian.campbell@docker.com>
 Date: Mon, 4 Apr 2016 14:50:10 +0100
 Subject: [PATCH 15/44] VSOCK: Only allow host network namespace to use

--- a/kernel/patches-4.4.x/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
+++ b/kernel/patches-4.4.x/0016-drivers-hv-Define-the-channel-type-for-Hyper-V-PCI-E.patch
@@ -1,4 +1,4 @@
-From ee2f7952d16d0f2577dbdac9fa87edd2ee3596f2 Mon Sep 17 00:00:00 2001
+From c79f537b734c26a6b63012b6f92e22d77ae949e9 Mon Sep 17 00:00:00 2001
 From: Jake Oshins <jakeo@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:41 -0800
 Subject: [PATCH 16/44] drivers:hv: Define the channel type for Hyper-V PCI

--- a/kernel/patches-4.4.x/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
+++ b/kernel/patches-4.4.x/0017-Drivers-hv-vmbus-Use-uuid_le-type-consistently.patch
@@ -1,4 +1,4 @@
-From b902872753aba2396599c6ad478af5003db63fc6 Mon Sep 17 00:00:00 2001
+From 203caf010132acf1863db979f735f079e0b5985a Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:43 -0800
 Subject: [PATCH 17/44] Drivers: hv: vmbus: Use uuid_le type consistently

--- a/kernel/patches-4.4.x/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
+++ b/kernel/patches-4.4.x/0018-Drivers-hv-vmbus-Use-uuid_le_cmp-for-comparing-GUIDs.patch
@@ -1,4 +1,4 @@
-From d4083840f20776561574c7564f695060383a7c0f Mon Sep 17 00:00:00 2001
+From 79c8576dc6863657ffd0019b33042f96c32242e5 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:44 -0800
 Subject: [PATCH 18/44] Drivers: hv: vmbus: Use uuid_le_cmp() for comparing

--- a/kernel/patches-4.4.x/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
+++ b/kernel/patches-4.4.x/0019-Drivers-hv-vmbus-do-sanity-check-of-channel-state-in.patch
@@ -1,4 +1,4 @@
-From cd57079ad92667fed7a1a3eca353b7601771c8b7 Mon Sep 17 00:00:00 2001
+From 42359c4e1f305a11cf5bd1fb9161e937c707628e Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:48 -0800
 Subject: [PATCH 19/44] Drivers: hv: vmbus: do sanity check of channel state in

--- a/kernel/patches-4.4.x/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
+++ b/kernel/patches-4.4.x/0020-Drivers-hv-vmbus-release-relid-on-error-in-vmbus_pro.patch
@@ -1,4 +1,4 @@
-From 4f756565d5ada47b35ba0c3f122b1a1d82c37753 Mon Sep 17 00:00:00 2001
+From 7a7b7561b99c1119c660fd675b5fa6002183a2db Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:50 -0800
 Subject: [PATCH 20/44] Drivers: hv: vmbus: release relid on error in

--- a/kernel/patches-4.4.x/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
+++ b/kernel/patches-4.4.x/0021-Drivers-hv-vmbus-channge-vmbus_connection.channel_lo.patch
@@ -1,4 +1,4 @@
-From c343f83cc32458770c7b3ea7652a95b595220671 Mon Sep 17 00:00:00 2001
+From 96dc05a04770f148a57ae9606aef8860210cd902 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 14 Dec 2015 16:01:51 -0800
 Subject: [PATCH 21/44] Drivers: hv: vmbus: channge

--- a/kernel/patches-4.4.x/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
+++ b/kernel/patches-4.4.x/0022-Drivers-hv-remove-code-duplication-between-vmbus_rec.patch
@@ -1,4 +1,4 @@
-From d2737d2b8265b2baa89056191686f955cd91c337 Mon Sep 17 00:00:00 2001
+From 49b366b913fab024d48c4c23ffb25eabcacfa822 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Mon, 14 Dec 2015 19:02:00 -0800
 Subject: [PATCH 22/44] Drivers: hv: remove code duplication between

--- a/kernel/patches-4.4.x/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
+++ b/kernel/patches-4.4.x/0023-Drivers-hv-vmbus-fix-the-building-warning-with-hyper.patch
@@ -1,4 +1,4 @@
-From fe3eb3b645100c557a38b546eed4c8590267bbba Mon Sep 17 00:00:00 2001
+From 54a7356ff6876c1e7db90470f9bf01fa446a0125 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Dec 2015 12:21:22 -0800
 Subject: [PATCH 23/44] Drivers: hv: vmbus: fix the building warning with

--- a/kernel/patches-4.4.x/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
+++ b/kernel/patches-4.4.x/0024-Drivers-hv-vmbus-Treat-Fibre-Channel-devices-as-perf.patch
@@ -1,4 +1,4 @@
-From 280aa6b848827e8b4e8ab10e69abc92a43f9957e Mon Sep 17 00:00:00 2001
+From 41289457299e7d5ef3f1049131a6021900b4aeb2 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Tue, 15 Dec 2015 16:27:27 -0800
 Subject: [PATCH 24/44] Drivers: hv: vmbus: Treat Fibre Channel devices as

--- a/kernel/patches-4.4.x/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
+++ b/kernel/patches-4.4.x/0025-Drivers-hv-vmbus-Add-vendor-and-device-atttributes.patch
@@ -1,4 +1,4 @@
-From bbcb304315e47d41152cafd5920a33158860dd9b Mon Sep 17 00:00:00 2001
+From 51b2141c503d91e422b99c3f4d01463c1839f21d Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Fri, 25 Dec 2015 20:00:30 -0800
 Subject: [PATCH 25/44] Drivers: hv: vmbus: Add vendor and device atttributes

--- a/kernel/patches-4.4.x/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
+++ b/kernel/patches-4.4.x/0026-Drivers-hv-vmbus-add-a-helper-function-to-set-a-chan.patch
@@ -1,4 +1,4 @@
-From f09db46611296ddf0b6a1216e913baac16933238 Mon Sep 17 00:00:00 2001
+From e2b5b1b10071384c60d10d61733881b7f4496425 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:37 -0800
 Subject: [PATCH 26/44] Drivers: hv: vmbus: add a helper function to set a

--- a/kernel/patches-4.4.x/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
+++ b/kernel/patches-4.4.x/0027-Drivers-hv-vmbus-define-the-new-offer-type-for-Hyper.patch
@@ -1,4 +1,4 @@
-From d1143d2449375bda99f1de72ac2197a3347a1a30 Mon Sep 17 00:00:00 2001
+From 78eebb27917a322ee39870a962a56688a6676c0d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:38 -0800
 Subject: [PATCH 27/44] Drivers: hv: vmbus: define the new offer type for

--- a/kernel/patches-4.4.x/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
+++ b/kernel/patches-4.4.x/0028-Drivers-hv-vmbus-vmbus_sendpacket_ctl-hvsock-avoid-u.patch
@@ -1,4 +1,4 @@
-From 72b56a59110c06f0773ea8d7630833b40dfda842 Mon Sep 17 00:00:00 2001
+From eb6a5c4f1b753a77a35ff6054cf6bfbbb42f4312 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:39 -0800
 Subject: [PATCH 28/44] Drivers: hv: vmbus: vmbus_sendpacket_ctl: hvsock: avoid

--- a/kernel/patches-4.4.x/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
+++ b/kernel/patches-4.4.x/0029-Drivers-hv-vmbus-define-a-new-VMBus-message-type-for.patch
@@ -1,4 +1,4 @@
-From e8017edfef59d2910c30228948f2b911f7f17eb8 Mon Sep 17 00:00:00 2001
+From 5d2da72fe06297148e36977f9fcf0277c1ffc303 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:40 -0800
 Subject: [PATCH 29/44] Drivers: hv: vmbus: define a new VMBus message type for

--- a/kernel/patches-4.4.x/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
+++ b/kernel/patches-4.4.x/0030-Drivers-hv-vmbus-add-a-hvsock-flag-in-struct-hv_driv.patch
@@ -1,4 +1,4 @@
-From 026e220ef854d76be1fb61d0697b6efc055ed8c4 Mon Sep 17 00:00:00 2001
+From 06a6028a591a3c9a82b1a635fd3c5c40ff9648d4 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:41 -0800
 Subject: [PATCH 30/44] Drivers: hv: vmbus: add a hvsock flag in struct

--- a/kernel/patches-4.4.x/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
+++ b/kernel/patches-4.4.x/0031-Drivers-hv-vmbus-add-a-per-channel-rescind-callback.patch
@@ -1,4 +1,4 @@
-From dba565d66b212ad7512a4c8e40a451743374ea11 Mon Sep 17 00:00:00 2001
+From df67e0147158f00e382011ae0edcecd6ecd09b26 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:42 -0800
 Subject: [PATCH 31/44] Drivers: hv: vmbus: add a per-channel rescind callback

--- a/kernel/patches-4.4.x/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
+++ b/kernel/patches-4.4.x/0032-Drivers-hv-vmbus-add-an-API-vmbus_hvsock_device_unre.patch
@@ -1,4 +1,4 @@
-From 3ca4d0363a4108ca3b94aa613da36b7374ef872a Mon Sep 17 00:00:00 2001
+From 3b8465453aa3d9ac3d6c9705aa8a2f18a6ae40f1 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:43 -0800
 Subject: [PATCH 32/44] Drivers: hv: vmbus: add an API

--- a/kernel/patches-4.4.x/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
+++ b/kernel/patches-4.4.x/0033-Drivers-hv-vmbus-Give-control-over-how-the-ring-acce.patch
@@ -1,4 +1,4 @@
-From ce03a15d794f0379fee8a0d3fa0f42caef537d48 Mon Sep 17 00:00:00 2001
+From efaef63cbcc1be793ff8eef49d0f31e82f1ed843 Mon Sep 17 00:00:00 2001
 From: "K. Y. Srinivasan" <kys@microsoft.com>
 Date: Wed, 27 Jan 2016 22:29:45 -0800
 Subject: [PATCH 33/44] Drivers: hv: vmbus: Give control over how the ring

--- a/kernel/patches-4.4.x/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
+++ b/kernel/patches-4.4.x/0034-Drivers-hv-vmbus-avoid-wait_for_completion-on-crash.patch
@@ -1,4 +1,4 @@
-From 0410ab457cd8282c21fb39a10aa7f58ebc7e7cfd Mon Sep 17 00:00:00 2001
+From bc8eb673c2e447d5e63a3fcd57cde37fb555d0cf Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:16 -0800
 Subject: [PATCH 34/44] Drivers: hv: vmbus: avoid wait_for_completion() on

--- a/kernel/patches-4.4.x/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
+++ b/kernel/patches-4.4.x/0035-Drivers-hv-vmbus-avoid-unneeded-compiler-optimizatio.patch
@@ -1,4 +1,4 @@
-From 4665e06fab385f540a641d864f5fc56e0e29a45e Mon Sep 17 00:00:00 2001
+From 52605992f09cc42bd2a2ab64ee0dd49b86c8d78c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Fri, 26 Feb 2016 15:13:18 -0800
 Subject: [PATCH 35/44] Drivers: hv: vmbus: avoid unneeded compiler

--- a/kernel/patches-4.4.x/0036-kcm-Kernel-Connection-Multiplexor-module.patch
+++ b/kernel/patches-4.4.x/0036-kcm-Kernel-Connection-Multiplexor-module.patch
@@ -1,4 +1,4 @@
-From b26c47635e6de22fc63a80e6d47a301275f08268 Mon Sep 17 00:00:00 2001
+From 09227af3081806ca1d43f00ae87866d3240f9531 Mon Sep 17 00:00:00 2001
 From: Tom Herbert <tom@herbertland.com>
 Date: Mon, 7 Mar 2016 14:11:06 -0800
 Subject: [PATCH 36/44] kcm: Kernel Connection Multiplexor module

--- a/kernel/patches-4.4.x/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4.x/0037-net-add-the-AF_KCM-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From ea17c0ee0d22e410d1e31c69bb56c3f856797bd9 Mon Sep 17 00:00:00 2001
+From 8968175b1cf9a795be3545165ccfc1fc5ddc8af6 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:51:09 -0700
 Subject: [PATCH 37/44] net: add the AF_KCM entries to family name tables

--- a/kernel/patches-4.4.x/0038-net-Add-Qualcomm-IPC-router.patch
+++ b/kernel/patches-4.4.x/0038-net-Add-Qualcomm-IPC-router.patch
@@ -1,4 +1,4 @@
-From 8da54710092ad0eeea81964d447220fb031cc119 Mon Sep 17 00:00:00 2001
+From b699ea0c09de5a601128908e0da26768aaa6d350 Mon Sep 17 00:00:00 2001
 From: Courtney Cavin <courtney.cavin@sonymobile.com>
 Date: Wed, 27 Apr 2016 12:13:03 -0700
 Subject: [PATCH 38/44] net: Add Qualcomm IPC router

--- a/kernel/patches-4.4.x/0039-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.4.x/0039-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From a1e3a97baa63e4f06dcf4189e6109db511e0367e Mon Sep 17 00:00:00 2001
+From 18d491bc605b4732afdf89508cedbeb93a3d9194 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 15 May 2016 09:53:11 -0700
 Subject: [PATCH 39/44] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.4.x/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
+++ b/kernel/patches-4.4.x/0040-net-add-the-AF_HYPERV-entries-to-family-name-tables.patch
@@ -1,4 +1,4 @@
-From 286b7a92cd3c6400e5ca6b08ab7338e62710d6d5 Mon Sep 17 00:00:00 2001
+From 56e911fbe45aad38ebfffc0ed68c786a8cd08252 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Mon, 21 Mar 2016 02:53:08 -0700
 Subject: [PATCH 40/44] net: add the AF_HYPERV entries to family name tables

--- a/kernel/patches-4.4.x/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
+++ b/kernel/patches-4.4.x/0041-Drivers-hv-vmbus-fix-the-race-when-querying-updating.patch
@@ -1,4 +1,4 @@
-From 8d673a93094b8946640ec9a5f9d0a50d0ecad4c7 Mon Sep 17 00:00:00 2001
+From 9132bb3d870d991e03a7720333fa64e124ba0e54 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 21 May 2016 16:55:50 +0800
 Subject: [PATCH 41/44] Drivers: hv: vmbus: fix the race when querying &

--- a/kernel/patches-4.4.x/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.4.x/0042-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 16595c5b5839967b67eef4e67b3d6027248d8233 Mon Sep 17 00:00:00 2001
+From c2deb3d4f6dd9135ec4bc3425bceda02ab306a0d Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 42/44] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.4.x/0043-fs-add-filp_clone_open-API.patch
+++ b/kernel/patches-4.4.x/0043-fs-add-filp_clone_open-API.patch
@@ -1,4 +1,4 @@
-From 9918bff16b128e702092d4759bad69d024052867 Mon Sep 17 00:00:00 2001
+From 09df0d6b6420d571bc59096a0602849cd0b151cc Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:49:38 -0800
 Subject: [PATCH 43/44] fs: add filp_clone_open API

--- a/kernel/patches-4.4.x/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
+++ b/kernel/patches-4.4.x/0044-binfmt_misc-add-persistent-opened-binary-handler-for.patch
@@ -1,4 +1,4 @@
-From 58b161084f1be28e39fdb736e875c4b8e827d855 Mon Sep 17 00:00:00 2001
+From 84b610e0b08cc6ce24c04daba7bd4ffa8ee45dc3 Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
 Date: Wed, 17 Feb 2016 16:51:16 -0800
 Subject: [PATCH 44/44] binfmt_misc: add persistent opened binary handler for

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From dd5d3c7fa43b9071b919eb9d5de1990f264ea33e Mon Sep 17 00:00:00 2001
+From 3bfa68c09e30b02170ed9935985e573b8594a301 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/13] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 48e7d620e4ef3bc407351554cf769986d3c86480 Mon Sep 17 00:00:00 2001
+From aef6bbb26e7cdf433703341d831122492fe82d57 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/13] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 81205ab43e0894309544abbdeec868759fc64d55 Mon Sep 17 00:00:00 2001
+From 1a76df7afc2e61612f3d149fab9f3a5dc750ed37 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/13] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From d694b77ff238754a9f30f1f35e476842ff7799fc Mon Sep 17 00:00:00 2001
+From 67b441ffba36c1f93257739b4f09ccfd1b56d31e Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/13] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From b20202c38961dc48c33c0e345a418d4697dadf95 Mon Sep 17 00:00:00 2001
+From a49ec4cb143b9f435d223ba52e8389b32b2388e5 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/13] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From e518639ccd919905193c5161520ff445dee7a483 Mon Sep 17 00:00:00 2001
+From b18fa5463e53c839e2d4cd1a21a98dc0e818c1b5 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/13] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From 3266c525d53ce5ab9b9506e3b5615ad84c8fcaef Mon Sep 17 00:00:00 2001
+From eb6ef98a8a7d7ff793c936ec3aa2994dc78d90be Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/13] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From 094dfa948b1bcd41244f372cf725936827996ed3 Mon Sep 17 00:00:00 2001
+From 7cc7010eed341b8a1273c7cbb82666abf1ffe7e9 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/13] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 19664ad5ce3d5b009201a3b53405eec030175caf Mon Sep 17 00:00:00 2001
+From 2ebd78d7159847950ea8a9ddad52803a2ab08811 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/13] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From f98f08a98de1c46e44be60c5f6244f3f084d454e Mon Sep 17 00:00:00 2001
+From 2e1b4254ab636befc4de341a2f1b1fbb92e8da0d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/13] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 804e5a29709fca5d5e797f55453a4fbad7f0221b Mon Sep 17 00:00:00 2001
+From d4fa748e0d7319d8623fcd0d4b3fd04f47293299 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/13] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 78dbc7317a2c86a60f8282cd10c25ab3a40a4b40 Mon Sep 17 00:00:00 2001
+From 483d33290f59d37d0babb4ab05477df6d9b5594b Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/13] vmbus: dynamically enqueue/dequeue the channel on

--- a/kernel/patches-4.9.x/0013-vmbus-fix-the-missed-signaling-in-hv_signal_on_read.patch
+++ b/kernel/patches-4.9.x/0013-vmbus-fix-the-missed-signaling-in-hv_signal_on_read.patch
@@ -1,4 +1,4 @@
-From b10b858e81621347a6edfb74a75f48156db0d65d Mon Sep 17 00:00:00 2001
+From 3db62c259a11e5363606470ee9b11a6c1310d38c Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Thu, 6 Jul 2017 21:37:11 +0000
 Subject: [PATCH 13/13] vmbus: fix the missed signaling in hv_signal_on_read()

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/projects/kubernetes/kube-master.yml
+++ b/projects/kubernetes/kube-master.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/projects/kubernetes/kube-node.yml
+++ b/projects/kubernetes/kube-node.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f # with runc, logwrite, startmemlogd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test-kernel-config.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test-kernel-config.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/004_config_4.12.x/test-kernel-config.yml
+++ b/test/cases/020_kernel/004_config_4.12.x/test-kernel-config.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/010_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.49 AS ksrc
+FROM linuxkit/kernel:4.9.50 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:f4f5b333fa1a8433334fcae996d1637173144a72 AS build

--- a/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/kmod.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/010_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.9.x/test.sh
@@ -18,7 +18,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.49
+docker pull linuxkit/kernel:4.9.50
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.87
+  image: linuxkit/kernel:4.4.88
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/030_echo-udp-ipv4-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/031_echo-udp-ipv4-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/035_echo-udp-ipv4-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/036_echo-udp-ipv4-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/040_echo-udp-ipv6-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/041_echo-udp-ipv6-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/045_echo-udp-ipv6-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/046_echo-udp-ipv6-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/010_echo-short-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/011_echo-short-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/012_echo-short-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/015_echo-long-1con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/016_echo-long-10con-single/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/050_unix-domain/017_echo-long-5con-multi/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/010_veth-unix-domain-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/011_veth-unix-domain-echo-reverse/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/012_veth-ipv4-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/012_veth-ipv4-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/013_veth-ipv6-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/013_veth-ipv6-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/014_veth-tcp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/014_veth-tcp-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/015_veth-udp-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/015_veth-udp-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/020_unix-domain-echo/test-ns.yml
+++ b/test/cases/020_kernel/110_namespace/004_kernel-4.12.x/100_mix/020_unix-domain-echo/test-ns.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.12.12
+  image: linuxkit/kernel:4.12.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/030_security/000_docker-bench/test-docker-bench.yml
+++ b/test/cases/030_security/000_docker-bench/test-docker-bench.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/002_binfmt/test-binfmt.yml
+++ b/test/cases/040_packages/002_binfmt/test-binfmt.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
+++ b/test/cases/040_packages/003_ca-certificates/test-ca-certificates.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/003_containerd/test-containerd.yml
+++ b/test/cases/040_packages/003_containerd/test-containerd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
+++ b/test/cases/040_packages/004_dhcpcd/test-dhcpcd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/cases/040_packages/019_sysctl/test-sysctl.yml
+++ b/test/cases/040_packages/019_sysctl/test-sysctl.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.50
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:851e9c3ad0574d640b733b92fdb26c368d2f7f8f


### PR DESCRIPTION
x86_64 kernels already pushed so CI should pick them up. arm64 kernel builds kicked off.

![panda](https://user-images.githubusercontent.com/3338098/30441791-51065be4-9972-11e7-9787-133f8434afd3.jpg)
