### PR TITLE
Move CI build artifacts to top level

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,3 +53,4 @@ jobs:
           command: cd bin && sha256sum linuxkit-*-* > SHA256SUM
       - store_artifacts:
           path: ./bin
+          destination: .


### PR DESCRIPTION
Currently one has to click down through a sequence of nested directories in the web UI:
```
 ↓ Container 0
    ↓ go/
        ↓ src/
            ↓ github.com/
                ↓ linuxkit/
                    ↓ linuxkit/
                        ↓ bin/
                              «actual binaries»
```

Which is super tedious.

Signed-off-by: Ian Campbell <ijc@docker.com>
