### PR TITLE
linuxkit pkg: defer content trust passphrase setup until we know it i…

### DIFF
--- a/src/cmd/linuxkit/pkg.go
+++ b/src/cmd/linuxkit/pkg.go
@@ -20,7 +20,7 @@ func pkgUsage() {
 	fmt.Printf("See '%s pkg [command] --help' for details.\n\n", invoked)
 }
 
-func setupContentTrust() {
+func setupContentTrustPassphrase() {
 	// If it is already set there is nothing to do.
 	if _, ok := os.LookupEnv("DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE"); ok {
 		return
@@ -48,8 +48,6 @@ func pkg(args []string) {
 		pkgUsage()
 		os.Exit(1)
 	}
-
-	setupContentTrust()
 
 	switch args[0] {
 	case "build":

--- a/src/cmd/linuxkit/pkg_push.go
+++ b/src/cmd/linuxkit/pkg_push.go
@@ -28,6 +28,10 @@ func pkgPush(args []string) {
 		os.Exit(1)
 	}
 
+	if p.TrustEnabled() {
+		setupContentTrustPassphrase()
+	}
+
 	fmt.Printf("Building and pushing %q\n", p.Tag())
 
 	var opts []pkglib.BuildOpt

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -192,6 +192,11 @@ func (p Pkg) Tag() string {
 	return p.org + "/" + p.image + ":" + p.hash
 }
 
+// TrustEnabled returns true if trust is enabled
+func (p Pkg) TrustEnabled() bool {
+	return p.trust
+}
+
 func (p Pkg) archSupported(want string) bool {
 	for _, supp := range p.arches {
 		if supp == want {


### PR DESCRIPTION
…s needed

Otherwise "linuxkit pkg build" etc will needlessly run the command (which might
prompt the user).

Signed-off-by: Ian Campbell <ijc@docker.com>

Followup to https://github.com/linuxkit/linuxkit/pull/2608#issuecomment-336474518.