### PR TITLE
Update kernels to 4.14.4/4.9.67.4.4.104

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -1,6 +1,6 @@
 # This is a blueprint for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:15c56c57ac9a7adeec20b34f36f2bc165c347679 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -339,10 +339,10 @@ file:
 
 ```
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.<version>
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - <foo>/zfs-kmod:4.9.47
+  - <foo>/zfs-kmod:4.9.<version>
   ...
 ```
 

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS1 console=ttyAMA0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=tty0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -171,11 +171,11 @@ endef
 # Build Targets
 # Debug targets only for latest stable and LTS stable
 #
-$(eval $(call kernel,4.14.3,4.14.x,$(EXTRA)))
-$(eval $(call kernel,4.14.3,4.14.x,-dbg))
-$(eval $(call kernel,4.9.66,4.9.x,$(EXTRA)))
-$(eval $(call kernel,4.9.66,4.9.x,-dbg))
-$(eval $(call kernel,4.4.103,4.4.x,$(EXTRA)))
+$(eval $(call kernel,4.14.4,4.14.x,$(EXTRA)))
+$(eval $(call kernel,4.14.4,4.14.x,-dbg))
+$(eval $(call kernel,4.9.67,4.9.x,$(EXTRA)))
+$(eval $(call kernel,4.9.67,4.9.x,-dbg))
+$(eval $(call kernel,4.4.104,4.4.x,$(EXTRA)))
 
 # Target for kernel config
 kconfig: | sources

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.3 Kernel Configuration
+# Linux/arm64 4.14.4 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.3 Kernel Configuration
+# Linux/x86 4.14.4 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.4.x-aarch64
+++ b/kernel/config-4.4.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.4.103 Kernel Configuration
+# Linux/arm64 4.4.104 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.103 Kernel Configuration
+# Linux/x86 4.4.104 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-aarch64
+++ b/kernel/config-4.9.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.9.66 Kernel Configuration
+# Linux/arm64 4.9.67 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.66 Kernel Configuration
+# Linux/x86 4.9.67 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From d1697181aaefb53c6c1b3e45a0ef275dd5d4272e Mon Sep 17 00:00:00 2001
+From 6e55146090474d47fc3f3a2619e44cd5267cf63d Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB (page

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 35ef9254b0c4cfb8d1ca108ae114c49b7b9c0b2b Mon Sep 17 00:00:00 2001
+From 9bbf583a71b6a1440167f1082f839132ebeba3e5 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 90fc913acdd81b67d7b367a3c0cfc4885b72e1f3 Mon Sep 17 00:00:00 2001
+From f0c021bbfe46b2de56265d598adc841144db9701 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From a4b5046bf47f507bf514154444f49b20cb434ea5 Mon Sep 17 00:00:00 2001
+From cd8234b912d3261ed97e0a5eb6148ac89b0215a9 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From ead831c3415e24149a5d871911f8b25895a908ff Mon Sep 17 00:00:00 2001
+From e4504f021bbeebf7ceb36e39b1fcd2edbbf7de9b Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 70b74738d9b75517ce4ff02aa390e10bea72afa1 Mon Sep 17 00:00:00 2001
+From 170fa6f98adb45a3f8cf3fce9bab2515a2a05fa0 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From b14ddee6415c3b0ecae19e5c52bb1865b7d6980f Mon Sep 17 00:00:00 2001
+From b0feab16b6f7084c07edab37296ec9ef9079ec0d Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From a93030d11246445ebafbb1ac965bb4cfc160b71e Mon Sep 17 00:00:00 2001
+From edf8b19346fab6dd3e3a14b71e6ea770f516b996 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From bed22e1348f22c79b9f95172418ba0704cdce6a5 Mon Sep 17 00:00:00 2001
+From 43e7f99e2da49f57c40409690eab9e4c985c4588 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 8fd6b628c6022656ae2fb02dc68445fedcf54ccd Mon Sep 17 00:00:00 2001
+From b8045255345236eecb35dd8a451dfe546ebb8f44 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From 6cd38bb68454303af6e7f38a4e4d91675b3b2708 Mon Sep 17 00:00:00 2001
+From 374e5a51ad07d7a6c7ad03f58f623b24ffe52959 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 16b7ee65a4962f5c7f62868f2b9163f4ad73324e Mon Sep 17 00:00:00 2001
+From 9d933af72768b076fe8835e0c4cac175f6a69aa4 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From ff1dc8b45d014829cbafe74e1457c9561ff4ddd8 Mon Sep 17 00:00:00 2001
+From 3abcd7a7acc2b9af02d66826a39bbb16f07b3ffb Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75 # with runc, logwrite, startmemlogd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:6b3755e47f00d6027321d3fca99a19af6504be75

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/000_build/000_outputs/test.yml
+++ b/test/cases/000_build/000_outputs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.103
+  image: linuxkit/kernel:4.4.104
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.3
+  image: linuxkit/kernel:4.14.4
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.4.103 AS ksrc
+FROM linuxkit/kernel:4.4.104 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.66
+docker pull linuxkit/kernel:4.9.67
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.103
+  image: linuxkit/kernel:4.4.104
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.66 AS ksrc
+FROM linuxkit/kernel:4.9.67 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.66
+docker pull linuxkit/kernel:4.9.67
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
+++ b/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.14.3 AS ksrc
+FROM linuxkit/kernel:4.14.4 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.sh
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.66
+docker pull linuxkit/kernel:4.9.67
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.3
+  image: linuxkit/kernel:4.14.4
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.103
+  image: linuxkit/kernel:4.4.104
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.3
+  image: linuxkit/kernel:4.14.4
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.9.66
+  image: linuxkit/kernel:4.9.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776


### PR DESCRIPTION
This is a mechanic update, except for a minor tweak to `docs/kernels.md` where the mechanic `git grep | sed` approach of updating would update one part of the doc but not others.

x86_64 and arm64 kernels already build and pushed.

![pelican](https://user-images.githubusercontent.com/3338098/33665697-b771d2e2-da8f-11e7-85c2-a9f067b3ef96.jpg)
