### PR TITLE
Fix KB calculation for raw images

### DIFF
--- a/tools/mkimage-raw-bios/make-bios
+++ b/tools/mkimage-raw-bios/make-bios
@@ -52,8 +52,7 @@ ESP_FILE_SIZE=$(( $KERNEL_FILE_SIZE + $INITRD_FILE_SIZE + $ESP_HEADROOM ))
 # we will round up to the nearest multiple of 2048 blocks
 # since each block is 512 bytes, we want the size to be a multiple of
 # 2048 blocks * 512 bytes = 1048576 bytes = 1024KB
-ESP_FILE_SIZE_KB=$(( ( ($ESP_FILE_SIZE+1024) / 1024 ) / 1024 * 1024 ))
-ESP_FILE_SIZE_MB=$(( $ESP_FILE_SIZE_KB / 1024 ))
+ESP_FILE_SIZE_KB=$(( ( ( ($ESP_FILE_SIZE+1024-1) / 1024 ) + 1024-1) / 1024 * 1024 ))
 # and for sectors
 ESP_FILE_SIZE_SECTORS=$(( $ESP_FILE_SIZE_KB * 2 ))
 

--- a/tools/mkimage-raw-efi/make-efi
+++ b/tools/mkimage-raw-efi/make-efi
@@ -76,7 +76,7 @@ ESP_FILE_SIZE=$(( $KERNEL_FILE_SIZE + $INITRD_FILE_SIZE + $EFI_FILE_SIZE + $ESP_
 # we will round up to the nearest multiple of 2048 blocks
 # since each block is 512 bytes, we want the size to be a multiple of
 # 2048 blocks * 512 bytes = 1048576 bytes = 1024KB
-ESP_FILE_SIZE_KB=$(( ( ($ESP_FILE_SIZE+1024) / 1024 ) / 1024 * 1024 ))
+ESP_FILE_SIZE_KB=$(( ( ( ($ESP_FILE_SIZE+1024-1) / 1024 ) + 1024-1) / 1024 * 1024 ))
 # and for sectors
 ESP_FILE_SIZE_SECTORS=$(( $ESP_FILE_SIZE_KB * 2 ))
 


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the raw image calculation. Because of the shell's integer calc, the image size in KB sometimes would return a size smaller than it should be. This ensures it always rounds **up** to the nearest whole KB, and then again **up** to the nearest multiple of 1024KB. Fixed in raw-efi and raw-bios.

**- How I did it**
Changed a line in each mkimage.

**- How to verify it**
Build the image (or not, since I already pushed with latest hash), run it. Easiest is to run `moby build -format tar-kernel-initrd ...` and then `cat <output>.tar | docker run -i --rm -e DEBUG=true <image> > output.img`

For `<image>`, the following are available as pushed:

* `linuxkit/mkimage-raw-bios:eac4dcb78f837618e7e009060146977c2adabe19`
* `linuxkit/mkimage-raw-efi:f2bae7a502598d6b78c2f0b6de77f207df27add7`


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Improve size calculation for raw-bios and raw-efi


**- A picture of a cute animal (not mandatory but encouraged)**
![ferret](https://www.texvetpets.org/wp-content/uploads/2014/09/other-14-finkelstein-ferrets-image-01-610x428.jpg)
