### PR TITLE
linuxkit pkg: pull the actual tag before build

### DIFF
--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -85,7 +85,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	d := newDockerRunner(p.trust, p.cache)
 
 	if !bo.force {
-		ok, err := d.pull(p.Tag() + suffix)
+		ok, err := d.pull(p.Tag())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Pulling the arch suffixed version does not provide any assurance that a
previous build was actually completed.

Signed-off-by: Ian Campbell <ijc@docker.com>

Relates a little to the issue with failing to push the cache images I mentioned in #2667, since I discovered it while investigating, but I don't think it is a fix for that.