### PR TITLE
hyperkit: split network option into 3

### DIFF
--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -219,7 +219,7 @@ func runHyperKit(args []string) {
 		dflt := hyperkitNetworkingDefault
 		networking = &dflt
 	}
-	netMode := strings.SplitN(*networking, ",", 2)
+	netMode := strings.SplitN(*networking, ",", 3)
 	switch netMode[0] {
 	case hyperkitNetworkingDockerForMac:
 		h.VPNKitSock = filepath.Join(os.Getenv("HOME"), "Library/Containers/com.docker.docker/Data/s50")


### PR DESCRIPTION
vpnkit mode has one or two arguments (eth socket and port control socket).

If splitting into only 2 then
    vpnkit,vpnkit-state/eth.sock,vpnkit-state/port.sock
becomes
    2: vpnkit
    1: vpnkit-state/eth.sock,vpnkit-state/port.sock
rather than
    0: vpnkit
    1: vpnkit-state/eth.sock
    2: vpnkit-state/port.sock
as desired.

Signed-off-by: Ian Campbell <ijc@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
