### PR TITLE
linuxkit pkg: Add `config` field to `build.yml`

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -13,7 +13,7 @@ onboot:
   - name: metadata
     image: linuxkit/metadata:026aca5c08c22589a7e319f79449bef2c65f04c5
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: sysfs
     image: linuxkit/sysfs:5367b46211882278b84a9e8048855ca5df65beda
   - name: binfmt

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -29,6 +29,7 @@ A package source consists of a directory containing at least two files:
 - `network` _(bool)_: Allow network access during the package build (default: no)
 - `disable-content-trust` _(bool)_: Disable Docker content trust for this package (default: no)
 - `disable-cache` _(bool)_: Disable build cache for this package (default: no)
+- `config`: _(struct `github.com/moby/tool/src/moby.ImageConfig`)_: Image configuration, marshalled to JSON and added as `org.mobyproject.config` label on image (default: no label)
 
 ## Building packages
 

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
 services:
   - name: rngd
     image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: sysfs
     image: linuxkit/sysfs:5367b46211882278b84a9e8048855ca5df65beda
   - name: format

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
     command: ["/sbin/rngd", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: rngd1
     image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
     command: ["/sbin/rngd", "-1"]

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
 services:
   - name: getty
     image: linuxkit/getty:6af22c32c98536a79230eef000e9abd06b037faa

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/pkg/sysctl/Dockerfile
+++ b/pkg/sysctl/Dockerfile
@@ -13,4 +13,3 @@ WORKDIR /
 COPY --from=mirror /go/bin/sysctl /usr/bin/sysctl
 COPY etc/ /etc/
 CMD ["/usr/bin/sysctl"]
-LABEL org.mobyproject.config='{"pid": "host", "readonly": true, "capabilities": ["CAP_SYS_ADMIN"]}'

--- a/pkg/sysctl/build.yml
+++ b/pkg/sysctl/build.yml
@@ -1,1 +1,6 @@
 image: sysctl
+config:
+  pid: "host"
+  readonly: true
+  capabilities:
+    - CAP_SYS_ADMIN

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
     binds:
      - /etc/sysctl.d/01-swarmd.conf:/etc/sysctl.d/01-swarmd.conf
   - name: dhcpcd

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -1,6 +1,7 @@
 package pkglib
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"runtime"
@@ -120,6 +121,15 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 
 		if !p.network {
 			args = append(args, "--network=none")
+		}
+
+		if p.config != nil {
+			b, err := json.Marshal(*p.config)
+			if err != nil {
+				return err
+			}
+
+			args = append(args, "--label=org.mobyproject.config="+string(b))
 		}
 
 		if err := d.build(p.Tag()+suffix, p.pkgPath, args...); err != nil {

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -8,17 +8,20 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/moby/tool/src/moby"
 )
 
 // Containers fields settable in the build.yml
 type pkgInfo struct {
-	Image               string   `yaml:"image"`
-	Org                 string   `yaml:"org"`
-	Arches              []string `yaml:"arches"`
-	GitRepo             string   `yaml:"gitrepo"` // ??
-	Network             bool     `yaml:"network"`
-	DisableContentTrust bool     `yaml:"disable-content-trust"`
-	DisableCache        bool     `yaml:"disable-cache"`
+	Image               string            `yaml:"image"`
+	Org                 string            `yaml:"org"`
+	Arches              []string          `yaml:"arches"`
+	GitRepo             string            `yaml:"gitrepo"` // ??
+	Network             bool              `yaml:"network"`
+	DisableContentTrust bool              `yaml:"disable-content-trust"`
+	DisableCache        bool              `yaml:"disable-cache"`
+	Config              *moby.ImageConfig `yaml:"config"`
 }
 
 // Pkg encapsulates information about a package's source
@@ -31,6 +34,7 @@ type Pkg struct {
 	network bool
 	trust   bool
 	cache   bool
+	config  *moby.ImageConfig
 
 	// Internal state
 	pkgPath    string
@@ -185,6 +189,7 @@ func NewFromCLI(fs *flag.FlagSet, args ...string) (Pkg, error) {
 		network:    pi.Network,
 		trust:      !pi.DisableContentTrust,
 		cache:      !pi.DisableCache,
+		config:     pi.Config,
 		dirty:      dirty,
 		pkgPath:    pkgPath,
 		git:        git,

--- a/src/cmd/linuxkit/vendor.conf
+++ b/src/cmd/linuxkit/vendor.conf
@@ -24,7 +24,7 @@ github.com/jmespath/go-jmespath bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 github.com/mitchellh/go-ps 4fdf99ab29366514c69ccccddab5dc58b8d84062
 github.com/moby/datakit 97b3d230535397a813323902c23751e176481a86
 github.com/moby/hyperkit a12cd7250bcd8d689078e3e42ae4a7cf6a0cbaf3
-github.com/moby/tool 63a5dedd28a459900eba56dd191edaeb688cfdf4
+github.com/moby/tool 656bd87fd26b4cfc7da735939ce78cc7cb541181
 github.com/moby/vpnkit 0e4293bb1058598c4b0a406ed171f52573ef414c
 github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
 github.com/opencontainers/image-spec v1.0.0

--- a/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/config.go
+++ b/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/config.go
@@ -62,8 +62,14 @@ type File struct {
 
 // Image is the type of an image config
 type Image struct {
-	Name              string                  `yaml:"name" json:"name"`
-	Image             string                  `yaml:"image" json:"image"`
+	Name        string `yaml:"name" json:"name"`
+	Image       string `yaml:"image" json:"image"`
+	ImageConfig `yaml:",inline"`
+}
+
+// ImageConfig is the configuration part of Image, it is the subset
+// which is valid in a "org.mobyproject.config" label on an image.
+type ImageConfig struct {
 	Capabilities      *[]string               `yaml:"capabilities" json:"capabilities,omitempty"`
 	Ambient           *[]string               `yaml:"ambient" json:"ambient,omitempty"`
 	Mounts            *[]specs.Mount          `yaml:"mounts" json:"mounts,omitempty"`

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: sysfs
     image: linuxkit/sysfs:5367b46211882278b84a9e8048855ca5df65beda
   - name: format

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: format
     image: linuxkit/format:6b46d0450082f397177da36be6b4d74d93eacd1e
   - name: mount

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
   - name: test
     image: alpine:3.6
     net: host


### PR DESCRIPTION
~~**DO NOT MERGE:** Depends on https://github.com/moby/tool/pull/189. I will push `pkg/sysctl` image and crank yaml once that is merged and pulled in here.~~ https://github.com/moby/tool/pull/189 merged and folded in here.

This is a `moby.ImageConfig` struct which is marshalled into JSON and added as
the `org.mobyproject.config` label on the built image.

Convert `pkg/sysctl` as PoC.

Signed-off-by: Ian Campbell <ijc@docker.com>
