### PR TITLE
Improve language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 **/vendor/** linguist-vendored
 kernel/config-* linguist-language=text
+kernel_config-* linguist-language=text


### PR DESCRIPTION
github is marking a lot of ekrnel config files as "logos" again.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![cute-kittens68](https://user-images.githubusercontent.com/482364/32953487-40ac649c-cba8-11e7-9a75-d7e11f630ba6.jpg)
