### PR TITLE
pkg: rngd service support on AArch64

### DIFF
--- a/pkg/rngd/cmd/rngd/rng_linux_amd64.go
+++ b/pkg/rngd/cmd/rngd/rng_linux_amd64.go
@@ -44,13 +44,17 @@ var disableRdseed = flag.Bool("disable-rdseed", false, "Disable use of RDSEED")
 
 var hasRdrand, hasRdseed bool
 
-func initRand() bool {
+func initDRNG(ctx *rng) bool {
 	hasRdrand = C.hasrdrand() == 1 && !*disableRdrand
 	hasRdseed = C.hasrdseed() == 1 && !*disableRdseed
-	return hasRdrand || hasRdseed
+	b := hasRdrand || hasRdseed
+	if b == false {
+		ctx.disabled = true
+	}
+	return b
 }
 
-func rand() (uint64, error) {
+func readDRNG(_ *rng) (uint64, error) {
 	var x C.uint64_t
 	// prefer rdseed as that is correct seed
 	if hasRdseed && C.rdseed(&x) == 1 && !*disableRdseed {

--- a/pkg/rngd/cmd/rngd/rng_linux_arm64.go
+++ b/pkg/rngd/cmd/rngd/rng_linux_arm64.go
@@ -10,12 +10,12 @@ import (
 	"errors"
 )
 
-// No standard RNG on arm64
-
-func initRand() bool {
+// No standard RNG instruction on arm64
+func initDRNG(ctx *rng) bool {
+	ctx.disabled = true
 	return false
 }
 
-func rand() (uint64, error) {
+func readDRNG(_ *rng) (uint64, error) {
 	return 0, errors.New("No randomness available")
 }


### PR DESCRIPTION
Enable the rngd service in case of a real hardware RNG
device is available on AArch64 platform

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Enable the `rngd` service on AArch64 in case of a hardware RNG device available
**- How I did it**
Check the `/dev/hwrng` and use it as the entropy source to feed the `/dev/random` if `/dev/hwrng` is the real character device of a RNG hardware.
**- How to verify it**
1. `linuxkit pkg build -org m1130 rngd/`
2.  `docker run --privileged --rm --device /dev/hwrng m1130/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9-dirty`
3. On an AArch64 platform which has a real RNG device such as Cavium ThunderX, we can see the `/sbin/rngd` is running inside the docker.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/33416678-d033975e-d5d8-11e7-9c82-48a80afded73.jpg)
