### PR TITLE
kernel/wireguard: version bump

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -37,8 +37,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20171001
-ENV WIREGUARD_SHA256=ecff9a184685b7dd2d81576eba5bd96bb59031c9e9b5eeee05d6dc298f30998e
+ENV WIREGUARD_VERSION=0.0.20171005
+ENV WIREGUARD_SHA256=832a3b7cbb510f6986fd0c3a6b2d86bc75fc9f23b6754d8f46bc58ea8e02d608
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # PGP keys: 589DA6B1 (greg@kroah.com) & 6092693E (autosigner@kernel.org) & 00411886 (torvalds@linux-foundation.org)


### PR DESCRIPTION
This is a simple version bump, which you can merge whenever is convenient for you. Now that we've moved to netlink, shipping this update requires no corresponding changes to the tools or any place else, which means you should be able to lazily just press "merge" without worrying about complex interactions or conflicts.

Release notes [from](https://lists.zx2c4.com/pipermail/wireguard/2017-October/001791.html) the mailing list:

```
  * community: code welcomed
  
  There's a small disorganized list of things to do, some of which are large
  projects, and others are just little cleanups:
  
  https://www.wireguard.com/todo/
  
  If anybody is interested in working on something, please don't hesitate to
  send an email to this list, team at wireguard.com, or me directly.
  
  * tools: simmer down silly compilers
  * tools: compile on non-Linux
  * contrib: remove worthless build artifact
  * kernel-tree: remember UAPI in patch creation
  * curve25519-neon-arm: force ARM encoding, since this is unrepresentable in Thumb
  * compat: support ptr_ring for old kernels
  * compat: conditionally redefine GENL_UNS_ADMIN_PERM
  * compat: RHEL backported netlink changes
  
  These here are all compatibility-related fixes mostly left over from churn of
  the previous snapshots, where we lost some compatibility with old kernels and
  weird toolchains. The above series of fixes brings us back up to par, and
  should make life slightly easier for a few packagers who had to work-around
  things in the last snapshot.
  
  * compat: macro rewrite netlink instead of cluttering
  * global: satisfy bitshift pedantry
  * global: use _WG prefix for include guards
  * global: add space around variable declarations
  * queueing: cleanup skb_padding
  
  Style, mostly.
  
  * Makefile: add non-verbose mode to tools
  * Makefile: clang now builds the kernel, so use scan-build
  
  One touch static analysis: `make check`.
  
  * receive: simplify message type validation
  * receive: use local keypair, not ctx keypair in error path
  * send: put keypair reference
  * receive: we're not planning on turning that into a while loop now
  * queueing: use ptr_ring instead of linked lists
  * receive: do not store endpoint in ctx
  * queueing: move from ctx to cb
  
  This is another huge change, and the main motivation for releasing this
  snapshot. We move from using a linked list-based queue to a ring buffer-based
  queue, which yields considerable performance increases. It also allows us to
  entirely rid ourselves of a memory cache object, which further increases
  performance and decreases latency. The move to a ring buffer will also make
  writing lock-less algorithms easier, which will eventually increase our
  performance on systems with extremely high core counts.
```