### PR TITLE
ci: remove gcp-hack and ltp make targets

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,7 @@
 default: check-deps test 
 pr: check-deps test-pr
 # TODO: should have a separate target
-all: check-deps test-pr ltp
+all: check-deps test-pr
 
 LINUXKIT:=$(shell command -v linuxkit 2> /dev/null)
 RTF:=$(shell command -v rtf 2> /dev/null)
@@ -17,33 +17,8 @@ ifndef RTF
 	$(error "rtf is not available. please install it!")
 endif
 
-
-# TODO: Remove this section once we no longer depend on this in CI
-### -------
-# Currently the linuxkit-ci runs GCP tests outside of rtf and expects some
-# files in ../artifacts. This hacky target puts them there until
-# the CI can use rtf for running GCP tests
-gcp-hack: ../artifacts/test.img.tar.gz
-../artifacts/test.img.tar.gz:
-	rm -rf ../artifacts
-	mkdir -p ../artifacts
-	$(LINUXKIT) build -format gcp -pull -name ../artifacts/test hack/test.yml
-
-define check_test_log
-	@cat $1 |grep -q 'test suite PASSED'
-endef
-
-.PHONY: ltp
-ltp: export CLOUDSDK_IMAGE_NAME?=test-ltp
-ltp: $(LINUXKIT) test-ltp.img.tar.gz
-	$(LINUXKIT) build -format gcp -pull hack/test-ltp.yml
-	$(LINUXKIT) push gcp test-ltp.img.tar.gz
-	$(LINUXKIT) run gcp -skip-cleanup -machine n1-highcpu-4 $(CLOUDSDK_IMAGE_NAME) | tee test-ltp.log
-	$(call check_test_log, test-ltp.log)
-### ------
-
-test: gcp-hack
+test:
 	@rtf -l build -x run
 
-test-pr: gcp-hack
+test-pr:
 	@rtf -l build -x run


### PR DESCRIPTION
These GCP-related targets are causing linuxkit.datakit.ci runs to fail,
and might not be needed.

Signed-off-by: Robb Kistler <robb.kistler@docker.com>

**- How to verify it**
Tests on merge to master do not fail in `make test` with:
```
 make[1]: *** No rule to make target 'test-ltp.img.tar.gz', needed by 'ltp'.  Stop.
```