### PR TITLE
Include tool version info in package/image labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ bin/linuxkit: tmp_linuxkit_bin.tar
 	touch $@
 
 tmp_linuxkit_bin.tar: $(LINUXKIT_DEPS)
-	tar cf - -C src/cmd/linuxkit . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/linuxkit/linuxkit/src/cmd/linuxkit --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o bin/linuxkit > $@
+	tar cf - -C src/cmd/linuxkit . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/linuxkit/linuxkit/src/cmd/linuxkit --ldflags "-X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.GitCommit=$(GIT_COMMIT) -X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.Version=$(VERSION)" -o bin/linuxkit > $@
 
 .PHONY: test-cross
 test-cross:
@@ -67,7 +67,7 @@ LOCAL_BUILDMODE?=pie
 endif
 LOCAL_BUILDMODE?=default
 
-LOCAL_LDFLAGS += -s -w -extldflags \"-static\" -X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)
+LOCAL_LDFLAGS += -s -w -extldflags \"-static\" -X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.GitCommit=$(GIT_COMMIT) -X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.Version=$(VERSION)
 LOCAL_TARGET ?= bin/linuxkit
 
 .PHONY: local-check local-build local-test local

--- a/src/cmd/linuxkit/main.go
+++ b/src/cmd/linuxkit/main.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/version"
+
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
@@ -27,12 +29,6 @@ type PkgConfig struct {
 var (
 	defaultLogFormatter = &log.TextFormatter{}
 
-	// Version is the human-readable version
-	Version = "unknown"
-
-	// GitCommit hash, set at compile time
-	GitCommit = "unknown"
-
 	// Config is the global tool configuration
 	Config = GlobalConfig{}
 )
@@ -49,9 +45,9 @@ func (f *infoFormatter) Format(entry *log.Entry) ([]byte, error) {
 	return defaultLogFormatter.Format(entry)
 }
 
-func version() {
-	fmt.Printf("%s version %s\n", filepath.Base(os.Args[0]), Version)
-	fmt.Printf("commit: %s\n", GitCommit)
+func printVersion() {
+	fmt.Printf("%s version %s\n", filepath.Base(os.Args[0]), version.Version)
+	fmt.Printf("commit: %s\n", version.GitCommit)
 	os.Exit(0)
 }
 
@@ -129,7 +125,7 @@ func main() {
 	case "run":
 		run(args[1:])
 	case "version":
-		version()
+		printVersion()
 	case "help":
 		flag.Usage()
 	default:

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+
+	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/version"
 )
 
 type buildOpts struct {
@@ -131,6 +133,9 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 
 			args = append(args, "--label=org.mobyproject.config="+string(b))
 		}
+
+		args = append(args, "--label=org.mobyproject.linuxkit.version="+version.Version)
+		args = append(args, "--label=org.mobyproject.linuxkit.revision="+version.GitCommit)
 
 		if err := d.build(p.Tag()+suffix, p.pkgPath, args...); err != nil {
 			return err

--- a/src/cmd/linuxkit/version/version.go
+++ b/src/cmd/linuxkit/version/version.go
@@ -1,0 +1,9 @@
+package version
+
+var (
+	// Version is the human-readable version
+	Version = "unknown"
+
+	// GitCommit hash, set at compile time
+	GitCommit = "unknown"
+)


### PR DESCRIPTION
Since the tool can have some impact on the resulting image it seems like a good idea to track these so add `org.mobyproject.linuxkit.version` with the version and `org.mobyproject.linuxkit.revision` with the git commit.

Not sure if I should guard with `!= "unknown"` in both cases, I didn't but maybe it makes sense.