### PR TITLE
Fix missing Docker hub images

### DIFF
--- a/projects/kubernetes/docker-master.yml
+++ b/projects/kubernetes/docker-master.yml
@@ -1,3 +1,3 @@
 services:
   - name: kubernetes-image-cache-control-plane
-    image: linuxkitprojects/kubernetes-image-cache-control-plane:b0fa7a0191616ed8bef9b7d4a5014dffc62c2082
+    image: linuxkitprojects/kubernetes-image-cache-control-plane:b06b6eb0b97026b2cbe8521509477c55471a7ca0

--- a/projects/kubernetes/docker.yml
+++ b/projects/kubernetes/docker.yml
@@ -23,7 +23,7 @@ services:
     runtime:
       mkdir: ["/var/lib/kubeadm", "/var/lib/cni/etc", "/var/lib/cni/opt", "/var/lib/kubelet-plugins"]
   - name: kubernetes-image-cache-common
-    image: linuxkitprojects/kubernetes-image-cache-common:b0fa7a0191616ed8bef9b7d4a5014dffc62c2082
+    image: linuxkitprojects/kubernetes-image-cache-common:b06b6eb0b97026b2cbe8521509477c55471a7ca0
 files:
   - path: /etc/kubelet.sh.conf
     contents: ""


### PR DESCRIPTION
Signed-off-by: Jesse White <anonymuse@gmail.com>

There are missing Docker hub images for the Kubernetes project, so I updated them to the latest of what's in Docker Hub.