### PR TITLE
[OpenStack] Metadata service support

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -11,7 +11,7 @@ init:
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata
-    image: linuxkit/metadata:da3138079c168e0c5608d8f3853366c113ed91d2
+    image: linuxkit/metadata:52a3d36ed158357125f3a998f9d03784eb0636d3
   - name: sysctl
     image: linuxkit/sysctl:154913b72c6f1f33eb408609fca9963628e8c051
   - name: sysfs

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:d4408777ed6b6e6e562a5d4938fd09804324b33e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:da3138079c168e0c5608d8f3853366c113ed91d2
+    image: linuxkit/metadata:52a3d36ed158357125f3a998f9d03784eb0636d3
 services:
   - name: rngd
     image: linuxkit/rngd:558e86a36242bb74353bc9287b715ddb8567357e

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:d4408777ed6b6e6e562a5d4938fd09804324b33e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:da3138079c168e0c5608d8f3853366c113ed91d2
+    image: linuxkit/metadata:52a3d36ed158357125f3a998f9d03784eb0636d3
 services:
   - name: getty
     image: linuxkit/getty:a19851531487b7bfbe45dcf77e3309c127cc78a6

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/dhcpcd:d4408777ed6b6e6e562a5d4938fd09804324b33e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:da3138079c168e0c5608d8f3853366c113ed91d2
+    image: linuxkit/metadata:52a3d36ed158357125f3a998f9d03784eb0636d3
     command: ["/usr/bin/metadata", "packet"]
 services:
   - name: rngd

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:d4408777ed6b6e6e562a5d4938fd09804324b33e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:da3138079c168e0c5608d8f3853366c113ed91d2
+    image: linuxkit/metadata:52a3d36ed158357125f3a998f9d03784eb0636d3
 services:
   - name: getty
     image: linuxkit/getty:a19851531487b7bfbe45dcf77e3309c127cc78a6

--- a/pkg/metadata/main.go
+++ b/pkg/metadata/main.go
@@ -19,6 +19,10 @@ const (
 
 	// SSH is the path where sshd configuration from the provider is stored
 	SSH = "ssh"
+
+	// Standard AWS-compatible Metadata URLs
+	userDataURL = "http://169.254.169.254/latest/user-data"
+	metaDataURL = "http://169.254.169.254/latest/meta-data"
 )
 
 // Provider is a generic interface for metadata/userdata providers.
@@ -41,7 +45,7 @@ var netProviders []Provider
 var cdromProviders []Provider
 
 func main() {
-	providers := []string{"aws", "gcp", "vultr", "packet", "cdrom"}
+	providers := []string{"aws", "gcp", "openstack", "vultr", "packet", "cdrom"}
 	if len(os.Args) > 1 {
 		providers = os.Args[1:]
 	}
@@ -51,6 +55,8 @@ func main() {
 			netProviders = append(netProviders, NewAWS())
 		case "gcp":
 			netProviders = append(netProviders, NewGCP())
+		case "openstack":
+			netProviders = append(netProviders, NewOpenstack())
 		case "packet":
 			netProviders = append(netProviders, NewPacket())
 		case "vultr":

--- a/pkg/metadata/provider_aws.go
+++ b/pkg/metadata/provider_aws.go
@@ -10,11 +10,6 @@ import (
 	"time"
 )
 
-const (
-	userDataURL = "http://169.254.169.254/latest/user-data"
-	metaDataURL = "http://169.254.169.254/latest/meta-data/"
-)
-
 // ProviderAWS is the type implementing the Provider interface for AWS
 type ProviderAWS struct {
 }

--- a/pkg/metadata/provider_openstack.go
+++ b/pkg/metadata/provider_openstack.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"time"
+)
+
+// ProviderOpenstack is the type implementing the Provider interface for OpenStack
+type ProviderOpenstack struct {
+}
+
+// NewOpenstack returns a new ProviderOpenstack
+func NewOpenstack() *ProviderOpenstack {
+	return &ProviderOpenstack{}
+}
+
+func (p *ProviderOpenstack) String() string {
+	return "openstack"
+}
+
+// Probe checks if we are running on OpenStack
+func (p *ProviderOpenstack) Probe() bool {
+	// Getting the hostname should always work...
+	_, err := openstackGet(metaDataURL + "hostname")
+	return (err == nil)
+}
+
+// Extract gets both the OpenStack specific and generic userdata
+func (p *ProviderOpenstack) Extract() ([]byte, error) {
+	// Get host name. This must not fail
+	hostname, err := openstackGet(metaDataURL + "hostname")
+	if err != nil {
+		return nil, err
+	}
+	err = ioutil.WriteFile(path.Join(ConfigPath, Hostname), hostname, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("OpenStack: Failed to write hostname: %s", err)
+	}
+
+	// public ipv4
+	openstackMetaGet("public-ipv4", "public_ipv4", 0644)
+
+	// private ipv4
+	openstackMetaGet("local-ipv4", "local_ipv4", 0644)
+
+	// availability zone
+	openstackMetaGet("placement/availability-zone", "availability_zone", 0644)
+
+	// instance type
+	openstackMetaGet("instance-type", "instance_type", 0644)
+
+	// instance-id
+	openstackMetaGet("instance-id", "instance_id", 0644)
+
+	// local-hostname
+	openstackMetaGet("local-hostname", "local_hostname", 0644)
+
+	// ssh
+	if err := p.handleSSH(); err != nil {
+		log.Printf("OpenStack: Failed to get ssh data: %s", err)
+	}
+
+	// Generic userdata
+	userData, err := openstackGet(userDataURL)
+	if err != nil {
+		log.Printf("OpenStack: Failed to get user-data: %s", err)
+		// This is not an error
+		return nil, nil
+	}
+	return userData, nil
+}
+
+// lookup a value (lookupName) in OpenStack's metaservice and store in given fileName
+func openstackMetaGet(lookupName string, fileName string, fileMode os.FileMode) {
+	if lookupValue, err := openstackGet(metaDataURL + lookupName); err == nil {
+		// we got a value from the metadata server, now save to filesystem
+		err = ioutil.WriteFile(path.Join(ConfigPath, fileName), lookupValue, fileMode)
+		if err != nil {
+			// we couldn't save the file for some reason
+			log.Printf("OpenStack: Failed to write %s:%s %s", fileName, lookupValue, err)
+		}
+	} else {
+		// we did not get a value back from the metadata server
+		log.Printf("OpenStack: Failed to get %s: %s", lookupName, err)
+	}
+}
+
+// openstackGet requests and extracts the requested URL
+func openstackGet(url string) ([]byte, error) {
+	var client = &http.Client{
+		Timeout: time.Second * 2,
+	}
+
+	req, err := http.NewRequest("", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("OpenStack: http.NewRequest failed: %s", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("OpenStack: Could not contact metadata service: %s", err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("OpenStack: Status not ok: %d", resp.StatusCode)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("OpenStack: Failed to read http response: %s", err)
+	}
+	return body, nil
+}
+
+// SSH keys:
+func (p *ProviderOpenstack) handleSSH() error {
+	sshKeys, err := openstackGet(metaDataURL + "public-keys/0/openssh-key")
+	if err != nil {
+		return fmt.Errorf("Failed to get sshKeys: %s", err)
+	}
+
+	if err := os.Mkdir(path.Join(ConfigPath, SSH), 0755); err != nil {
+		return fmt.Errorf("Failed to create %s: %s", SSH, err)
+	}
+
+	err = ioutil.WriteFile(path.Join(ConfigPath, SSH, "authorized_keys"), sshKeys, 0600)
+	if err != nil {
+		return fmt.Errorf("Failed to write ssh keys: %s", err)
+	}
+	return nil
+}

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/dhcpcd:d4408777ed6b6e6e562a5d4938fd09804324b33e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:da3138079c168e0c5608d8f3853366c113ed91d2
+    image: linuxkit/metadata:52a3d36ed158357125f3a998f9d03784eb0636d3
 services:
   - name: rngd
     image: linuxkit/rngd:558e86a36242bb74353bc9287b715ddb8567357e

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:d4408777ed6b6e6e562a5d4938fd09804324b33e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:da3138079c168e0c5608d8f3853366c113ed91d2
+    image: linuxkit/metadata:52a3d36ed158357125f3a998f9d03784eb0636d3
 services:
   - name: rngd
     image: mobylinux/rngd:3dad6dd43270fa632ac031e99d1947f20b22eec9

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/dhcpcd:d4408777ed6b6e6e562a5d4938fd09804324b33e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:da3138079c168e0c5608d8f3853366c113ed91d2
+    image: linuxkit/metadata:52a3d36ed158357125f3a998f9d03784eb0636d3
   - name: format
     image: linuxkit/format:f180a74d878c8c0c86f6208f9311474c91452a79
   - name: mounts

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -20,7 +20,7 @@ onboot:
     image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/swarmd"]
   - name: metadata
-    image: linuxkit/metadata:da3138079c168e0c5608d8f3853366c113ed91d2
+    image: linuxkit/metadata:52a3d36ed158357125f3a998f9d03784eb0636d3
 services:
   - name: getty
     image: linuxkit/getty:a19851531487b7bfbe45dcf77e3309c127cc78a6


### PR DESCRIPTION
**- What I did**
Added support for retrieving basic metadata for instances deployed on OpenStack clouds.

**- How I did it**
Mostly by just copying the AWS metadata provider, as OpenStack strives to be largely compatible in this regard.

**- How to verify it**
Build an image with networking support and the metadata package included and boot it up on an OpenStack installation.  Boot logs should confirm that the 'openstack' metadata probe succeeded, and things such as hostname are set appropriately. 

**- Description for the changelog**
This commit adds basic support for retrieving instance metadata on OpenStack clouds.

Signed-off-by: Nick Jones <nick@dischord.org>

**- A picture of a cute animal (not mandatory but encouraged)**

![img_4522 2](https://user-images.githubusercontent.com/436656/31318352-983bda1e-ac48-11e7-809a-1e8a4b2d9a15.JPG)
