### PR TITLE
Fix kernel version in Wireguard example

### DIFF
--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.49
+  image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:98e95fb67e8afcf02c09ba927e4b357fec42977a


### PR DESCRIPTION
This must have had a merge error. Fixes version mismatch which
stops this working. The test was updated so is fine.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![wire guard](https://user-images.githubusercontent.com/482364/31500782-4ac70d2e-af60-11e7-8076-ac26ed886f16.jpg)
