### PR TITLE
kubernetes: do not try to re-init the cluster on subsequent boots

### DIFF
--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -36,7 +36,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:d313eea3d9d7fbcbc927d06a6700325725db2a82
   - name: kubelet
-    image: linuxkitprojects/kubernetes:710738dd5a75bb06a1a5a88c74df136ea05bc8a5
+    image: linuxkitprojects/kubernetes:807de925610de344864cadd21b9860342a5c2bda
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/projects/kubernetes/kubernetes/kubelet.sh
+++ b/projects/kubernetes/kubernetes/kubelet.sh
@@ -10,7 +10,12 @@ fi
 if [ -e /etc/kubelet.sh.conf ] ; then
     . /etc/kubelet.sh.conf
 fi
-if [ -e /var/config/kubeadm/init ] ; then
+
+conf=/var/lib/kubeadm/kubelet.conf
+
+if [ -f "${conf}" ] ; then
+    echo "kubelet.sh: kubelet already configured"
+elif [ -e /var/config/kubeadm/init ] ; then
     echo "kubelet.sh: init cluster with metadata \"$(cat /var/config/kubeadm/init)\""
     # This needs to be in the background since it waits for kubelet to start.
     # We skip printing the token so it is not persisted in the log.
@@ -22,8 +27,6 @@ elif [ -e /var/config/userdata ] ; then
     echo "kubelet.sh: joining cluster with metadata \"$(cat /var/config/userdata)\""
     kubeadm join --skip-preflight-checks $(cat /var/config/userdata)
 fi
-
-conf=/var/lib/kubeadm/kubelet.conf
 
 echo "kubelet.sh: waiting for ${conf}"
 # TODO(ijc) is there a race between kubeadm creating this file and


### PR DESCRIPTION
If `kubelet.conf` already exits then don't try to redo `kubeadm`, no matter
what the metadata requests.
    
Signed-off-by: Ian Campbell <ijc@docker.com>
