### PR TITLE
allow hyperkit console input/output to be redirected

### DIFF
--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -57,6 +57,9 @@ func runHyperKit(args []string) {
 	isoBoot := flags.Bool("iso", false, "Boot image is an ISO")
 	kernelBoot := flags.Bool("kernel", false, "Boot image is kernel+initrd+cmdline 'path'-kernel/-initrd/-cmdline")
 
+	// Hyperkit settings
+	consoleToFile := flags.Bool("console-file", false, "Output the console to a tty file")
+
 	// Paths and settings for UEFI firmware
 	// Note, the default uses the firmware shipped with Docker for Mac
 	fw := flags.String("fw", "/Applications/Docker.app/Contents/Resources/uefi/UEFI.fd", "Path to OVMF firmware for UEFI boot")
@@ -195,6 +198,10 @@ func runHyperKit(args []string) {
 	h, err := hyperkit.New(*hyperkitPath, "", *state)
 	if err != nil {
 		log.Fatalln("Error creating hyperkit: ", err)
+	}
+
+	if *consoleToFile {
+		h.Console = hyperkit.ConsoleFile
 	}
 
 	for i, d := range disks {


### PR DESCRIPTION
**- What I did**

When running linuxkit targeting hyperkit we allow redirection of console input/output to a file

**- How I did it**

Hyperkit go bindings make this very straight forward and we just set a single property when a flag is enabled

**- How to verify it**
After you start the VM with this new flag you should see the console-ring and tty in the state dir. Using `cat` and `screen`with the `console-ring` and `tty` behave as expected.

**- Description for the changelog**
Allow `linuxkit hyperkit run` to redirect all console input & output to a file

**- A picture of a cute animal (not mandatory but encouraged)**

![Cute Animal](https://cdn.pixabay.com/photo/2015/07/14/17/26/owl-845131_960_720.jpg)
