### PR TITLE
Fix GCP error printing

### DIFF
--- a/src/cmd/linuxkit/gcp.go
+++ b/src/cmd/linuxkit/gcp.go
@@ -461,7 +461,7 @@ func (g *GCPClient) pollOperationStatus(operationName string) error {
 			return fmt.Errorf("error fetching operation status: %v", err)
 		}
 		if operation.Error != nil {
-			return fmt.Errorf("error running operation: %v", operation.Error)
+			return fmt.Errorf("error running operation: %s", operation.Error)
 		}
 		if operation.Status == "DONE" {
 			return nil
@@ -478,7 +478,7 @@ func (g *GCPClient) pollZoneOperationStatus(operationName, zone string) error {
 			return fmt.Errorf("error fetching operation status: %v", err)
 		}
 		if operation.Error != nil {
-			return fmt.Errorf("error running operation: %v", operation.Error)
+			return fmt.Errorf("error running operation: %s", operation.Error)
 		}
 		if operation.Status == "DONE" {
 			return nil


### PR DESCRIPTION
Before:

```
$ ./bin/linuxkit push gcp -project ... -bucket ... ./broken.img.tar.gz
...
Creating image: broken
FATA[0013] Error creating Google Compute Image: error running operation: &{[0xc4203a71a0] [] []}
```

After:
```
FATA[0006] Error creating Google Compute Image: error running operation: &{[%!s(*compute.OperationErrorErrors=&{INVALID_IMAGE_TAR  The tar archive is not a valid image. [] []})] [] []}
```
Still not the best error, but at least it includes the relevant details now.

