### PR TITLE
linuxkit pkg: Support --release option to pkg push.

### DIFF
--- a/src/cmd/linuxkit/pkg_push.go
+++ b/src/cmd/linuxkit/pkg_push.go
@@ -20,6 +20,7 @@ func pkgPush(args []string) {
 	}
 
 	force := flags.Bool("force", false, "Force rebuild")
+	release := flags.String("release", "", "Release the given version")
 
 	p, err := pkglib.NewFromCLI(flags, args...)
 	if err != nil {
@@ -32,7 +33,9 @@ func pkgPush(args []string) {
 	if *force {
 		opts = append(opts, pkglib.WithBuildForce())
 	}
-
+	if *release != "" {
+		opts = append(opts, pkglib.WithRelease(*release))
+	}
 	if err := p.Build(opts...); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This overrides the default (which is to look for an exact git tag) and releases
just that.

Signed-off-by: Ian Campbell <ijc@docker.com>

/cc @eyz I can't easily test this without releasing something, are you able to test?