### PR TITLE
kubernetes: easier support for single master, plus slight robustness improvement

### DIFF
--- a/projects/kubernetes/boot.sh
+++ b/projects/kubernetes/boot.sh
@@ -5,6 +5,7 @@ set -e
 : ${KUBE_MASTER_VCPUS:=2}
 : ${KUBE_MASTER_MEM:=1024}
 : ${KUBE_MASTER_DISK:=4G}
+: ${KUBE_MASTER_UNTAINT:=n}
 
 : ${KUBE_NODE_VCPUS:=2}
 : ${KUBE_NODE_MEM:=4096}
@@ -27,10 +28,16 @@ if [ $# -eq 0 ] ; then
     # then we configure for auto init. If it is completely unset then
     # we do not.
     if [ -n "${KUBE_MASTER_AUTOINIT+x}" ] ; then
-	data="{\"kubeadm\": {\"init\": \"${KUBE_MASTER_AUTOINIT}\"} }"
-    else
-	data=""
+	kubeadm_data="${kubeadm_data+$kubeadm_data, }\"init\": \"${KUBE_MASTER_AUTOINIT}\""
     fi
+    if [ "${KUBE_MASTER_UNTAINT}" = "y" ] ; then
+	kubeadm_data="${kubeadm_data+$kubeadm_data, }\"untaint-master\": \"\""
+    fi
+
+    if [ -n "${kubeadm_data}" ] ; then
+	data="{ \"kubeadm\": { ${kubeadm_data} } }"
+    fi
+
     state="kube-master-state"
 
     : ${KUBE_VCPUS:=$KUBE_MASTER_VCPUS}

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -36,7 +36,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:d313eea3d9d7fbcbc927d06a6700325725db2a82
   - name: kubelet
-    image: linuxkitprojects/kubernetes:98d03686d3665b935dcd68da192f79c4cb618ec7
+    image: linuxkitprojects/kubernetes:2a42ca12c52a756ffd83ec014f2b396891880e4a
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/projects/kubernetes/kubernetes/kubeadm-init.sh
+++ b/projects/kubernetes/kubernetes/kubeadm-init.sh
@@ -7,3 +7,7 @@ for i in /etc/kubeadm/kube-system.init/*.yaml ; do
 	kubectl create -n kube-system -f "$i"
     fi
 done
+if [ -f /var/config/kubeadm/untaint-master ] ; then
+    echo "Removing \"node-role.kubernetes.io/master\" taint from all nodes"
+    kubectl taint nodes --all node-role.kubernetes.io/master-
+fi

--- a/projects/kubernetes/kubernetes/kubeadm-init.sh
+++ b/projects/kubernetes/kubernetes/kubeadm-init.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+touch /var/lib/kubeadm/.kubeadm-init.sh-started
 kubeadm init --skip-preflight-checks --kubernetes-version @KUBERNETES_VERSION@ $@
 for i in /etc/kubeadm/kube-system.init/*.yaml ; do
     if [ -e "$i" ] ; then
@@ -11,3 +12,4 @@ if [ -f /var/config/kubeadm/untaint-master ] ; then
     echo "Removing \"node-role.kubernetes.io/master\" taint from all nodes"
     kubectl taint nodes --all node-role.kubernetes.io/master-
 fi
+touch /var/lib/kubeadm/.kubeadm-init.sh-finished

--- a/projects/kubernetes/kubernetes/kubelet.sh
+++ b/projects/kubernetes/kubernetes/kubelet.sh
@@ -15,15 +15,17 @@ await=/etc/kubernetes/kubelet.conf
 
 if [ -f "/etc/kubernetes/kubelet.conf" ] ; then
     echo "kubelet.sh: kubelet already configured"
-elif [ -e /var/config/kubeadm/init ] ; then
-    echo "kubelet.sh: init cluster with metadata \"$(cat /var/config/kubeadm/init)\""
-    # This needs to be in the background since it waits for kubelet to start.
-    # We skip printing the token so it is not persisted in the log.
-    kubeadm-init.sh --skip-token-print $(cat /var/config/kubeadm/init) &
-elif [ -e /var/config/kubeadm/join ] ; then
-    echo "kubelet.sh: joining cluster with metadata \"$(cat /var/config/kubeadm/join)\""
-    kubeadm join --skip-preflight-checks $(cat /var/config/kubeadm/join)
-    await=/etc/kubernetes/bootstrap-kubelet.conf
+elif [ -d /var/config/kubeadm ] ; then
+    if [ -f /var/config/kubeadm/init ] ; then
+	echo "kubelet.sh: init cluster with metadata \"$(cat /var/config/kubeadm/init)\""
+	# This needs to be in the background since it waits for kubelet to start.
+	# We skip printing the token so it is not persisted in the log.
+	kubeadm-init.sh --skip-token-print $(cat /var/config/kubeadm/init) &
+    elif [ -e /var/config/kubeadm/join ] ; then
+	echo "kubelet.sh: joining cluster with metadata \"$(cat /var/config/kubeadm/join)\""
+	kubeadm join --skip-preflight-checks $(cat /var/config/kubeadm/join)
+	await=/etc/kubernetes/bootstrap-kubelet.conf
+    fi
 elif [ -e /var/config/userdata ] ; then
     echo "kubelet.sh: joining cluster with metadata \"$(cat /var/config/userdata)\""
     kubeadm join --skip-preflight-checks $(cat /var/config/userdata)


### PR DESCRIPTION
The primary change here is to support triggering untainting the master node after `kubeadm init` via metadata, making it easier to quickly standup a usable single node dev VM. This involved a bit of reworking of how metadata is handled.

The secondary change is to aid debugging by dropping some stamp files around the init process, so it is possible to spot if it did not complete (e.g. because the VM was rebooted, which can easily happen since the init can need to do some largish pulls).