### PR TITLE
wireguard: update to 0.0.20171031

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -37,8 +37,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20171017
-ENV WIREGUARD_SHA256=57b79a62874d9b99659a744513d4f6f9d88cb772deaa99e485b6fed3004a35cd
+ENV WIREGUARD_VERSION=0.0.20171031
+ENV WIREGUARD_SHA256=69b9787b7ae2c681532a7a346e170471f1a651359ed53ff9e6fb8b2c60b9f96a
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
Simple version bump. Changes:

* netns: use read built-in instead of ncat hack for dmesg
* netns: use time-based test instead of quantity-based
* qemu: allow for cross compilation
* qemu: work around ccache bugs
* qemu: test using four cores
* selftest: initialize mutex in routingtable selftest

We now cross compile and run in QEMU for x86_64, i686,
ARMv7, Aarch64, and MIPS. You can see the current build
status on: https://www.wireguard.com/build-status/

* stats: more robust accounting
* compat: fix up stat calculation for udp tunnel

The statistics from `ip link -stats` or from `wg show` are
now much more accurate.

* global: accept decent check_patch.pl suggestions
* global: infuriating kernel iterator style
* global: style nits
* global: use fewer BUG_ONs
* global: get rid of useless forward declarations
* blake2: include headers for macros
* tools: correct type for CTRL_ATTR_FAMILY_ID

Lots of style cleanups.

* crypto/avx: make sure we can actually use ymm registers

This fixes an issue on some Xen platforms that expose
conflicting CPU features.

* peer: get rid of peer_for_each magic
* peer: store total number of peers instead of iterating

A major cleanup of our peer iteration logic, getting rid
of a big ugly macro and clarifying our locking semantics.

* compat: be sure to include header before testing

* wg-quick: allow specifiying multiple hooks

You can now specify {Post,Pre}{Down,Up} multiple times, and
the commands will then run in succession.

* wg-quick: remember to rewind DNS settings on failure

Small consistency fix.

* wg-quick: allow for saving existing interface

There is now a 'save' option for saving an existing
configuration without having to bring down the device.

* wg-quick: fsync the temporary file before renaming

In case the system looses power, you are now left with
either the old file or the new file but not an empty file.

* wg-quick: allow for the hatchet, but not by default

In order to account for distributions that do not have an
implementation of resolvconf(8), the contrib directory ships
with an alternative implementation that may be patched in.
This was extensively discussed and debated on the mailing
list.

* device: only take reference if netns is different

Solves an important memory leak when tearing down network
namespaces that haven't moved the wireguard device.

* device: expand scope of destruct lock
* timers: guard entire setting in block

Just to be certain.

* curve25519: only enable int128 if compiler support is sound

Allows building for Aarch64 with old gcc (such as that used
by Android) where we don't want to branch to a __multi3.

* contrib: add reresolve-dns

A small script that's been passed around for a while now for
reresolving DNS entries from a cronjob.

![image](https://user-images.githubusercontent.com/10643/32242283-a22c95ea-be72-11e7-8ce9-31c12c196bb8.png)

