### PR TITLE
Makefile: Fix binaries generation issue when 'docker run' failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DELETE_ON_ERROR:
+
 .PHONY: default all
 default: bin/linuxkit bin/rtf
 all: default


### PR DESCRIPTION
Currently we will always create a temp tar file even the 'docker run'
failed for some reason,e.g, the docker daemon doesn't run. As a result,
we'll get the 2nd error even we've fixed 'docker run' failure.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix binaries generation failure
**- How I did it**
Add some interim target names to mitigate the `docker run` failure case. 
**- How to verify it**
1. `systemctl stop docker` (Actually I happened to build the binaries in case of docker daemon is not running and get the error information)
2. `make bin/rtf`
3. The `docker run` will fail in this case, but it generate a invalid temp file `tmp_rtf_bin.tar` (size = 0)
4. `systemctl start docker`
5. `make bin/rtf`, since the invalid `tmp_rtf_bin.tar` target is already there(invalid though), so the `make bin/rtf` will continue the following operations, result in below error message:
```
mkdir -p bin
tar xf tmp_rtf_bin.tar
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors
Makefile:26: recipe for target 'bin/rtf' failed
make: *** [bin/rtf] Error 2
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/33253613-33d505c4-d37f-11e7-9c32-b1c7a3125365.jpg)
