### PR TITLE
Update cadvisor and add build test

### DIFF
--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.62
+  image: linuxkit/kernel:4.9.64
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558

--- a/test/cases/000_build/100_examples/080_cadvisor/test.sh
+++ b/test/cases/000_build/100_examples/080_cadvisor/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Test the cadvisor example
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+NAME=cadvisor
+
+clean_up() {
+	rm -f ${NAME}*
+}
+
+trap clean_up EXIT
+
+# Test code goes here
+linuxkit build "${LINUXKIT_EXAMPLES_DIR}/${NAME}.yml" 
+
+exit 0


### PR DESCRIPTION
`eamples/cadvisor` overlapped with a kernel update. This brings it up-to-date. Also add a build test for the example while at it
![owls](https://user-images.githubusercontent.com/3338098/33146690-22b5aa20-cfbd-11e7-8062-22da7354bd57.jpg)
