### PR TITLE
Alpine update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: default
 VERSION="0.0" # dummy for now
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:758282e180b4bcc7259f77edd22c46b890be2549
+GO_COMPILE=linuxkit/go-compile:fb53f01a669de5e91ec855b4f67a57b514b4f6ed
 
 MOBY?=bin/moby
 LINUXKIT?=bin/linuxkit

--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -3,30 +3,30 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/vpnkit-expose-port:0832f0cfdfc02214680588a5018619cd1eb4b93f # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/vpnkit-expose-port:15c56c57ac9a7adeec20b34f36f2bc165c347679 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   # support metadata for optional config in /var/config
   - name: metadata
-    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
+    image: linuxkit/metadata:9506d124d0a3ff645c9781c47f207423abf6154d
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: sysfs
-    image: linuxkit/sysfs:a844eb2ac09df07f5eda89d5588d76bf8d96cfca
+    image: linuxkit/sysfs:5367b46211882278b84a9e8048855ca5df65beda
   - name: binfmt
-    image: linuxkit/binfmt:7b2fdd981f3cdb5d21961e7d584e600af5a934a0
+    image: linuxkit/binfmt:4d959cc25447fc1c8aa6bf695bc6fc9734d626df
   # Format and mount the disk image in /var/lib/docker
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib"]
   # make a swap file on the mounted disk
   - name: swap
-    image: linuxkit/swap:195ef5c89fcd68ff412ecb01a330e75503dc7b83
+    image: linuxkit/swap:25a2f13110585f3d964a8191fa3a84de51dbb8fd
     command: ["/swap.sh", "--path", "/var/lib/swap", "--size", "1024M"]
   # mount-vpnkit mounts the 9p share used by vpnkit to coordinate port forwarding
   - name: mount-vpnkit
@@ -44,41 +44,41 @@ onboot:
         - /var:/host_var
     command: ["sh", "-c", "mv -v /host_var/log /host_var/lib && ln -vs /var/lib/log /host_var/log"]
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   # Enable acpi to shutdown on power events
   - name: acpid
-    image: linuxkit/acpid:6e3f0c5deca1633230dce9a35b67e1f61f05c47a
+    image: linuxkit/acpid:168f871c7211c9d5e96002d53cb497b26e2d622b
   # Enable getty for easier debugging
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
         - INSECURE=true
   # Run ntpd to keep time synchronised in the VM
   - name: ntpd
-    image: linuxkit/openntpd:8d32daf90ecf70b7e185cb7a2db53b4c539d371c
+    image: linuxkit/openntpd:07a80c3e3e816658318ac027e1253ff9a228b8de
   # VSOCK to unix domain socket forwarding. Forwards guest /var/run/docker.sock
   # to a socket on the host.
   - name: vsudd
-    image: linuxkit/vsudd:a0336f99442a81e5f9bb117353c0c74455f5556b
+    image: linuxkit/vsudd:26f6a75d35f05b6bbd7d9a2d67c843b7003b3e05
     binds:
         - /var/run:/var/run
     command: ["/vsudd", "-inport", "2376:unix:/var/run/docker.sock"]
   # vpnkit-forwarder forwards network traffic to/from the host via VSOCK port 62373. 
   # It needs access to the vpnkit 9P coordination share 
   - name: vpnkit-forwarder
-    image: linuxkit/vpnkit-forwarder:42e88e9338c3b93eda79f6582f58d87fd78d0001
+    image: linuxkit/vpnkit-forwarder:c7e61d9250de0b21455dc5c8bb885bd8faa31621
     binds:
         - /var/vpnkit:/port
     net: host
     command: ["/vpnkit-forwarder", "-vsockPort", "62373"]
   # Monitor for image deletes and invoke a TRIM on the container filesystem
   - name: trim-after-delete
-    image: linuxkit/trim-after-delete:b20b16638f6712ce83699ae4aea5a6e8d3658db3
+    image: linuxkit/trim-after-delete:9ae85973d9f2516a75ff855705ddf513c031c425
   # When the host resumes from sleep, force a clock resync
   - name: host-timesync-daemon
-    image: linuxkit/host-timesync-daemon:5d706ccc6d0d3e5b4b5d798deafde2e76acfe01d
+    image: linuxkit/host-timesync-daemon:2423a4014d9425a7f9820a85db808686cfa48e4a
 
 trust:
     org:

--- a/blueprints/lcow.yml
+++ b/blueprints/lcow.yml
@@ -4,8 +4,8 @@ kernel:
   cmdline: "console=ttyS0"
   tar: none
 init:
-  - linuxkit/init-lcow:00195e5eb94189512ccf681730609d005dfa3979
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init-lcow:f47a2a1f2e7d739eefd7e4f5fa8dc1b1da574876
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -22,7 +22,7 @@ docker run -it --rm \
 -v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:758282e180b4bcc7259f77edd22c46b890be2549
+linuxkit/go-compile:fb53f01a669de5e91ec855b4f67a57b514b4f6ed
 ```
 
 To update a single dependency:
@@ -32,7 +32,7 @@ docker run -it --rm \
 -v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:758282e180b4bcc7259f77edd22c46b890be2549
+linuxkit/go-compile:fb53f01a669de5e91ec855b4f67a57b514b4f6ed
 github.com/docker/docker
 ```
 

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
+    image: linuxkit/metadata:9506d124d0a3ff645c9781c47f207423abf6154d
 services:
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: sshd
-    image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
+    image: linuxkit/sshd:f55ec010619e19178d5daecb4e595e84ecbf7d67
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
 services:
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
   - name: sshd
-    image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
+    image: linuxkit/sshd:f55ec010619e19178d5daecb4e595e84ecbf7d67
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,31 +2,31 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: sysfs
-    image: linuxkit/sysfs:a844eb2ac09df07f5eda89d5588d76bf8d96cfca
+    image: linuxkit/sysfs:5367b46211882278b84a9e8048855ca5df65beda
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
   - name: ntpd
-    image: linuxkit/openntpd:8d32daf90ecf70b7e185cb7a2db53b4c539d371c
+    image: linuxkit/openntpd:07a80c3e3e816658318ac027e1253ff9a228b8de
   - name: docker
     image: docker:17.07.0-ce-dind
     capabilities:

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,27 +2,27 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
+    image: linuxkit/metadata:9506d124d0a3ff645c9781c47f207423abf6154d
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: sshd
-    image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
+    image: linuxkit/sshd:f55ec010619e19178d5daecb4e595e84ecbf7d67
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,24 +2,24 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,18 +2,18 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
   - name: node_exporter
     image: linuxkit/node_exporter:a058fe1c6a4440a9689022a9fd7cffdcfd56d52c
 trust:

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,24 +2,24 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:154913b72c6f1f33eb408609fca9963628e8c051
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: dhcpcd
-    image: linuxkit/dhcpcd:d4408777ed6b6e6e562a5d4938fd09804324b33e
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
+    image: linuxkit/metadata:9506d124d0a3ff645c9781c47f207423abf6154d
     command: ["/usr/bin/metadata", "openstack"]
 services:
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: sshd
-    image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
+    image: linuxkit/sshd:f55ec010619e19178d5daecb4e595e84ecbf7d67
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,27 +2,27 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS1"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: rngd1
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
     command: ["/sbin/rngd", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
+    image: linuxkit/metadata:9506d124d0a3ff645c9781c47f207423abf6154d
     command: ["/usr/bin/metadata", "packet"]
 services:
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: sshd
-    image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
+    image: linuxkit/sshd:f55ec010619e19178d5daecb4e595e84ecbf7d67
 trust:
   org:
     - linuxkit

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,16 +4,16 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
   - name: redis

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,27 +2,27 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: rngd1
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
     command: ["/sbin/rngd", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
   - name: sshd
-    image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
+    image: linuxkit/sshd:f55ec010619e19178d5daecb4e595e84ecbf7d67
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,33 +2,33 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/external"]
   - name: swap
-    image: linuxkit/swap:195ef5c89fcd68ff412ecb01a330e75503dc7b83
+    image: linuxkit/swap:25a2f13110585f3d964a8191fa3a84de51dbb8fd
     # to use unencrypted swap, use:
     # command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G"]
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: nginx
     image: nginx:alpine
     capabilities:

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,25 +2,25 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
   - name: tss
-    image: linuxkit/tss:2c29b212733e90fbbd7aeaf032cadc044dbc7fe4
+    image: linuxkit/tss:8bf8e058ad1195be631bcaac126c6d396d03edd9
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,22 +2,22 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
   - name: nginx
     image: nginx:alpine
     capabilities:

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,12 +2,12 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: mount-vpnkit
     image: alpine:3.6
@@ -19,15 +19,15 @@ onboot:
     command: ["sh", "-c", "mkdir /host_var/vpnkit && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
 services:
   - name: sshd
-    image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
+    image: linuxkit/sshd:f55ec010619e19178d5daecb4e595e84ecbf7d67
   - name: vpnkit-forwarder
-    image: linuxkit/vpnkit-forwarder:42e88e9338c3b93eda79f6582f58d87fd78d0001
+    image: linuxkit/vpnkit-forwarder:c7e61d9250de0b21455dc5c8bb885bd8faa31621
     binds:
         - /var/vpnkit:/port
     net: host
     command: ["/vpnkit-forwarder"]
   - name: vpnkit-expose-port
-    image: linuxkit/vpnkit-forwarder:42e88e9338c3b93eda79f6582f58d87fd78d0001
+    image: linuxkit/vpnkit-forwarder:c7e61d9250de0b21455dc5c8bb885bd8faa31621
     net: none
     binds:
         - /var/vpnkit:/port

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: vsudd
-    image: linuxkit/vsudd:a0336f99442a81e5f9bb117353c0c74455f5556b
+    image: linuxkit/vsudd:26f6a75d35f05b6bbd7d9a2d67c843b7003b3e05
     binds:
         - /run/containerd/containerd.sock:/run/containerd/containerd.sock
     command: ["/vsudd",

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,27 +2,27 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
+    image: linuxkit/metadata:9506d124d0a3ff645c9781c47f207423abf6154d
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: sshd
-    image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
+    image: linuxkit/sshd:f55ec010619e19178d5daecb4e595e84ecbf7d67
     binds:
      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,18 +2,18 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:30fa3497a42cf941301c1e9cde09b3d68f01b847
+    image: linuxkit/ip:0d1d6d9810812bc23652556c3cbe7d2e87655278
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -26,7 +26,7 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:30fa3497a42cf941301c1e9cde09b3d68f01b847
+    image: linuxkit/ip:0d1d6d9810812bc23652556c3cbe7d2e87655278
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -40,12 +40,12 @@ onboot:
           net: /run/netns/wg1
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
     net: /run/netns/wg1
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: nginx
     image: nginx:alpine
     net: /run/netns/wg0

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS kernel-build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS kernel-build
 RUN apk add \
     argp-standalone \
     automake \

--- a/kernel/Dockerfile.kconfig
+++ b/kernel/Dockerfile.kconfig
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS kernel-build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS kernel-build
 RUN apk add \
     argp-standalone \
     build-base \

--- a/kernel/Dockerfile.zfs
+++ b/kernel/Dockerfile.zfs
@@ -1,6 +1,6 @@
 ARG IMAGE
 FROM ${IMAGE} AS ksrc
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 RUN apk add \
     attr-dev \
     autoconf \

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,15 +2,15 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 onshutdown:
   - name: shutdown
@@ -18,11 +18,11 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: nginx
     image: nginx:alpine
     capabilities:

--- a/pkg/acpid/Dockerfile
+++ b/pkg/acpid/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -6,7 +6,7 @@ RUN apk add --no-cache --initdb -p /out \
     busybox
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror2
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror2
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     busybox-initscripts

--- a/pkg/auditd/Dockerfile
+++ b/pkg/auditd/Dockerfile
@@ -1,10 +1,10 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 RUN apk add abuild gcc git
 
 ADD build.sh /
 RUN adduser -D -G abuild builder && sudo -u builder /build.sh
 
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 COPY --from=build /home/builder/*apk /
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,10 +1,10 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS qemu
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS qemu
 RUN apk add \
     qemu-aarch64 \
     qemu-arm \
     qemu-ppc64le
 
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/ca-certificates/Dockerfile
+++ b/pkg/ca-certificates/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d as alpine
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 as alpine
 
 RUN apk add ca-certificates
 

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a as alpine
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/dhcpcd/Dockerfile
+++ b/pkg/dhcpcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/extend/Dockerfile
+++ b/pkg/extend/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -15,7 +15,7 @@ RUN apk add --no-cache --initdb -p /out \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/format/Dockerfile
+++ b/pkg/format/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -15,7 +15,7 @@ RUN apk add --no-cache --initdb -p /out \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/getty/Dockerfile
+++ b/pkg/getty/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/host-timesync-daemon/Dockerfile
+++ b/pkg/host-timesync-daemon/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN apk add --no-cache go musl-dev git
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/init-lcow/Dockerfile
+++ b/pkg/init-lcow/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
@@ -7,7 +7,7 @@ RUN apk add --no-cache --initdb -p /out \
     musl
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 ENV OPENGCS_REPO=https://github.com/Microsoft/opengcs
 ENV OPENGCS_COMMIT=48ae4e3ba3d2fea746fb4dc20a72832a46f45466
 RUN apk add --no-cache build-base curl git go musl-dev

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -16,7 +16,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/ip/Dockerfile
+++ b/pkg/ip/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add curl
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/metadata/Dockerfile
+++ b/pkg/metadata/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN apk add --no-cache go musl-dev linux-headers
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/mkimage/Dockerfile
+++ b/pkg/mkimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/modprobe/Dockerfile
+++ b/pkg/modprobe/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/mount/Dockerfile
+++ b/pkg/mount/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -9,7 +9,7 @@ RUN apk add --no-cache --initdb -p /out \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/open-vm-tools/Dockerfile
+++ b/pkg/open-vm-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/openntpd/Dockerfile
+++ b/pkg/openntpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/qemu-ga/Dockerfile
+++ b/pkg/qemu-ga/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN mkdir -p /out/var/run
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN apk add --no-cache go gcc musl-dev linux-headers
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a as alpine
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 as alpine
 RUN \
   apk add \
   bash \

--- a/pkg/sshd/Dockerfile
+++ b/pkg/sshd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/swap/Dockerfile
+++ b/pkg/swap/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/sysctl/Dockerfile
+++ b/pkg/sysctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/sysfs/Dockerfile
+++ b/pkg/sysfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/trim-after-delete/Dockerfile
+++ b/pkg/trim-after-delete/Dockerfile
@@ -1,5 +1,5 @@
 # We need the `fstrim` binary:
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/tss/Dockerfile
+++ b/pkg/tss/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 
 ENV TROUSERS_COMMIT de57f069ef2297d6a6b3a0353e217a5a2f66e444
 ENV TPM_TOOLS_COMMIT bdf9f1bc8f63cd6fc370c2deb58d03ac55079e84

--- a/pkg/vpnkit-expose-port/Dockerfile
+++ b/pkg/vpnkit-expose-port/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/pkg/vpnkit-forwarder/Dockerfile
+++ b/pkg/vpnkit-forwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/pkg/vsudd/Dockerfile
+++ b/pkg/vsudd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/projects/kubernetes/cri-containerd/Dockerfile
+++ b/projects/kubernetes/cri-containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 
 RUN \
   apk add \

--- a/projects/kubernetes/docker-master.yml
+++ b/projects/kubernetes/docker-master.yml
@@ -1,3 +1,3 @@
 services:
   - name: kubernetes-image-cache-control-plane
-    image: linuxkitprojects/kubernetes-image-cache-control-plane:b06b6eb0b97026b2cbe8521509477c55471a7ca0
+    image: linuxkitprojects/kubernetes-image-cache-control-plane:b0fa7a0191616ed8bef9b7d4a5014dffc62c2082

--- a/projects/kubernetes/docker.yml
+++ b/projects/kubernetes/docker.yml
@@ -23,7 +23,7 @@ services:
     runtime:
       mkdir: ["/var/lib/kubeadm", "/var/lib/cni/etc", "/var/lib/cni/opt", "/var/lib/kubelet-plugins"]
   - name: kubernetes-image-cache-common
-    image: linuxkitprojects/kubernetes-image-cache-common:b06b6eb0b97026b2cbe8521509477c55471a7ca0
+    image: linuxkitprojects/kubernetes-image-cache-common:b0fa7a0191616ed8bef9b7d4a5014dffc62c2082
 files:
   - path: /etc/kubelet.sh.conf
     contents: ""

--- a/projects/kubernetes/image-cache/Dockerfile
+++ b/projects/kubernetes/image-cache/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -36,7 +36,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:f55ec010619e19178d5daecb4e595e84ecbf7d67
   - name: kubelet
-    image: linuxkitprojects/kubernetes:be292678cf385309de7c5e578b31a7d2c78e7578
+    image: linuxkitprojects/kubernetes:d6caf404753aa1d72ad96ff149ea5edc7c24be8f
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -2,39 +2,39 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
     binds:
      - /etc/sysctl.d/01-kubernetes.conf:/etc/sysctl.d/01-kubernetes.conf
     readonly: false
   - name: sysfs
-    image: linuxkit/sysfs:a844eb2ac09df07f5eda89d5588d76bf8d96cfca
+    image: linuxkit/sysfs:5367b46211882278b84a9e8048855ca5df65beda
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
+    image: linuxkit/metadata:9506d124d0a3ff645c9781c47f207423abf6154d
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
   - name: mounts
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/"]
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: ntpd
-    image: linuxkit/openntpd:8d32daf90ecf70b7e185cb7a2db53b4c539d371c
+    image: linuxkit/openntpd:07a80c3e3e816658318ac027e1253ff9a228b8de
   - name: sshd
-    image: linuxkit/sshd:4a2fc7be31fa57dcade391de6173e0af55296e7f
+    image: linuxkit/sshd:f55ec010619e19178d5daecb4e595e84ecbf7d67
   - name: kubelet
     image: linuxkitprojects/kubernetes:be292678cf385309de7c5e578b31a7d2c78e7578
 files:

--- a/projects/kubernetes/kubernetes/Dockerfile
+++ b/projects/kubernetes/kubernetes/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 
 ENV kubernetes_version v1.8.1
 ENV cni_version        v0.6.0

--- a/projects/memorizer/kernel-memorizer/Dockerfile
+++ b/projects/memorizer/kernel-memorizer/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS kernel-build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS kernel-build
 RUN apk add \
     argp-standalone \
     automake \

--- a/projects/okernel/Dockerfile.okernel
+++ b/projects/okernel/Dockerfile.okernel
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS kernel-build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS kernel-build
 RUN apk --no-cache add \
     argp-standalone \
     automake \

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,38 +2,38 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
     binds:
      - /etc/sysctl.d/01-swarmd.conf:/etc/sysctl.d/01-swarmd.conf
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/swarmd"]
   - name: metadata
-    image: linuxkit/metadata:c385bb2dce56acf8b831bbf7fca3c8fc836ded66
+    image: linuxkit/metadata:9506d124d0a3ff645c9781c47f207423abf6154d
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
     env:
      - INSECURE=true
   - name: qemu-ga
-    image: linuxkit/qemu-ga:2f002fffcb6f5f65bc034b5c0fef60545631ff93
+    image: linuxkit/qemu-ga:4152b81a19db95eebdc73879fd01575e2c77a88a
     binds:
       - /dev/vport0p1:/dev/vport0p1
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: ntpd
-    image: linuxkit/openntpd:8d32daf90ecf70b7e185cb7a2db53b4c539d371c
+    image: linuxkit/openntpd:07a80c3e3e816658318ac027e1253ff9a228b8de
   - name: weave
     image: weaveworks/weave:2.0.1@sha256:2d70caac7db33365482cc923d40ff8d3ec1238ae7fe06a00b3dde310d09f226e # Must match swarmd/Dockerfile
     command: ["/bin/sh", "/home/weave/weaver-wrapper"]

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -45,7 +45,7 @@ services:
       - /var:/var
       - /var/lib/swarmd:/weavedb
   - name: swarmd
-    image: linuxkitprojects/swarmd:668f9f78502d4069841552219845dc57dc846492
+    image: linuxkitprojects/swarmd:8c034e2862d3a0fce1e445511a69c4330a1d4dd5
     command: ["/usr/bin/swarmd", "--containerd-addr=/run/containerd/containerd.sock", "--log-level=debug", "--state-dir=/var/lib/swarmd"]
     capabilities:
      - all

--- a/projects/swarmd/swarmd/Dockerfile
+++ b/projects/swarmd/swarmd/Dockerfile
@@ -2,7 +2,7 @@ FROM weaveworks/weave:2.0.1@sha256:2d70caac7db33365482cc923d40ff8d3ec1238ae7fe06
 
 # Nothing to do in here, just for COPY --from=weave below
 
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 
 RUN \
   apk update && apk upgrade && \

--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -20,7 +20,7 @@ import (
 
 // QemuImg is the version of qemu container
 const (
-	QemuImg       = "linuxkit/qemu:f185296d0420d3771cfea26e069e595069a5be3e"
+	QemuImg       = "linuxkit/qemu:a8ac18dcf0ecaf6dffc887192ea30e0fb2f702de"
 	defaultFWPath = "/usr/share/ovmf/bios.bin"
 )
 

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,12 +2,12 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
 services:
   - name: acpid
-    image: linuxkit/acpid:6e3f0c5deca1633230dce9a35b67e1f61f05c47a
+    image: linuxkit/acpid:168f871c7211c9d5e96002d53cb497b26e2d622b
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.94
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -6,9 +6,9 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc
+    image: linuxkit/test-kernel-config:ff8fac1c318403aff3e2993dd9b130304e09f92e
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -6,9 +6,9 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc
+    image: linuxkit/test-kernel-config:ff8fac1c318403aff3e2993dd9b130304e09f92e
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/005_config_4.13.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.13.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.13.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc

--- a/test/cases/020_kernel/005_config_4.13.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.13.x/test.yml
@@ -6,9 +6,9 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc
+    image: linuxkit/test-kernel-config:ff8fac1c318403aff3e2993dd9b130304e09f92e
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/010_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.9.x/Dockerfile
@@ -6,7 +6,7 @@
 FROM linuxkit/kernel:4.9.58 AS ksrc
 
 # Extract headers and compile module
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 RUN apk add build-base
 
 COPY --from=ksrc /kernel-dev.tar /

--- a/test/cases/020_kernel/010_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/010_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/test.yml
@@ -13,7 +13,7 @@ onboot:
     capabilities:
      - all
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/010_echo-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/011_echo-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/012_echo-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/015_echo-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/016_echo-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/050_unix-domain/017_echo-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/010_veth-unix-domain-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/011_veth-unix-domain-echo-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-reverse"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/012_veth-ipv4-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv4"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/013_veth-ipv6-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv6"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/014_veth-tcp-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-tcp"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/015_veth-udp-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-udp"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/100_mix/020_unix-domain-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-unix"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.94
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/010_echo-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/011_echo-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/012_echo-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/015_echo-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/016_echo-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/050_unix-domain/017_echo-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/010_veth-unix-domain-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/011_veth-unix-domain-echo-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-reverse"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/012_veth-ipv4-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv4"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/013_veth-ipv6-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv6"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/014_veth-tcp-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-tcp"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/015_veth-udp-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-udp"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/100_mix/020_unix-domain-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-unix"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/010_echo-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/010_echo-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/011_echo-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/011_echo-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/012_echo-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/012_echo-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/015_echo-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/015_echo-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/016_echo-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/016_echo-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/017_echo-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/050_unix-domain/017_echo-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/010_veth-unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/010_veth-unix-domain-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/011_veth-unix-domain-echo-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/011_veth-unix-domain-echo-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-reverse"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/012_veth-ipv4-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/012_veth-ipv4-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv4"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/013_veth-ipv6-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/013_veth-ipv6-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv6"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/014_veth-tcp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/014_veth-tcp-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-tcp"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/015_veth-udp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/015_veth-udp-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-udp"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/020_unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/100_mix/020_unix-domain-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:89b4d611eb4c3a3e4f894d5996711ec177a20c4b
+    image: linuxkit/test-ns:1fca30ea85c94571200d00c7b282c537b537de48
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-unix"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.13.9
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 trust:
   org:
     - linuxkit

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -34,7 +34,7 @@ services:
      - /run:/var/run
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: test-docker-bench
-    image: linuxkit/test-docker-bench:759499d829289f0b4a33ae2d6892dd5e2c1eb901
+    image: linuxkit/test-docker-bench:972d07b4b8e084188365643334919cfe5d4016f2
     ipc: host
     pid: host
     net: host

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,25 +2,25 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: sysfs
-    image: linuxkit/sysfs:a844eb2ac09df07f5eda89d5588d76bf8d96cfca
+    image: linuxkit/sysfs:5367b46211882278b84a9e8048855ca5df65beda
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd
-    image: linuxkit/rngd:45ed7759dd927f4cce3863073ea2e0da1d52a427
+    image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
   - name: docker
     image: docker:17.07.0-ce-dind
     capabilities:

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -12,7 +12,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: binfmt
-    image: linuxkit/binfmt:7b2fdd981f3cdb5d21961e7d584e600af5a934a0
+    image: linuxkit/binfmt:4d959cc25447fc1c8aa6bf695bc6fc9734d626df
   - name: test
     image: alpine:3.6
     binds:

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -14,7 +14,7 @@ onboot:
       - /proc/sys/fs/binfmt_misc:/binfmt_misc
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -13,7 +13,7 @@ onboot:
       - /etc:/host-etc
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
     image: linuxkit/test-containerd:a74697f70cdc5f19cfc4d0d7828621f3cef5b264

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -18,9 +18,9 @@ onboot:
     image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:a74697f70cdc5f19cfc4d0d7828621f3cef5b264
+    image: linuxkit/test-containerd:9fdfba5efad713b869389f10ee860a11757f9bf2
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -15,7 +15,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -16,7 +16,7 @@ onboot:
       - /var/lib/docker:/var/lib/docker
     command: ["touch", "/var/lib/docker/bar"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org: 

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: extend
-    image: linuxkit/extend:24c25db2ef9b329b5ac67a6c3bcb84ec808141d7
+    image: linuxkit/extend:8b6db5bf68330cc4e91c74532732a7e227ae12fd
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -17,7 +17,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -24,7 +24,7 @@ onboot:
       - /var/lib/docker:/var/lib/docker
     command: ["touch", "/var/lib/docker/bar"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org: 

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: modprobe
     image: alpine:3.6
@@ -13,10 +13,10 @@ onboot:
       - /sys:/sys
     command: ["modprobe", "btrfs"]
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: modprobe
     image: alpine:3.6
@@ -13,10 +13,10 @@ onboot:
       - /sys:/sys
     command: ["modprobe", "btrfs"]
   - name: extend
-    image: linuxkit/extend:24c25db2ef9b329b5ac67a6c3bcb84ec808141d7
+    image: linuxkit/extend:8b6db5bf68330cc4e91c74532732a7e227ae12fd
     command: ["/usr/bin/extend", "-type", "btrfs"]
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -25,7 +25,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -17,7 +17,7 @@ onboot:
       - /var/lib/docker:/var/lib/docker
     command: ["touch", "/var/lib/docker/bar"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org: 

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: extend
-    image: linuxkit/extend:24c25db2ef9b329b5ac67a6c3bcb84ec808141d7
+    image: linuxkit/extend:8b6db5bf68330cc4e91c74532732a7e227ae12fd
     command: ["/usr/bin/extend", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format"]
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format", "-label", "docker"]
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format", "@DEVICE@"]
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "-device", "@DEVICE@1", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -25,7 +25,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: modprobe
     image: alpine:3.6
@@ -13,10 +13,10 @@ onboot:
       - /sys:/sys
     command: ["modprobe", "btrfs"]
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format", "-type", "xfs" ]
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -26,7 +26,7 @@ onboot:
       - CAP_SYS_ADMIN
       - CAP_MKNOD
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format", "-verbose", "-type", "ext4", "/dev/sda"]
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format", "-verbose", "-type", "ext4", "/dev/sdb"]
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format", "-verbose", "-type", "xfs", "/dev/sda"]
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format", "-verbose", "-force", "-type", "xfs", "/dev/sdb"]
   - name: test
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     binds:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -25,7 +25,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format", "-label", "docker"]
   - name: format
-    image: linuxkit/format:be811ded880af37a916f23bc9ddb274026ccc514
+    image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81
     command: ["/usr/bin/format", "-label", "foo"]
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: mount
-    image: linuxkit/mount:ef2e2106212b2d333b548821191f04da984ef48f
+    image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "-label", "foo", "/var/foo"]
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,17 +2,17 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:7abaf7b276c59f80891d92e9279e3e3ee8e2f512
+    image: linuxkit/getty:626ccc8e1766c40447f29a790d3a7cfff126f2a2
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -8,7 +8,7 @@ onboot:
   - name: mkimage
     image: linuxkit/mkimage:a5dd896053b08abea3141628f7245f4d16a5fc1f
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: mkimage
-    image: linuxkit/mkimage:13b6efeefd97fed9043c9cd3a8fe1fe7ad1cda12
+    image: linuxkit/mkimage:a5dd896053b08abea3141628f7245f4d16a5fc1f
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
 trust:

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -16,7 +16,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:1644bf07edbcaf5ce0bb764fa925b544183547f9
+    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
   - name: test
     image: alpine:3.6
     net: host

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
-  - linuxkit/ca-certificates:ea3c4c120f929f4f07ac8535d75933365b5e9582
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
+  - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:30fa3497a42cf941301c1e9cde09b3d68f01b847
+    image: linuxkit/ip:0d1d6d9810812bc23652556c3cbe7d2e87655278
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -24,7 +24,7 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:30fa3497a42cf941301c1e9cde09b3d68f01b847
+    image: linuxkit/ip:0d1d6d9810812bc23652556c3cbe7d2e87655278
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -11,7 +11,7 @@ onboot:
     binds:
      - /etc/ltp/baseline:/etc/ltp/baseline
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
 files:
   - path: /etc/ltp/baseline
     contents: "100"

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,12 +4,12 @@ kernel:
   image: linuxkit/kernel:4.9.58
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
-  - linuxkit/containerd:ed8e8f92e24dd4b94260cf147594ae3fd13a2182
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/containerd:82be2bbb7cf83bab161ffe2a64624ba1107725ff
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:aa685261ceb2557990dcfe9dd8824c6b9ec416e2
+    image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -12,9 +12,9 @@ onboot:
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:8b09b3d6e69440582e590a8981585851e9206bdc
+    image: linuxkit/test-kernel-config:ff8fac1c318403aff3e2993dd9b130304e09f92e
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   image:

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/docker-bench/Dockerfile
+++ b/test/pkg/docker-bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/test/pkg/kernel-config/Dockerfile
+++ b/test/pkg/kernel-config/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl bash

--- a/test/pkg/ns/Dockerfile
+++ b/test/pkg/ns/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
@@ -8,7 +8,7 @@ RUN apk add --no-cache --initdb -p /out \
     musl
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 RUN apk add --no-cache \
     build-base \
     git \

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75
-  - linuxkit/runc:52f92cb577879ce4cfe4e89be2d63af82523fc92
+  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -14,7 +14,7 @@ onboot:
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:ffd3f539a6f4e67d4cd4ff36503636de35edd7b2
+    image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/pkg/poweroff/Dockerfile
+++ b/test/pkg/poweroff/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache

--- a/test/pkg/virtsock/Dockerfile
+++ b/test/pkg/virtsock/Dockerfile
@@ -1,10 +1,10 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     tini
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 
 RUN apk add --no-cache go musl-dev git make
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -12,6 +12,7 @@ binutils
 binutils-dev
 bison
 blkid
+bridge-utils
 bsd-compat-headers
 btrfs-progs
 btrfs-progs-dev
@@ -50,6 +51,7 @@ installkernel
 iperf3
 iproute2
 iptables
+ipvsadm
 jq
 kmod
 libarchive-tools

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:28d7666c7476243d43694ab392f79953622b98d4-arm64
+# linuxkit/alpine:dd83bdc4a5fb196685194dfd0cb6f69a4ec5e987-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -9,7 +9,7 @@ argp-standalone-1.3-r2
 attr-2.4.47-r6
 attr-dev-2.4.47-r6
 autoconf-2.69-r0
-automake-1.15-r0
+automake-1.15.1-r0
 bash-4.3.48-r1
 bc-1.06.95-r2
 binutils-2.28-r2
@@ -17,6 +17,7 @@ binutils-dev-2.28-r2
 binutils-libs-2.28-r2
 bison-3.0.4-r0
 blkid-2.28.2-r2
+bridge-utils-1.6-r0
 bsd-compat-headers-0.7.1-r0
 btrfs-progs-4.10.2-r0
 btrfs-progs-dev-4.10.2-r0
@@ -85,6 +86,7 @@ installkernel-3.5-r0
 iperf3-3.1.7-r0
 iproute2-4.10.0-r1
 iptables-1.6.1-r0
+ipvsadm-1.29-r0
 isl-0.17.1-r0
 jq-1.5-r3
 json-c-0.12.1-r0
@@ -107,7 +109,7 @@ libburn-1.4.6-r0
 libbz2-1.0.6-r5
 libc-dev-0.7.1-r0
 libc-utils-0.7.1-r0
-libc6-compat-1.1.16-r13
+libc6-compat-1.1.16-r14
 libcap-2.25-r1
 libcap-ng-0.7.8-r0
 libcap-ng-dev-0.7.8-r0
@@ -142,6 +144,7 @@ libmount-2.28.2-r2
 libnfs-1.11.0-r0
 libnfsidmap-0.25-r1
 libnftnl-libs-1.0.7-r0
+libnl-1.1.4-r0
 libnl3-3.2.28-r0
 libogg-1.3.2-r1
 libpcap-1.8.1-r0
@@ -183,9 +186,9 @@ mpc1-1.0.3-r0
 mpfr3-3.1.5-r0
 mtools-4.0.18-r1
 multipath-tools-0.7.1-r1
-musl-1.1.16-r13
-musl-dev-1.1.16-r13
-musl-utils-1.1.16-r13
+musl-1.1.16-r14
+musl-dev-1.1.16-r14
+musl-utils-1.1.16-r14
 ncurses-dev-6.0_p20170930-r0
 ncurses-libs-6.0_p20170930-r0
 ncurses-terminfo-6.0_p20170930-r0
@@ -254,9 +257,9 @@ util-linux-dev-2.28.2-r2
 vde2-libs-2.3.2-r7
 vim-8.0.0595-r0
 wayland-1.13.0-r0
-wireguard-tools-0.0.20171011-r0
+wireguard-tools-0.0.20171017-r0
 wireless-tools-30_pre9-r0
-wpa_supplicant-2.6-r3
+wpa_supplicant-2.6-r4
 xfsprogs-4.5.0-r0
 xfsprogs-extra-4.5.0-r0
 xfsprogs-libs-4.5.0-r0

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:dd83bdc4a5fb196685194dfd0cb6f69a4ec5e987-arm64
+# linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:b3f8da6c6f02440ee9c4c72bbf4dabdf500b1d8c-amd64
+# linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -9,7 +9,7 @@ argp-standalone-1.3-r2
 attr-2.4.47-r6
 attr-dev-2.4.47-r6
 autoconf-2.69-r0
-automake-1.15-r0
+automake-1.15.1-r0
 bash-4.3.48-r1
 bc-1.06.95-r2
 binutils-2.28-r2
@@ -17,6 +17,7 @@ binutils-dev-2.28-r2
 binutils-libs-2.28-r2
 bison-3.0.4-r0
 blkid-2.28.2-r2
+bridge-utils-1.6-r0
 bsd-compat-headers-0.7.1-r0
 btrfs-progs-4.10.2-r0
 btrfs-progs-dev-4.10.2-r0
@@ -87,6 +88,7 @@ installkernel-3.5-r0
 iperf3-3.1.7-r0
 iproute2-4.10.0-r1
 iptables-1.6.1-r0
+ipvsadm-1.29-r0
 isl-0.17.1-r0
 jq-1.5-r3
 json-c-0.12.1-r0
@@ -110,7 +112,7 @@ libburn-1.4.6-r0
 libbz2-1.0.6-r5
 libc-dev-0.7.1-r0
 libc-utils-0.7.1-r0
-libc6-compat-1.1.16-r13
+libc6-compat-1.1.16-r14
 libcap-2.25-r1
 libcap-ng-0.7.8-r0
 libcap-ng-dev-0.7.8-r0
@@ -146,6 +148,7 @@ libmspack-0.5_alpha-r1
 libnfs-1.11.0-r0
 libnfsidmap-0.25-r1
 libnftnl-libs-1.0.7-r0
+libnl-1.1.4-r0
 libnl3-3.2.28-r0
 libogg-1.3.2-r1
 libpcap-1.8.1-r0
@@ -189,9 +192,9 @@ mpc1-1.0.3-r0
 mpfr3-3.1.5-r0
 mtools-4.0.18-r1
 multipath-tools-0.7.1-r1
-musl-1.1.16-r13
-musl-dev-1.1.16-r13
-musl-utils-1.1.16-r13
+musl-1.1.16-r14
+musl-dev-1.1.16-r14
+musl-utils-1.1.16-r14
 ncurses-dev-6.0_p20170930-r0
 ncurses-libs-6.0_p20170930-r0
 ncurses-terminfo-6.0_p20170930-r0
@@ -262,9 +265,9 @@ util-linux-dev-2.28.2-r2
 vde2-libs-2.3.2-r7
 vim-8.0.0595-r0
 wayland-1.13.0-r0
-wireguard-tools-0.0.20171011-r0
+wireguard-tools-0.0.20171017-r0
 wireless-tools-30_pre9-r0
-wpa_supplicant-2.6-r3
+wpa_supplicant-2.6-r4
 xfsprogs-4.5.0-r0
 xfsprogs-extra-4.5.0-r0
 xfsprogs-libs-4.5.0-r0

--- a/tools/go-compile/Dockerfile
+++ b/tools/go-compile/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6211ec0252873c9ff9604101fb256353f5a3832a AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/tools/mkimage-iso-bios/Dockerfile
+++ b/tools/mkimage-iso-bios/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-iso-efi/Dockerfile
+++ b/tools/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS grub-build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS grub-build
 
 RUN apk add \
   automake \
@@ -45,7 +45,7 @@ RUN mkdir /grub-lib && \
     ;; \
   esac
 
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS make-img
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS make-img
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-raw-bios/Dockerfile
+++ b/tools/mkimage-raw-bios/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-raw-efi/Dockerfile
+++ b/tools/mkimage-raw-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:8b53d842a47fce43464e15f65ee2f68b82542330 AS grub-build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS grub-build
 
 RUN apk add \
   automake \
@@ -46,7 +46,7 @@ RUN mkdir /grub-lib && \
     ;; \
   esac
 
-FROM linuxkit/alpine:77287352db68b442534c0005edd6ff750c8189f3 AS make-img
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS make-img
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-rpi3/Dockerfile
+++ b/tools/mkimage-rpi3/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:b3f8da6c6f02440ee9c4c72bbf4dabdf500b1d8c as build
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 as build
 RUN apk add \
     bc \
     dtc \

--- a/tools/qemu/Dockerfile
+++ b/tools/qemu/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:ad35b6ddbc70faa07e59a9d7dee7707c08122e8d AS mirror
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \


### PR DESCRIPTION
Bump/rebuild alpine.

Picks up CVE-2017-15650 fix and some other updates.
    
Adds ipvsadm and bridge-utils (fixes: #2606).
    
Update packages which are effected and the corresponding yml.