### PR TITLE
add support for OS_CACERT, OS_INSECURE

### DIFF
--- a/docs/platform-openstack.md
+++ b/docs/platform-openstack.md
@@ -19,6 +19,8 @@ OS_PASSWORD="xxx"
 OS_TENANT_NAME="linuxkit"
 OS_AUTH_URL="https://keystone.com:5000/v3"
 OS_USER_DOMAIN_NAME=default
+OS_CACERT=/path/to/cacert.pem
+OS_INSECURE=false
 ```
 
 ## Push


### PR DESCRIPTION
Signed-off-by: Marco Mariani <marco.mariani@alterway.fr>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I've added basic support for self-signed TLS authentication in the OpenStack commands.

**- How I did it**

Since the gophercloud package does not support passing a certificate, I override the HTTPClient instance of the ProviderClient.

**- How to verify it**

Set OS_CACERT to a self-signed certificate, or pass it with --cacert.
To verify --insecure, set OS_AUTH_URL to the ip address instead of the hostname. It should fail unless the --insecure flag is set.

**- Description for the changelog**

Added OS_CACERT and OS_INSECURE to "run openstack" and "push openstack".

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://i.imgur.com/lkw1KCt.jpg)