### PR TITLE
added support for guest shut down in pkg/open-vm-tools

### DIFF
--- a/pkg/open-vm-tools/Dockerfile
+++ b/pkg/open-vm-tools/Dockerfile
@@ -13,4 +13,7 @@ ENTRYPOINT []
 CMD []
 WORKDIR /
 COPY --from=mirror /out/ /
+COPY scripts /etc/vmware-tools/scripts
 CMD ["/usr/bin/vmtoolsd"]
+
+LABEL org.mobyproject.config='{"pid": "host", "capabilities": ["CAP_SYS_BOOT"]}'

--- a/pkg/open-vm-tools/scripts/poweroff-vm-default.d/poweroff.sh
+++ b/pkg/open-vm-tools/scripts/poweroff-vm-default.d/poweroff.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# send SIGTERM to the init system (PID 1), which causes a clean VM host-initiated shutdown
+kill -s SIGTERM 1
+exit 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I enabled hypervisor-initiated guest shut down in `pkg/open-vm-tools`

**- How I did it**
I added `poweroff-vm-default.d/poweroff.sh` to `/etc/vmware-tools/scripts`, which sends a `SIGTERM` to PID 1 (the LinuxKit init system) when a guest shut down event is received through `vmtoolsd`. The `poweroff.sh` script then returns exit code 0 through `vmtoolsd` to send success back to the hypervisor UX.

**- How to verify it**
With a running LinuxKit OS in VMware vSphere, choose `Power` -> `Shut Down Guest` on the applicable VM. LinuxKit will shut down via the init system.

**- Description for the changelog**
added support for guest shut down in pkg/open-vm-tools

**- A picture of a cute animal (not mandatory but encouraged)**
![56269_1559857750243_5587211_o](https://user-images.githubusercontent.com/4591181/30514620-b49d46de-9acd-11e7-9153-c60c29e9a094.jpg)
