### PR TITLE
qemu: Fix performance downgrade when running multiple VM instances

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -491,7 +491,9 @@ func runQemuContainer(config QemuConfig) error {
 func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 	// Iterate through the flags and build arguments
 	var qemuArgs []string
-	qemuArgs = append(qemuArgs, "-device", "virtio-rng-pci")
+	if config.Arch != "aarch64" {
+		qemuArgs = append(qemuArgs, "-device", "virtio-rng-pci")
+	}
 	qemuArgs = append(qemuArgs, "-smp", config.CPUs)
 	qemuArgs = append(qemuArgs, "-m", config.Memory)
 	qemuArgs = append(qemuArgs, "-uuid", config.UUID.String())


### PR DESCRIPTION
This PR is used to fix the issue of #2636. 

On AArch64 platform, it doesn't have an architected methods to obtain
entropy, e.g, via instructions, nor does it have real hardware rng
device, so we don't need to provide a "virtio-rng-pci" as a paravirtualized
device to expose entropy inside the virtual machine.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the performance downgrade when running multiple LinuxKit instances on Qualcomm and Huawei AArch64 platforms.
**- How I did it**
Remove the unnecessary 'virtio-rng-pci' device from the AArch64 platform, since this device has no contribution to the entropy on that platform.

**- How to verify it**
Run multiple LinuxKit instances simultaneously as we do triggering the symptoms. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/32428777-91adc632-c302-11e7-9ad7-641daa662d7e.jpg)
