### PR TITLE
Ensure VPNKit process is properly killed when errors occur

### DIFF
--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -291,6 +291,7 @@ func runHyperKit(args []string) {
 				log.Fatalf("Publish ports failed with: %v", err)
 			}
 			defer f()
+			log.RegisterExitHandler(f)
 		default:
 			log.Fatalf("Port publishing requires %q or %q networking mode", hyperkitNetworkingDockerForMac, hyperkitNetworkingVPNKit)
 		}

--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -240,14 +240,10 @@ func runHyperKit(args []string) {
 			if err != nil {
 				log.Fatalln("Unable to start vpnkit: ", err)
 			}
-			defer func() {
-				if vpnkitProcess != nil {
-					err := vpnkitProcess.Kill()
-					if err != nil {
-						log.Println(err)
-					}
-				}
-			}()
+			defer shutdownVPNKit(vpnkitProcess)
+			log.RegisterExitHandler(func() {
+				shutdownVPNKit(vpnkitProcess)
+			})
 			// The guest will use this 9P mount to configure which ports to forward
 			h.Sockets9P = []hyperkit.Socket9P{{Path: vpnkitPortSocket, Tag: "port"}}
 			// VSOCK port 62373 is used to pass traffic from host->guest
@@ -303,6 +299,16 @@ func runHyperKit(args []string) {
 	err = h.Run(string(cmdline))
 	if err != nil {
 		log.Fatalf("Cannot run hyperkit: %v", err)
+	}
+}
+
+func shutdownVPNKit(process *os.Process) {
+	if process == nil {
+		return
+	}
+
+	if err := process.Kill(); err != nil {
+		log.Println(err)
 	}
 }
 


### PR DESCRIPTION
**- What I did**

Ensure VPNKit process is properly killed when errors occur

**- How I did it**

We added an ExitHandler to logrus so that VPNKit will be shutdown
when log.Fatal* is invoked

**- How to verify it**
1. Start LinuxKit (hyperkit backend) with VPNKit networking 
2. Send a KILL signal to hyperkit
3. Ensure vpnkit process exits

**- Description for the changelog**
VPNKit process will exit when hyperkit fails to start or is terminated

**- A picture of a cute animal (not mandatory but encouraged)**
![cute animal](https://i.pinimg.com/736x/77/a3/2b/77a32bd2f3f141294f26fd53746cd3ca--marmoset-monkey-pygmy-marmoset.jpg)