### PR TITLE
Bump to containerd-v1.0.0-rc.0

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:15c56c57ac9a7adeec20b34f36f2bc165c347679 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   # support metadata for optional config in /var/config

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
 services:
   - name: getty
     image: linuxkit/getty:6af22c32c98536a79230eef000e9abd06b037faa

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS1 console=ttyAMA0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: rngd1

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:7d79062909882186e881aad263668d66e6df2a28 as alpine
+FROM linuxkit/alpine:a99d4f10971f30b20688b4a4c40763150b9e4355 as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:7d79062909882186e881aad263668d66e6df2a28 AS build
+FROM linuxkit/alpine:a99d4f10971f30b20688b4a4c40763150b9e4355 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -16,7 +16,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS mirror
+FROM linuxkit/alpine:a99d4f10971f30b20688b4a4c40763150b9e4355 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
 services:
   - name: acpid
     image: linuxkit/acpid:168f871c7211c9d5e96002d53cb497b26e2d622b

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.102
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/005_config_4.13.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.13.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.13.16
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.2
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.102
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check

--- a/test/cases/020_kernel/015_kmod_4.13.x/test.yml
+++ b/test/cases/020_kernel/015_kmod_4.13.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.13.16
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.2
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.102
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 trust:
   org:

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 trust:
   org:

--- a/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/005_kernel-4.13.x/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.13.16
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 trust:
   org:

--- a/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.2
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:41685ecc8039643948e5dff46e17584753469a7a
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:a2384bb503c16b791986710a2636c4640bfdb31e
+    image: linuxkit/test-containerd:22e315c1b787c6e3b55a8ef9184b571bad897925
   - name: poweroff
     image: linuxkit/poweroff:280bd01daa8776fbe1f4d912977f1886b8374834
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: dhcpcd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.65
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:737e4b004e28510d2dd504942b80fa5ffa409315
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:48831507404049660b960e4055f544917d90378e

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:7d79062909882186e881aad263668d66e6df2a28 AS mirror
+FROM linuxkit/alpine:a99d4f10971f30b20688b4a4c40763150b9e4355 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:7357177a8be310e40fef7424305a72c198e857c4
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
 onboot:
   - name: test-ns

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -46,7 +46,7 @@ RUN go get -u github.com/LK4D4/vndr
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.0.0-beta.3
+ENV CONTAINERD_COMMIT=v1.0.0-rc.0
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \
@@ -54,7 +54,7 @@ RUN mkdir -p $GOPATH/src/github.com/containerd && \
   git checkout $CONTAINERD_COMMIT
 RUN apk add --no-cache btrfs-progs-dev gcc libc-dev linux-headers make
 RUN cd $GOPATH/src/github.com/containerd/containerd && \
-  make binaries EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS="-extldflags \\\"-fno-PIC -static\\\""
+  make binaries EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"' BUILD_TAGS="static_build"
 
 FROM alpine:3.6
 

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:4e4f7a9be7a10f1378542c6cb739c43806f02fde-arm64
+# linuxkit/alpine:31ac51dd8ec0510a1cf585b425782569f67bfa1a-arm64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -23,7 +23,7 @@ btrfs-progs-4.10.2-r0
 btrfs-progs-dev-4.10.2-r0
 btrfs-progs-libs-4.10.2-r0
 build-base-0.5-r0
-busybox-1.26.2-r7
+busybox-1.26.2-r9
 busybox-initscripts-3.1-r1
 bzip2-1.0.6-r5
 ca-certificates-20161130-r2
@@ -259,7 +259,7 @@ util-linux-dev-2.28.2-r2
 vde2-libs-2.3.2-r7
 vim-8.0.0595-r0
 wayland-1.13.0-r0
-wireguard-tools-0.0.20171111-r0
+wireguard-tools-0.0.20171127-r0
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r4
 xfsprogs-4.5.0-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:585174df463ba33e6c0e2050a29a0d9e942d56cb-amd64
+# linuxkit/alpine:a99d4f10971f30b20688b4a4c40763150b9e4355-amd64
 # automatically generated list of installed packages
 abuild-3.0.0_rc2-r8
 alpine-baselayout-3.0.4-r0
@@ -23,7 +23,7 @@ btrfs-progs-4.10.2-r0
 btrfs-progs-dev-4.10.2-r0
 btrfs-progs-libs-4.10.2-r0
 build-base-0.5-r0
-busybox-1.26.2-r7
+busybox-1.26.2-r9
 busybox-initscripts-3.1-r1
 bzip2-1.0.6-r5
 ca-certificates-20161130-r2
@@ -267,7 +267,7 @@ util-linux-dev-2.28.2-r2
 vde2-libs-2.3.2-r7
 vim-8.0.0595-r0
 wayland-1.13.0-r0
-wireguard-tools-0.0.20171111-r0
+wireguard-tools-0.0.20171127-r0
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r4
 xfsprogs-4.5.0-r0


### PR DESCRIPTION
Release notes:    
    https://github.com/containerd/containerd/releases/tag/v1.0.0-rc.0
    
Some minor fiddling in [`pkg/init/cmd/service/start.go`](https://github.com/linuxkit/linuxkit/compare/master...ijc:containerd-v1.0.0-rc.0?expand=1#diff-ff45df16bbcd1fbb7b9b7370398c6b50) due to some renaming/movement in containerd, but otherwise mechanical.