### PR TITLE
tools: Use alpine multi-arch image for linuxkit/alpine

### DIFF
--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG BASE=alpine:3.6
-FROM $BASE AS mirror
+FROM alpine:3.6 AS mirror
 
 # update base image
 RUN apk update && apk upgrade -a
@@ -57,7 +56,7 @@ RUN apk add --no-cache btrfs-progs-dev gcc libc-dev linux-headers make
 RUN cd $GOPATH/src/github.com/containerd/containerd && \
   make binaries EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS="-extldflags \\\"-fno-PIC -static\\\""
 
-FROM $BASE
+FROM alpine:3.6
 
 COPY --from=mirror /etc/apk/repositories /etc/apk/repositories
 COPY --from=mirror /etc/apk/repositories.upstream /etc/apk/repositories.upstream

--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -27,15 +27,12 @@ endif
 
 ARCH := $(shell uname -m)
 ifeq ($(ARCH), x86_64)
-BASE=alpine:3.6
 DEPS += packages.x86_64
 SUFFIX=-amd64
 endif
 ifeq ($(ARCH), aarch64)
-BASE=arm64v8/alpine:3.6
 DEPS += packages.aarch64
 SUFFIX=-arm64
-DOCKER_CONTENT_PULL=0
 endif
 
 default: push
@@ -44,8 +41,7 @@ show-tag:
 	@sed -n -e '1s/# \(.*\/.*:[0-9a-f]\{40\}\)/\1/p;q' versions.$(ARCH)
 
 iid: Dockerfile Makefile $(DEPS)
-	DOCKER_CONTENT_TRUST=$(DOCKER_CONTENT_PULL) docker pull $(BASE)
-	DOCKER_CONTENT_TRUST=0 docker build --no-cache --build-arg BASE=$(BASE) --iidfile iid .
+	DOCKER_CONTENT_TRUST=1 docker build --no-cache --iidfile iid .
 
 hash: Makefile iid
 	docker run --rm $(shell cat iid) sh -c 'echo Dockerfile /lib/apk/db/installed $$(find /mirror -name '*.apk' -type f) $$(find /go/bin -type f) | xargs cat | sha1sum' | sed 's/ .*//' | sed 's/$$/$(SUFFIX)/'> $@

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,10 +1,10 @@
-# linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213-arm64
+# linuxkit/alpine:9403ab03f754228313f5bc2b0fb131330a2f4bab-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
 alpine-keys-2.1-r1
 alsa-lib-1.1.3-r0
-apk-tools-2.7.3-r0
+apk-tools-2.7.4-r0
 argp-standalone-1.3-r2
 attr-2.4.47-r6
 attr-dev-2.4.47-r6
@@ -12,9 +12,9 @@ autoconf-2.69-r0
 automake-1.15.1-r0
 bash-4.3.48-r1
 bc-1.06.95-r2
-binutils-2.28-r2
-binutils-dev-2.28-r2
-binutils-libs-2.28-r2
+binutils-2.28-r3
+binutils-dev-2.28-r3
+binutils-libs-2.28-r3
 bison-3.0.4-r0
 blkid-2.28.2-r2
 bridge-utils-1.6-r0
@@ -34,7 +34,7 @@ cmake-3.8.1-r0
 coreutils-8.27-r0
 cryptsetup-1.7.5-r0
 cryptsetup-libs-1.7.5-r0
-curl-7.56.0-r0
+curl-7.56.1-r0
 db-5.3.28-r0
 dbus-1.10.14-r0
 dbus-libs-1.10.14-r0
@@ -75,8 +75,8 @@ gmp-6.1.2-r0
 gmp-dev-6.1.2-r0
 gnupg-2.1.20-r0
 gnutls-3.5.13-r0
-go-1.8.3-r0
-go-1.9.1-r0
+go-1.8.4-r0
+go-1.9.2-r0
 grep-3.0-r0
 guile-2.0.13-r0
 guile-libs-2.0.13-r0
@@ -115,7 +115,7 @@ libcap-ng-0.7.8-r0
 libcap-ng-dev-0.7.8-r0
 libcom_err-1.43.4-r0
 libcrypto1.0-1.0.2k-r0
-libcurl-7.56.0-r0
+libcurl-7.56.1-r0
 libdrm-2.4.80-r0
 libedit-20170329.3.1-r2
 libelf-0.8.13-r2

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213-amd64
+# linuxkit/alpine:3bd325c47d5f6e6f5126e588d9d9404572399c42-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -12,9 +12,9 @@ autoconf-2.69-r0
 automake-1.15.1-r0
 bash-4.3.48-r1
 bc-1.06.95-r2
-binutils-2.28-r2
-binutils-dev-2.28-r2
-binutils-libs-2.28-r2
+binutils-2.28-r3
+binutils-dev-2.28-r3
+binutils-libs-2.28-r3
 bison-3.0.4-r0
 blkid-2.28.2-r2
 bridge-utils-1.6-r0
@@ -34,7 +34,7 @@ cmake-3.8.1-r0
 coreutils-8.27-r0
 cryptsetup-1.7.5-r0
 cryptsetup-libs-1.7.5-r0
-curl-7.56.0-r0
+curl-7.56.1-r0
 db-5.3.28-r0
 dbus-1.10.14-r0
 dbus-libs-1.10.14-r0
@@ -76,8 +76,8 @@ gmp-6.1.2-r0
 gmp-dev-6.1.2-r0
 gnupg-2.1.20-r0
 gnutls-3.5.13-r0
-go-1.8.3-r0
-go-1.9.1-r0
+go-1.8.4-r0
+go-1.9.2-r0
 grep-3.0-r0
 guile-2.0.13-r0
 guile-libs-2.0.13-r0
@@ -118,7 +118,7 @@ libcap-ng-0.7.8-r0
 libcap-ng-dev-0.7.8-r0
 libcom_err-1.43.4-r0
 libcrypto1.0-1.0.2k-r0
-libcurl-7.56.0-r0
+libcurl-7.56.1-r0
 libdrm-2.4.80-r0
 libedit-20170329.3.1-r2
 libelf-0.8.13-r2


### PR DESCRIPTION
https://github.com/docker-library/official-images/pull/3623
introduced alpine multi-arch images. Use it instead of
separate base images.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

![dog-wind](https://user-images.githubusercontent.com/3338098/32143697-65eddd24-bca5-11e7-9fde-5e8221263558.jpeg)
