### PR TITLE
Add dependent images to build.yml

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -30,6 +30,10 @@ A package source consists of a directory containing at least two files:
 - `disable-content-trust` _(bool)_: Disable Docker content trust for this package (default: no)
 - `disable-cache` _(bool)_: Disable build cache for this package (default: no)
 - `config`: _(struct `github.com/moby/tool/src/moby.ImageConfig`)_: Image configuration, marshalled to JSON and added as `org.mobyproject.config` label on image (default: no label)
+- `depends`: Contains information on prerequisites which must be satisfied in order to build the package. Has subfields:
+    - `docker-images`: Docker images to be made available (as `tar` files via `docker image save`) within the package build context. Contains the following nested fields:
+        - `from-file` and `list`: _(string and string list respectively)_. Mutually exclusive fields specifying the list of images to include. Each image must include a valid digest (`sha256:...`) in order to maintain determinism. If `from-file` is used then it is a path relative to (and within) the package directory with one image per line (lines with `#` in column 0 and blank lines are ignore). If `list` is used then each entry is an image.
+        - `target` and `target-dir`: _(string)_ Mutually exclusive fields specifying the target location, if `target` is used then it is a path relative to (and within) the package dir which names a `tar` file into which all of the listed images will be saved. If `target-dir` then it is a path relative to (and within) the package directory which names a directory into which each image will be saved (as `«image name»@«digest».tar`). **NB**: The path referenced by `target-dir` will be _removed_ prior to populating (to avoid issues with stale files).
 
 ## Building packages
 

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -137,7 +137,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 		args = append(args, "--label=org.mobyproject.linuxkit.version="+version.Version)
 		args = append(args, "--label=org.mobyproject.linuxkit.revision="+version.GitCommit)
 
-		if err := d.build(p.Tag()+suffix, p.pkgPath, args...); err != nil {
+		if err := d.build(p.Tag()+suffix, p.path, args...); err != nil {
 			return err
 		}
 

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -110,6 +110,10 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	if !bo.skipBuild {
 		var args []string
 
+		if err := p.dockerDepends.Do(d); err != nil {
+			return err
+		}
+
 		if p.git != nil && p.gitRepo != "" {
 			args = append(args, "--label", "org.opencontainers.image.source="+p.gitRepo)
 		}

--- a/src/cmd/linuxkit/pkglib/depends.go
+++ b/src/cmd/linuxkit/pkglib/depends.go
@@ -1,0 +1,133 @@
+package pkglib
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/containerd/reference"
+)
+
+type dockerDepends struct {
+	images []reference.Spec
+	path   string
+	dir    bool
+}
+
+func newDockerDepends(pkgPath string, pi *pkgInfo) (dockerDepends, error) {
+	var err error
+
+	if (pi.Depends.DockerImages.TargetDir != "") && (pi.Depends.DockerImages.Target != "") {
+		return dockerDepends{}, fmt.Errorf("\"depends.images.target\" and \"depends.images.target-dir\" are mutually exclusive")
+	}
+	if (pi.Depends.DockerImages.FromFile != "") && (len(pi.Depends.DockerImages.List) > 0) {
+		return dockerDepends{}, fmt.Errorf("\"depends.images.list\" and \"depends.images.from-file\" are mutually exclusive")
+	}
+
+	if pi.Depends.DockerImages.Target, err = makeAbsSubpath("depends.image.target", pkgPath, pi.Depends.DockerImages.Target); err != nil {
+		return dockerDepends{}, err
+	}
+	if pi.Depends.DockerImages.TargetDir, err = makeAbsSubpath("depends.image.target-dir", pkgPath, pi.Depends.DockerImages.TargetDir); err != nil {
+		return dockerDepends{}, err
+	}
+	if pi.Depends.DockerImages.FromFile != "" {
+		p, err := makeAbsSubpath("depends.image.from-file", pkgPath, pi.Depends.DockerImages.FromFile)
+		if err != nil {
+			return dockerDepends{}, err
+		}
+		f, err := os.Open(p)
+		if err != nil {
+			return dockerDepends{}, err
+		}
+		defer f.Close()
+
+		s := bufio.NewScanner(f)
+		for s.Scan() {
+			t := s.Text()
+			if len(t) > 0 && t[0] != '#' {
+				pi.Depends.DockerImages.List = append(pi.Depends.DockerImages.List, s.Text())
+			}
+		}
+
+		if err := s.Err(); err != nil {
+			return dockerDepends{}, err
+		}
+	}
+
+	var specs []reference.Spec
+	for _, i := range pi.Depends.DockerImages.List {
+		s, err := reference.Parse(i)
+		if err != nil {
+			return dockerDepends{}, err
+		}
+		dgst := s.Digest()
+		if dgst == "" {
+			return dockerDepends{}, fmt.Errorf("image %q lacks a digest", i)
+		}
+		if err := dgst.Validate(); err != nil {
+			return dockerDepends{}, fmt.Errorf("unable to validate digest in %q: %v", i, err)
+		}
+		specs = append(specs, s)
+	}
+
+	var dir bool
+	path := pi.Depends.DockerImages.Target
+	if pi.Depends.DockerImages.TargetDir != "" {
+		path = pi.Depends.DockerImages.TargetDir
+		dir = true
+	}
+	return dockerDepends{
+		images: specs,
+		path:   path,
+		dir:    dir,
+	}, nil
+}
+
+// Do ensures that any dependencies the package has declared are met.
+func (dd dockerDepends) Do(d dockerRunner) error {
+	if len(dd.images) == 0 {
+		return nil
+	}
+
+	if dd.dir {
+		dir := dd.path
+
+		// Delete and recreate so it is empty
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("failed to remove %q: %v", dir, err)
+		}
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create %q: %v", dir, err)
+		}
+	}
+
+	var refs []string
+
+	for _, s := range dd.images {
+		if ok, err := d.pull(s.String()); !ok || err != nil {
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("failed to pull %q", s.String())
+		}
+
+		refs = append(refs, s.Locator)
+		if dd.dir {
+			bn := filepath.Base(s.Locator) + "@" + s.Digest().String()
+			path := filepath.Join(dd.path, bn+".tar")
+			fmt.Printf("Adding %q as dependency\n", bn)
+			if err := d.save(path, s.String()); err != nil {
+				return err
+			}
+		}
+	}
+
+	if !dd.dir {
+		if err := d.save(dd.path, refs...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/src/cmd/linuxkit/pkglib/docker.go
+++ b/src/cmd/linuxkit/pkglib/docker.go
@@ -103,3 +103,8 @@ func (dr dockerRunner) build(tag, pkg string, opts ...string) error {
 	args = append(args, "-t", tag, pkg)
 	return dr.command(args...)
 }
+
+func (dr dockerRunner) save(tgt string, refs ...string) error {
+	args := append([]string{"image", "save", "-o", tgt}, refs...)
+	return dr.command(args...)
+}

--- a/src/cmd/linuxkit/pkglib/docker.go
+++ b/src/cmd/linuxkit/pkglib/docker.go
@@ -53,7 +53,7 @@ func (dr dockerRunner) command(args ...string) error {
 }
 
 func (dr dockerRunner) pull(img string) (bool, error) {
-	err := dr.command("pull", img)
+	err := dr.command("image", "pull", img)
 	if err == nil {
 		return true, nil
 	}
@@ -66,7 +66,7 @@ func (dr dockerRunner) pull(img string) (bool, error) {
 }
 
 func (dr dockerRunner) push(img string) error {
-	return dr.command("push", img)
+	return dr.command("image", "push", img)
 }
 
 func (dr dockerRunner) pushWithManifest(img, suffix string) error {
@@ -91,7 +91,7 @@ func (dr dockerRunner) pushWithManifest(img, suffix string) error {
 
 func (dr dockerRunner) tag(ref, tag string) error {
 	fmt.Printf("Tagging %s as %s\n", ref, tag)
-	return dr.command("tag", ref, tag)
+	return dr.command("image", "tag", ref, tag)
 }
 
 func (dr dockerRunner) build(tag, pkg string, opts ...string) error {

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -37,7 +37,7 @@ type Pkg struct {
 	config  *moby.ImageConfig
 
 	// Internal state
-	pkgPath    string
+	path       string
 	hash       string
 	dirty      bool
 	commitHash string
@@ -191,7 +191,7 @@ func NewFromCLI(fs *flag.FlagSet, args ...string) (Pkg, error) {
 		cache:      !pi.DisableCache,
 		config:     pi.Config,
 		dirty:      dirty,
-		pkgPath:    pkgPath,
+		path:       pkgPath,
 		git:        git,
 	}, nil
 }


### PR DESCRIPTION
This implements (close to) the second proposal in #2766. There are a couple of preparatory patches but the main work is in the final patch, so I reproduce that commit message here:

>    linuxkit: implement docker image dependencies for pkg build.
>    
>    This allows the `linuxkit/kubernetes` "image-cache" packages to use a standard
>    `linuxkit pkg build` based flow rather than requiring surrounding scaffolding.
>    
>    Fixes #2766. Compared with the original (actually, the second) proposal made in
>    issue #2766, the field is `docker-images` rather than `images` to allow for
>    future inclusion of e.g. `containerd-images`.
>    
>    Signed-off-by: Ian Campbell <ijc@docker.com>

I will shortly be raising a WIP PR against https://github.com/linuxkit/kubernetes which uses this (I need the binary to be built by CI first) and will xpost here.