### PR TITLE
Kubernetes : add capability not to start kubelet

### DIFF
--- a/projects/kubernetes/kubernetes/kubelet.sh
+++ b/projects/kubernetes/kubernetes/kubelet.sh
@@ -2,11 +2,15 @@
 # Kubelet outputs only to stderr, so arrange for everything we do to go there too
 exec 1>&2
 
+if [ -e /etc/kubelet.sh.conf ] ; then
+    . /etc/kubelet.sh.conf
+fi
+
 if [ -f /var/config/kubelet/disabled ] ; then
     echo "kubelet.sh: /var/config/kubelet/disabled file is present, exiting"
     exit 0
 fi
-if ! [ -z "$KUBELET_DISABLED" ] ; then
+if [ -n "$KUBELET_DISABLED" ] ; then
     echo "kubelet.sh: KUBELET_DISABLED environ variable is set, exiting"
     exit 0
 fi
@@ -15,9 +19,6 @@ if [ ! -e /var/lib/cni/.opt.defaults-extracted ] ; then
     mkdir -p /var/lib/cni/opt/bin
     tar -xzf /root/cni.tgz -C /var/lib/cni/opt/bin
     touch /var/lib/cni/.opt.defaults-extracted
-fi
-if [ -e /etc/kubelet.sh.conf ] ; then
-    . /etc/kubelet.sh.conf
 fi
 
 await=/etc/kubernetes/kubelet.conf

--- a/projects/kubernetes/kubernetes/kubelet.sh
+++ b/projects/kubernetes/kubernetes/kubelet.sh
@@ -2,6 +2,15 @@
 # Kubelet outputs only to stderr, so arrange for everything we do to go there too
 exec 1>&2
 
+if [ -f /var/config/kubelet/disabled ] ; then
+    echo "kubelet.sh: /var/config/kubelet/disabled file is present, exiting"
+    exit 0
+fi
+if ! [ -z "$KUBELET_DISABLED" ] ; then
+    echo "kubelet.sh: KUBELET_DISABLED environ variable is set, exiting"
+    exit 0
+fi
+
 if [ ! -e /var/lib/cni/.opt.defaults-extracted ] ; then
     mkdir -p /var/lib/cni/opt/bin
     tar -xzf /root/cni.tgz -C /var/lib/cni/opt/bin


### PR DESCRIPTION
For kubernetes integration in D4D, we need to be able to enable or disable the kubelet at startup in the linuxkit VM (to start it or not).

Currently, there is no way to do this properly with the `linuxkit/kubernetes` image. We could create a custom image for our needs, but it's possible that other uses of the `linuxkit/kubernetes` image get the same needs, so the original image is probably the place to do the improvement.

PR adds checks in the kubelet.sh script to be able to instantly exit the script if `/var/config/kubelet/disabled` file or `KUBELET_DISABLED` envvar is present. 

Default script behaviour is unaltered : if nothing is set, the kubelet script will execute normally.