### PR TITLE
Build containerd in Alpine image

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/vpnkit-expose-port:fa4ab4ac78b83fe392e39b861b4114c3bb02d170 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   # support metadata for optional config in /var/config

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
 services:
   - name: getty
     image: linuxkit/getty:bf6872ce0a9f3ab519b3e502cc41ba3958bda2a6

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: rngd1

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -6,7 +6,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,18 +1,7 @@
-FROM linuxkit/alpine:1e67b8fdba849ed2f7e8537c13b7f280639623d6 as alpine
-RUN \
-  apk add \
-  btrfs-progs-dev \
-  gcc \
-  git \
-  go \
-  libc-dev \
-  linux-headers \
-  make \
-  tzdata \
-  && true
+FROM linuxkit/alpine:77287352db68b442534c0005edd6ff750c8189f3 as alpine
+RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd
-RUN make binaries EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS="-extldflags \\\"-fno-PIC -static\\\""
 RUN cp bin/containerd bin/ctr bin/containerd-shim /usr/bin/
 
 RUN mkdir -p /etc/init.d && ln -s /usr/bin/service /etc/init.d/020-containerd

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7 # with runc, logwrite, startmemlogd
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:154913b72c6f1f33eb408609fca9963628e8c051

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
 services:
   - name: acpid
     image: linuxkit/acpid:79e5c20de96e1633c9c40935b99dde45aefba37b

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
   - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
 onboot:
   - name: dhcpcd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:38cec1526acc8b1a2ce4b4ece78a810078c807e1

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -6,7 +6,7 @@ kernel:
 init:
   - linuxkit/init:6fe9d31a53bbd200183bb31edd795305e868d5a7
   - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
-  - linuxkit/containerd:06876ceef325e49e9ba119659357768d5df89075
+  - linuxkit/containerd:ad6710e069cb538c76314a28e09d6b49958c88e0
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -40,7 +40,7 @@ RUN go get -u github.com/golang/lint/golint
 RUN go get -u github.com/gordonklaus/ineffassign
 RUN go get -u github.com/LK4D4/vndr
 
-# checkout containerd
+# checkout and compile containerd
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
@@ -50,6 +50,9 @@ RUN mkdir -p $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \
   cd $GOPATH/src/github.com/containerd/containerd && \
   git checkout $CONTAINERD_COMMIT
+RUN apk add --no-cache btrfs-progs-dev gcc libc-dev linux-headers make
+RUN cd $GOPATH/src/github.com/containerd/containerd && \
+  make binaries EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS="-extldflags \\\"-fno-PIC -static\\\""
 
 FROM $BASE
 

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:415e9417004bbd8940a4c2303195b20a5dbd8c9a-arm64
+# linuxkit/alpine:a662efbaf4226d0ac358cc009ead9a95b3b1dd99-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:79987c65c66700171c073151c1d3f0372597bec2-amd64
+# linuxkit/alpine:77287352db68b442534c0005edd6ff750c8189f3-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0


### PR DESCRIPTION
This makes it easier to add the containerd testing tools like
`containerd-stress` to test packages, for example, and also at
some point move `ctr` out of the base image as it can be installed
from the alpine image.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![img_20170918_195345](https://user-images.githubusercontent.com/482364/30668422-85f89190-9e0f-11e7-9323-b1a86355688b.jpg)
