### PR TITLE
examples/packet: Add ssh keys to example

### DIFF
--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -27,6 +27,11 @@ services:
      - INSECURE=true
   - name: sshd
     image: linuxkit/sshd:b7f21ef1b13300a994e35eac3644e4f84f0ada8a
+files:
+  - path: root/.ssh/authorized_keys
+    source: ~/.ssh/id_rsa.pub
+    mode: "0600"
+    optional: true
 trust:
   org:
     - linuxkit


### PR DESCRIPTION
without it sshd will not start

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

![no-jump](https://user-images.githubusercontent.com/3338098/32778677-b789d16c-c932-11e7-997e-377ee4f2879d.jpg)
