### PR TITLE
Add Azure boot diagnostics

### DIFF
--- a/src/cmd/linuxkit/azure.go
+++ b/src/cmd/linuxkit/azure.go
@@ -415,6 +415,12 @@ func setVirtualMachineParameters(storageAccountName string, networkInterfaceID, 
 					},
 				},
 			},
+			DiagnosticsProfile: &compute.DiagnosticsProfile{
+				BootDiagnostics: &compute.BootDiagnostics{
+					Enabled:    to.BoolPtr(true),
+					StorageURI: to.StringPtr(fmt.Sprintf("https://%s.blob.core.windows.net", storageAccountName)),
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: Thomas Conte <thomas@conte.com>

**- What I did**
Added support for Azure boot diagnostics so that the VM boot log can be read using the `az` command.

**- How I did it**
Added a DiagnosticsProfile section to the VirtualMachineProperties.

**- How to verify it**
`linuxkit run azure`, and then (after a few seconds):

```
az vm boot-diagnostics get-boot-log -g LXKTEST -n linuxkitvmxxx
```

**- Description for the changelog**
Added support for Azure boot diagnostics.

**- A picture of a cute animal (not mandatory but encouraged)**
![22708789_267655750422109_810758674363449344_n](https://user-images.githubusercontent.com/199027/31945761-65d63a9e-b8d0-11e7-9e54-78d52f586f42.jpg)
