### PR TITLE
Add support for newer AWS networking types

### DIFF
--- a/src/cmd/linuxkit/push_aws.go
+++ b/src/cmd/linuxkit/push_aws.go
@@ -30,6 +30,8 @@ func pushAWS(args []string) {
 	timeoutFlag := flags.Int("timeout", 0, "Upload timeout in seconds")
 	bucketFlag := flags.String("bucket", "", "S3 Bucket to upload to. *Required*")
 	nameFlag := flags.String("img-name", "", "Overrides the name used to identify the file in Amazon S3 and the VM image. Defaults to the base of 'path' with the file extension removed.")
+	enaFlag := flags.Bool("ena", false, "Enable ENA networking")
+	sriovNetFlag := flags.String("sriov", "", "SRIOV network support, set to 'simple' to enable 82599 VF networking")
 
 	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
@@ -158,6 +160,8 @@ func pushAWS(args []string) {
 		Description:        aws.String(fmt.Sprintf("LinuxKit: %s image", name)),
 		RootDeviceName:     aws.String("/dev/sda1"),
 		VirtualizationType: aws.String("hvm"),
+		EnaSupport:         enaFlag,
+		SriovNetSupport:    sriovNetFlag,
 	}
 	log.Debugf("RegisterImage:\n%v", regParams)
 	regResp, err := compute.RegisterImage(regParams)


### PR DESCRIPTION
- ENA networking is what the very new (and bare metal) machines have
- sriov "simple" mode is Intel VF passthrough

I reflect the underlying APIs, which is bool for ENA and a string
for sriov even though there is currently only one valid sriov option...

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![hyenas](https://user-images.githubusercontent.com/482364/33380929-81d565f2-d514-11e7-8215-04229d7dca2e.jpg)
