### PR TITLE
pkg/ip: updating linuxkit/ip sha to image built in #2605

### DIFF
--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:0d1d6d9810812bc23652556c3cbe7d2e87655278
+    image: linuxkit/ip:54971b6664cb7b52912e909a8f6a45e5a5c94506
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -26,7 +26,7 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:0d1d6d9810812bc23652556c3cbe7d2e87655278
+    image: linuxkit/ip:54971b6664cb7b52912e909a8f6a45e5a5c94506
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:0d1d6d9810812bc23652556c3cbe7d2e87655278
+    image: linuxkit/ip:54971b6664cb7b52912e909a8f6a45e5a5c94506
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -24,7 +24,7 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:0d1d6d9810812bc23652556c3cbe7d2e87655278
+    image: linuxkit/ip:54971b6664cb7b52912e909a8f6a45e5a5c94506
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- updated sha for `linuxkit/ip` to `linuxkit/ip:54971b6664cb7b52912e909a8f6a45e5a5c94506`

**- How I did it**
- `scripts/update-component-sha.sh linuxkit/ip:0d1d6d9810812bc23652556c3cbe7d2e87655278 linuxkit/ip:54971b6664cb7b52912e909a8f6a45e5a5c94506`

**- How to verify it**
- I verified the linuxkit/ip:54971b6664cb7b52912e909a8f6a45e5a5c94506 image was pushed before this change

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
pkg/ip: updated sha tag in examples for #2605 

**- A picture of a cute animal (not mandatory but encouraged)**
![img_20171005_124047](https://user-images.githubusercontent.com/4591181/31514926-3bc14ac8-af48-11e7-9d3b-98dc1640d181.jpg)