### PR TITLE
Better error message when running qemu on macOS when --fw not supplied

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -359,6 +359,10 @@ func runQemuLocal(config QemuConfig) error {
 	// Check for OVMF firmware before running
 	if config.UEFI {
 		if config.FWPath == "" {
+			// there is no default on mac
+			if runtime.GOOS == "darwin" {
+				return fmt.Errorf("To run qemu with UEFI firmware on macOS, you must specify the path to locally installed OVMF firmware as `--fw <path>`. You can download OVMF from https://sourceforge.net/projects/edk2/files/OVMF/ ")
+			}
 			config.FWPath = defaultFWPath
 		}
 		if _, err := os.Stat(config.FWPath); err != nil {


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a more descriptive error message when running qemu on macOS

**- How I did it**
Added an additional check if `runtime.GOOS == "darwin"`

**- How to verify it**
Run it on macOS with `linuxkit run qemu ` both with and without `--fw <fw>`. It should give the more descriptive error message when `--fw` is not supplied.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
More descriptive error message when firmware not supplied on macOS for qemu.

**- A picture of a cute animal (not mandatory but encouraged)**

![Armadillo](http://media.npr.org/assets/img/2011/04/26/armadillo_wide-2258269a1e1501ec358c9cf54d95af9f89182175-s900-c85.jpg)



Fixes #2510 