### PR TITLE
update boot.sh metadata

### DIFF
--- a/projects/kubernetes/kubernetes/kubeadm-init.sh
+++ b/projects/kubernetes/kubernetes/kubeadm-init.sh
@@ -11,9 +11,6 @@ else
     kubeadm init --skip-preflight-checks --kubernetes-version @KUBERNETES_VERSION@ $@
 fi
 
-if [ -d /var/config/cni/etc/net.d ]; then
-  cp /var/config/cni/etc/net.d/* /var/lib/cni/etc/net.d/
-fi
 # sorting by basename relies on the dirnames having the same number of directories
 YAML=$(ls -1 /var/config/kube-system.init/*.yaml /etc/kubeadm/kube-system.init/*.yaml 2>/dev/null | sort --field-separator=/ --key=5)
 for i in ${YAML}; do

--- a/projects/kubernetes/kubernetes/kubelet.sh
+++ b/projects/kubernetes/kubernetes/kubelet.sh
@@ -21,6 +21,11 @@ if [ ! -e /var/lib/cni/.opt.defaults-extracted ] ; then
     touch /var/lib/cni/.opt.defaults-extracted
 fi
 
+if [ -d /var/config/cni/etc/net.d ]; then
+    mkdir -p /var/lib/cni/etc/net.d
+    cp /var/config/cni/etc/net.d/* /var/lib/cni/etc/net.d/
+fi
+
 await=/etc/kubernetes/kubelet.conf
 
 if [ -f "/etc/kubernetes/kubelet.conf" ] ; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
use the new metadata scheme and combine it with KUBE_METADATA which can be either a file or json string. NOTE: KUBE_METADATA must be without root brackets.
load cni configuration on every boot from metadata directory and before the kubelet starts.
`kube-weave.yaml` gets created by makefile not `weave-sa.yaml`
**- How I did it**
start the data variable with `{` and add external metadata and/or init specific metadata. end data with `}`.
**- How to verify it**
set KUBE_METADATA to a string which is not a filename or a filename to load the file. Combine with `KUBE_MASTER_AUTOINIT`.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
update Kubernetes metadata
