### PR TITLE
examples: Update packet.net examples

### DIFF
--- a/docs/platform-packet.md
+++ b/docs/platform-packet.md
@@ -29,6 +29,11 @@ device ID on subsequent `linuxkit run` invocations to re-use an
 existing machine. These subsequent runs will update the iPXE data so
 you can boot alternative kernels on an existing machine.
 
+There is an example YAML file for [x86_64](../examples/packet.yml) and
+an additional YAML for [arm64](../examples/packet.arm64.yml) servers
+which provide both access to the serial console and via ssh and
+configures bonding for network devices via metadata (if supported).
+
 **Note**: The update of the iPXE configuration sometimes may take some
 time and the first boot may fail. Hitting return on the console to
 retry the boot typically fixes this.
@@ -46,22 +51,31 @@ If you don't have a public HTTP server at hand, you can use the
 be run on another Packet machine or be made accessible with tools
 like [ngrok](https://ngrok.com/).
 
-For example, to boot the toplevel [linuxkit.yml](../linuxkit.yml)
-example with a local HTTP server:
+For example, to boot the [example](../examples/packet.net)
+with a local HTTP server:
 
 ```sh
-moby build linuxkit.yml
+moby build packet.yml
 # run the web server
 # run 'ngrok http 8080' in another window
-PACKET_API_KEY=<API key> linuxkit run packet -serve :8080 -base-url http://9b828514.ngrok.io -project-id <Project ID> linuxkit
+PACKET_API_KEY=<API key> PACKET_PROJECT_ID=<Project ID> \
+linuxkit run packet -serve :8080 -base-url <ngrok url> packet
 ```
 
-To boot a `arm64` kernel on a Type 2a machine (`-machine
-baremetal_2a`) you currently need to un-compress both the kernel and
+To boot a `arm64` image for Type 2a machine (`-machine
+baremetal_2a`) you currently need build using `moby build packet.yml packet.arm64.yml` and then un-compress both the kernel and
 the initrd before booting, e.g:
+
+```sh
+mv packet-initrd.img packet-initrd.img.gz && gzip -d packet-initrd.img.gz
+mv packet-kernel packet-kernel.gz && gzip -d packet-kernel.gz
 ```
-mv linuxkit-initrd.img linuxkit-initrd.img.gz && gzip -d linuxkit-initrd.img.gz
-mv linuxkit-kernel.img linuxkit-kernel.img.gz && gzip -d linuxkit-kernel.img.gz
+
+The LinuxKit image can then be booted with:
+
+```sh
+PACKET_API_KEY=<API key> PACKET_PROJECT_ID=<Project ID> \
+linuxkit run packet -machine baremetal_2a  -serve :8080 -base-url -base-url <ngrok url> packet
 ```
 
 **Note**: It may take several minutes to deploy a new server. If you

--- a/examples/packet.arm64.yml
+++ b/examples/packet.arm64.yml
@@ -1,0 +1,4 @@
+onboot:
+  - name: modprobe
+    image: linuxkit/modprobe:2d153653d1111877a8f53704ef85063a44182ade
+    command: ["modprobe", "nicvf"]

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.9.61
-  cmdline: "console=ttyS1"
+  cmdline: "console=ttyS1 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
   - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
@@ -21,6 +21,10 @@ onboot:
 services:
   - name: rngd
     image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
+  - name: getty
+    image: linuxkit/getty:6af22c32c98536a79230eef000e9abd06b037faa
+    env:
+     - INSECURE=true
   - name: sshd
     image: linuxkit/sshd:b7f21ef1b13300a994e35eac3644e4f84f0ada8a
 trust:


### PR DESCRIPTION
- Add getty to get access to the serial console
- Add a arm64 example for baremetal type 2a
- Update documentation (and use example in documentation)

I've tested the PXE boot on arm64 and the bond interface gets
set up and seems usable.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>


![giraffe-plane](https://user-images.githubusercontent.com/3338098/32741945-d59c916e-c89f-11e7-8510-434ac5bb77d6.jpg)

