### PR TITLE
support for OpenStack security groups

### DIFF
--- a/docs/platform-openstack.md
+++ b/docs/platform-openstack.md
@@ -65,6 +65,7 @@ linuxkit run openstack \
   -password=xxx \
   -project=linuxkit \
   -keyname=deadline_ed25519 \
+  -sec-groups=allow_ssh,nginx \
   -network c5d02c5f-c625-4539-8aed-1dab3aa85a0a \
   LinuxKitTest
 ```

--- a/src/cmd/linuxkit/run_openstack.go
+++ b/src/cmd/linuxkit/run_openstack.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
@@ -36,6 +37,7 @@ func runOpenStack(args []string) {
 	flavorName := flags.String("flavor", defaultOSFlavor, "Instance size (flavor)")
 	instanceName := flags.String("instancename", "", "Name of instance.  Defaults to the name of the image if not specified")
 	networkID := flags.String("network", "", "The ID of the network to attach the instance to")
+	secGroups := flags.String("sec-groups", "", "Security Group names separated by comma")
 	keyName := flags.String("keyname", "", "The name of the SSH keypair to associate with the instance")
 	passwordFlag := flags.String("password", "", "Password for the specified username")
 	projectNameFlag := flags.String("project", "", "Name of the Project (aka Tenant) to be used")
@@ -88,11 +90,12 @@ func runOpenStack(args []string) {
 	var serverOpts servers.CreateOptsBuilder
 
 	serverOpts = &servers.CreateOpts{
-		FlavorName:    *flavorName,
-		ImageName:     name,
-		Name:          *instanceName,
-		Networks:      []servers.Network{network},
-		ServiceClient: client,
+		FlavorName:     *flavorName,
+		ImageName:      name,
+		Name:           *instanceName,
+		Networks:       []servers.Network{network},
+		ServiceClient:  client,
+		SecurityGroups: strings.Split(*secGroups, ","),
 	}
 
 	if *keyName != "" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add support for -sec-groups with a list of comma-separated group names.

It mimics docker-machine. If the argument is not provided, the default group is assigned as usual.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

OpenStack security groups are now supported with the `-sec-groups <group1>,<group2>...` flag.

**- A picture of a cute animal (not mandatory but encouraged)**

![](http://i.imgur.com/lC9v0TR.jpg)