### PR TITLE
node_exporter 0.15.1; updated parameters

### DIFF
--- a/pkg/node_exporter/Dockerfile
+++ b/pkg/node_exporter/Dockerfile
@@ -1,7 +1,7 @@
-FROM prom/node-exporter:v0.14.0@sha256:ea8396dd32be6195ef03438b2f459b2e69a88b8fc798c3fc51559f56d4b158fa
+FROM prom/node-exporter:v0.15.1@sha256:88c602650e861bb8045ac83421edecbd056fc58708d47554a0d1a10f19ed7556
 
-ENTRYPOINT ["/bin/node_exporter", "-collector.procfs",  "/host/proc", \
-            "-collector.sysfs",  "/host/sys", \
-            "-collector.filesystem.ignored-mount-points", \
+ENTRYPOINT ["/bin/node_exporter", "--path.procfs",  "/host/proc", \
+            "--path.sysfs",  "/host/sys", \
+            "--collector.filesystem.ignored-mount-points", \
             "^/(sys|proc|dev|host|etc)($|/)"]
 LABEL org.mobyproject.config='{"pid": "host", "binds": ["/proc:/host/proc", "/sys:/host/sys", "/:/rootfs"], "capabilities": ["all"]}'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Updated the node_exporter package to the current version, had to change the argument names.

