### PR TITLE
remove subreaper config item

### DIFF
--- a/pkg/containerd/etc/containerd/config.toml
+++ b/pkg/containerd/etc/containerd/config.toml
@@ -2,7 +2,6 @@ state = "/run/containerd"
 root = "/var/lib/containerd"
 snapshotter = "io.containerd.snapshotter.v1.overlayfs"
 differ = "io.containerd.differ.v1.base-diff"
-subreaper = false
 
 [grpc]
   address = "/run/containerd/containerd.sock"


### PR DESCRIPTION
containerd v1.0.0-rc.0 changed the subreaper config entry to the
negative given subreaper "on" is the default. However, linuxkit
does not need to change the default subreaper setting so removing
the now invalid config line.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

Ref: containerd/containerd#1822
It looks like this missed the release notes :(