### PR TITLE
Fix some typos and no-break char in reports markd

### DIFF
--- a/reports/2017-07-02.md
+++ b/reports/2017-07-02.md
@@ -35,7 +35,7 @@ The Docker for Mac Blueprint continues to integrate customisations from the down
 - Bind `/etc/docker/daemon.json` in `examples/docker.yml` ([#2130] [@caminada] [@justincormack] [@MagnusS] [@riyazdf])
 - Split DfM blueprint in base and docker yml ([#2137]  [@justincormack] [@MagnusS])
 
-## Projects
+## Projects
 
 The MirageSDK project development continues, with support for a new file descriptor sharing daemon
 that allows linked containers to drop even more privileges while transmitting data securely

--- a/reports/2017-07-09.md
+++ b/reports/2017-07-09.md
@@ -2,7 +2,7 @@
 
 This report covers weekly developments in the [linuxkit], [linuxkit-ci], [rtf] and [virtsock] repositories.
 
-**Security SIG on Memorizer:** This week's security SIG featured [@ndauten] explaining his [ops+memorizer project](sig-security/2017-07-05.md) that provides infrastructure for fine-grained security policy enforcement in Linux. There are meeting notes and slides available ([#2153] [#2160] [@ndauten] [@riyazdf]), as well as work-in-progress PR to addd a memorizer project to LinuxKit ([#2171] [#2170] [@ndauten] [@justincormack]).	
+**Security SIG on Memorizer:** This week's security SIG featured [@ndauten] explaining his [ops+memorizer project](sig-security/2017-07-05.md) that provides infrastructure for fine-grained security policy enforcement in Linux. There are meeting notes and slides available ([#2153] [#2160] [@ndauten] [@riyazdf]), as well as work-in-progress PR to add a memorizer project to LinuxKit ([#2171] [#2170] [@ndauten] [@justincormack]).
 
 **Kernel:** The kernel images were updated to 4.11.9/4.9.36/4.4.76 from upstream ([#2167] [@rn]).
 
@@ -10,7 +10,7 @@ This report covers weekly developments in the [linuxkit], [linuxkit-ci], [rtf] a
 
 **ARM64:** `linuxkit run` no longer hardcodes x86_64 as the architecture, thus letting ARM64 run more easily ([#2162] [@arm64b]). Work is also ongoing to fix Golang ARM binaries running under emulation ([#1348] [@justincormack] [@rogaha] [@ncopa]) and multiarch manifest generation for base images used by LinuxKit ([#1377] [@arm64b] [@mor1] [@justincormack]).
 
-**Example and build cleanups:** The build now works from behind an HTTP proxy ([#2144] [@kunalkushwaha] [@justincormack] [@rn]) and cleaning build outputs now covers raw files as well ([#2176] [@justincormack]). The example yaml files are also simpler now by moving `ttyS0` after `tty0` as it is more common ([#2177] [@justincormack]), and we also consistently dont use quotes around image names ([#2178] [@justincormack])
+**Example and build cleanups:** The build now works from behind an HTTP proxy ([#2144] [@kunalkushwaha] [@justincormack] [@rn]) and cleaning build outputs now covers raw files as well ([#2176] [@justincormack]). The example yaml files are also simpler now by moving `ttyS0` after `tty0` as it is more common ([#2177] [@justincormack]), and we also consistently don't use quotes around image names ([#2178] [@justincormack])
 
 **Virtsock:** The virtsock library for HyperV integration had various improvements to build stress tests using it:
 - Pass `SOCK_CLOEXEC` to syscall.Socket ([virtsock#35] [@rn])


### PR DESCRIPTION
Signed-off-by: Damiano Donati <damiano.donati@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I've fixed some typos in the markdowns of the reports directory.

**- How I did it**
Trivial.

**- How to verify it**
Trivial.

**- Description for the changelog**
Fix some typos and no-break char in reports' markdowns.