### PR TITLE
kernel: Add NVDIMM size patch to 4.14.x

### DIFF
--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,0 +1,28 @@
+From d1697181aaefb53c6c1b3e45a0ef275dd5d4272e Mon Sep 17 00:00:00 2001
+From: Cheng-mean Liu <soccerl@microsoft.com>
+Date: Tue, 11 Jul 2017 16:58:26 -0700
+Subject: [PATCH] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB (page
+ size)
+
+Signed-off-by: Cheng-mean Liu <soccerl@microsoft.com>
+Origin: https://github.com/Microsoft/opengcs/blob/master/kernelconfig/4.11/patch_lower-the-minimum-PMEM-size.patch
+---
+ include/uapi/linux/ndctl.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/uapi/linux/ndctl.h b/include/uapi/linux/ndctl.h
+index 3f03567631cb..e63c201ed1ef 100644
+--- a/include/uapi/linux/ndctl.h
++++ b/include/uapi/linux/ndctl.h
+@@ -263,7 +263,7 @@ enum nd_driver_flags {
+ };
+ 
+ enum {
+-	ND_MIN_NAMESPACE_SIZE = 0x00400000,
++	ND_MIN_NAMESPACE_SIZE = 0x00001000,
+ };
+ 
+ enum ars_masks {
+-- 
+2.15.0
+


### PR DESCRIPTION
This change hasn't made it upstream but seems to be required
for LCOW to work. We carried it in the 4.11/4.12/4.13 kernels.

I haven't pushed new kernels yet as some testing with a local build revealed other LCOW issues, but the specific issue related to this (https://github.com/Microsoft/opengcs/issues/174) is fixed with this patch.

![bear-bum](https://user-images.githubusercontent.com/3338098/33603853-de2be4ca-d9ab-11e7-8d0a-f8307c7c4a66.jpg)
