### PR TITLE
Remove containerd config from shiftfs.yaml

### DIFF
--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -27,26 +27,6 @@ services:
      - CAP_SETUID
      - CAP_SETGID
      - CAP_DAC_OVERRIDE
-files:
-  - path: etc/containerd/config.toml
-    contents: |
-      state = "/run/containerd"
-      root = "/var/lib/containerd"
-      snapshotter = "io.containerd.snapshotter.v1.overlayfs"
-      differ = "io.containerd.differ.v1.base-diff"
-      subreaper = false
-
-      [grpc]
-      address = "/run/containerd/containerd.sock"
-      uid = 0
-      gid = 0
-
-      [debug]
-      address = "/run/containerd/debug.sock"
-      level = "info"
-
-      [metrics]
-      address = ":13337"
 trust:
   org:
     - linuxkit


### PR DESCRIPTION
No need to have a special containerd daemon config file; might have been
a vestige of earlier variants of LinuxKit? It is also out of date and
incorrect for current containerd version.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
