### PR TITLE
linux-firmware image for linuxkit

### DIFF
--- a/pkg/linux-firmware/Dockerfile
+++ b/pkg/linux-firmware/Dockerfile
@@ -1,0 +1,11 @@
+FROM linuxkit/alpine:28254e4530703db4caa6b0199a025c30a987dfa1 AS mirror
+
+RUN apk add --no-cache git
+ENV HEAD=a61ac5cf8374edbfe692d12f805a1b194f7fead2
+
+RUN git clone -n git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git /var/linux-firmware && \
+    cd /var/linux-firmware && \
+    git checkout $HEAD
+
+FROM scratch
+COPY --from=mirror /var/linux-firmware/ /lib/firmware/

--- a/pkg/linux-firmware/Makefile
+++ b/pkg/linux-firmware/Makefile
@@ -1,0 +1,4 @@
+IMAGE=linux-firmware
+NETWORK=1
+
+include ../package.mk

--- a/pkg/linux-firmware/README.md
+++ b/pkg/linux-firmware/README.md
@@ -1,0 +1,10 @@
+# LinuxKit linux-firmware
+Image with firmware images for a [linuxkit](https://github.com/linuxkit/linuxkit)-generated image.
+
+## Usage
+The sample configuration for your `linuxkit.yml`:
+
+```
+init:
+  - linuxkit/linux-firmware:<hash>
+```


### PR DESCRIPTION
**- What I did**

Added linux-firmware image for linuxkit.

Please note that there is nothing special about linuxkit in this docker image, however you may want to include additional firmwares (like Alpine Linux or other distros do) specific for linuxkit. Otherwise (or for any other reasons), please feel free to disregard this PR, and I'll just keep and maintain my own docker image.

**- How I did it**

Pulled the original linux-firmware blobs into the image. Please notice that linux-firmware Git repo doesn't do any tagging, so the latest commit hash has been used.

**- How to verify it**

Please use the sample configuration for your `linuxkit.yml`:

```
init:
  - nuald/linux-firmware:2837c74cdb79bb5d9ef3359e230ef394b98d0965
```

Root FS will have firmwares available at /lib/firmware.

**- Description for the changelog**

Added linux-firmware image for linuxkit.
