### PR TITLE
tools/alpine: Explicitly add blkid

### DIFF
--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -11,6 +11,7 @@ bc
 binutils
 binutils-dev
 bison
+blkid
 bsd-compat-headers
 btrfs-progs
 btrfs-progs-dev

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:8517600ba827ecea0849e3e0d7eb61d9a4b518be-arm64
+# linuxkit/alpine:0b37067e4bdd813841c212b9cf28303751a21871-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -16,6 +16,7 @@ binutils-2.28-r2
 binutils-dev-2.28-r2
 binutils-libs-2.28-r2
 bison-3.0.4-r0
+blkid-2.28.2-r2
 bsd-compat-headers-0.7.1-r0
 btrfs-progs-4.10.2-r0
 btrfs-progs-dev-4.10.2-r0
@@ -247,7 +248,7 @@ util-linux-dev-2.28.2-r2
 vde2-libs-2.3.2-r7
 vim-8.0.0595-r0
 wayland-1.13.0-r0
-wireguard-tools-0.0.20170918-r0
+wireguard-tools-0.0.20171001-r0
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r3
 xfsprogs-4.5.0-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:4476496e70a41705f9a8f1c9162a4e21a40817fe-amd64
+# linuxkit/alpine:d1778ee29f11475548f0e861f57005a84e82ba4e-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -256,7 +256,7 @@ util-linux-dev-2.28.2-r2
 vde2-libs-2.3.2-r7
 vim-8.0.0595-r0
 wayland-1.13.0-r0
-wireguard-tools-0.0.20170918-r0
+wireguard-tools-0.0.20171001-r0
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r3
 xfsprogs-4.5.0-r0


### PR DESCRIPTION
On x86_64, the blkid package gets installed as a dependency, but
not on arm64. Explicitly add it as the new format package depends
on it.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
![bull-dog](https://user-images.githubusercontent.com/3338098/31090771-b81eb6b4-a7a0-11e7-9f46-f92b9eda5b61.jpg)
