### PR TITLE
kernel: Fixing kernel_perf and kernel_zfs build issue

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -122,16 +122,16 @@ fetch: sources/linux-$(1).tar.xz
 # 'docker build' with the FROM image supplied as --build-arg
 # *and* with DOCKER_CONTENT_TRUST=1 currently does not work
 # (https://github.com/moby/moby/issues/34199). So, we pull the image
-# with DCT and then build with DOCKER_CONTENT_TRUST explicitly set to 0.
+# with DCT as part of the dependency on build_$(2)$(3) and then build 
+# with DOCKER_CONTENT_TRUST explicitly set to 0
 
 ifneq ($(2), 4.4.x)
 # perf does not build out of the box for 4.4.x and 4.4.x is not that relevant anymore to work on a fix
 build_perf_$(2)$(3): build_$(2)$(3)
 	docker pull $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG)$(SUFFIX) || \
-		(docker pull $(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) && \
 		 DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile.perf \
 			--build-arg IMAGE=$(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) \
-			--no-cache --network=none $(LABEL) -t $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG)$(SUFFIX) .)
+			--no-cache --network=none $(LABEL) -t $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG)$(SUFFIX) .
 
 push_perf_$(2)$(3): build_perf_$(2)$(3)
 	@if [ x"$(DIRTY)" != x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
@@ -151,10 +151,9 @@ ifneq ($(3), -dbg)
 # is incompatible with CDDL, apparently (this is ./configure check)
 build_zfs_$(2)$(3): build_$(2)$(3)
 	docker pull $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) || \
-		(docker pull $(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) && \
 		 DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile.zfs \
 			--build-arg IMAGE=$(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) \
-			--no-cache $(LABEL) -t $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) .)
+			--no-cache $(LABEL) -t $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) .
 
 push_zfs_$(2)$(3): build_zfs_$(2)$(3)
 	@if [ x"$(DIRTY)" != x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi


### PR DESCRIPTION
For 'build_perf_' and 'build_zfs_' targets in the Makefile,
since both of them are dependends on the build_$(2)$(3) target,
So, we pull the image with DCT as part of the dependency on build_$(2)$(3) and then build with DOCKER_CONTENT_TRUST explicitly set to 0

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix `build_perf_` and `build_zfs_` target build issue
**- How I did it**
Remove the reduplicated ones
**- How to verify it**
`make ORG=m1115 build_perf_4.13.x` to build a standalone one.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
