### PR TITLE
Add swap to the Docker for Mac blueprint

### DIFF
--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -30,10 +30,10 @@ To build it with the latest Docker CE:
 $ moby build -name docker-for-mac base.yml docker-ce.yml
 ```
 
-To run the VM with a 500M disk:
+To run the VM with a 4G disk:
 
 ```
-linuxkit run hyperkit -networking=vpnkit -vsock-ports=2376 -disk size=500M -data ./metadata.json docker-for-mac
+linuxkit run hyperkit -networking=vpnkit -vsock-ports=2376 -disk size=4096M -data ./metadata.json docker-for-mac
 ```
 
 In another terminal you should now be able to access docker via the socket `guest.00000947` in the state directory (`docker-for-mac-state/` by default):

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -24,6 +24,10 @@ onboot:
   - name: mount
     image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
     command: ["/usr/bin/mountie", "/var/lib"]
+  # make a swap file on the mounted disk
+  - name: swap
+    image: linuxkit/swap:3881b1e0fadb7765d2fa85d03563c887ab9335a6
+    command: ["/swap.sh", "--path", "/var/lib/swap", "--size", "1024M"]
   # mount-vpnkit mounts the 9p share used by vpnkit to coordinate port forwarding
   - name: mount-vpnkit
     image: alpine:3.6

--- a/pkg/swap/README.md
+++ b/pkg/swap/README.md
@@ -9,10 +9,10 @@ Normally, unless you are running explicitly in a desktop version, LinuxKit image
 onboot:
   - name: swap
     image: linuxkit/swap:<hash>
-    command: ["swap.sh","--path","/var/external/swap","--size","2G"]
+    command: ["/swap.sh","--path","/var/external/swap","--size","2G"]
 ```
 
-Note that you **nust** mount the following:
+Note that you **must** mount the following:
 
 * `/var` to `/var` so it can place the swapfile in the right location.
 * `/dev` to `/dev` so it can do the right thing for devices


### PR DESCRIPTION
We always had 1G swap to work better with small memory setups, but this
was omitted in the update to LinuxKit.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

cc @djs55 I noticed this on the desktop build, plus we didnt actually have a swap example.

![image-20170917_100205](https://user-images.githubusercontent.com/482364/30720535-c52c26ba-9edc-11e7-92d5-c157ad7cfa8c.jpg)
