### PR TITLE
wireguard: bump version

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -37,8 +37,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20171005
-ENV WIREGUARD_SHA256=832a3b7cbb510f6986fd0c3a6b2d86bc75fc9f23b6754d8f46bc58ea8e02d608
+ENV WIREGUARD_VERSION=0.0.20171011
+ENV WIREGUARD_SHA256=e2e44ff658743507bca0f6b443c2f85aacc48d507ba2dcd4812717145df10b96
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # PGP keys: 589DA6B1 (greg@kroah.com) & 6092693E (autosigner@kernel.org) & 00411886 (torvalds@linux-foundation.org)


### PR DESCRIPTION
Routine version bump. Release notes [from the list](https://lists.zx2c4.com/pipermail/wireguard/2017-October/001815.html):

```

  * receive: do not consider 0 jiffies as being set
  
  This should fix some issues on 32-bit platforms with sending cookie reply
  messages when they're not required.
  
  * socket: compare while unlocked first
  * socket: don't bother recomparing afterwards
  * socket: gcc inlining makes this faster
  
  We no longer take a lock when updating the endpoint, which should yield
  some performance benefits.
  
  * tools: try again if dump is interrupted
  
  The tools will now try again to get information about a device if somebody
  tries to modify the device while a dump is occurring.
  
  * Makefile: quiet recursive make
  
  Our makefile produces slightly slicker output now.
  
  * qemu: bump stable kernel
  
  Usual test suite house maintenance.
  
  * crypto/x86_64: satisfy stack validation 2.0
  
  The kernel's new objtool used to warn on some things in our AVX
  implementations, especially code generated from qhasm which uses its own
  stack layout. This commit works around it to squelch warnings.
  
  * routingtable: only use device's mutex, not a special rt one
  * routingtable: iterate progressively
  * tools: store tail pointer to make coalescing peers fast
  
  We replace the Netlink algorithms for grabbing the allowed IPs, so
  that they're now O(n) instead of O(n^2).
  
  * tools: warn once on unrecognized items
  
  This follows this LKML discussion:
  https://www.spinics.net/lists/netdev/msg457468.html
  
  * compat: move version logic to compat.h and out of main .c
  * contrib: filter compat lines
  
  Should make it easier to produce a compat-free WireGuard tree.
  
  * send: do not requeue if packet is dead
  * socket: set skb->mark in addition to flowi
  
  Mangle tables now work with wg-quick.
  
  * tools: man: include kill-switch documentation using fwmark
  
  Essentially:
  iptables -I OUTPUT ! -o %i -m mark ! --mark $(wg show %i fwmark) -j REJECT
  
  * receive: disable bh before using stats seq lock
  
  This avoids a potential deadlock with interrupts and the stats counters.
```