### PR TITLE
Bump to containerd v1.0.0-beta.2

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:62c36a9df76b53b36103783040d26246a5670697 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   # support metadata for optional config in /var/config

--- a/blueprints/lcow.yml
+++ b/blueprints/lcow.yml
@@ -5,7 +5,7 @@ kernel:
   tar: none
 init:
   - linuxkit/init-lcow:50112be5023c21bf5a355323243c56b30890bc89
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
 services:
   - name: getty
     image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: rngd1

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d as alpine
+FROM linuxkit/alpine:90aa5d87063049827de536371016bc02138a8f59 as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:90aa5d87063049827de536371016bc02138a8f59 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -11,7 +11,7 @@ RUN \
   make \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin
-ENV RUNC_COMMIT=v1.0.0-rc4
+ENV RUNC_COMMIT=0351df1c5a66838d0c392b4ac4cf9450de844e2d
 RUN mkdir -p $GOPATH/src/github.com/opencontainers && \
   cd $GOPATH/src/github.com/opencontainers && \
   git clone https://github.com/opencontainers/runc.git

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a # with runc, logwrite, startmemlogd
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967 # with runc, logwrite, startmemlogd
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
 services:
   - name: acpid
     image: linuxkit/acpid:6e3f0c5deca1633230dce9a35b67e1f61f05c47a

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.91
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc

--- a/test/cases/020_kernel/005_config_4.13.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.13.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.13.5
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc

--- a/test/cases/020_kernel/010_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.91
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.13.5
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 trust:
   org:
     - linuxkit

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:dff7a32108d8e40922027642b598b4eb011f46bb

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test.sh
+++ b/test/cases/040_packages/003_containerd/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # SUMMARY: Run containerd test
-# LABELS:
+# skipping while status of go 1.8 support in containerd is unsure
+# https://github.com/containerd/containerd/issues/1632
+# LABELS: skip
 # REPEAT:
 
 set -e

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:f6b01d5513313524e307dffef786f605075b78a7
+    image: linuxkit/test-containerd:8b52d80236b990224120612acf0422e8b81c443c
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: format
     image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: extend
     image: linuxkit/extend:84839cd2c713b7479ce8c7b076b748336c5a94dd

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: modprobe
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: modprobe
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: format
     image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: extend
     image: linuxkit/extend:84839cd2c713b7479ce8c7b076b748336c5a94dd

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: format
     image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: format
     image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: format
     image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: modprobe
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: format
     image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: format
     image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: format
     image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:13b6efeefd97fed9043c9cd3a8fe1fe7ad1cda12

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: dhcpcd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:96c9845f8bca2cfb2d3c5e6ca53d82f77b2fddd0

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
-  - linuxkit/containerd:eaf0d615cfceb9d854408dd3c80429ee8ac4d051
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:90aa5d87063049827de536371016bc02138a8f59 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a
-  - linuxkit/runc:991ef358ad8fc1111d64f4d8071f2009cc561f6a
+  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -44,7 +44,7 @@ RUN go get -u github.com/LK4D4/vndr
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.0.0-beta.1
+ENV CONTAINERD_COMMIT=v1.0.0-beta.2
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d-arm64
+# linuxkit/alpine:d5f568a60d76990407d15fb128fc9d53e363fcee-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -184,10 +184,10 @@ multipath-tools-0.7.1-r1
 musl-1.1.16-r13
 musl-dev-1.1.16-r13
 musl-utils-1.1.16-r13
-ncurses-dev-6.0-r8
-ncurses-libs-6.0-r8
-ncurses-terminfo-6.0-r8
-ncurses-terminfo-base-6.0-r8
+ncurses-dev-6.0_p20170930-r0
+ncurses-libs-6.0_p20170930-r0
+ncurses-terminfo-6.0_p20170930-r0
+ncurses-terminfo-base-6.0_p20170930-r0
 nettle-3.3-r0
 nfs-utils-1.3.4-r1
 npth-1.2-r0
@@ -205,7 +205,7 @@ patch-2.7.5-r1
 pax-utils-1.2.2-r0
 pcre-8.41-r0
 pcsc-lite-libs-1.8.21-r0
-perl-5.24.1-r2
+perl-5.24.3-r1
 pinentry-1.0.0-r0
 pixman-0.34.0-r0
 pkgconf-1.3.7-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d-amd64
+# linuxkit/alpine:90aa5d87063049827de536371016bc02138a8f59-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -190,10 +190,10 @@ multipath-tools-0.7.1-r1
 musl-1.1.16-r13
 musl-dev-1.1.16-r13
 musl-utils-1.1.16-r13
-ncurses-dev-6.0-r8
-ncurses-libs-6.0-r8
-ncurses-terminfo-6.0-r8
-ncurses-terminfo-base-6.0-r8
+ncurses-dev-6.0_p20170930-r0
+ncurses-libs-6.0_p20170930-r0
+ncurses-terminfo-6.0_p20170930-r0
+ncurses-terminfo-base-6.0_p20170930-r0
 nettle-3.3-r0
 nfs-utils-1.3.4-r1
 npth-1.2-r0
@@ -213,7 +213,7 @@ patch-2.7.5-r1
 pax-utils-1.2.2-r0
 pcre-8.41-r0
 pcsc-lite-libs-1.8.21-r0
-perl-5.24.1-r2
+perl-5.24.3-r1
 pinentry-1.0.0-r0
 pixman-0.34.0-r0
 pkgconf-1.3.7-r0


### PR DESCRIPTION
Bumps containerd to v1.0.0-beta.2 in the usual semi-mechanical way

Also bumps runc to 0351df1c5a66838d0c392b4ac4cf9450de844e2d which is the one used by this containerd release /cc @SvenDowideit this replaces #2569.