### PR TITLE
moby no longer uses efi in EFI ISO suffix

### DIFF
--- a/projects/kubernetes/boot.sh
+++ b/projects/kubernetes/boot.sh
@@ -20,7 +20,7 @@ set -e
 [ "$(uname -s)" = "Darwin" ] && KUBE_EFI=1
 
 suffix=".iso"
-[ -n "${KUBE_EFI}" ] && suffix="-efi.iso" && uefi="--uefi"
+[ -n "${KUBE_EFI}" ] && uefi="--uefi"
 
 if [ $# -eq 0 ] ; then
     img="kube-master"


### PR DESCRIPTION
This was changed a while back and the boot method is no longer
encoded in any of the output names.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![cat-iso](https://user-images.githubusercontent.com/482364/32846981-9f0b381c-ca20-11e7-87e0-80568e0ae030.jpg)
