### PR TITLE
kubernetes: allow yaml, CNI configuration to be provided via metadata

### DIFF
--- a/projects/kubernetes/kubernetes/kubeadm-init.sh
+++ b/projects/kubernetes/kubernetes/kubeadm-init.sh
@@ -10,7 +10,13 @@ if [ -f /etc/kubeadm/kubeadm.yaml ]; then
 else
     kubeadm init --skip-preflight-checks --kubernetes-version @KUBERNETES_VERSION@ $@
 fi
-for i in /etc/kubeadm/kube-system.init/*.yaml ; do
+
+if [ -d /var/config/cni/etc/net.d ]; then
+  cp /var/config/cni/etc/net.d/* /var/lib/cni/etc/net.d/
+fi
+# sorting by basename relies on the dirnames having the same number of directories
+YAML=$(ls -1 /var/config/kube-system.init/*.yaml /etc/kubeadm/kube-system.init/*.yaml 2>/dev/null | sort --field-separator=/ --key=5)
+for i in ${YAML}; do
     n=$(basename "$i")
     if [ -e "$i" ] ; then
 	if [ ! -s "$i" ] ; then # ignore zero sized files


### PR DESCRIPTION

**- What I did**

This patch allows network policy to be supplied at runtime via the metadata directories:

- /var/config/cni/etc/net.d/
- /var/config/kube-system.init/

Previously the network policy had to be hard-coded in the image. 

**- How I did it**

The startup script in the `kubelet` container copies `/var/config/cni/etc/net.d` (if it exists) and it combines the contents of `/var/config/kube-system.init/` and `/etc/kubeadm/kube-system.init/` taking care to sort by filename correctly.

**- How to verify it**

Add a file to the kubernetes image by extending kube.yml with
```
- path: /etc/kubeadm/kube-system.init/50-foo.yaml
  contents: 'hello'
```

Create a metadata file:
```
$ cat > metadata.json <<EOT
{
  "kube-system.init": {
    "01-empty.yaml": {
      "perm": "0755",
      "content": "hello"
    },

    "51-empty.yaml": {
      "perm": "0755",
      "content": "hello"
    }
  },
  "kubeadm": {
    "init": {
      "perm": "0644",
      "content": ""
    },
    "untaint-master": {
      "perm": "0644",
      "content": ""
    }
  },
  "kubelet": {
    "args": {
      "perm": "0644",
      "content": ""
    }
  }
}
EOT
```
Boot the VM with
```
$ linuxkit run -networking default -cpus 2 -mem 1024 -state kube-master-state -disk size=4G -data ./metadata.json --uefi kube-master-efi.iso
```
In the logs you will see the yamls being created in the correct order:

```
$ grep Applying /var/log/kubelet.err.log 
Applying 01-empty.yaml
Applying 50-foo.yaml
Applying 51-empty.yaml
```

**- Description for the changelog**

Allow the kubernetes network policy to be supplied by metadata, rather than baked into the image.

**- A picture of a cute animal (not mandatory but encouraged)**

![piglet drinking the first coffee of the day](http://cdn.attackofthecute.com/September-24-2011-15-31-33-piggy468x321.jpeg)