### PR TITLE
kubernetes: add optional support for a kubeadm.yaml

### DIFF
--- a/projects/kubernetes/kubernetes/kubeadm-init.sh
+++ b/projects/kubernetes/kubernetes/kubeadm-init.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
 set -e
 touch /var/lib/kubeadm/.kubeadm-init.sh-started
-kubeadm init --skip-preflight-checks --kubernetes-version @KUBERNETES_VERSION@ $@
+if [ -f /etc/kubeadm/kubeadm.yaml ]; then
+    echo Using the configuration from /etc/kubeadm/kubeadm.yaml
+    if [ $# -ne 0 ] ; then
+        echo WARNING: Ignoring command line options: $@
+    fi
+    kubeadm init --skip-preflight-checks --config /etc/kubeadm/kubeadm.yaml
+else
+    kubeadm init --skip-preflight-checks --kubernetes-version @KUBERNETES_VERSION@ $@
+fi
 for i in /etc/kubeadm/kube-system.init/*.yaml ; do
     if [ -e "$i" ] ; then
 	echo "Applying "$(basename "$i")


### PR DESCRIPTION
**- What I did**

Allow more `kubeadm` options to be selected by supplying a `yaml` file. Unfortunately not all options are available via the CLI interface.

**- How I did it**

In the `kubeadm-init.sh` if the `/etc/kubeadm/kubeadm.yaml` file exists, then it uses it. Otherwise it falls back to the original behaviour.

**- How to verify it**

Supply an `/etc/kubeadm/kubeadm.yaml` with some new options, and observe they take effect on a new cluster.

**- Description for the changelog**

Allow custom `kubeadm` configuration files to be provided via `/etc/kubeadm/kubeadm.yaml`

