### PR TITLE
kubernetes: Bump to cri-containerd v1.0.0-alpha.1 + add socat

### DIFF
--- a/projects/kubernetes/cri-containerd.yml
+++ b/projects/kubernetes/cri-containerd.yml
@@ -1,6 +1,6 @@
 services:
   - name: cri-containerd
-    image: linuxkitprojects/cri-containerd:afb7c111a40788b1e085856fbddacf8a878385e7
+    image: linuxkitprojects/cri-containerd:7059f247c4135c75722047a2ce2fe6119a0e1681
 files:
   - path: /etc/kubelet.sh.conf
     contents: |

--- a/projects/kubernetes/cri-containerd/Dockerfile
+++ b/projects/kubernetes/cri-containerd/Dockerfile
@@ -10,6 +10,7 @@ RUN \
   libseccomp-dev \
   linux-headers \
   make \
+  socat \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin
 

--- a/projects/kubernetes/cri-containerd/Dockerfile
+++ b/projects/kubernetes/cri-containerd/Dockerfile
@@ -16,7 +16,7 @@ ENV GOPATH=/go PATH=$PATH:/go/bin
 
 ENV CRI_CONTAINERD_URL https://github.com/kubernetes-incubator/cri-containerd.git
 #ENV CRI_CONTAINERD_BRANCH pull/NNN/head
-ENV CRI_CONTAINERD_COMMIT v1.0.0-alpha.0
+ENV CRI_CONTAINERD_COMMIT v1.0.0-alpha.1
 RUN mkdir -p $GOPATH/src/github.com/kubernetes-incubator && \
     cd $GOPATH/src/github.com/kubernetes-incubator && \
     git clone $CRI_CONTAINERD_URL cri-containerd


### PR DESCRIPTION
Just bumps to the next cri-containerd release.

`socat` addition is due to #2639 and subsumes part of #2645.