### PR TITLE
Disk driver and format are now passed along to the hyperkit go library

### DIFF
--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -204,7 +204,12 @@ func runHyperKit(args []string) {
 		if d.Path == "" {
 			log.Fatalf("disk specified with no size or name")
 		}
-		hd := hyperkit.DiskConfig{Path: d.Path, Size: d.Size}
+		hd := hyperkit.DiskConfig{
+			Path:   d.Path,
+			Size:   d.Size,
+			Driver: d.Driver,
+			Format: d.Format,
+		}
 		h.Disks = append(h.Disks, hd)
 	}
 


### PR DESCRIPTION
**- What I did**

Disk driver and format are now passed along to the hyperkit go library. The use case is to provide existing qcow2 disks

Also tweak the disk flag parsing to allow the use of qcow_config within
the format option

**- How I did it**

Wrote some go - hands free

**- How to verify it**

You'll need this PR - https://github.com/moby/hyperkit/pull/168

Using the linuxkit swap.yml example on a Mac
`linuxkit run -disk "file=file://$PWD/disk.qcow2,format=qcow,qcow-config=..." swap`

See the qcow2 disk using `lsblk`

**- Description for the changelog**
Hyperkit backend allows you to specific the disk driver & format

**- A picture of a cute animal (not mandatory but encouraged)**
![cute animal](https://i.amz.mshcdn.com/3h4tC8Nw1eMbrHNvdnnb1-gjGXo=/fit-in/1200x9600/http%3A%2F%2Fi.imgur.com%2FCgly4.jpg)