### PR TITLE
wireguard: update to 0.0.20171101

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -37,8 +37,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20171031
-ENV WIREGUARD_SHA256=69b9787b7ae2c681532a7a346e170471f1a651359ed53ff9e6fb8b2c60b9f96a
+ENV WIREGUARD_VERSION=0.0.20171101
+ENV WIREGUARD_SHA256=096b6482a65e566c7bf8c059f5ee6aadb2de565b04b6d810c685f1c377540325
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
20171031, the Halloween edition, had a show stopper bug, which was
neither security related, nor did it affect LinuxKit kernels, but
was important enough for me to bump the snapshot. This is the
corresponding LinuxKit bump. Changes:

* wg-quick: save all hooks on save

Tiny bug fix for 'wg-quick save'.

* timers: switch to kees' new timer_list functions

Shiny new things for Linux 4.14.

* compat: unbreak unloading on kernels 4.6 through 4.9

The real motivation for this extra snapshot bump. Before we would run into
some issues when unloading the module, which was not good.