### PR TITLE
Add support to make minimal raw bios images

### DIFF
--- a/tools/mkimage-raw-bios/Dockerfile
+++ b/tools/mkimage-raw-bios/Dockerfile
@@ -1,0 +1,14 @@
+FROM linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630
+
+RUN \
+  apk update && apk upgrade && \
+  apk add --no-cache \
+  dosfstools \
+  libarchive-tools \
+  sfdisk \
+  syslinux \
+  && true
+
+COPY . .
+
+ENTRYPOINT [ "/make-bios" ]

--- a/tools/mkimage-raw-bios/build.yml
+++ b/tools/mkimage-raw-bios/build.yml
@@ -1,0 +1,2 @@
+image: mkimage-raw-bios
+arches: ["amd64"]

--- a/tools/mkimage-raw-bios/make-bios
+++ b/tools/mkimage-raw-bios/make-bios
@@ -1,0 +1,105 @@
+#!/bin/sh
+
+set -e
+
+# for debugging
+[ -n "$DEBUG" ] && set -x
+
+IMGFILE=$PWD/disk.img
+
+
+# we want everything except the final result to stderr
+( exec 1>&2;
+
+ESP_FILE=$PWD/boot.img
+
+
+mkdir -p /tmp/bios
+cd /tmp/bios
+
+# input is a tarball of filesystem on stdin with kernel in /boot
+# output is an iso on stdout
+
+# extract. BSD tar auto recognises compression, unlike GNU tar
+# only if stdin is a tty, if so need files volume mounted...
+[ -t 0 ] || bsdtar xzf -
+
+INITRD="$(find . -name '*.img')"
+KERNEL="$(find . -name kernel)"
+CMDLINE_FILE="$(find . -name cmdline)"
+CMDLINE="$(cat $CMDLINE_FILE )"
+
+
+cat >> syslinux.cfg <<EOF
+DEFAULT linux
+LABEL linux
+    KERNEL /kernel
+    INITRD /initrd.img
+    APPEND ${CMDLINE}
+EOF
+
+# now build an img file
+KERNEL_FILE_SIZE=$(stat -c %s "$KERNEL")
+INITRD_FILE_SIZE=$(stat -c %s "$INITRD")
+# minimum headroom needed in ESP, in bytes
+# 511KiB headroom seems to be enough
+ESP_HEADROOM=$(( 1024 * 1024 ))
+
+
+ESP_FILE_SIZE=$(( $KERNEL_FILE_SIZE + $INITRD_FILE_SIZE + $ESP_HEADROOM ))
+# (x+1024)/1024*1024 rounds up to multiple of 1024KB, or 2048 sectors
+# some firmwares get confused if the partitions are not aligned on 2048 blocks
+# we will round up to the nearest multiple of 2048 blocks
+# since each block is 512 bytes, we want the size to be a multiple of
+# 2048 blocks * 512 bytes = 1048576 bytes = 1024KB
+ESP_FILE_SIZE_KB=$(( ( ($ESP_FILE_SIZE+1024) / 1024 ) / 1024 * 1024 ))
+ESP_FILE_SIZE_MB=$(( $ESP_FILE_SIZE_KB / 1024 ))
+# and for sectors
+ESP_FILE_SIZE_SECTORS=$(( $ESP_FILE_SIZE_KB * 2 ))
+
+# create a raw disk with an EFI boot partition
+# Stuff it into a FAT filesystem, making it as small as possible.
+mkfs.vfat -v -C $ESP_FILE $(( $ESP_FILE_SIZE_KB )) > /dev/null
+echo "mtools_skip_check=1" >> /etc/mtools.conf && \
+mcopy -i $ESP_FILE syslinux.cfg ::/
+mcopy -i $ESP_FILE $KERNEL ::/kernel
+mcopy -i $ESP_FILE $INITRD ::/initrd.img
+
+# install syslinux
+syslinux --install $ESP_FILE
+
+# now make our actual filesystem image
+# how big an image do we want?
+# it should be the size of our ESP file+1MB for BIOS boot + 1MB for MBR + 1MB for backup
+ONEMB=$(( 1024 * 1024 ))
+SIZE_IN_BYTES=$(( $(stat -c %s "$ESP_FILE") + 4*$ONEMB ))
+
+# and make sure the ESP is bootable for BIOS mode
+# settings
+BLKSIZE=512
+MB_BLOCKS=$(( $SIZE_IN_BYTES / $ONEMB ))
+
+# make the image
+dd if=/dev/zero of=$IMGFILE bs=1M count=$MB_BLOCKS
+
+
+echo "w" | fdisk $IMGFILE || true
+# format one large partition of the apprropriate size
+echo ","$ESP_FILE_SIZE_SECTORS",;" | sfdisk $IMGFILE
+
+# of course, "one large partition" means minus the 2048 at the beginning
+ESP_SECTOR_START=2048
+
+# copy in our EFI System Partition image
+dd if=$ESP_FILE of=$IMGFILE bs=$BLKSIZE count=$ESP_FILE_SIZE_SECTORS conv=notrunc seek=$ESP_SECTOR_START
+
+# install mbr
+#dd if=/usr/share/syslinux/mbr.bin of="$IMGFILE" bs=440 count=1 conv=notrunc
+dd if=/usr/share/syslinux/altmbr.bin bs=439 count=1 conv=notrunc of=$IMGFILE
+printf '\1' | dd bs=1 count=1 seek=439 conv=notrunc of=$IMGFILE
+
+sfdisk -A "$IMGFILE" 1
+
+)
+
+cat $IMGFILE


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Created a new `tools/` entry and therefore images:

* `tools/mkimage-raw-bios/`: create raw images that are bootable BIOS

The bios images are intended as a replacement for the `pkg/mkimage/`, but provides 2 advantages:

1. Much smaller builds (using `linuxkit.yml` gives ~64MB image vs 1.0GB)
2. Simpler builds: everything is done in a container, no need to spin up a VM in linuxkit to do filesystem manipulation

**- How I did it**
1. Created new directory
2. Created entrypoint that creates correct image given the `tar` input on stdin from moby

The intent, once merged, is to update moby build to remove the output format `raw` and replace it with `raw-bios`. We then can remove `pkg/mkimage` from the linuxkit repo entirely.

**Note:** There is some overlap between `raw-bios` and `iso-bios`. I would _like_ to extract common code, perhaps simplifying to just 1 docker image, perhaps merging common code with `raw-efi` but it was enough work to get this here and working fully. Let's merge it in first and get it working, then remove duplication.

**- How to verify it**
1. Create a `linuxkit.tar` as the usual input format for builders. This is *not* the output of `moby build -format tar ...`, since that puts everything in the tar as if on an iso. Instead, recreate the output of `tarToInitrd()` by either getting kernel+cmdline+initrd and tarring up, or doing `moby build -format raw ...` and taking the 3 files off the iso image and tarring them up.
2. Build the image using `make tag`
3. Create a raw image the way `moby build` would: `cat linuxkit.tar | docker run -i --rm <image_name> > linuxkit-bios.raw`
4. Run the image

To run the image, you can load it into qemu, vbox or a bare metal server.

For qemu, my command-lines (shamelessly hijacked and modified from `linuxkit run qemu ...`  are:

```
$ /usr/local/bin/qemu-system-x86_64 -device virtio-rng-pci -smp 1 -m 1024 -uuid 940c5cec-0640-47cf-aa48-feea2dd23037 -pidfile linuxkit.raw-state/qemu.pid -drive file=./linuxkit-bios.raw,index=0,media=disk  -device virtio-net-pci,netdev=t0,mac=12:7b:f1:13:29:2a -netdev user,id=t0 --nographic
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Simplify and shrink raw BIOS images

**- A picture of a cute animal (not mandatory but encouraged)**
![Marmot](https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Himalayan_Marmot_at_Tshophu_Lake_Bhutan_091007_b.jpg/280px-Himalayan_Marmot_at_Tshophu_Lake_Bhutan_091007_b.jpg)

NOTE: This is a split from #2540. Some of the discussion with @justincormack will be replicated in a separate comment.