### PR TITLE
Only add in ttyS1 to kernel cmdline on Packet if not there already

### DIFF
--- a/src/cmd/linuxkit/run_packet.go
+++ b/src/cmd/linuxkit/run_packet.go
@@ -14,6 +14,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/packethost/packngo"
@@ -129,7 +130,12 @@ func runPacket(args []string) {
 	userData += "dhcp\n"
 	userData += fmt.Sprintf("set base-url %s\n", url)
 	if *machineFlag != "baremetal_2a" {
-		userData += fmt.Sprintf("set kernel-params ip=dhcp nomodeset ro serial console=ttyS1,115200 %s\n", cmdline)
+		var tty string
+		// x86_64 Packet machines have console on non standard ttyS1 which is not in most examples
+		if !strings.Contains(cmdline, "console=ttyS1") {
+			tty = "console=ttyS1,115200"
+		}
+		userData += fmt.Sprintf("set kernel-params ip=dhcp nomodeset ro serial %s %s\n", tty, cmdline)
 		userData += fmt.Sprintf("kernel ${base-url}/%s-kernel ${kernel-params}\n", name)
 		userData += fmt.Sprintf("initrd ${base-url}/%s-initrd.img\n", name)
 	} else {


### PR DESCRIPTION
This is not in most examples, but is in the Packet example, and
causes a duplicated console.

fix #2735

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![term_cat](https://user-images.githubusercontent.com/482364/32844855-3f02352e-ca1b-11e7-90c4-60db5c8fcaca.jpg)
