### PR TITLE
tools: Add dtc to alpine base

### DIFF
--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -27,6 +27,7 @@ curl
 dhcpcd
 diffutils
 dosfstools
+dtc
 e2fsprogs
 e2fsprogs-extra
 ebtables

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:d316ab2d54f92b96cde13cff90ead9bc307d9936-arm64
+# linuxkit/alpine:28d7666c7476243d43694ab392f79953622b98d4-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -41,6 +41,7 @@ device-mapper-libs-2.02.168-r3
 dhcpcd-6.11.5-r1
 diffutils-3.5-r0
 dosfstools-4.1-r1
+dtc-1.4.4-r0
 e2fsprogs-1.43.4-r0
 e2fsprogs-dev-1.43.4-r0
 e2fsprogs-extra-1.43.4-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a-amd64
+# linuxkit/alpine:b3f8da6c6f02440ee9c4c72bbf4dabdf500b1d8c-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -41,6 +41,7 @@ device-mapper-libs-2.02.168-r3
 dhcpcd-6.11.5-r1
 diffutils-3.5-r0
 dosfstools-4.1-r1
+dtc-1.4.4-r0
 e2fsprogs-1.43.4-r0
 e2fsprogs-dev-1.43.4-r0
 e2fsprogs-extra-1.43.4-r0


### PR DESCRIPTION
The device tree compiler is needed for some of the ongoing
arm64 work

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

![hippo](https://user-images.githubusercontent.com/3338098/31550640-f41ce082-b029-11e7-8c23-3c645b0729d4.jpg)
