### PR TITLE
Add support to make raw efi images

### DIFF
--- a/tools/mkimage-raw-efi/Dockerfile
+++ b/tools/mkimage-raw-efi/Dockerfile
@@ -1,0 +1,66 @@
+FROM linuxkit/alpine:8b53d842a47fce43464e15f65ee2f68b82542330 AS grub-build
+
+RUN apk add \
+  automake \
+  make \
+  bison \
+  gettext \
+  flex \
+  gcc \
+  git \
+  libtool \
+  libc-dev \
+  linux-headers \
+  python3 \
+
+  autoconf
+
+# because python is not available
+RUN ln -s python3 /usr/bin/python
+
+ENV GRUB_MODULES="part_gpt fat ext2 iso9660 gzio linux acpi normal cpio crypto disk boot crc64 gpt \
+search_disk_uuid tftp verify xzio xfs video"
+ENV GRUB_COMMIT=6782f6d431d22b4e9ab14e94d263795c7991e160
+
+COPY patches/* /patches/
+RUN mkdir /grub-lib && \
+  set -e && \
+  git clone https://github.com/coreos/grub.git && \
+  cd grub && \
+  git checkout -b grub-build ${GRUB_COMMIT} && \
+  for patch in /patches/*.patch; do \
+    echo "Applying $patch"; \
+    patch -p1 < "$patch"; \
+  done && \
+  ./autogen.sh && \
+  ./configure --libdir=/grub-lib --with-platform=efi CFLAGS="-Os -Wno-unused-value" && \
+  make -j "$(getconf _NPROCESSORS_ONLN)" && \
+  make install && \
+# create the grub core image
+  case $(uname -m) in \
+  x86_64) \
+    ./grub-mkimage -O x86_64-efi -d /grub-lib/grub/x86_64-efi -o /grub-lib/BOOTX64.EFI -p /EFI/BOOT ${GRUB_MODULES} linuxefi; \
+    ;; \
+  aarch64) \
+    ./grub-mkimage -O arm64-efi -d /grub-lib/grub/arm64-efi -o /grub-lib/BOOTAA64.EFI -p /EFI/BOOT ${GRUB_MODULES}; \
+    ;; \
+  esac
+
+FROM linuxkit/alpine:77287352db68b442534c0005edd6ff750c8189f3 AS make-img
+
+RUN \
+  apk update && apk upgrade && \
+  apk add --no-cache \
+  dosfstools \
+  libarchive-tools \
+  binutils \
+  mtools \
+  sfdisk \
+  sgdisk \
+  xfsprogs \
+  && true
+
+COPY . .
+COPY --from=grub-build /grub-lib/BOOT*.EFI /usr/local/share/
+
+ENTRYPOINT [ "/make-efi" ]

--- a/tools/mkimage-raw-efi/build.yml
+++ b/tools/mkimage-raw-efi/build.yml
@@ -1,0 +1,2 @@
+image: mkimage-raw-efi
+network: true

--- a/tools/mkimage-raw-efi/make-efi
+++ b/tools/mkimage-raw-efi/make-efi
@@ -1,0 +1,124 @@
+#!/bin/sh
+
+set -e
+# for debugging
+[ -n "$DEBUG" ] && set -x
+
+IMGFILE=$PWD/disk.img
+
+
+# we want everything except the final result to stderr
+( exec 1>&2;
+
+ESP_FILE=$PWD/boot.img
+
+
+
+# get the GRUB2 boot file name
+ARCH=`uname -m`
+case $ARCH in
+x86_64)
+  BOOTFILE=BOOTX64.EFI
+  LINUX_ENTRY=linuxefi
+  INITRD_ENTRY=initrdefi
+  ;;
+aarch64)
+  BOOTFILE=BOOTAA64.EFI
+  LINUX_ENTRY=linux
+  INITRD_ENTRY=initrd
+  ;;
+esac
+
+mkdir -p /tmp/efi
+cd /tmp/efi
+
+# input is a tarball on stdin with kernel and cmdline in /boot
+# output is an iso on stdout
+
+# extract. BSD tar auto recognises compression, unlike GNU tar
+# only if stdin is a tty, if so need files volume mounted...
+[ -t 0 ] || bsdtar xzf -
+
+INITRD="$(find . -name '*.img')"
+KERNEL="$(find . -name kernel)"
+CMDLINE_FILE="$(find . -name cmdline)"
+CMDLINE="$(cat $CMDLINE_FILE )"
+
+# PARTUUID for root
+PARTUUID=$(cat /proc/sys/kernel/random/uuid)
+
+cp /usr/local/share/$BOOTFILE .
+
+mkdir -p EFI/BOOT
+cat >> EFI/BOOT/grub.cfg <<EOF
+set timeout=0
+set gfxpayload=text
+menuentry 'LinuxKit ISO Image' {
+	$LINUX_ENTRY /kernel ${CMDLINE} text
+  $INITRD_ENTRY /initrd.img
+}
+EOF
+
+#
+# calculate sizes
+KERNEL_FILE_SIZE=$(stat -c %s "$KERNEL")
+INITRD_FILE_SIZE=$(stat -c %s "$INITRD")
+EFI_FILE_SIZE=$(stat -c %s "$BOOTFILE")
+# minimum headroom needed in ESP, in bytes
+# 511KiB headroom seems to be enough
+ESP_HEADROOM=$(( 1024 * 1024 ))
+
+# this is the minimum size of our EFI System Partition
+ESP_FILE_SIZE=$(( $KERNEL_FILE_SIZE + $INITRD_FILE_SIZE + $EFI_FILE_SIZE + $ESP_HEADROOM ))
+
+# (x+1024)/1024*1024 rounds up to multiple of 1024KB, or 2048 sectors
+# some firmwares get confused if the partitions are not aligned on 2048 blocks
+# we will round up to the nearest multiple of 2048 blocks
+# since each block is 512 bytes, we want the size to be a multiple of
+# 2048 blocks * 512 bytes = 1048576 bytes = 1024KB
+ESP_FILE_SIZE_KB=$(( ( ($ESP_FILE_SIZE+1024) / 1024 ) / 1024 * 1024 ))
+# and for sectors
+ESP_FILE_SIZE_SECTORS=$(( $ESP_FILE_SIZE_KB * 2 ))
+
+# create a raw disk with an EFI boot partition
+# Stuff it into a FAT filesystem, making it as small as possible.
+mkfs.vfat -v -C $ESP_FILE $(( $ESP_FILE_SIZE_KB )) > /dev/null
+echo "mtools_skip_check=1" >> /etc/mtools.conf && \
+mmd -i $ESP_FILE ::/EFI
+mmd -i $ESP_FILE ::/EFI/BOOT
+mcopy -i $ESP_FILE $BOOTFILE ::/EFI/BOOT/
+mcopy -i $ESP_FILE EFI/BOOT/grub.cfg ::/EFI/BOOT/
+mcopy -i $ESP_FILE $KERNEL ::/
+mcopy -i $ESP_FILE $INITRD ::/
+
+
+# now make our actual filesystem image
+# how big an image do we want?
+# it should be the size of our ESP file+1MB for BIOS boot + 1MB for MBR + 1MB for GPT
+ONEMB=$(( 1024 * 1024 ))
+SIZE_IN_BYTES=$(( $(stat -c %s "$ESP_FILE") + 4*$ONEMB ))
+
+# and make sure the ESP is bootable for BIOS mode
+# settings
+BLKSIZE=512
+MB_BLOCKS=$(( $SIZE_IN_BYTES / $ONEMB ))
+
+# make the image
+dd if=/dev/zero of=$IMGFILE bs=1M count=$MB_BLOCKS
+
+ESP_SECTOR_START=2048
+ESP_SECTOR_END=$(( $ESP_SECTOR_START + $ESP_FILE_SIZE_SECTORS - 1 ))
+
+# create the partitions - size of the ESP must match our image
+# and make sure the ESP is bootable for BIOS mode
+sgdisk --clear \
+    --new 1:$ESP_SECTOR_START:$ESP_SECTOR_END --typecode=1:ef00 --change-name=1:'EFI System' --partition-guid=1:$PARTUUID \
+    --attributes 1:set:2 \
+     $IMGFILE
+
+# copy in our EFI System Partition image
+dd if=$ESP_FILE of=$IMGFILE bs=$BLKSIZE count=$ESP_FILE_SIZE_SECTORS conv=notrunc seek=$ESP_SECTOR_START
+
+)
+
+cat $IMGFILE

--- a/tools/mkimage-raw-efi/patches/0001-TPM-build-issue-fixing.patch
+++ b/tools/mkimage-raw-efi/patches/0001-TPM-build-issue-fixing.patch
@@ -1,0 +1,72 @@
+From 617b08377dbaa9ea3876b5585fe0ba36286fbed6 Mon Sep 17 00:00:00 2001
+From: Dennis Chen <dennis.chen@arm.com>
+Date: Thu, 17 Aug 2017 05:47:55 +0000
+Subject: [PATCH] TPM: build issue fixing
+
+Fix the build issue on arm64 and amd64.
+
+Signed-off-by: Dennis Chen <dennis.chen@arm.com>
+---
+ grub-core/kern/efi/tpm.c | 12 ++++++------
+ include/grub/efi/tpm.h   |  4 ++--
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/grub-core/kern/efi/tpm.c b/grub-core/kern/efi/tpm.c
+index c9fb3c1..ed40f98 100644
+--- a/grub-core/kern/efi/tpm.c
++++ b/grub-core/kern/efi/tpm.c
+@@ -175,7 +175,7 @@ grub_tpm1_log_event(grub_efi_handle_t tpm_handle, unsigned char *buf,
+ 		    grub_size_t size, grub_uint8_t pcr,
+ 		    const char *description)
+ {
+-  Event *event;
++  TCG_PCR_EVENT *event;
+   grub_efi_status_t status;
+   grub_efi_tpm_protocol_t *tpm;
+   grub_efi_physical_address_t lastevent;
+@@ -188,15 +188,15 @@ grub_tpm1_log_event(grub_efi_handle_t tpm_handle, unsigned char *buf,
+   if (!grub_tpm_present(tpm))
+     return 0;
+ 
+-  event = grub_zalloc(sizeof (Event) + grub_strlen(description) + 1);
++  event = grub_zalloc(sizeof (TCG_PCR_EVENT) + grub_strlen(description) + 1);
+   if (!event)
+     return grub_error (GRUB_ERR_OUT_OF_MEMORY,
+ 		       N_("cannot allocate TPM event buffer"));
+ 
+-  event->pcrindex = pcr;
+-  event->eventtype = EV_IPL;
+-  event->eventsize = grub_strlen(description) + 1;
+-  grub_memcpy(event->event, description, event->eventsize);
++  event->PCRIndex = pcr;
++  event->EventType = EV_IPL;
++  event->EventSize = grub_strlen(description) + 1;
++  grub_memcpy(event->Event, description, event->EventSize);
+ 
+   algorithm = TCG_ALG_SHA;
+   status = efi_call_7 (tpm->log_extend_event, tpm, buf, (grub_uint64_t) size,
+diff --git a/include/grub/efi/tpm.h b/include/grub/efi/tpm.h
+index e2aff4a..fb3bb0e 100644
+--- a/include/grub/efi/tpm.h
++++ b/include/grub/efi/tpm.h
+@@ -69,7 +69,7 @@ struct grub_efi_tpm_protocol
+ 					    grub_efi_uint32_t TpmOutputParameterBlockSize,
+ 					    grub_efi_uint8_t *TpmOutputParameterBlock);
+   grub_efi_status_t (*log_extend_event) (struct grub_efi_tpm_protocol *this,
+-					 grub_efi_physical_address_t HashData,
++					 grub_efi_uint8_t *HashData,
+ 					 grub_efi_uint64_t HashDataLen,
+ 					 grub_efi_uint32_t AlgorithmId,
+ 					 TCG_PCR_EVENT *TCGLogData,
+@@ -129,7 +129,7 @@ struct grub_efi_tpm2_protocol
+ 				      grub_efi_boolean_t *EventLogTruncated);
+   grub_efi_status_t (*hash_log_extend_event) (struct grub_efi_tpm2_protocol *this,
+ 					      grub_efi_uint64_t Flags,
+-					      grub_efi_physical_address_t *DataToHash,
++					      grub_efi_uint8_t *DataToHash,
+ 					      grub_efi_uint64_t DataToHashLen,
+ 					      EFI_TCG2_EVENT *EfiTcgEvent);
+   grub_efi_status_t (*submit_command) (struct grub_efi_tpm2_protocol *this,
+-- 
+2.7.4
+

--- a/tools/mkimage-raw-efi/patches/0002-video-Allow-to-set-pure-text-mode-in-case-of-EFI.patch
+++ b/tools/mkimage-raw-efi/patches/0002-video-Allow-to-set-pure-text-mode-in-case-of-EFI.patch
@@ -1,0 +1,33 @@
+From ac7afa666cb2b7b133b6e27bcf22c9cd90a2936a Mon Sep 17 00:00:00 2001
+From: Dennis Chen <dennis.chen@arm.com>
+Date: Wed, 6 Sep 2017 09:06:54 +0000
+Subject: [PATCH] video: Allow to set pure 'text' mode in case of EFI
+
+Current code doesn't accept a pure text mode when booting
+from UEFI firmware on i386 platform, this will result in
+below error message even we already have 'set gfxpayload=text'
+configured: "no suitable video mode found". This often happens
+when we boot a VM which UEFI firmware doesn't include 'suitable'
+video modes.
+
+Signed-off-by: Dennis Chen <dennis.chen@arm.com>
+---
+ grub-core/loader/i386/linux.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/loader/i386/linux.c b/grub-core/loader/i386/linux.c
+index 5fdfea3..8cf1086 100644
+--- a/grub-core/loader/i386/linux.c
++++ b/grub-core/loader/i386/linux.c
+@@ -49,7 +49,7 @@ GRUB_MOD_LICENSE ("GPLv3+");
+ #include <grub/efi/efi.h>
+ #define HAS_VGA_TEXT 0
+ #define DEFAULT_VIDEO_MODE "auto"
+-#define ACCEPTS_PURE_TEXT 0
++#define ACCEPTS_PURE_TEXT 1
+ #elif defined (GRUB_MACHINE_IEEE1275)
+ #include <grub/ieee1275/ieee1275.h>
+ #define HAS_VGA_TEXT 0
+-- 
+2.7.4
+


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

UPDATE: removed `raw-bios` from this PR, separated to [2558](https://github.com/linuxkit/linuxkit/pull/2558)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Created a new `tools/` entry and therefore images:

* `tools/mkimage-raw-efi/`: create raw images that are bootable EFI

**- How I did it**
1. Created new directory
2. Created entrypoint for EFI that creates correct image given the `tar` input on stdin from moby

The intent, once this is merged, is to update moby build to add the output format `raw-efi`.

**Note:** There is some overlap between this raw format builder `raw-efi` and `iso-efi`. I would _like_ to extract common code to all, perhaps simplifying to just 1 docker image, but it was enough work to get this here and working fully. Let's merge it in first and get it working, then remove duplication.

**- How to verify it**
1. Create a `linuxkit.tar` as the usual input format for builders. This is *not* the output of `moby build -format tar ...`, since that puts everything in the tar as if on an iso. Instead, recreate the output of `tarToInitrd()` by either getting kernel+cmdline+initrd and tarring up, or doing `moby build -format raw ...` and taking the 3 files off the iso image and tarring them up.
2. Build the images using `make tag`
3. Create a raw image the way `moby build` would: `cat linuxkit.tar | docker run -i --rm <image_name> > linuxkit-bios.efi`
4. Run the image

To run the image, you can load it into qemu, vbox, a bare metal server, or hyperkit.

For qemu, my command-lines (shamelessly hijacked and modified from `linuxkit run qemu ...`  are:

```
$ /usr/local/bin/qemu-system-x86_64 -device virtio-rng-pci -smp 1 -m 1024 -uuid 940c5cec-0640-47cf-aa48-feea2dd23037 -pidfile linuxkit.raw-state/qemu.pid -drive file=./linuxkit-efi.raw,index=0,media=disk -drive if=pflash,format=raw,file=./OVMF.fd -device virtio-net-pci,netdev=t0,mac=12:7b:f1:13:29:2a -netdev user,id=t0 --nographic
```

You can run the EFI image in hyperkit with:

```
$ /usr/local/bin/hyperkit -A -u -F linuxkit-state/hyperkit.pid -c 1 -m 1024M -s 0:0,hostbridge -s 31,lpc -s 1:0,virtio-vpnkit,path=$HOME/Library/Containers/com.docker.docker/Data/s50,uuid=1edc6091-1bb8-4f9e-9550-d5a4844589a9 -U 841601a7-189b-4a13-8dea-6e65df9875f2 -s 2:0,virtio-blk,./linuxkit-efi.raw  -s 3,virtio-sock,guest_cid=3,path=./linuxkit-state -s 4,virtio-rnd -l com1,stdio -f bootrom,/Applications/Docker.app/Contents/Resources/uefi/UEFI.fd,,
```





**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add support for raw EFI images

**- A picture of a cute animal (not mandatory but encouraged)**
![Marmot](https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Himalayan_Marmot_at_Tshophu_Lake_Bhutan_091007_b.jpg/280px-Himalayan_Marmot_at_Tshophu_Lake_Bhutan_091007_b.jpg)

Cannot recall if I used a marmot before, but saw them in France and in Western Canada :-)
