### PR TITLE
Output image_id, server_id in stdout to ease automation

### DIFF
--- a/src/cmd/linuxkit/push_openstack.go
+++ b/src/cmd/linuxkit/push_openstack.go
@@ -121,5 +121,6 @@ func createOpenStackImage(filePath string, imageName string, provider *gopherclo
 		log.Fatalf("Error uploading image, status is %s", validImage.Status)
 	} else {
 		log.Infof("Image uploaded successfully!")
+		fmt.Println(image.ID)
 	}
 }

--- a/src/cmd/linuxkit/run_openstack.go
+++ b/src/cmd/linuxkit/run_openstack.go
@@ -108,6 +108,7 @@ func runOpenStack(args []string) {
 	}
 
 	servers.WaitForStatus(client, server.ID, "ACTIVE", 600)
-	fmt.Printf("Server created, UUID is %s", server.ID)
+	log.Info("Server created, UUID is %s", server.ID)
+	fmt.Println(server.ID)
 
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I've added the image_id, server_id values to the command output, in addition to the log messages.

**- How I did it**

Just a couple of prints.

**- How to verify it**

image_id=$(linuxkit push openstack ...)
server_id=$(linuxkit run openstack ...)

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

"run openstack" and "push openstack" now print image.id and server.id to stdout to avoid the need of parsing the command result in scripts.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://i.pinimg.com/736x/9d/bd/63/9dbd6371188d6c3496d014e631ddd4fb--flying-dog-baby-bats.jpg)