### PR TITLE
Some linting improvements from gometalinter

### DIFF
--- a/src/cmd/linuxkit/azure.go
+++ b/src/cmd/linuxkit/azure.go
@@ -34,7 +34,6 @@ const (
 
 	defaultVirtualNetworkAddressPrefix = "10.0.0.0/16"
 	defaultSubnetAddressPrefix         = "10.0.0.0/24"
-	defaultRegion                      = "westeurope"
 
 	// These values are only provided so the deployment gets validated
 	// Since there is currently no Azure Linux Agent, these values
@@ -91,19 +90,6 @@ func initializeAzureClients(subscriptionID, tenantID, clientID, clientSecret str
 	virtualMachinesClient = compute.NewVirtualMachinesClient(subscriptionID)
 	virtualMachinesClient.Authorizer = autorest.NewBearerAuthorizer(token)
 
-}
-
-func getOrCreateResourceGroup(resourceGroupName, location string) *resources.Group {
-	var resourceGroup resources.Group
-	resourceGroup, err := groupsClient.Get(resourceGroupName)
-	if err != nil {
-		log.Fatalf("Error in getting resource group: %v", err)
-	}
-	if &resourceGroup != nil {
-		return &resourceGroup
-	}
-
-	return createResourceGroup(resourceGroupName, location)
 }
 
 func createResourceGroup(resourceGroupName, location string) *resources.Group {

--- a/src/cmd/linuxkit/run_aws.go
+++ b/src/cmd/linuxkit/run_aws.go
@@ -155,7 +155,7 @@ func runAWS(args []string) {
 		}
 	}
 
-	log.Warnf("AWS doesn't stream serial console output.\n Please use the AWS Management Console to obtain this output \n Console ouput will be displayed when the instance has been stopped.")
+	log.Warnf("AWS doesn't stream serial console output.\n Please use the AWS Management Console to obtain this output \n Console output will be displayed when the instance has been stopped.")
 	log.Warn("Waiting for instance to stop...")
 
 	if err = compute.WaitUntilInstanceStopped(instanceFilter); err != nil {

--- a/src/cmd/linuxkit/run_gcp.go
+++ b/src/cmd/linuxkit/run_gcp.go
@@ -10,9 +10,8 @@ import (
 )
 
 const (
-	defaultZone     = "europe-west1-d"
-	defaultMachine  = "g1-small"
-	defaultDiskSize = 1
+	defaultZone    = "europe-west1-d"
+	defaultMachine = "g1-small"
 	// Environment variables. Some are non-standard
 	zoneVar    = "CLOUDSDK_COMPUTE_ZONE"
 	machineVar = "CLOUDSDK_COMPUTE_MACHINE" // non-standard

--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -62,7 +62,7 @@ func runHyperKit(args []string) {
 	}
 	remArgs := flags.Args()
 	if len(remArgs) == 0 {
-		fmt.Println("Please specify the prefix to the image to boot\n")
+		fmt.Println("Please specify the prefix to the image to boot")
 		flags.Usage()
 		os.Exit(1)
 	}

--- a/src/cmd/linuxkit/run_hyperv.go
+++ b/src/cmd/linuxkit/run_hyperv.go
@@ -38,7 +38,7 @@ func runHyperV(args []string) {
 	}
 	remArgs := flags.Args()
 	if len(remArgs) == 0 {
-		fmt.Println("Please specify the path to the ISO image to boot\n")
+		fmt.Println("Please specify the path to the ISO image to boot")
 		flags.Usage()
 		os.Exit(1)
 	}
@@ -223,7 +223,7 @@ func hypervChecks() {
 
 	out, _, err = poshCmd("@(Get-Command Get-VM).ModuleName")
 	if err != nil {
-		log.Fatalf("Check for Hyper-V powershell modules failed: %v")
+		log.Fatalf("Check for Hyper-V powershell modules failed: %v", err)
 	}
 	res = splitLines(out)
 	if res[0] != "Hyper-V" {

--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -279,7 +279,7 @@ func runQemu(args []string) {
 		netdevConfig = "user,id=t0"
 	case qemuNetworkingTap:
 		if len(netMode) != 2 {
-			log.Fatalf("Not enough arugments for %q networking mode", qemuNetworkingTap)
+			log.Fatalf("Not enough arguments for %q networking mode", qemuNetworkingTap)
 		}
 		if len(publishFlags) != 0 {
 			log.Fatalf("Port publishing requires %q networking mode", qemuNetworkingUser)
@@ -287,7 +287,7 @@ func runQemu(args []string) {
 		netdevConfig = fmt.Sprintf("tap,id=t0,ifname=%s,script=no,downscript=no", netMode[1])
 	case qemuNetworkingBridge:
 		if len(netMode) != 2 {
-			log.Fatalf("Not enough arugments for %q networking mode", qemuNetworkingBridge)
+			log.Fatalf("Not enough arguments for %q networking mode", qemuNetworkingBridge)
 		}
 		if len(publishFlags) != 0 {
 			log.Fatalf("Port publishing requires %q networking mode", qemuNetworkingUser)

--- a/src/cmd/linuxkit/util.go
+++ b/src/cmd/linuxkit/util.go
@@ -113,7 +113,7 @@ func splitLines(in string) []string {
 }
 
 // This function parses the "size" parameter of a disk specification
-// and returns the size in MB. The "size" paramter defaults to GB, but
+// and returns the size in MB. The "size" parameter defaults to GB, but
 // the unit can be explicitly set with either a G (for GB) or M (for
 // MB). It returns the disk size in MB.
 func getDiskSizeMB(s string) (int, error) {


### PR DESCRIPTION
There is more to do on these, but clean up some unused variables,
missing args, stray `\n` etc.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![pet-shedding-lint-roller](https://user-images.githubusercontent.com/482364/32377006-50ca1456-c09e-11e7-8ca3-e9fe03bfa480.jpg)
