### PR TITLE
linuxkit pkg: Log before building or pushing.

### DIFF
--- a/src/cmd/linuxkit/pkg_build.go
+++ b/src/cmd/linuxkit/pkg_build.go
@@ -27,6 +27,8 @@ func pkgBuild(args []string) {
 		os.Exit(1)
 	}
 
+	fmt.Printf("Building %q\n", p.Tag())
+
 	var opts []pkglib.BuildOpt
 	if *force {
 		opts = append(opts, pkglib.WithBuildForce())

--- a/src/cmd/linuxkit/pkg_push.go
+++ b/src/cmd/linuxkit/pkg_push.go
@@ -13,7 +13,7 @@ func pkgPush(args []string) {
 	flags := flag.NewFlagSet("pkg push", flag.ExitOnError)
 	flags.Usage = func() {
 		invoked := filepath.Base(os.Args[0])
-		fmt.Fprintf(os.Stderr, "USAGE: %s pkg build [options] path\n\n", invoked)
+		fmt.Fprintf(os.Stderr, "USAGE: %s pkg push [options] path\n\n", invoked)
 		fmt.Fprintf(os.Stderr, "'path' specifies the path to the package source directory.\n")
 		fmt.Fprintf(os.Stderr, "\n")
 		flags.PrintDefaults()

--- a/src/cmd/linuxkit/pkg_push.go
+++ b/src/cmd/linuxkit/pkg_push.go
@@ -27,6 +27,8 @@ func pkgPush(args []string) {
 		os.Exit(1)
 	}
 
+	fmt.Printf("Building and pushing %q\n", p.Tag())
+
 	var opts []pkglib.BuildOpt
 	opts = append(opts, pkglib.WithBuildPush())
 	if *force {


### PR DESCRIPTION
Previously there would be a make "entering directory" hint in the logs, but
with the switch to `linuxkit pkg` that no longer occurs.

Signed-off-by: Ian Campbell <ijc@docker.com>
