### PR TITLE
Move mounted file from /var/html to /etc/html

### DIFF
--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -36,19 +36,19 @@ services:
      - /var/lib/docker:/var/lib/docker
      - /lib/modules:/lib/modules
      - /var/run:/var/run
-     - /var/html:/var/html
+     - /etc/html:/var/html
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: compose
     image: linuxkitprojects/compose:0535e78608f57702745dfd56fbe78d28d237e469
     binds:
      - /var/run:/var/run
-     - /var/compose:/compose
+     - /etc/compose:/compose
 files:
-  - path: var/html/a/index.html
+  - path: etc/html/a/index.html
     source: html-a.html
-  - path: var/html/b/index.html
+  - path: etc/html/b/index.html
     source: html-b.html
-  - path: var/compose/docker-compose.yml
+  - path: etc/compose/docker-compose.yml
     source: docker-compose.yml
 trust:
   org:

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -36,23 +36,23 @@ services:
      - /var/lib/docker:/var/lib/docker
      - /lib/modules:/lib/modules
      - /var/run:/var/run
-     - /var/html:/var/html
+     - /etc/html:/var/html
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: compose
     image: linuxkitprojects/compose:0535e78608f57702745dfd56fbe78d28d237e469
     binds:
      - /var/run:/var/run
-     - /var/compose:/compose
+     - /etc/compose:/compose
 files:
-  - path: var/html/a/index.html
+  - path: etc/html/a/index.html
     source: html-a.html
-  - path: var/html/b/index.html
+  - path: etc/html/b/index.html
     source: html-b.html
-  - path: var/compose/docker-compose.yml
+  - path: etc/compose/docker-compose.yml
     source: docker-compose.yml
-  - path: var/compose/images/nginx:alpine.tar
+  - path: etc/compose/images/nginx:alpine.tar
     source: image-cache/nginx:alpine.tar
-  - path: var/compose/images/traefik.tar
+  - path: etc/compose/images/traefik.tar
     source: image-cache/traefik.tar
 trust:
   org:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed the compose example to insert files in `/etc/html` and `/etc/compose`  instead of `/var/html` and `/var/compose`, since `/var` now is mounted tmpfs and overrides it. See #2596 

/cc @justincormack @dprotaso 

**- How I did it**
changed the 2 yml files in `projects/compose/`

**- How to verify it**
`moby build` and `linuxkit run`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Changes copy path for `files` to suit current tmpfs use of `/var`

**- A picture of a cute animal (not mandatory but encouraged)**
![furry](https://www.peta.org/wp-content/uploads/2013/10/raccoon7.jpg)
