### PR TITLE
alpine: Remove the 'content trust build' workaround

### DIFF
--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -4,25 +4,10 @@ ORG?=linuxkit
 IMAGE=alpine
 DEPS=packages
 
-# The logic for content trust is a bit convoluted because:
-# - The arm64 base image is currently not signed so we need to pull it
-#   with content trust disabled. This is controlled by
-#   DOCKER_CONTENT_PULL.
-# - 'docker build' with the FROM image supplied as environment
-#   variable *and* with DOCKER_CONTENT_TRUST=1 currently does not work
-#   (https://github.com/moby/moby/issues/34199). We therefor build
-#   with DOCKER_CONTENT_TRUST explicitly set to 0. However, we pull
-#   the base image just before with content trust enabled (if
-#   supported, see above).
-# - By default we always pull and push the linuxkit/alpine image with
-#   content trust, unless explicitly disabled with NOTRUST. Once the
-#   above issues are resolved, this will be the only mechanism to control
-#   content trust.
-ifdef NOTRUST
-DOCKER_CONTENT_PULL=0
-else
-DOCKER_CONTENT_PULL=1
+ifeq ($(DOCKER_CONTENT_TRUST),)
+ifndef NOTRUST
 export DOCKER_CONTENT_TRUST=1
+endif
 endif
 
 ARCH := $(shell uname -m)
@@ -41,7 +26,7 @@ show-tag:
 	@sed -n -e '1s/# \(.*\/.*:[0-9a-f]\{40\}\)/\1/p;q' versions.$(ARCH)
 
 iid: Dockerfile Makefile $(DEPS)
-	DOCKER_CONTENT_TRUST=1 docker build --no-cache --iidfile iid .
+	docker build --no-cache --iidfile iid .
 
 hash: Makefile iid
 	docker run --rm $(shell cat iid) sh -c 'echo Dockerfile /lib/apk/db/installed $$(find /mirror -name '*.apk' -type f) $$(find /go/bin -type f) | xargs cat | sha1sum' | sed 's/ .*//' | sed 's/$$/$(SUFFIX)/'> $@


### PR DESCRIPTION
Before the alpine image can be multi-arched and signed, the
DOCKER_CONTENT_TRUST=1 doesn't work on AArch64 based image build.
Now since we've used 'push_manifest.sh' to sign the multi-arch
supported alpine base image, we need to always enable
DOCKER_CONTENT_TRUST for the 'docker build' and DOCKER_CONTENT_PULL
for the 'docker pull' from the Perspective of security.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Remove the workaround of 'content trust build' issue when build AArch64 docker image with `--arg`
**- How I did it**
Remove the NOTRUST and always exported both DOCKER_CONTENT_TRUST and DOCKER_CONTENT_TRUST as 1.
**- How to verify it**
Build the individual alpine image on both AArch64 and amd64 platform.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/32823197-1c67a7a0-ca17-11e7-9da2-97d8e812fbe7.jpg)
