### PR TITLE
LCOW: Update OpenGCS to latest

### DIFF
--- a/blueprints/lcow.yml
+++ b/blueprints/lcow.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0"
   tar: none
 init:
-  - linuxkit/init-lcow:f47a2a1f2e7d739eefd7e4f5fa8dc1b1da574876
+  - linuxkit/init-lcow:f18287f91bf996fd931c3b59b538048653cd4f5f
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 files:
   - path: etc/linuxkit.yml

--- a/pkg/init-lcow/Dockerfile
+++ b/pkg/init-lcow/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
+FROM linuxkit/alpine:7d79062909882186e881aad263668d66e6df2a28 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
@@ -7,9 +7,9 @@ RUN apk add --no-cache --initdb -p /out \
     musl
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
+FROM linuxkit/alpine:7d79062909882186e881aad263668d66e6df2a28 AS build
 ENV OPENGCS_REPO=https://github.com/Microsoft/opengcs
-ENV OPENGCS_COMMIT=48ae4e3ba3d2fea746fb4dc20a72832a46f45466
+ENV OPENGCS_COMMIT=2a3a94cca366171f159399ffbd1333058e1cef53
 RUN apk add --no-cache build-base curl git go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin
 RUN git clone $OPENGCS_REPO /go/src/github.com/Microsoft/opengcs && \


### PR DESCRIPTION
Manually tested with latest master:
```
PS C:\Users\rneugeba\Desktop\docker> .\docker.exe version
Client:
 Version:      master-dockerproject-2017-11-13
 API version:  1.35
 Go version:   go1.8.5
 Git commit:   365c525
 Built:        Mon Nov 13 23:49:13 2017
 OS/Arch:      windows/amd64

Server:
 Version:      master-dockerproject-2017-11-13
 API version:  1.35 (minimum version 1.24)
 Go version:   go1.8.5
 Git commit:   aea31ab
 Built:        Mon Nov 13 23:53:17 2017
 OS/Arch:      windows/amd64
 Experimental: true
```
and a alpine interactive container

![gnus-shaddow](https://user-images.githubusercontent.com/3338098/32792295-ef7a6ae6-c95a-11e7-8b54-2144afce2bed.jpg)
