### PR TITLE
Ensure depmod is run on ZFS module builds (fixes ZFS modprobe)

### DIFF
--- a/kernel/Dockerfile.zfs
+++ b/kernel/Dockerfile.zfs
@@ -8,7 +8,7 @@ RUN apk add \
     build-base \
     file \
     git \
-    libtirpc-dev \ 
+    libtirpc-dev \
     libtool \
     util-linux-dev \
     zlib-dev
@@ -51,6 +51,10 @@ RUN ./autogen.sh && \
     cd module && \
     make -j "$(getconf _NPROCESSORS_ONLN)" && \
     make install
+
+# Run depmod against the new module directory.
+RUN cd /lib/modules && \
+    depmod -ae * 
 
 FROM scratch
 ENTRYPOINT []


### PR DESCRIPTION
Depmod in the zfs makefiles will never run as `/boot/` and relevant map files dont exist in our build environments.

Signed-off-by: Matt Johnson <matjohn2@cisco.com>

**- What I did**
Depmod in the zfs makefiles will never run as the`/boot/` dir, system maps and relevant files don't exist in our build environments.

Running depmod on whatever is in the `/lib/modules` directory solves this issue.
Tested with local builds successfully.

**- How to verify it**
If you can modprobe zfs once adding the image to `init:` it's working.

**- Description for the changelog**
Depmod now runs correctly on the ZFS kernel module build.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/4842186/30492189-96098732-9a37-11e7-9fda-20e5780f843f.png)

