### PR TITLE
Update kernels to 4.13.13/4.9.62/4.4.98

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -1,6 +1,6 @@
 # This is a blueprint for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:15c56c57ac9a7adeec20b34f36f2bc165c347679 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -339,7 +339,7 @@ file:
 
 ```
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - <foo>/zfs-kmod:4.9.47

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS1 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -174,11 +174,11 @@ endef
 #
 $(eval $(call kernel,4.14,4.14.x,$(EXTRA)))
 $(eval $(call kernel,4.14,4.14.x,-dbg))
-$(eval $(call kernel,4.13.12,4.13.x,$(EXTRA)))
-$(eval $(call kernel,4.13.12,4.13.x,-dbg))
-$(eval $(call kernel,4.9.61,4.9.x,$(EXTRA)))
-$(eval $(call kernel,4.9.61,4.9.x,-dbg))
-$(eval $(call kernel,4.4.97,4.4.x,$(EXTRA)))
+$(eval $(call kernel,4.13.13,4.13.x,$(EXTRA)))
+$(eval $(call kernel,4.13.13,4.13.x,-dbg))
+$(eval $(call kernel,4.9.62,4.9.x,$(EXTRA)))
+$(eval $(call kernel,4.9.62,4.9.x,-dbg))
+$(eval $(call kernel,4.4.98,4.4.x,$(EXTRA)))
 
 # Target for kernel config
 kconfig: | sources

--- a/kernel/config-4.13.x-aarch64
+++ b/kernel/config-4.13.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.13.12 Kernel Configuration
+# Linux/arm64 4.13.13 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.13.x-x86_64
+++ b/kernel/config-4.13.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.13.12 Kernel Configuration
+# Linux/x86 4.13.13 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.4.x-aarch64
+++ b/kernel/config-4.4.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.4.97 Kernel Configuration
+# Linux/arm64 4.4.98 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.97 Kernel Configuration
+# Linux/x86 4.4.98 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-aarch64
+++ b/kernel/config-4.9.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.9.61 Kernel Configuration
+# Linux/arm64 4.9.62 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.61 Kernel Configuration
+# Linux/x86 4.9.62 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.13.x/0001-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
+++ b/kernel/patches-4.13.x/0001-vmbus-vmbus_open-reset-onchannel_callback-on-error.patch
@@ -1,4 +1,4 @@
-From b4a6da2360e629d4bf704f66f5a619d8de6523f7 Mon Sep 17 00:00:00 2001
+From d43464fb275afeba676d2402bd24305b2812c81d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:12 -0600
 Subject: [PATCH 01/12] vmbus: vmbus_open(): reset onchannel_callback on error

--- a/kernel/patches-4.13.x/0002-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.13.x/0002-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 18dba5dd454b7589683cd828ad351fcba9e35cce Mon Sep 17 00:00:00 2001
+From 608ca133adfc444f5824e455ee5b92590e4110ed Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:20 -0600
 Subject: [PATCH 02/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.13.x/0003-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
+++ b/kernel/patches-4.13.x/0003-hv_sock-implements-Hyper-V-transport-for-Virtual-Soc.patch
@@ -1,4 +1,4 @@
-From c07ab7568f12c3f9fa1dd65c5fd77f15b22de482 Mon Sep 17 00:00:00 2001
+From 49aec551372d5b95714c54a8ac6e8e478f1f719d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:26 -0600
 Subject: [PATCH 03/12] hv_sock: implements Hyper-V transport for Virtual

--- a/kernel/patches-4.13.x/0004-VMCI-only-try-to-load-on-VMware-hypervisor.patch
+++ b/kernel/patches-4.13.x/0004-VMCI-only-try-to-load-on-VMware-hypervisor.patch
@@ -1,4 +1,4 @@
-From 1ade1eda6ad1fd73f8a41f8c680d9797226e4455 Mon Sep 17 00:00:00 2001
+From 2ca5a13b8f72016d874876b884e1c2a8187927d4 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:29 -0600
 Subject: [PATCH 04/12] VMCI: only try to load on VMware hypervisor

--- a/kernel/patches-4.13.x/0005-hv_sock-add-the-support-of-auto-loading.patch
+++ b/kernel/patches-4.13.x/0005-hv_sock-add-the-support-of-auto-loading.patch
@@ -1,4 +1,4 @@
-From 7e65ab4c0560dc9ac97f4649f4d2a0314669136e Mon Sep 17 00:00:00 2001
+From c7695e20566be27138e55893d5a23b997f04e425 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 16:57:35 -0600
 Subject: [PATCH 05/12] hv_sock: add the support of auto-loading

--- a/kernel/patches-4.13.x/0006-tools-hv_sock-2-simple-test-cases.patch
+++ b/kernel/patches-4.13.x/0006-tools-hv_sock-2-simple-test-cases.patch
@@ -1,4 +1,4 @@
-From 8c2a03e9e65631bb45180220cdb7ce94b0fdfd37 Mon Sep 17 00:00:00 2001
+From 23b672dd198b20112e33577f99f9371923377fac Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 5 May 2017 18:52:02 -0600
 Subject: [PATCH 06/12] tools: hv_sock: 2 simple test cases.

--- a/kernel/patches-4.13.x/0007-hvsock-fix-a-race-in-hvs_stream_dequeue.patch
+++ b/kernel/patches-4.13.x/0007-hvsock-fix-a-race-in-hvs_stream_dequeue.patch
@@ -1,4 +1,4 @@
-From 4875b13b30ed47eef8b9e7b66ea1fbf68127f29f Mon Sep 17 00:00:00 2001
+From e8eb16e6cd31bb62f933b59c31dda745b29cd3e7 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Tue, 16 May 2017 22:14:03 +0800
 Subject: [PATCH 07/12] hvsock: fix a race in hvs_stream_dequeue()

--- a/kernel/patches-4.13.x/0008-hvsock-fix-vsock_dequeue-enqueue_accept-race.patch
+++ b/kernel/patches-4.13.x/0008-hvsock-fix-vsock_dequeue-enqueue_accept-race.patch
@@ -1,4 +1,4 @@
-From bfa61181922324ce85d524631910506aae7a2fd2 Mon Sep 17 00:00:00 2001
+From 5f039667d878b45eff799c432f0b5c7049b33981 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 19 May 2017 21:49:59 +0800
 Subject: [PATCH 08/12] hvsock: fix vsock_dequeue/enqueue_accept race

--- a/kernel/patches-4.13.x/0009-hv-sock-a-temporary-workaround-for-the-pending_send_.patch
+++ b/kernel/patches-4.13.x/0009-hv-sock-a-temporary-workaround-for-the-pending_send_.patch
@@ -1,4 +1,4 @@
-From 5f05b12bae6a416e4e4ebe87f172bc44fb0df5ef Mon Sep 17 00:00:00 2001
+From 7a0d26c3069406c6b862ffb48c9974cc147be766 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 21 Jun 2017 22:30:42 +0800
 Subject: [PATCH 09/12] hv-sock: a temporary workaround for the

--- a/kernel/patches-4.13.x/0010-hv-sock-avoid-double-FINs-if-shutdown-is-called.patch
+++ b/kernel/patches-4.13.x/0010-hv-sock-avoid-double-FINs-if-shutdown-is-called.patch
@@ -1,4 +1,4 @@
-From 6b28e5950ebe178c58990438cb98383b09141056 Mon Sep 17 00:00:00 2001
+From 57019e6ea3017c0ad0d78cbefa03994f3df93db1 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 7 Jul 2017 09:15:29 +0800
 Subject: [PATCH 10/12] hv-sock: avoid double FINs if shutdown() is called

--- a/kernel/patches-4.13.x/0011-ext4-fix-fault-handling-when-mounted-with-o-dax-ro.patch
+++ b/kernel/patches-4.13.x/0011-ext4-fix-fault-handling-when-mounted-with-o-dax-ro.patch
@@ -1,4 +1,4 @@
-From 4320b99f4c0800962e897a16b6e0ea3b10759fc8 Mon Sep 17 00:00:00 2001
+From 963aeff4efef364aceab72434c5b25cc13cbb5b4 Mon Sep 17 00:00:00 2001
 From: Randy Dodgen <dodgen@google.com>
 Date: Thu, 24 Aug 2017 15:26:01 -0400
 Subject: [PATCH 11/12] ext4: fix fault handling when mounted with -o dax,ro

--- a/kernel/patches-4.13.x/0012-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.13.x/0012-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 8d1b4f7093e712e4dbe7d82cc91830b3b87f1c8c Mon Sep 17 00:00:00 2001
+From 03ef1166593af9b9a9e36875ea2cab95076fe497 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 12/12] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 084a30381f25504242e3246a715de6715e3a59a0 Mon Sep 17 00:00:00 2001
+From 8bfd0bbc4cfde912748d3f808df5b4209104e0de Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 193b76e6dfc69beecc9209cda44a99c9e9edb220 Mon Sep 17 00:00:00 2001
+From d03af585a538dbf9ee9590e8642928c50da7cec9 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 9f90f32639fa7cfe814333990c4a3a6fc02da36b Mon Sep 17 00:00:00 2001
+From 17017600d2d9bbcfa7a0a03564e08be8b968c5a6 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 24770d86d978bc57c9733c6df3ac15a42d30140e Mon Sep 17 00:00:00 2001
+From e0a24f69fddb3a1400f2ad6c89641188008cc5ca Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 7eacfb650447fc1188489cc17bcf49c94b0dd8e4 Mon Sep 17 00:00:00 2001
+From 7193e0024dbfef76366a8c2a320b24388d0024ec Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From a51bb7594f604258b4dfe4685db744a2304b0805 Mon Sep 17 00:00:00 2001
+From 48569e58deb80292bc54df0f6b69ae5d00cbdb0c Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From a763c9f355a2bfb2c51f6f5f9da349ecbf56ecb5 Mon Sep 17 00:00:00 2001
+From fcbd72600dad702cfb38ac90697876fe3b659ce5 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From 14ca4fc3046c8f293e79991c89bd945b43292c6d Mon Sep 17 00:00:00 2001
+From d671eb3d9d0fa92f69e52866b8444866c9ed6ff6 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 4666ebbfa968d7203ce61f3729bdb717ee34b8bb Mon Sep 17 00:00:00 2001
+From 0a74d546a03ef026a234d65eacb3091a6928c9b1 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From ce9adfaf896b5154aac62dfcb3fdef2b715b92d3 Mon Sep 17 00:00:00 2001
+From b8c9e3b14cdb864c833081312202b6dd74d4167c Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From f459644d0b05e85c00ed9e9d924f45e9c3574c34 Mon Sep 17 00:00:00 2001
+From 3e99b1aae367a0978feff895ea1745c27e942fb5 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From eafa9793eae8131a4ed405dcfc686255b9318da5 Mon Sep 17 00:00:00 2001
+From 8e5978d4c9416531d7d3de14da3aacf711114702 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75

--- a/projects/kubernetes/kube.yml
+++ b/projects/kubernetes/kube.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75 # with runc, logwrite, startmemlogd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.97
+  image: linuxkit/kernel:4.4.98
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/020_kernel/005_config_4.13.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.13.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.13.12
+  image: linuxkit/kernel:4.13.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/020_kernel/010_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.61 AS ksrc
+FROM linuxkit/kernel:4.9.62 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build

--- a/test/cases/020_kernel/010_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.9.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.61
+docker pull linuxkit/kernel:4.9.62
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/010_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.97
+  image: linuxkit/kernel:4.4.98
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.13.12
+  image: linuxkit/kernel:4.13.13
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.9.61
+  image: linuxkit/kernel:4.9.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558


### PR DESCRIPTION
Straight forward, mechanical bump of kernel versions

x86_64 already build/pushed. arm64 still building

![pengus-headless](https://user-images.githubusercontent.com/3338098/32906530-0720127c-caf5-11e7-994a-af2b621425ad.jpg)
