### PR TITLE
wireguard: update to 0.0.20171017

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -37,8 +37,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20171011
-ENV WIREGUARD_SHA256=e2e44ff658743507bca0f6b443c2f85aacc48d507ba2dcd4812717145df10b96
+ENV WIREGUARD_VERSION=0.0.20171017
+ENV WIREGUARD_SHA256=57b79a62874d9b99659a744513d4f6f9d88cb772deaa99e485b6fed3004a35cd
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # PGP keys: 589DA6B1 (greg@kroah.com) & 6092693E (autosigner@kernel.org) & 00411886 (torvalds@linux-foundation.org)


### PR DESCRIPTION
Simple version bump. Changes:

  * noise: handshake constants can be read-only after init
  * noise: no need to take the RCU lock if we're not dereferencing
  * send: improve dead packet control flow
  * receive: improve control flow
  * socket: eliminate dead code
  * device: our use of queues means this check is worthless
  * device: no need to take lock for integer comparison
  * blake2s: modernize API and have faster _final
  * compat: support READ_ONCE
  * compat: just make ro_after_init read_mostly

  Assorted cleanups to the module, including nice things like marking our
  precomputations as const.

  * Makefile: even prettier output
  * Makefile: do not clean before cloc
  * selftest: better test index for rate limiter
  * netns: disable accept_dad for all interfaces

  Fixes in our testing and build infrastructure. Now works on the 4.14 rc
  series.

  * qemu: add build-only target
  * qemu: work on ubuntu toolchain
  * qemu: add more debugging options to main makefile
  * qemu: simplify shutdown
  * qemu: open /dev/console if we're started early
  * qemu: phase out bitbanging
  * qemu: always create directory before untarring
  * qemu: newer packages
  * qemu: put hvc directive into configuration

  This is the beginning of working out a cross building test suite, so we do
  several tricks to be less platform independent.

  * tools: encoding: be more paranoid
  * tools: retry resolution except when fatal
  * tools: don't insist on having a private key
  * tools: add pass example to wg-quick man page
  * tools: style
  * tools: newline after warning
  * tools: account for padding being in zero attribute

  Several important tools fixes, one of which suppresses a needless warning.


![image](https://user-images.githubusercontent.com/10643/31687406-6490e2c0-b389-11e7-88f9-df568f44a677.png)