### PR TITLE
Remove double invocation of virtio-rng-pci

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -491,7 +491,6 @@ func runQemuContainer(config QemuConfig) error {
 func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 	// Iterate through the flags and build arguments
 	var qemuArgs []string
-	qemuArgs = append(qemuArgs, "-device", "virtio-rng-pci")
 	qemuArgs = append(qemuArgs, "-smp", config.CPUs)
 	qemuArgs = append(qemuArgs, "-m", config.Memory)
 	qemuArgs = append(qemuArgs, "-uuid", config.UUID.String())


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed the double invocation of `-device virtue-rng-pci`

**- How I did it**
Removed a single line

**- How to verify it**
Build and run `linuxkit run qemu ...`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove double invocation of virtio-rng-pci

**- A picture of a cute animal (not mandatory but encouraged)**
![lemur](http://lemur.duke.edu/wordpress/wp-content/uploads/2013/12/remus-cover.jpg)
