### PR TITLE
wireguard: update to 0.0.20171111

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -37,11 +37,9 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20171101
-ENV WIREGUARD_SHA256=096b6482a65e566c7bf8c059f5ee6aadb2de565b04b6d810c685f1c377540325
+ENV WIREGUARD_VERSION=0.0.20171111
+ENV WIREGUARD_SHA256=d9347786a9406ac276d86321ca64aadb1f0639cb0582c6e0519c634cf6e81157
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
-# XXX REMOVE FOR NEXT RELEASE
-ENV WIREGUARD_PATCH=https://git.zx2c4.com/WireGuard/patch/?id=cc310a5dd1899417971e993d61d1230b14fe4f87
 
 # We copy the entire directory. This copies some unneeded files, but
 # allows us to check for the existence /patches-${KERNEL_SERIES} to
@@ -111,8 +109,6 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
 RUN curl -sSL -o /wireguard.tar.xz "${WIREGUARD_URL}" && \
     echo "${WIREGUARD_SHA256}  /wireguard.tar.xz" | sha256sum -c - && \
     tar -C / --one-top-level=wireguard --strip-components=2 -xJf /wireguard.tar.xz "WireGuard-${WIREGUARD_VERSION}/src" && \
-    curl -sSL -o /wireguard.patch "${WIREGUARD_PATCH}" && \
-    (cd /wireguard &&  patch -p 2 < /wireguard.patch) && \
     make -j "$(getconf _NPROCESSORS_ONLN)" M="/wireguard" modules
 
 # Modules and Device Tree binaries


### PR DESCRIPTION
Routine version bump that also removes the necessity of carrying that extra patch. Changes:

```
  * Kconfig: remove trailing whitespace
  * allowedips: rename from routingtable
  * tools: remove ioctl cruft
  * global: revert checkpatch.pl changes

  Cleanliness.

  * device: please lockdep
  * device: wait for all peers to be freed before destroying

  These make the various checkers happy.

  * netlink: plug memory leak
  * qemu: check for memory leaks

  There was a small memory leak on the netlink configuration layer that's now
  been fixed.

  * receive: hoist fpu outside of receive loop

  Should be a small speedup on x86_64.

  * qemu: more debugging
  * qemu: bump kernel version

  Significantly more debugging checkers have been turned on.

  * wg-quick: stat the correct enclosing folder of config file
  * wg-quick: allow for tabs in keys

  Minor fixups for wg-quick(8).

  * compat: 4.4.0 has strange ECN function

  Nobody actually runs base 4.4.0, but this is more correct anyway.

  * netlink: make sure we reserve space for NLMSG_DONE

  A rather important change - due to an upstream kernel bug, that's existed
  since the advent of netlink itself, sometimes wg(8) failed to receive valid
  data back from kernelspace, resulting in "ENOBUFS" when trying to dump all
  peers. This patch works around it while we wait for upstream to commit the
  fix.

  * curve25519: reject deriving from NULL private keys
  * tools: allow for NULL keys everywhere

  A null 25519 private point isn't a valid point (prior to normalization), which
  is why we use it as the "unsetting" value. Conversely, however, except for
  psk, we should be using the existence of it in the netlink message being an
  indication of whether or not it's set, for the tools.
```

![image](https://user-images.githubusercontent.com/10643/32848727-786e4c5a-ca2d-11e7-9675-823e5fe6cede.png)
