### PR TITLE
Node exporter

### DIFF
--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -15,7 +15,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
   - name: node_exporter
-    image: linuxkit/node_exporter:a058fe1c6a4440a9689022a9fd7cffdcfd56d52c
+    image: linuxkit/node_exporter:1239aef345141a7e6a587a144f4b12aa54d0b1f1
 trust:
   org:
     - linuxkit

--- a/pkg/node_exporter/Dockerfile
+++ b/pkg/node_exporter/Dockerfile
@@ -1,7 +1,27 @@
-FROM prom/node-exporter:v0.15.1@sha256:88c602650e861bb8045ac83421edecbd056fc58708d47554a0d1a10f19ed7556
+FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 as build
+
+RUN apk add --no-cache go git musl-dev make
+
+ENV GOPATH=/go PATH=$PATH:/go/bin
+ENV GITREPO=github.com/prometheus/node_exporter
+ENV COMMIT=v0.15.1
+
+RUN go get -d ${GITREPO} \
+    && cd /go/src/${GITREPO} \
+    && git checkout ${COMMIT} \
+    && CGO_ENABLED=0 make build \
+    && mv node_exporter /bin/
+
+
+FROM scratch
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=build /bin/node_exporter /bin/node_exporter
 
 ENTRYPOINT ["/bin/node_exporter", "--path.procfs",  "/host/proc", \
             "--path.sysfs",  "/host/sys", \
             "--collector.filesystem.ignored-mount-points", \
             "^/(sys|proc|dev|host|etc)($|/)"]
 LABEL org.mobyproject.config='{"pid": "host", "binds": ["/proc:/host/proc", "/sys:/host/sys", "/:/rootfs"], "capabilities": ["all"]}'
+

--- a/pkg/node_exporter/build.yml
+++ b/pkg/node_exporter/build.yml
@@ -1,0 +1,2 @@
+image: node_exporter
+network: true

--- a/pkg/node_exporter/build.yml-skip
+++ b/pkg/node_exporter/build.yml-skip
@@ -1,3 +1,0 @@
-image: node_exporter
-# Can't pull with content trust. Skip for now
-# https://github.com/linuxkit/linuxkit/issues/2349


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Built node-exporter from sources. Static, minimal image. Used 0.15.0 since the 0.15.1 tag exists only on dockerhub.

This aims to fix https://github.com/linuxkit/linuxkit/issues/2349 but the current PR does not pass the test-pr target. Any idea why? It's not clear to me from the logs.

**- A picture of a cute animal (not mandatory but encouraged)**

![](http://zoonooz.sandiegozoo.org/wp-content/uploads/2015/10/22229287295_7f62718aaf_o-860x450.jpg)