### PR TITLE
Kubernetes: disable fail on swap

### DIFF
--- a/projects/kubernetes/kubernetes/kubelet.sh
+++ b/projects/kubernetes/kubernetes/kubelet.sh
@@ -59,4 +59,5 @@ exec kubelet --kubeconfig=/etc/kubernetes/kubelet.conf \
 	      --cni-conf-dir=/var/lib/cni/etc/net.d \
 	      --cni-bin-dir=/var/lib/cni/opt/bin \
 	      --cadvisor-port=0 \
+	      --fail-swap-on=false \
 	      $KUBELET_ARGS $@


### PR DESCRIPTION
The kubelet command often fails with the following error :

`Error: failed to run Kubelet: Running with swap on is not supported, please disable swap! or set --fail-swap-on flag to false. /proc/swaps contained: [Filename Type Size Used Priority /dev/dm-1 partition 4001788 0 **-1]**`

PR disables the swap check by adding -fail-swap-on=false to the kubelet arguments

Signed-off-by: pgayvallet <pierre.gayvallet@gmail.com>

