### PR TITLE
Bump runc to 74a17296470088de3805e138d3d87c62e613dfc4

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -5,7 +5,7 @@ kernel:
 init:
   - linuxkit/vpnkit-expose-port:15c56c57ac9a7adeec20b34f36f2bc165c347679 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/blueprints/lcow.yml
+++ b/blueprints/lcow.yml
@@ -5,7 +5,7 @@ kernel:
   tar: none
 init:
   - linuxkit/init-lcow:f47a2a1f2e7d739eefd7e4f5fa8dc1b1da574876
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
 onboot:
   - name: dhcpcd

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
 services:
   - name: getty

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS1 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -5,7 +5,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
 onboot:
   - name: dhcpcd

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
 onboot:
   - name: dhcpcd

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
 onboot:
   - name: dhcpcd

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -11,7 +11,7 @@ RUN \
   make \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin
-ENV RUNC_COMMIT=0351df1c5a66838d0c392b4ac4cf9450de844e2d
+ENV RUNC_COMMIT=74a17296470088de3805e138d3d87c62e613dfc4
 RUN mkdir -p $GOPATH/src/github.com/opencontainers && \
   cd $GOPATH/src/github.com/opencontainers && \
   git clone https://github.com/opencontainers/runc.git

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
 services:
   - name: acpid

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:ff8fac1c318403aff3e2993dd9b130304e09f92e

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:ff8fac1c318403aff3e2993dd9b130304e09f92e

--- a/test/cases/020_kernel/005_config_4.13.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.13.x/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:ff8fac1c318403aff3e2993dd9b130304e09f92e

--- a/test/cases/020_kernel/010_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/common.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 trust:
   org:
     - linuxkit

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: test
     image: alpine:3.6

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:742781d22fe851e7a1c589fc8d1cf3bd4e264b22

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format
     image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: extend
     image: linuxkit/extend:8b6db5bf68330cc4e91c74532732a7e227ae12fd

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:2d153653d1111877a8f53704ef85063a44182ade

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:2d153653d1111877a8f53704ef85063a44182ade

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format
     image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: extend
     image: linuxkit/extend:8b6db5bf68330cc4e91c74532732a7e227ae12fd

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format
     image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format
     image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format
     image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:2d153653d1111877a8f53704ef85063a44182ade

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format
     image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format
     image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format
     image: linuxkit/format:10e75e78e1f134d310c62e9a0352df1c67b0dd81

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:a5dd896053b08abea3141628f7245f4d16a5fc1f

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
 onboot:
   - name: ltp

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -5,7 +5,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
 onboot:
   - name: dhcpcd

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>


### PR DESCRIPTION
As recommended by containerd v1.0.0-beta.3
    
Signed-off-by: Ian Campbell <ijc@docker.com>

Should have been in #2699 but I seem to be pathologically unable to remember to bump runc.