### PR TITLE
Added initial Vagrant support.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,8 +5,6 @@
 Vagrant.configure("2") do |config|
 	config.vm.box = "bento/ubuntu-16.04"
 
-	config.vm.synced_folder ".", "/vagrant", disabled: true
-
 	config.vm.provision "shell", inline: <<-SHELL
 		# apt-get update
 		# DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
@@ -17,7 +15,11 @@ Vagrant.configure("2") do |config|
 	config.vm.provision "docker"
 
 	config.vm.provision "shell", privileged: false, inline: <<-SHELL
-		go get -u github.com/linuxkit/linuxkit/src/cmd/linuxkit
+		mkdir -p ~/go/src/github.com/linuxkit/
+		ln -s /vagrant ~/go/src/github.com/linuxkit/linuxkit
+		cd ~/go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit
+		go get -d
+		go install
 		echo "export PATH=${PATH}:${HOME}/go/bin" >> ~/.bashrc
 	SHELL
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,10 +8,10 @@ Vagrant.configure("2") do |config|
 	config.vm.synced_folder ".", "/vagrant", disabled: true
 
 	config.vm.provision "shell", inline: <<-SHELL
-		apt-get update
-		DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+		# apt-get update
+		# DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 		snap install --classic go
-		apt-get clean
+		# apt-get clean
 	SHELL
 
 	config.vm.provision "docker"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,10 +6,7 @@ Vagrant.configure("2") do |config|
 	config.vm.box = "bento/ubuntu-16.04"
 
 	config.vm.provision "shell", inline: <<-SHELL
-		# apt-get update
-		# DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 		snap install --classic go
-		# apt-get clean
 	SHELL
 
 	config.vm.provision "docker"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+# Author: David Manouchehri
+
+Vagrant.configure("2") do |config|
+	config.vm.box = "bento/ubuntu-16.04"
+
+	config.vm.synced_folder ".", "/vagrant", disabled: true
+
+	config.vm.provision "shell", inline: <<-SHELL
+		apt-get update
+		DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+		snap install --classic go
+		apt-get clean
+	SHELL
+
+	config.vm.provision "docker"
+
+	config.vm.provision "shell", privileged: false, inline: <<-SHELL
+		go get -u github.com/linuxkit/linuxkit/src/cmd/linuxkit
+		echo "export PATH=${PATH}:/home/`whoami`/go/bin" >> ~/.bashrc
+	SHELL
+
+	%w(vmware_fusion vmware_workstation vmware_appcatalyst).each do |provider|
+		config.vm.provider provider do |v|
+			v.vmx["vhv.enable"] = "TRUE"
+			v.vmx['ethernet0.virtualDev'] = 'vmxnet3'
+		end
+	end
+
+	config.vm.provider "virtualbox"
+	config.vm.provider "hyperv"
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
 
 	config.vm.provision "shell", privileged: false, inline: <<-SHELL
 		go get -u github.com/linuxkit/linuxkit/src/cmd/linuxkit
-		echo "export PATH=${PATH}:/home/`whoami`/go/bin" >> ~/.bashrc
+		echo "export PATH=${PATH}:${HOME}/go/bin" >> ~/.bashrc
 	SHELL
 
 	%w(vmware_fusion vmware_workstation vmware_appcatalyst).each do |provider|

--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -5,6 +5,9 @@
 Vagrant.configure("2") do |config|
 	config.vm.box = "bento/ubuntu-16.04"
 
+	config.vm.synced_folder ".", "/vagrant", disabled: true
+	config.vm.synced_folder "../", "/vagrant"
+
 	config.vm.provision "shell", inline: <<-SHELL
 		snap install --classic go
 	SHELL

--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -13,14 +13,14 @@ Vagrant.configure("2") do |config|
 	SHELL
 
 	config.vm.provision "docker"
+	config.vm.provision "shell", inline: "ps aux | grep 'sshd:' | awk '{print $2}' | xargs kill"
 
 	config.vm.provision "shell", privileged: false, inline: <<-SHELL
 		mkdir -p ~/go/src/github.com/linuxkit/
 		ln -s /vagrant ~/go/src/github.com/linuxkit/linuxkit
-		cd ~/go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit
-		go get -d
-		go install
-		echo "export PATH=${PATH}:${HOME}/go/bin" >> ~/.bashrc
+		cd ~/go/src/github.com/linuxkit/linuxkit
+		make all
+		sudo make install
 	SHELL
 
 	%w(vmware_fusion vmware_workstation vmware_appcatalyst).each do |provider|

--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -1,6 +1,5 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
-# Author: David Manouchehri
 
 Vagrant.configure("2") do |config|
 	config.vm.box = "bento/ubuntu-16.04"


### PR DESCRIPTION
**- What I did**

Added Vagrant support (VMware Fusion, VMware Workstation, VirtualBox, and Hyper-V).

**- How I did it**

Added a `Vagrantfile`.

**- How to verify it**

```bash
mbp:~ dave$ git clone -b vagrant https://github.com/Manouchehri/linuxkit
mbp:~ dave$ cd linuxkit/
mbp:linuxkit dave$ vagrant up # Wait for a few minutes and a couple hundred lines of output. 
mbp:linuxkit dave$ vagrant ssh 
vagrant@vagrant:~$ linuxkit build ./go/src/github.com/linuxkit/linuxkit/examples/minimal.yml
Extract kernel image: linuxkit/kernel:4.9.65
....
Create outputs:
  minimal-kernel minimal-initrd.img minimal-cmdline
vagrant@vagrant:~$ ls -l minimal*
-rw-r--r-- 1 vagrant vagrant       42 Nov 30 02:43 minimal-cmdline
-rw-r--r-- 1 vagrant vagrant 41308847 Nov 30 02:43 minimal-initrd.img
-rw-r--r-- 1 vagrant vagrant  6570576 Nov 30 02:43 minimal-kernel
```

**- Description for the changelog**

Added Vagrant support.

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://cdn.pixabay.com/photo/2016/11/02/11/06/moose-1791108_960_720.jpg)