### PR TITLE
kubernetes: Mount /etc/os-release into docker cotainer too

### DIFF
--- a/projects/kubernetes/docker.yml
+++ b/projects/kubernetes/docker.yml
@@ -10,6 +10,7 @@ services:
     binds:
      - /dev:/dev
      - /etc/resolv.conf:/etc/resolv.conf
+     - /etc/os-release:/etc/os-release
      - /lib/modules:/lib/modules
      - /run:/run
      - /var:/var:rshared,rbind


### PR DESCRIPTION
This makes `docker info` show the same OS as `kubectl get -o wide nodes`.

Signed-off-by: Ian Campbell <ijc@docker.com>

Followup for #2599 