### PR TITLE
Fix broken AWS / OpenStack metadata, add example config for latter

### DIFF
--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -1,0 +1,36 @@
+kernel:
+  image: linuxkit/kernel:4.9.54
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
+  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
+  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+onboot:
+  - name: sysctl
+    image: linuxkit/sysctl:154913b72c6f1f33eb408609fca9963628e8c051
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:d4408777ed6b6e6e562a5d4938fd09804324b33e
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+  - name: metadata
+    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
+    command: ["/usr/bin/metadata", "openstack"]
+services:
+  - name: rngd
+    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+  - name: sshd
+    image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
+    binds:
+     - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
+  - name: nginx
+    image: nginx:alpine
+    capabilities:
+     - CAP_NET_BIND_SERVICE
+     - CAP_CHOWN
+     - CAP_SETUID
+     - CAP_SETGID
+     - CAP_DAC_OVERRIDE
+trust:
+  org:
+    - linuxkit
+    - library

--- a/pkg/metadata/main.go
+++ b/pkg/metadata/main.go
@@ -22,7 +22,7 @@ const (
 
 	// Standard AWS-compatible Metadata URLs
 	userDataURL = "http://169.254.169.254/latest/user-data"
-	metaDataURL = "http://169.254.169.254/latest/meta-data"
+	metaDataURL = "http://169.254.169.254/latest/meta-data/"
 )
 
 // Provider is a generic interface for metadata/userdata providers.


### PR DESCRIPTION
**- What I did**

Fix a typo that somehow snuck in via 6deabe8a2 *cough* and which broke metadata access for AWS and OpenStack providers.

By way of penance, this commit adds a configuration example for OpenStack.

**- How to verify it**

Booting an image should now result in successful metadata retrieval on AWS and OpenStack, as verified in logs such as:

```
2017/10/18 21:44:52 openstack: Probe succeeded
```

**- Description for the changelog**

Fix metadata URL typo, add an example configuration file for OpenStack.

**- A picture of a cute animal (not mandatory but encouraged)**

![img_4480](https://user-images.githubusercontent.com/436656/31744663-91858226-b457-11e7-97d0-f3e61547bd85.JPG)


