### PR TITLE
enable content trust for a bunch more repos

### DIFF
--- a/scripts/update-component-sha.sh
+++ b/scripts/update-component-sha.sh
@@ -23,6 +23,9 @@ Replace by image: $0 --image <IMAGE> <NEW>
 	Example: $0 --image linuxkit/foo abcdef567899
 	   Will tag all instances of linuxkit/foo with abcdef567899
 
+        $0 --image <IMAGE>:<NEW> is accepted as a convenient shortcut for cutting
+        and pasting e.g.the output of linuxkit pkg show-tag
+
 By default, for convenience, if no mode is given (--image or --hash), the first method (--hash) is assumed. 
 Thus the following are equivalent:
 	$0 <OLD> <NEW>
@@ -33,28 +36,39 @@ EOF
 
 
 # backwards compatibility
-if [ $# -eq 2 ]; then
+if [ $# -eq 2 -a -n "${1%--*}" ]; then
   set -- "--hash" "$1" "$2"
 fi
 
 # sufficient arguments
-if [ $# -ne 3 ] ; then
+if [ $# -lt 2 -o $# -gt 3 ] ; then
     usage
     exit 1
 fi
 
-
 # which mode?
 case "$1" in
     --hash)
+	if [ $# -ne 3 ] ; then
+	    usage
+	    exit 1
+	fi
         old=$2
         new=$3
 
         git grep -w -l "\b$old\b" | xargs sed -i.bak -e "s,$old,$new,g"
         ;;
     --image)
-        image=$2
-        hash=$3
+	case $# in
+	    2)
+		image=${2%:*}
+		hash=${2#*:}
+		;;
+	    3)
+		image=$2
+		hash=$3
+		;;
+	    esac
         git grep -E -l "\b$image:" | xargs sed -i.bak -e "s,$image:[[:xdigit:]]"'\{40\}'",$image:$hash,g"
         ;;
     *)

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
 onboot:
   - name: ltp
-    image: linuxkit/test-ltp:96c9845f8bca2cfb2d3c5e6ca53d82f77b2fddd0
+    image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd
     binds:
      - /etc/ltp/baseline:/etc/ltp/baseline
   - name: poweroff

--- a/test/pkg/ltp/build.yml
+++ b/test/pkg/ltp/build.yml
@@ -1,5 +1,4 @@
 image: test-ltp
 network: true
-disable-content-trust: true
 arches:
   - amd64

--- a/tools/mkimage-dynamic-vhd/build.yml
+++ b/tools/mkimage-dynamic-vhd/build.yml
@@ -1,2 +1,1 @@
 image: mkimage-dynamic-vhd
-disable-content-trust: true

--- a/tools/mkimage-gcp/build.yml
+++ b/tools/mkimage-gcp/build.yml
@@ -1,2 +1,1 @@
 image: mkimage-gcp
-disable-content-trust: true

--- a/tools/mkimage-iso-bios/build.yml
+++ b/tools/mkimage-iso-bios/build.yml
@@ -1,4 +1,3 @@
 image: mkimage-iso-bios
-disable-content-trust: true
 arches:
   - amd64

--- a/tools/mkimage-iso-efi/build.yml
+++ b/tools/mkimage-iso-efi/build.yml
@@ -1,3 +1,2 @@
 image: mkimage-iso-efi
-disable-content-trust: true
 network: true

--- a/tools/mkimage-vhd/build.yml
+++ b/tools/mkimage-vhd/build.yml
@@ -1,2 +1,1 @@
 image: mkimage-vhd
-disable-content-trust: true

--- a/tools/mkimage-vmdk/build.yml
+++ b/tools/mkimage-vmdk/build.yml
@@ -1,2 +1,1 @@
 image: mkimage-vmdk
-disable-content-trust: true


### PR DESCRIPTION
* linuxkit/test-ltp
* linuxkit/mkimage-dynamic-vhd
* linuxkit/mkimage-gcp
* linuxkit/mkimage-iso-bios
* linuxkit/mkimage-iso-efi
* linuxkit/mkimage-vhd
* linuxkit/mkimage-vmdk

Fixes #2580.

I also made what I thought would be a convenient extension to `./scripts/update-component-sha.sh` before I remembered that `linuxkit/mkimage-*` are used elsewhere and not in tree.
