### PR TITLE
pkglib: Enable runtime debug output

### DIFF
--- a/src/cmd/linuxkit/pkglib/docker.go
+++ b/src/cmd/linuxkit/pkglib/docker.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-)
 
-const debugDockerCommands = false
+	log "github.com/sirupsen/logrus"
+)
 
 const dctEnableEnv = "DOCKER_CONTENT_TRUST=1"
 
@@ -36,16 +36,15 @@ func (dr dockerRunner) command(args ...string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
+
+	dct := ""
 	if dr.dct {
 		cmd.Env = append(cmd.Env, dctEnableEnv)
+		dct = dctEnableEnv + " "
 	}
-	if debugDockerCommands {
-		var dct string
-		if dr.dct {
-			dct = dctEnableEnv + " "
-		}
-		fmt.Fprintf(os.Stderr, "+ %s%v\n", dct, cmd.Args)
-	}
+
+	log.Debugf("Executing: %s%v", dct, cmd.Args)
+
 	err := cmd.Run()
 	if isExecErrNotFound(err) {
 		return fmt.Errorf("linuxkit pkg requires docker to be installed")
@@ -85,9 +84,8 @@ func (dr dockerRunner) pushWithManifest(img, suffix string) error {
 	cmd := exec.Command("/bin/sh", "-c", manifestPushScript, "manifest-push-script", img, dctArg)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if debugDockerCommands {
-		fmt.Fprintf(os.Stderr, "+ %v\n", cmd.Args)
-	}
+	log.Debugf("Executing: %v", cmd.Args)
+
 	return cmd.Run()
 }
 

--- a/src/cmd/linuxkit/pkglib/git.go
+++ b/src/cmd/linuxkit/pkglib/git.go
@@ -9,9 +9,9 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
-)
 
-const debugGitCommands = false
+	log "github.com/sirupsen/logrus"
+)
 
 // 040000 tree 7804129bd06218b72c298139a25698a748d253c6\tpkg/init
 var treeHashRe *regexp.Regexp
@@ -46,10 +46,8 @@ func (g git) mkCmd(args ...string) *exec.Cmd {
 func (g git) commandStdout(stderr io.Writer, args ...string) (string, error) {
 	cmd := g.mkCmd(args...)
 	cmd.Stderr = stderr
+	log.Debugf("Executing: %v", cmd.Args)
 
-	if debugGitCommands {
-		fmt.Fprintf(os.Stderr, "+ %v\n", cmd.Args)
-	}
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -61,9 +59,8 @@ func (g git) command(args ...string) error {
 	cmd := g.mkCmd(args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if debugGitCommands {
-		fmt.Fprintf(os.Stderr, "+ %v\n", cmd.Args)
-	}
+	log.Debugf("Executing: %v", cmd.Args)
+
 	return cmd.Run()
 }
 


### PR DESCRIPTION
Log commands executed when '-v' is used on the commandline.

By default we do not dump the environment as this may contain
sensitive information, such as passwords and passphrases.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

![fox-golf](https://user-images.githubusercontent.com/3338098/32500324-fbcd90ea-c3cc-11e7-868b-2d4dc70c3c76.jpg)
