### PR TITLE
Update to go 1.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: default
 VERSION="0.0" # dummy for now
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:20621b2539e546a8c94e625928f8d59f12684398
+GO_COMPILE=linuxkit/go-compile:758282e180b4bcc7259f77edd22c46b890be2549
 
 MOBY?=bin/moby
 LINUXKIT?=bin/linuxkit

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -3,26 +3,26 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/vpnkit-expose-port:62c36a9df76b53b36103783040d26246a5670697 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/vpnkit-expose-port:0832f0cfdfc02214680588a5018619cd1eb4b93f # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata
-    image: linuxkit/metadata:4920d2b7f987c4cf67c5472308b0badcdfac4b2b
+    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: sysfs
-    image: linuxkit/sysfs:7ff47034ed61c8e4c7ca5b8992056c66c6f39df8
+    image: linuxkit/sysfs:a844eb2ac09df07f5eda89d5588d76bf8d96cfca
   - name: binfmt
-    image: linuxkit/binfmt:dff7a32108d8e40922027642b598b4eb011f46bb
+    image: linuxkit/binfmt:7b2fdd981f3cdb5d21961e7d584e600af5a934a0
   # Format and mount the disk image in /var/lib/docker
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib"]
   # make a swap file on the mounted disk
   - name: swap
@@ -61,24 +61,24 @@ services:
   # VSOCK to unix domain socket forwarding. Forwards guest /var/run/docker.sock
   # to a socket on the host.
   - name: vsudd
-    image: linuxkit/vsudd:c6afbe7c0abc87e9aa204fa98247f8b05dee3488
+    image: linuxkit/vsudd:a0336f99442a81e5f9bb117353c0c74455f5556b
     binds:
         - /var/run:/var/run
     command: ["/vsudd", "-inport", "2376:unix:/var/run/docker.sock"]
   # vpnkit-forwarder forwards network traffic to/from the host via VSOCK port 62373. 
   # It needs access to the vpnkit 9P coordination share 
   - name: vpnkit-forwarder
-    image: linuxkit/vpnkit-forwarder:41dea19da37ce88d351ef3bd612004fb455a5a71
+    image: linuxkit/vpnkit-forwarder:42e88e9338c3b93eda79f6582f58d87fd78d0001
     binds:
         - /var/vpnkit:/port
     net: host
     command: ["/vpnkit-forwarder", "-vsockPort", "62373"]
   # Monitor for image deletes and invoke a TRIM on the container filesystem
   - name: trim-after-delete
-    image: linuxkit/trim-after-delete:75f57f502528aa16dea1f9ac78b8993b217917fb
+    image: linuxkit/trim-after-delete:b20b16638f6712ce83699ae4aea5a6e8d3658db3
   # When the host resumes from sleep, force a clock resync
   - name: host-timesync-daemon
-    image: linuxkit/host-timesync-daemon:a5f86805ac54c086fc1ef6fa107d50a13ef2ec7e
+    image: linuxkit/host-timesync-daemon:5d706ccc6d0d3e5b4b5d798deafde2e76acfe01d
 
 trust:
     org:

--- a/blueprints/lcow.yml
+++ b/blueprints/lcow.yml
@@ -4,8 +4,8 @@ kernel:
   cmdline: "console=ttyS0"
   tar: none
 init:
-  - linuxkit/init-lcow:50112be5023c21bf5a355323243c56b30890bc89
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init-lcow:00195e5eb94189512ccf681730609d005dfa3979
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -22,7 +22,7 @@ docker run -it --rm \
 -v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:20621b2539e546a8c94e625928f8d59f12684398
+linuxkit/go-compile:758282e180b4bcc7259f77edd22c46b890be2549
 ```
 
 To update a single dependency:
@@ -32,7 +32,7 @@ docker run -it --rm \
 -v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:20621b2539e546a8c94e625928f8d59f12684398
+linuxkit/go-compile:758282e180b4bcc7259f77edd22c46b890be2549
 github.com/docker/docker
 ```
 

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,21 +2,21 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:4920d2b7f987c4cf67c5472308b0badcdfac4b2b
+    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
 services:
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: sshd
     image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
     binds:

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
 services:
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
   - name: sshd

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,19 +2,19 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: sysfs
-    image: linuxkit/sysfs:7ff47034ed61c8e4c7ca5b8992056c66c6f39df8
+    image: linuxkit/sysfs:a844eb2ac09df07f5eda89d5588d76bf8d96cfca
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty
@@ -22,7 +22,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
   - name: ntpd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,25 +2,25 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:4920d2b7f987c4cf67c5472308b0badcdfac4b2b
+    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
 services:
   - name: getty
     image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: sshd
     image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
     binds:

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -19,7 +19,7 @@ services:
     #env:
     # - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
 services:
   - name: getty
     image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
   - name: node_exporter

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,25 +2,25 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: rngd1
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
     command: ["/sbin/rngd", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:4920d2b7f987c4cf67c5472308b0badcdfac4b2b
+    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
     command: ["/usr/bin/metadata", "packet"]
 services:
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: sshd
     image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
 trust:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,15 +2,15 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: rngd1
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
     command: ["/sbin/rngd", "-1"]
 services:
   - name: getty
@@ -18,7 +18,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
   - name: sshd

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/external"]
   - name: swap
     image: linuxkit/swap:195ef5c89fcd68ff412ecb01a330e75503dc7b83
@@ -28,7 +28,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: nginx
     image: nginx:alpine
     capabilities:

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -20,7 +20,7 @@ services:
   - name: tss
     image: linuxkit/tss:2c29b212733e90fbbd7aeaf032cadc044dbc7fe4
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
 services:
   - name: getty
     image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
   - name: nginx

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
@@ -21,13 +21,13 @@ services:
   - name: sshd
     image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
   - name: vpnkit-forwarder
-    image: linuxkit/vpnkit-forwarder:41dea19da37ce88d351ef3bd612004fb455a5a71
+    image: linuxkit/vpnkit-forwarder:42e88e9338c3b93eda79f6582f58d87fd78d0001
     binds:
         - /var/vpnkit:/port
     net: host
     command: ["/vpnkit-forwarder"]
   - name: vpnkit-expose-port
-    image: linuxkit/vpnkit-forwarder:41dea19da37ce88d351ef3bd612004fb455a5a71
+    image: linuxkit/vpnkit-forwarder:42e88e9338c3b93eda79f6582f58d87fd78d0001
     net: none
     binds:
         - /var/vpnkit:/port

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: vsudd
-    image: linuxkit/vsudd:c6afbe7c0abc87e9aa204fa98247f8b05dee3488
+    image: linuxkit/vsudd:a0336f99442a81e5f9bb117353c0c74455f5556b
     binds:
         - /run/containerd/containerd.sock:/run/containerd/containerd.sock
     command: ["/vsudd",

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,25 +2,25 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:4920d2b7f987c4cf67c5472308b0badcdfac4b2b
+    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
 services:
   - name: getty
     image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: sshd
     image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
     binds:

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,18 +2,18 @@ kernel:
   image: linuxkit/kernel:4.9.49
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:7a82871df06767cfe26a04d0ed6bee1031ba5d04
+    image: linuxkit/ip:30fa3497a42cf941301c1e9cde09b3d68f01b847
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -26,7 +26,7 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:7a82871df06767cfe26a04d0ed6bee1031ba5d04
+    image: linuxkit/ip:30fa3497a42cf941301c1e9cde09b3d68f01b847
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -45,7 +45,7 @@ services:
      - INSECURE=true
     net: /run/netns/wg1
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: nginx
     image: nginx:alpine
     net: /run/netns/wg0

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -22,7 +22,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: nginx
     image: nginx:alpine
     capabilities:

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,10 +1,10 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS qemu
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS qemu
 RUN apk add \
     qemu-aarch64 \
     qemu-arm \
     qemu-ppc64le
 
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:90aa5d87063049827de536371016bc02138a8f59 as alpine
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/extend/Dockerfile
+++ b/pkg/extend/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -15,7 +15,7 @@ RUN apk add --no-cache --initdb -p /out \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/format/Dockerfile
+++ b/pkg/format/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -15,7 +15,7 @@ RUN apk add --no-cache --initdb -p /out \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/host-timesync-daemon/Dockerfile
+++ b/pkg/host-timesync-daemon/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 
 RUN apk add --no-cache go musl-dev git
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/init-lcow/Dockerfile
+++ b/pkg/init-lcow/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
@@ -7,7 +7,7 @@ RUN apk add --no-cache --initdb -p /out \
     musl
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
 ENV OPENGCS_REPO=https://github.com/Microsoft/opengcs
 ENV OPENGCS_COMMIT=48ae4e3ba3d2fea746fb4dc20a72832a46f45466
 RUN apk add --no-cache build-base curl git go musl-dev

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:90aa5d87063049827de536371016bc02138a8f59 AS build
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/ip/Dockerfile
+++ b/pkg/ip/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add curl
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/metadata/Dockerfile
+++ b/pkg/metadata/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 
 RUN apk add --no-cache go musl-dev linux-headers
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/mount/Dockerfile
+++ b/pkg/mount/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -9,7 +9,7 @@ RUN apk add --no-cache --initdb -p /out \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 
 RUN apk add --no-cache go gcc musl-dev linux-headers
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d as alpine
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a as alpine
 RUN \
   apk add \
   bash \

--- a/pkg/sysctl/Dockerfile
+++ b/pkg/sysctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/sysfs/Dockerfile
+++ b/pkg/sysfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/trim-after-delete/Dockerfile
+++ b/pkg/trim-after-delete/Dockerfile
@@ -1,5 +1,5 @@
 # We need the `fstrim` binary:
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/vpnkit-expose-port/Dockerfile
+++ b/pkg/vpnkit-expose-port/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/pkg/vpnkit-forwarder/Dockerfile
+++ b/pkg/vpnkit-forwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/pkg/vsudd/Dockerfile
+++ b/pkg/vsudd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,26 +2,26 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: sysfs
     image: linuxkit/sysfs:3ae01a25583ee37a5ff8b09a0e569cb4bd8cf2e9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:f180a74d878c8c0c86f6208f9311474c91452a79
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
   - name: mount
     image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: ntpd
     image: linuxkit/openntpd:0d7befc79842849d0b88d6c3b64200e340d7cf67
   - name: docker

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,26 +2,26 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: sysfs
     image: linuxkit/sysfs:3ae01a25583ee37a5ff8b09a0e569cb4bd8cf2e9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:f180a74d878c8c0c86f6208f9311474c91452a79
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
   - name: mount
     image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: ntpd
     image: linuxkit/openntpd:0d7befc79842849d0b88d6c3b64200e340d7cf67
   - name: docker

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -2,15 +2,15 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: format
-    image: linuxkit/format:f180a74d878c8c0c86f6208f9311474c91452a79
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
   - name: mount
     image: linuxkit/mount:96ac4d32d340ac6e4ddfbf506fa3a497d23649da
     command: ["/usr/bin/mountie", "/var/lib/etcd"]
@@ -21,7 +21,7 @@ onboot:
     image: linuxkit/metadata:52a3d36ed158357125f3a998f9d03784eb0636d3
 services:
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: ntpd
     image: linuxkit/openntpd:0d7befc79842849d0b88d6c3b64200e340d7cf67
   - name: node_exporter

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -2,13 +2,13 @@ kernel:
   image: mobylinux/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: nginx
     image: nginx:alpine
     capabilities:

--- a/projects/kubernetes/cri-containerd.yml
+++ b/projects/kubernetes/cri-containerd.yml
@@ -1,6 +1,6 @@
 services:
   - name: cri-containerd
-    image: linuxkitprojects/cri-containerd:5330c05b7eabba51d97af9d06204b7664e0719ef
+    image: linuxkitprojects/cri-containerd:afb7c111a40788b1e085856fbddacf8a878385e7
 files:
   - path: /etc/kubelet.sh.conf
     contents: |

--- a/projects/kubernetes/cri-containerd/Dockerfile
+++ b/projects/kubernetes/cri-containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
 
 RUN \
   apk add \

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -2,27 +2,27 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
     binds:
      - /etc/sysctl.d/01-kubernetes.conf:/etc/sysctl.d/01-kubernetes.conf
     readonly: false
   - name: sysfs
-    image: linuxkit/sysfs:7ff47034ed61c8e4c7ca5b8992056c66c6f39df8
+    image: linuxkit/sysfs:a844eb2ac09df07f5eda89d5588d76bf8d96cfca
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:4920d2b7f987c4cf67c5472308b0badcdfac4b2b
+    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
   - name: mounts
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/"]
 services:
   - name: getty
@@ -30,13 +30,13 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: ntpd
     image: linuxkit/openntpd:8d32daf90ecf70b7e185cb7a2db53b4c539d371c
   - name: sshd
     image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
   - name: kubelet
-    image: linuxkitprojects/kubernetes:f35e9c9879bb7d178f2148a91e4c5d5e812ecade
+    image: linuxkitprojects/kubernetes:718c9c7a47c518622d41ec0e8afeeacda3a363d6
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/projects/kubernetes/kubernetes/Dockerfile
+++ b/projects/kubernetes/kubernetes/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
 
 ENV kubernetes_version v1.8.0
 ENV cni_version        v0.6.0

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967 # with runc, logwrite, startmemlogd
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75 # with runc, logwrite, startmemlogd
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: nginx
     image: nginx:alpine
     capabilities:

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,21 +2,21 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
   - samoht/fdd
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
 services:
   - name: getty
     image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
 files:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,12 +2,12 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcp-client
     image: miragesdk/dhcp-client:22aa9d527820534295a8cd59901c0c5197af6585
     net: host

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,13 +2,13 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
 services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -18,7 +18,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: nginx
     image: nginx:alpine
     capabilities:

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,25 +2,25 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
     binds:
      - /etc/sysctl.d/01-swarmd.conf:/etc/sysctl.d/01-swarmd.conf
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/swarmd"]
   - name: metadata
-    image: linuxkit/metadata:4920d2b7f987c4cf67c5472308b0badcdfac4b2b
+    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
 services:
   - name: getty
     image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
@@ -31,7 +31,7 @@ services:
     binds:
       - /dev/vport0p1:/dev/vport0p1
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: ntpd
     image: linuxkit/openntpd:8d32daf90ecf70b7e185cb7a2db53b4c539d371c
   - name: weave
@@ -45,7 +45,7 @@ services:
       - /var:/var
       - /var/lib/swarmd:/weavedb
   - name: swarmd
-    image: linuxkitprojects/swarmd:89144a08c30ff753c23b1dad1f8127e9c1ed32e0
+    image: linuxkitprojects/swarmd:668f9f78502d4069841552219845dc57dc846492
     command: ["/usr/bin/swarmd", "--containerd-addr=/run/containerd/containerd.sock", "--log-level=debug", "--state-dir=/var/lib/swarmd"]
     capabilities:
      - all

--- a/projects/swarmd/swarmd/Dockerfile
+++ b/projects/swarmd/swarmd/Dockerfile
@@ -2,7 +2,7 @@ FROM weaveworks/weave:2.0.1@sha256:2d70caac7db33365482cc923d40ff8d3ec1238ae7fe06
 
 # Nothing to do in here, just for COPY --from=weave below
 
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
 
 RUN \
   apk update && apk upgrade && \

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
 services:
   - name: acpid
     image: linuxkit/acpid:6e3f0c5deca1633230dce9a35b67e1f61f05c47a

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.91
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc

--- a/test/cases/020_kernel/005_config_4.13.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.13.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.13.5
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc

--- a/test/cases/020_kernel/010_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-reverse"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv4"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv6"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-tcp"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-udp"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-unix"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.91
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-reverse"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv4"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv6"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-tcp"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-udp"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-unix"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/010_echo-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/010_echo-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/011_echo-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/011_echo-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/012_echo-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/012_echo-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/015_echo-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/015_echo-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/016_echo-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/016_echo-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/017_echo-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/017_echo-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/010_veth-unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/010_veth-unix-domain-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/011_veth-unix-domain-echo-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/011_veth-unix-domain-echo-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-reverse"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/012_veth-ipv4-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/012_veth-ipv4-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv4"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/013_veth-ipv6-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/013_veth-ipv6-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv6"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/014_veth-tcp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/014_veth-tcp-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-tcp"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/015_veth-udp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/015_veth-udp-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-udp"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/020_unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/020_unix-domain-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:d961c10f435069bd40fe60cc1a96adf9ce3ce364
+    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-unix"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.13.5
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 trust:
   org:
     - linuxkit

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: sysfs
-    image: linuxkit/sysfs:7ff47034ed61c8e4c7ca5b8992056c66c6f39df8
+    image: linuxkit/sysfs:a844eb2ac09df07f5eda89d5588d76bf8d96cfca
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd
-    image: linuxkit/rngd:719e087b06dd14c29acd23fa07cccd036bbab4db
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
   - name: docker

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: binfmt
-    image: linuxkit/binfmt:dff7a32108d8e40922027642b598b4eb011f46bb
+    image: linuxkit/binfmt:7b2fdd981f3cdb5d21961e7d584e600af5a934a0
   - name: test
     image: alpine:3.6
     binds:

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test.sh
+++ b/test/cases/040_packages/003_containerd/test.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 # SUMMARY: Run containerd test
-# skipping while status of go 1.8 support in containerd is unsure
-# https://github.com/containerd/containerd/issues/1632
-# LABELS: skip
+# LABELS:
 # REPEAT:
 
 set -e

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:8b52d80236b990224120612acf0422e8b81c443c
+    image: linuxkit/test-containerd:a74697f70cdc5f19cfc4d0d7828621f3cef5b264
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: extend
-    image: linuxkit/extend:84839cd2c713b7479ce8c7b076b748336c5a94dd
+    image: linuxkit/extend:24c25db2ef9b329b5ac67a6c3bcb84ec808141d7
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: modprobe
     image: alpine:3.6
@@ -13,10 +13,10 @@ onboot:
       - /sys:/sys
     command: ["modprobe", "btrfs"]
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: modprobe
     image: alpine:3.6
@@ -13,10 +13,10 @@ onboot:
       - /sys:/sys
     command: ["modprobe", "btrfs"]
   - name: extend
-    image: linuxkit/extend:84839cd2c713b7479ce8c7b076b748336c5a94dd
+    image: linuxkit/extend:24c25db2ef9b329b5ac67a6c3bcb84ec808141d7
     command: ["/usr/bin/extend", "-type", "btrfs"]
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: extend
-    image: linuxkit/extend:84839cd2c713b7479ce8c7b076b748336c5a94dd
+    image: linuxkit/extend:24c25db2ef9b329b5ac67a6c3bcb84ec808141d7
     command: ["/usr/bin/extend", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format"]
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format", "-label", "docker"]
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format", "@DEVICE@"]
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "-device", "@DEVICE@1", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: modprobe
     image: alpine:3.6
@@ -13,10 +13,10 @@ onboot:
       - /sys:/sys
     command: ["modprobe", "btrfs"]
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format", "-type", "xfs" ]
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format", "-verbose", "-type", "ext4", "/dev/sda"]
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format", "-verbose", "-type", "ext4", "/dev/sdb"]
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format", "-verbose", "-type", "xfs", "/dev/sda"]
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format", "-verbose", "-force", "-type", "xfs", "/dev/sdb"]
   - name: test
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     binds:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format", "-label", "docker"]
   - name: format
-    image: linuxkit/format:e7f06bd9bb96b663f8aab7d648a5dfc3ed7785fc
+    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
     command: ["/usr/bin/format", "-label", "foo"]
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: mount
-    image: linuxkit/mount:80c6aeef04260eaa7c74a93594ea7c5a4ab2808e
+    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "-label", "foo", "/var/foo"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:13b6efeefd97fed9043c9cd3a8fe1fe7ad1cda12

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:53f0c724919e8f76ea06c44ee703330290b22669
+    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: test
     image: alpine:3.6
     net: host

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
   - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:7a82871df06767cfe26a04d0ed6bee1031ba5d04
+    image: linuxkit/ip:30fa3497a42cf941301c1e9cde09b3d68f01b847
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -24,7 +24,7 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:7a82871df06767cfe26a04d0ed6bee1031ba5d04
+    image: linuxkit/ip:30fa3497a42cf941301c1e9cde09b3d68f01b847
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:96c9845f8bca2cfb2d3c5e6ca53d82f77b2fddd0

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
-  - linuxkit/containerd:097c6989255068b563e6e6f7b46a866ae4a3bc82
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:90aa5d87063049827de536371016bc02138a8f59 AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/ns/Dockerfile
+++ b/test/pkg/ns/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9d1b4ebe1bc8d9e52147c440efa16f2d8677d967
-  - linuxkit/runc:1f0edd2e25046389eb556551b99424cff86398c8
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>

--- a/test/pkg/virtsock/Dockerfile
+++ b/test/pkg/virtsock/Dockerfile
@@ -1,10 +1,10 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     tini
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
 
 RUN apk add --no-cache go musl-dev git make
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -16,6 +16,9 @@ RUN cat /tmp/packages.$(uname -m) >> /tmp/packages && \
 # add the tools for WireGuard, since the kernel module is now included, but from edge/testing
 RUN apk fetch --recursive -o /mirror/$(uname -m) -X http://dl-cdn.alpinelinux.org/alpine/edge/testing -U wireguard-tools
 
+# containerd requires go 1.9 which is only in edge
+RUN apk fetch --recursive -o /mirror/$(uname -m) -X http://dl-cdn.alpinelinux.org/alpine/edge/community -U go
+
 # install abuild for signing
 RUN apk add --no-cache abuild
 

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:d5f568a60d76990407d15fb128fc9d53e363fcee-arm64
+# linuxkit/alpine:d316ab2d54f92b96cde13cff90ead9bc307d9936-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -74,6 +74,7 @@ gmp-dev-6.1.2-r0
 gnupg-2.1.20-r0
 gnutls-3.5.13-r0
 go-1.8.3-r0
+go-1.9.1-r0
 grep-3.0-r0
 guile-2.0.13-r0
 guile-libs-2.0.13-r0
@@ -252,7 +253,7 @@ util-linux-dev-2.28.2-r2
 vde2-libs-2.3.2-r7
 vim-8.0.0595-r0
 wayland-1.13.0-r0
-wireguard-tools-0.0.20171005-r0
+wireguard-tools-0.0.20171011-r0
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r3
 xfsprogs-4.5.0-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:90aa5d87063049827de536371016bc02138a8f59-amd64
+# linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -75,6 +75,7 @@ gmp-dev-6.1.2-r0
 gnupg-2.1.20-r0
 gnutls-3.5.13-r0
 go-1.8.3-r0
+go-1.9.1-r0
 grep-3.0-r0
 guile-2.0.13-r0
 guile-libs-2.0.13-r0
@@ -260,7 +261,7 @@ util-linux-dev-2.28.2-r2
 vde2-libs-2.3.2-r7
 vim-8.0.0595-r0
 wayland-1.13.0-r0
-wireguard-tools-0.0.20171005-r0
+wireguard-tools-0.0.20171011-r0
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r3
 xfsprogs-4.5.0-r0

--- a/tools/go-compile/Dockerfile
+++ b/tools/go-compile/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \


### PR DESCRIPTION
containerd requires go 1.9 (see https://github.com/containerd/containerd/issues/1632, https://github.com/containerd/containerd/pull/1633, https://github.com/containerd/containerd/issues/1215). This has been the case for a while but we didn't notice until a test case broke the compile with 1.8, since the issues is a data race and potential panic we are updating to go 1.9.

Update `tools/alpine` to pull this from alpine:edge and update a raft of packages which seem to be using go (basically those which seem to be using `go-compile.sh` or are setting `$GOPATH`). Also update `linuxkit/ip` since the rebuild happened to pull in newer wireguard tools.

This reenables the `linuxkit.packages.containerd` test.