### PR TITLE
Update .gitattributes to match current kernel config names

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 **/vendor/** linguist-vendored
-kernel/*.x linguist-language=text
+kernel/kernel_config-* linguist-language=text


### PR DESCRIPTION
In 72ed2b3a0638 ("kernel: Rename kernel_config-4.x.x to
kernel_config-4.x.x-x86_64") this was changed, making GH's linguist think our
project is mostly written in logo!

Signed-off-by: Ian Campbell <ijc@docker.com>

/cc @rn 