### PR TITLE
Improve `linuxkit pkg` handling of git 

### DIFF
--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -71,7 +71,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	}
 
 	if bo.release == "" {
-		r, err := gitCommitTag("HEAD")
+		r, err := p.git.commitTag("HEAD")
 		if err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 		args = append(args, "--label", "org.opencontainers.image.source="+p.gitRepo)
 	}
 	if !p.dirty {
-		commit, err := gitCommitHash("HEAD")
+		commit, err := p.git.commitHash("HEAD")
 		if err != nil {
 			return err
 		}

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -70,7 +70,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 		return fmt.Errorf("Unknown arch %q", arch)
 	}
 
-	if bo.release == "" {
+	if p.git != nil && bo.release == "" {
 		r, err := p.git.commitTag("HEAD")
 		if err != nil {
 			return err
@@ -97,10 +97,10 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 
 	var args []string
 
-	if p.gitRepo != "" {
+	if p.git != nil && p.gitRepo != "" {
 		args = append(args, "--label", "org.opencontainers.image.source="+p.gitRepo)
 	}
-	if !p.dirty {
+	if p.git != nil && !p.dirty {
 		commit, err := p.git.commitHash("HEAD")
 		if err != nil {
 			return err

--- a/src/cmd/linuxkit/pkglib/git.go
+++ b/src/cmd/linuxkit/pkglib/git.go
@@ -4,6 +4,7 @@ package pkglib
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -31,9 +32,9 @@ func (g git) mkCmd(args ...string) *exec.Cmd {
 	return exec.Command("git", append([]string{"-C", g.dir}, args...)...)
 }
 
-func (g git) commandStdout(args ...string) (string, error) {
+func (g git) commandStdout(stderr io.Writer, args ...string) (string, error) {
 	cmd := g.mkCmd(args...)
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = stderr
 
 	if debugGitCommands {
 		fmt.Fprintf(os.Stderr, "+ %v\n", cmd.Args)
@@ -56,7 +57,7 @@ func (g git) command(args ...string) error {
 }
 
 func (g git) treeHash(pkg, commit string) (string, error) {
-	out, err := g.commandStdout("ls-tree", "--full-tree", commit, "--", pkg)
+	out, err := g.commandStdout(os.Stderr, "ls-tree", "--full-tree", commit, "--", pkg)
 	if err != nil {
 		return "", err
 	}
@@ -70,7 +71,7 @@ func (g git) treeHash(pkg, commit string) (string, error) {
 }
 
 func (g git) commitHash(commit string) (string, error) {
-	out, err := g.commandStdout("rev-parse", commit)
+	out, err := g.commandStdout(os.Stderr, "rev-parse", commit)
 	if err != nil {
 		return "", err
 	}
@@ -79,7 +80,7 @@ func (g git) commitHash(commit string) (string, error) {
 }
 
 func (g git) commitTag(commit string) (string, error) {
-	out, err := g.commandStdout("tag", "-l", "--points-at", commit)
+	out, err := g.commandStdout(os.Stderr, "tag", "-l", "--points-at", commit)
 	if err != nil {
 		return "", err
 	}

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -198,11 +198,11 @@ func (p Pkg) ReleaseTag(release string) (string, error) {
 
 // Tag returns the tag to use for the package
 func (p Pkg) Tag() string {
-	r := p.org + "/" + p.image
-	if p.hash != "" {
-		r += ":" + p.hash
+	t := p.hash
+	if t == "" {
+		t = "latest"
 	}
-	return r
+	return p.org + "/" + p.image + ":" + t
 }
 
 // TrustEnabled returns true if trust is enabled

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -36,6 +36,7 @@ type Pkg struct {
 	hash       string
 	dirty      bool
 	commitHash string
+	git        *git
 }
 
 // NewFromCLI creates a Pkg from a set of CLI arguments. Calls fs.Parse()
@@ -138,7 +139,9 @@ func NewFromCLI(fs *flag.FlagSet, args ...string) (Pkg, error) {
 		}
 	})
 
-	gitDirty, err := gitIsDirty(hashPath, hashCommit)
+	git := newGit(pkgPath)
+
+	gitDirty, err := git.isDirty(hashPath, hashCommit)
 	if err != nil {
 		return Pkg{}, err
 	}
@@ -146,7 +149,7 @@ func NewFromCLI(fs *flag.FlagSet, args ...string) (Pkg, error) {
 	dirty = dirty || gitDirty
 
 	if hash == "" {
-		if hash, err = gitTreeHash(hashPath, hashCommit); err != nil {
+		if hash, err = git.treeHash(hashPath, hashCommit); err != nil {
 			return Pkg{}, err
 		}
 
@@ -167,6 +170,7 @@ func NewFromCLI(fs *flag.FlagSet, args ...string) (Pkg, error) {
 		cache:      !pi.DisableCache,
 		dirty:      dirty,
 		pkgPath:    pkgPath,
+		git:        git,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes #2613 (allowing building etc of packages not in git) but also fixes a more general issue where things wouldn't work if invoking `linuxkit pkg` from outside the git tree containing the package.

Previously:
```
$ cd /not/a/git/dir
$ git status
fatal: Not a git repository (or any of the parent directories): .git
$ linuxkit pkg build $GOPATH/github.com/linuxkit/linuxkit/pkg/swap/
fatal: Not a git repository (or any of the parent directories): .git
exit status 128
```
Even though `$GOPATH/github.com/linuxkit/linuxkit/` is a git clone/

This now works correctly. As does:
```
$ git status
fatal: Not a git repository (or any of the parent directories): .git
$ ls -A
build.yml  Dockerfile
$ cat build.yml 
image: dummy
$ cat Dockerfile 
FROM hello-world:latest
$ linuxkit pkg build .
Building "linuxkit/dummy"
Using default tag: latest
[...]
Successfully tagged linuxkit/dummy-amd64:latest
Tagging hello-world@sha256:07d5f7800dfe37b8c2196c7b1c524c33808ce2e0f74e7aa00e603295ca9a0972 as hello-world:latest
Tagging linuxkit/dummy-amd64 as linuxkit/dummy
Build complete, not pushing, all done.
