### PR TITLE
kubernetes: update to latest cri-containerd

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -22,7 +22,7 @@ onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib"]
   # make a swap file on the mounted disk
   - name: swap

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -14,7 +14,7 @@ onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -15,7 +15,7 @@ onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/external"]
   - name: swap
     image: linuxkit/swap:3881b1e0fadb7765d2fa85d03563c887ab9335a6

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -17,7 +17,7 @@ onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -17,7 +17,7 @@ onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -12,7 +12,7 @@ onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/etcd"]
   - name: dhcpcd
     image: linuxkit/dhcpcd:d4408777ed6b6e6e562a5d4938fd09804324b33e

--- a/projects/kubernetes/cri-containerd.yml
+++ b/projects/kubernetes/cri-containerd.yml
@@ -1,6 +1,6 @@
 services:
   - name: cri-containerd
-    image: linuxkitprojects/cri-containerd:2ff7dce33400a4d184976ca439725d8306295f1a
+    image: linuxkitprojects/cri-containerd:da520622a5cecb07044ef76b0b84102807527fb5
 files:
   - path: /etc/kubelet.conf
     contents: |

--- a/projects/kubernetes/cri-containerd/Dockerfile
+++ b/projects/kubernetes/cri-containerd/Dockerfile
@@ -7,13 +7,15 @@ RUN \
   git \
   go \
   libc-dev \
+  libseccomp-dev \
+  linux-headers \
   make \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin
 
 ENV CRI_CONTAINERD_URL https://github.com/kubernetes-incubator/cri-containerd.git
 #ENV CRI_CONTAINERD_BRANCH pull/NNN/head
-ENV CRI_CONTAINERD_COMMIT a2dbc6ec1ce63fe8c54543c04df0a1a45abdd989
+ENV CRI_CONTAINERD_COMMIT 0e6e59348122e86842bcd93c75c1d4a264ca1288
 RUN mkdir -p $GOPATH/src/github.com/kubernetes-incubator && \
     cd $GOPATH/src/github.com/kubernetes-incubator && \
     git clone $CRI_CONTAINERD_URL cri-containerd
@@ -23,7 +25,7 @@ RUN set -e; \
         git fetch origin "$CRI_CONTAINERD_BRANCH"; \
     fi; \
     git checkout $CRI_CONTAINERD_COMMIT
-RUN make static-binaries
+RUN make static-binaries BUILD_TAGS="seccomp"
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # util-linux because a full ns-enter is required.
@@ -46,4 +48,4 @@ FROM scratch
 WORKDIR /
 ENTRYPOINT ["cri-containerd", "-v", "2", "--alsologtostderr", "--network-bin-dir", "/var/lib/cni/opt/bin", "--network-conf-dir", "/var/lib/cni/etc/net.d"]
 COPY --from=build /out /
-LABEL org.mobyproject.config='{"binds": ["/etc/resolv.conf:/etc/resolv.conf", "/run:/run:rshared,rbind", "/tmp:/tmp", "/var:/var:rshared,rbind", "/var/lib/kubeadm:/etc/kubernetes", "/var/lib/cni/etc:/etc/cni:rshared,rbind", "/var/lib/cni/opt:/opt/cni:rshared,rbind", "/run/containerd/containerd.sock:/run/containerd/containerd.sock"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}], "capabilities": ["all"], "rootfsPropagation": "shared", "pid": "host", "runtime": {"mkdir": ["/var/lib/kubeadm", "/var/lib/cni/etc/net.d", "/var/lib/cni/opt"]}}'
+LABEL org.mobyproject.config='{"binds": ["/etc/resolv.conf:/etc/resolv.conf", "/run:/run:rshared,rbind", "/dev:/dev", "/tmp:/tmp", "/var:/var:rshared,rbind", "/var/lib/kubeadm:/etc/kubernetes", "/var/lib/cni/etc:/etc/cni:rshared,rbind", "/var/lib/cni/opt:/opt/cni:rshared,rbind", "/run/containerd/containerd.sock:/run/containerd/containerd.sock"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}], "capabilities": ["all"], "rootfsPropagation": "shared", "pid": "host", "runtime": {"mkdir": ["/var/lib/kubeadm", "/var/lib/cni/etc/net.d", "/var/lib/cni/opt"]}}'

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -22,7 +22,7 @@ onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mounts
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/"]
 services:
   - name: getty

--- a/projects/kubernetes/ssh_into_kubelet.sh
+++ b/projects/kubernetes/ssh_into_kubelet.sh
@@ -15,4 +15,4 @@ case $(uname -s) in
 	    ijc25/alpine-ssh"
 	;;
 esac
-$ssh $sshopts -t root@"$1" ctr tasks exec --tty --exec-id ssh kubelet ash -l
+$ssh $sshopts -t root@"$1" ctr tasks exec --tty --exec-id ssh-$(hostname)-$$ kubelet ash -l

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -17,7 +17,7 @@ onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/swarmd"]
   - name: metadata
     image: linuxkit/metadata:da3138079c168e0c5608d8f3853366c113ed91d2

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -14,7 +14,7 @@ onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -15,7 +15,7 @@ onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
     image: linuxkit/test-containerd:d6d49adba473c8bd512555fb1bd3c4bd882c830c

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -8,7 +8,7 @@ onboot:
   - name: format
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -8,7 +8,7 @@ onboot:
   - name: extend
     image: linuxkit/extend:468cc677e35503a265235767d5f488253f51cfd6
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/extend:468cc677e35503a265235767d5f488253f51cfd6
     command: ["/usr/bin/extend", "-type", "btrfs"]
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
     command: ["/usr/bin/format", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/extend:468cc677e35503a265235767d5f488253f51cfd6
     command: ["/usr/bin/extend", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
     command: ["/usr/bin/format"]
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
     command: ["/usr/bin/format", "-label", "docker"]
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
     command: ["/usr/bin/format", "@DEVICE@"]
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "-device", "@DEVICE@1", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
     command: ["/usr/bin/format", "-type", "xfs" ]
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -12,10 +12,10 @@ onboot:
     image: linuxkit/format:158d992b7bf7ab984100c697d7e72161ea7d7382
     command: ["/usr/bin/format", "-label", "foo"]
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: mount
-    image: linuxkit/mount:4fe245efb01384e42622c36302e13e386bbaeb08
+    image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "-label", "foo", "/var/foo"]
   - name: test
     image: alpine:3.6


### PR DESCRIPTION
This new version vendors containerd v1.0.0-beta.1 which is our current base.

It also fixes the build for seccomp support so this PR enables that at build time.

Lastly this new version requires `/dev/disk/by-uuid` so it can report the UUID of the container storage filesystem back to kubernetes, implement support for that and ensure `/dev` is bound into the cri containerd.

Note that kube 1.7 does not currently use `/dev/disk/by-uuid` directly itself, but code in the master branch does, so this is future proof for that too (the kubelet container already binds `/dev`).

Also a bonus fix to the `ssh_to_kubelet` script which wasn't using a unique exec id.