### PR TITLE
qemu: Use /dev/urandom on Linux for virtio-rng-pci

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -521,6 +521,12 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 		}
 	}
 
+	rng := "rng-random,id=rng0"
+	if runtime.GOOS == "linux" {
+		rng = rng + ",filename=/dev/urandom"
+	}
+	qemuArgs = append(qemuArgs, "-object", rng, "-device", "virtio-rng-pci,rng=rng0")
+
 	var lastDisk int
 	for i, d := range config.Disks {
 		index := i


### PR DESCRIPTION
On Linux the default is /dev/random which may block if there
is not enough entropy (and it determines lack of entropy
conservatively). /dev/urandom never blocks but is fed from
the same entropy source as /dev/random so this change should
not affect platforms which have hardware RNGs but helps to
prevent stalls on platforms, in particular some arm64 platforms,
where the hardware RNG is either not present or not enabled.

If you really care about proper entropy inside a VM do not use
'linuxkit run', it's mostly for testing and shouldn't be used
for production anyway.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

fixes #2636

![goat-happy](https://user-images.githubusercontent.com/3338098/32440812-b6c11afc-c2ec-11e7-8197-f3efc939b666.jpeg)
