### PR TITLE
tools: remove the unused pkgs from the Dockerfile

### DIFF
--- a/tools/mkimage-iso-efi/Dockerfile
+++ b/tools/mkimage-iso-efi/Dockerfile
@@ -35,7 +35,6 @@ RUN mkdir /grub-lib && \
   ./configure --libdir=/grub-lib --with-platform=efi CFLAGS="-Os -Wno-unused-value" && \
   make -j "$(getconf _NPROCESSORS_ONLN)" && \
   make install && \
-# create the grub core image
   case $(uname -m) in \
   x86_64) \
     ./grub-mkimage -O x86_64-efi -d /grub-lib/grub/x86_64-efi -o /grub-lib/BOOTX64.EFI -p /EFI/BOOT ${GRUB_MODULES} linuxefi; \
@@ -52,7 +51,6 @@ RUN \
   apk add --no-cache \
   dosfstools \
   libarchive-tools \
-  binutils \
   mtools \
   xorriso \
   && true


### PR DESCRIPTION
1. Remove the pkgs used by gummiboot tool from the Dockerfile
2. Fix the 'Empty continuation line' warning message when building
   the grub2 image:
   [WARNING]: Empty continuation line found in:
   RUN mkdir /grub-lib &&   set -e &&   git clone https://github.com/coreos/grub.git && ...
   [WARNING]: Empty continuation lines will become errors in a future release.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Remove the unused pkgs from the Dockerfile; 2. Remove the warning message
**- How I did it**
2. Figure out which pkgs will not be used; Remove the comments between multi-lines in the Dockerfile 
**- How to verify it**
3. Build the standalone docker image and generate the final ISO image.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/30942646-e3afc5ba-a3a0-11e7-826f-8a2375f87dc5.jpg)
