### PR TITLE
vSphere Panic Fix

### DIFF
--- a/src/cmd/linuxkit/run_vcenter.go
+++ b/src/cmd/linuxkit/run_vcenter.go
@@ -199,9 +199,9 @@ func vCenterConnect(ctx context.Context, newVM vmConfig) (*govmomi.Client, *obje
 		log.Fatalln("Error locating default datacenter folder")
 	}
 
-	// Check if network connectivity is requested
+	// This code is shared between Push/Run, a network isn't needed for Pushing an image
 	var net object.NetworkReference
-	if *newVM.networkName != "" {
+	if newVM.networkName != nil && *newVM.networkName != "" {
 		net, err = f.NetworkOrDefault(ctx, *newVM.networkName)
 		if err != nil {
 			log.Fatalf("Network [%s], could not be found", *newVM.networkName)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This fixes issue #2635 related to no network being passed during an
image upload as no network is required. However a hostname is still
required due to vCenter handing the upload to a vSphere server and it’s
DataStore.
**- How I did it**
Ensuring that the network is checked as a nil before looking at it's actual value
**- How to verify it**

Tested in Lab env:

`./bin/linuxkit push vcenter -url https://dan:password@lab.test/sdk -datastore vSphereNFS -hostname lab01.fnnrn.me -path linuxkit linuxkit.iso`

In the Issue raised, the `-hostname <>` was missing, it is a requirement to upload images.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix for nil pointer reference in vSphere Push code.

**- A picture of a cute animal (not mandatory but encouraged)**

![](http://25.media.tumblr.com/f7f6b08336bb305d82eee6f0050e2bbc/tumblr_mw8f96mw6m1soefwzo7_1280.jpg)

Signed-off-by: Dan Finneran <daniel.finneran@gmail.com>