### PR TITLE
Update Packet docs to say we support bonding

### DIFF
--- a/docs/platform-packet.md
+++ b/docs/platform-packet.md
@@ -107,8 +107,8 @@ On the baremetal type 2a system (arm64 Cavium Thunder X) the network device driv
 
 to your YAML files before any containers requiring the network to be up, e.g., the `dhcpcd` container.
 
-Some Packet server types have bonded networks; the current code does
-not support that.
+Some Packet server types have bonded networks; the `metadata` package has support for setting
+these up, and also for adding additional IP addresses.
 
 
 ## Integration services and Metadata


### PR DESCRIPTION
Spotted this while reviewing another commit, has been supported for a while.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![two-otters-342174_960_720](https://user-images.githubusercontent.com/482364/32723589-efbf51e2-c865-11e7-9c52-f0f17873895f.jpg)
