### PR TITLE
test: Use the modprobe package instead of alpine:3.6

### DIFF
--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -6,11 +6,7 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: modprobe
-    image: alpine:3.6
-    capabilities: [all]
-    binds:
-      - /lib/modules:/lib/modules
-      - /sys:/sys
+    image: linuxkit/modprobe:2d153653d1111877a8f53704ef85063a44182ade
     command: ["modprobe", "btrfs"]
   - name: format
     image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -6,11 +6,7 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: modprobe
-    image: alpine:3.6
-    capabilities: [all]
-    binds:
-      - /lib/modules:/lib/modules
-      - /sys:/sys
+    image: linuxkit/modprobe:2d153653d1111877a8f53704ef85063a44182ade
     command: ["modprobe", "btrfs"]
   - name: extend
     image: linuxkit/extend:8b6db5bf68330cc4e91c74532732a7e227ae12fd

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -6,11 +6,7 @@ init:
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
 onboot:
   - name: modprobe
-    image: alpine:3.6
-    capabilities: [all]
-    binds:
-      - /lib/modules:/lib/modules
-      - /sys:/sys
+    image: linuxkit/modprobe:2d153653d1111877a8f53704ef85063a44182ade
     command: ["modprobe", "btrfs"]
   - name: format
     image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81


### PR DESCRIPTION
Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

![cat-sofa](https://user-images.githubusercontent.com/3338098/32145471-14ea88f2-bcc1-11e7-954b-7ce019957958.jpg)
