### PR TITLE
Specify punctual install targets for "make install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,9 @@ local: $(LINUXKIT_DEPS) | bin
 bin:
 	mkdir -p $@
 
+.PHONY: install
 install:
-	cp -R ./bin/* $(PREFIX)/bin
+	cp -R ./bin/{moby,linuxkit} $(PREFIX)bin
 
 .PHONY: test
 test:


### PR DESCRIPTION
I just noted that I had the `rtf` command in my path, I don't think that the intended behavior of the install target is to copy everything in bin to the installation directory but I may be wrong, so please lemme knoww!

Signed-off-by: Lorenzo Fontana <lo@linux.com>

**- What I did**
I just specified intended binaries to be installed in while calling the `install` target of the Makefile and added set install as phony target 🦄 


**- How I did it**
You can just look at it!

**- How to verify it**
Do a make install and see that `rtf` is not installed

**- Description for the changelog**
Installing only moby and linuxkit as result of `make install`

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/3083633/30561486-7e569a04-9cbb-11e7-93ab-64e377a121e5.png)
