### PR TITLE
wireguard: version bump

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -37,8 +37,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20170907
-ENV WIREGUARD_SHA256=a1ee12d60662607e4c5a19f84b5115e56f083e2600053882e161537f12d963fd
+ENV WIREGUARD_VERSION=0.0.20170918
+ENV WIREGUARD_SHA256=e083f18596574fb7050167090bfb4db4df09a1a99f3c1adc77f820c166368881
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # PGP keys: 589DA6B1 (greg@kroah.com) & 6092693E (autosigner@kernel.org) & 00411886 (torvalds@linux-foundation.org)


### PR DESCRIPTION
This is a version bump to 0.0.20170918 with some performance improvements.

![image](https://user-images.githubusercontent.com/10643/30572276-e0760568-9cec-11e7-86b1-b4c4db02489a.png)