### PR TITLE
tests: Update runc

### DIFF
--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:ff8fac1c318403aff3e2993dd9b130304e09f92e

--- a/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
-  - linuxkit/runc:817fdc592eac6cb7804fa1721a43a7f6e23fb50f
+  - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 trust:
   org:
     - linuxkit


### PR DESCRIPTION
8c3140885cbe ("tests: Add 4.14 tests") and d88a1e591dfc
("Bump runc yml") overlapped so the runc version used in
the new files added by the first commit need updating.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

![nose-pick](https://user-images.githubusercontent.com/3338098/32834260-dab40492-c9f9-11e7-84b6-5cd6a11f6394.jpg)
