### PR TITLE
Kubernetes updates

### DIFF
--- a/projects/kubernetes/.gitignore
+++ b/projects/kubernetes/.gitignore
@@ -2,5 +2,4 @@ image-cache/common/*.tar
 image-cache/common/Dockerfile
 image-cache/control-plane/*.tar
 image-cache/control-plane/Dockerfile
-weave.yaml
-network.yaml
+kube-weave.yaml

--- a/projects/kubernetes/Makefile
+++ b/projects/kubernetes/Makefile
@@ -4,6 +4,13 @@ KUBE_NETWORK ?= weave-v2.0.5
 INIT_YAML ?=
 INIT_YAML += network.yaml
 
+ifeq ($(shell uname -s),"Darwin")
+KUBE_FORMATS ?= iso-efi
+endif
+KUBE_FORMATS ?= iso-bios
+
+KUBE_FORMAT_ARGS := $(patsubst %,-format %,$(KUBE_FORMATS))
+
 all: build-container-images build-vm-images
 
 build-container-images:
@@ -20,10 +27,10 @@ build-vm-images: kube-master.iso kube-node.iso
 
 # NB cannot use $^ because $(INIT_YAML) is not for consumption by "moby build"
 kube-master.iso: kube.yml $(KUBE_RUNTIME).yml $(KUBE_RUNTIME)-master.yml $(INIT_YAML)
-	moby build -name kube-master -format iso-efi -format iso-bios kube.yml $(KUBE_RUNTIME).yml $(KUBE_RUNTIME)-master.yml
+	moby build -name kube-master $(KUBE_FORMAT_ARGS) kube.yml $(KUBE_RUNTIME).yml $(KUBE_RUNTIME)-master.yml
 
 kube-node.iso: kube.yml $(KUBE_RUNTIME).yml
-	moby build -name kube-node -format iso-efi -format iso-bios $^
+	moby build -name kube-node $(KUBE_FORMAT_ARGS) $^
 
 network.yaml: $(KUBE_NETWORK).yaml
 	ln -nf $< $@

--- a/projects/kubernetes/bridge.yml
+++ b/projects/kubernetes/bridge.yml
@@ -1,0 +1,8 @@
+onboot:
+  - name: bridge
+    image: busybox:latest
+    command: ["/bin/sh", "-c", "set -ex; echo '{\"cniVersion\":\"0.3.1\",\"name\":\"default\",\"plugins\":[{\"type\":\"bridge\",\"bridge\":\"cni0\",\"isDefaultGateway\":true,\"ipMasq\":false,\"hairpinMode\":true,\"ipam\":{\"type\":\"host-local\",\"subnet\":\"10.1.0.0/16\",\"gateway\":\"10.1.0.1\"},\"dns\":{\"nameservers\":[\"10.1.0.1\"]}},{\"type\":\"portmap\",\"capabilities\":{\"portMappings\":true},\"snat\":true}]}' > /var/lib/cni/etc/net.d/10-default.conflist; echo '{\"cniVersion\":\"0.2.0\",\"type\":\"loopback\"}' > /var/lib/cni/etc/net.d/99-loopback.conf"]
+    runtime:
+      mkdir: ["/var/lib/cni/etc/net.d"]
+    binds:
+      - /var/lib:/var/lib

--- a/projects/kubernetes/cri-containerd.yml
+++ b/projects/kubernetes/cri-containerd.yml
@@ -1,6 +1,6 @@
 services:
   - name: cri-containerd
-    image: linuxkitprojects/cri-containerd:7059f247c4135c75722047a2ce2fe6119a0e1681
+    image: linuxkitprojects/cri-containerd:72863deaa81a749fe8ff72bd69f863bab719aa06
 files:
   - path: /etc/kubelet.sh.conf
     contents: |

--- a/projects/kubernetes/cri-containerd/Dockerfile
+++ b/projects/kubernetes/cri-containerd/Dockerfile
@@ -16,7 +16,7 @@ ENV GOPATH=/go PATH=$PATH:/go/bin
 
 ENV CRI_CONTAINERD_URL https://github.com/kubernetes-incubator/cri-containerd.git
 #ENV CRI_CONTAINERD_BRANCH pull/NNN/head
-ENV CRI_CONTAINERD_COMMIT v1.0.0-alpha.1
+ENV CRI_CONTAINERD_COMMIT ac8b0979fa634703e0a8d03df03eb51774fcff3d
 RUN mkdir -p $GOPATH/src/github.com/kubernetes-incubator && \
     cd $GOPATH/src/github.com/kubernetes-incubator && \
     git clone $CRI_CONTAINERD_URL cri-containerd

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -36,7 +36,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:b7f21ef1b13300a994e35eac3644e4f84f0ada8a
   - name: kubelet
-    image: linuxkitprojects/kubernetes:4d8ef8789cc04cb0e8cf42dc3f34e03ec70daf3d
+    image: linuxkitprojects/kubernetes:a2693a182f9038d6ac5f7309f4678a9ad11d39ca
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -47,8 +47,8 @@ files:
       PRETTY_NAME="LinuxKit Kubernetes Project"
   - path: /usr/libexec/kubernetes/kubelet-plugins
     symlink: "/var/lib/kubelet-plugins"
-  - path: /etc/kubeadm/kube-system.init/50-network.yaml
-    source: network.yaml
+  - path: /etc/kubeadm/
+    directory: true
   - path: /etc/sysctl.d/01-kubernetes.conf
     contents: 'net.ipv4.ip_forward = 1'
   - path: /opt/cni

--- a/projects/kubernetes/kubernetes/kubeadm-init.sh
+++ b/projects/kubernetes/kubernetes/kubeadm-init.sh
@@ -11,9 +11,19 @@ else
     kubeadm init --skip-preflight-checks --kubernetes-version @KUBERNETES_VERSION@ $@
 fi
 for i in /etc/kubeadm/kube-system.init/*.yaml ; do
+    n=$(basename "$i")
     if [ -e "$i" ] ; then
-	echo "Applying "$(basename "$i")
-	kubectl create -n kube-system -f "$i"
+	if [ ! -s "$i" ] ; then # ignore zero sized files
+	    echo "Ignoring zero size file $n"
+	    continue
+	fi
+	echo "Applying $n"
+	if ! kubectl create -n kube-system -f "$i" ; then
+	    touch /var/lib/kubeadm/.kubeadm-init.sh-kube-system.init-failed
+	    touch /var/lib/kubeadm/.kubeadm-init.sh-kube-system.init-"$n"-failed
+	    echo "Failed to apply $n"
+	    continue
+	fi
     fi
 done
 if [ -f /var/config/kubeadm/untaint-master ] ; then

--- a/projects/kubernetes/weave.yml
+++ b/projects/kubernetes/weave.yml
@@ -1,0 +1,3 @@
+files:
+  - path: /etc/kubeadm/kube-system.init/50-weave.yaml
+    source: weave-sa.yaml


### PR DESCRIPTION
**- What I did**

Various updates:
* Add an option to do simple bridged networking. The way the files are injected is a bit hacky (alpine image doing echo) but will do for now, I'd like to figure out a way to do this with a kube yaml file (perhaps a `Job`) or some other way.
* Only build the images relevant to the build platform (but also make it configurable)
* Improvements to the handling of `/etc/kubeadm/kube-system.init/` with possibly invalid content.
* Bump to newer cri-containerd master, with vendoring updated to containerd beta3 and other fixes.

**- How I did it**

Individual commit messages have more info.

**- How to verify it**

`make KUBE_FORMATS="iso-efi iso-bios" KUBE_RUNTIME=docker KUBE_NETWORK=bridge kube-master.iso`

and variants.


**- Description for the changelog**
Support for simple bridged networking

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://target.scene7.com/is/image/Target/51035397?wid=520&hei=520&fmt=pjpeg "Sanzu, Heavy Over the Home")](https://www.metal-archives.com/albums/Sanzu/Heavy_over_the_Home/576429)

