### PR TITLE
fix dns not working in the docker blueprint

### DIFF
--- a/blueprints/docker-for-mac/docker-ce.yml
+++ b/blueprints/docker-for-mac/docker-ce.yml
@@ -11,6 +11,7 @@ services:
      - type: cgroup
        options: ["rw","nosuid","noexec","nodev","relatime"]
     binds:
+     - /etc/resolv.conf:/etc/resolv.conf
      - /var/lib/docker:/var/lib/docker
      - /lib/modules:/lib/modules
      - /var/vpnkit:/port # vpnkit control 9p mount


### PR DESCRIPTION
Signed-off-by: dave <dprotaso@gmail.com>



**- What I did**

`docker pull` was failing due to dns issues. We now bind the host's /etc/resolv.conf

**- How to verify it**
From the machine running the VM (in my case a Mac)
```
docker -H unix://docker-for-mac-state/guest.00000948 pull hello-world
```
