### PR TITLE
Update metadata image tag references

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -11,7 +11,7 @@ init:
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata
-    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
+    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
   - name: sysctl
     image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
   - name: sysfs

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
+    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
 services:
   - name: rngd
     image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
+    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
 services:
   - name: getty
     image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:d4408777ed6b6e6e562a5d4938fd09804324b33e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
+    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
     command: ["/usr/bin/metadata", "openstack"]
 services:
   - name: rngd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
+    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
     command: ["/usr/bin/metadata", "packet"]
 services:
   - name: rngd

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
+    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
 services:
   - name: getty
     image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
+    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
   - name: format
     image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
   - name: mounts

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -20,7 +20,7 @@ onboot:
     image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
     command: ["/usr/bin/mountie", "/var/lib/swarmd"]
   - name: metadata
-    image: linuxkit/metadata:4c588dba73ae7bec6f873130f715ba44082c4278
+    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
 services:
   - name: getty
     image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512


### PR DESCRIPTION
Signed-off-by: Nick Jones <nick@dischord.org>

**- What I did**

Updated tag references for the metadata image to one which includes fixes for OpenStack and AWS.

**- How I did it**

```shell
scripts/update-component-sha.sh --hash 4c588dba73ae7bec6f873130f715ba44082c4278 c385bb2dce56acf8b831bbf7fca3c8fc836ded66
```
**- Description for the changelog**

Update tag ref for the metadata image across various examples.