### PR TITLE
wireguard: update to 0.0.20171211

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -39,8 +39,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20171127
-ENV WIREGUARD_SHA256=5e0a93cccce70e5758ddebaaa94d3df74cb664f592895efbd43dc6171ee5b25b
+ENV WIREGUARD_VERSION=0.0.20171211
+ENV WIREGUARD_SHA256=57d799d35e92c905e548d00adeb7ed1ead4d6560f084c99e5aae0a87b4eb09e4
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
* curve25519: explictly depend on AS_AVX
* curve25519: modularize dispatch

It's now much cleaner to see which implementation we're calling, and it will
be simpler to add more implementations in the future.

* compat: support RAP in assembly

This should fix PaX/Grsecurity support.

* device: do not clear keys during sleep on Android

While we want to clear keys when going to sleep on ordinary Linux, this
doesn't make sense in the Android world, where phones often sleep but are
woken up every few milliseconds by the radios to process packets.

* compat: fix 3.10 backport

Important compat fixes for non-x86.

* device: clear last handshake timer on ifdown

When bringing up an interface, we don't want the rate limiting to handshakes
to apply.

* netlink: rename symbol to avoid clashes

Allows coexistance with horrible Android drivers.

* kernel-tree: jury rig is the more common spelling
* tools: no need to put this on the stack
* blake2s-x86_64: fix spacing

Small fixes.

* contrib: keygen-html for generating keys in the browser

This was covered here:
https://lists.zx2c4.com/pipermail/wireguard/2017-December/002127.html

* tools: remove undocumented unused syntax

Not only did nobody know about this or use it, but the implementation actually
exposed compiler bugs in Qualcomm's "Snapdragon Clang".

* poly1305: update x86-64 kernel to AVX512F only

From Samuel Neves, this pulls in Andy Polyakov's changes to only require F and
not VL for the Poly implementation.

* chacha20-arm: fix with clang -fno-integrated-as.

This pulls in David Benjamin's clang fix.

* global: add SPDX tags to all files

From Greg KH, we now have SPDX annotations on all files, matching upstream
kernel's new approach to file licenses.

* chacha20poly1305: cleaner generic code

This entirely removes the last remains of Martin Willi's ChaCha
implementation, and now the generic C implementation is extremely small and
clearly written, while delivering a small performance boost too.

* poly1305: fix avx512f alignment bug

Unlucky people may have had their linkers misalign a constant. This fixes that
potential.

* chacha20: avx512vl implementation

From Samuel Neves, this imports Andy Polyakov's AVX512VL implementation of
ChaCha which should have a ~50% performance improvement over AVX2, though it
is still much slower than our AVX512F implementation.

* chacha20poly1305: wire up avx512vl for skylake-x

Some Skylake machines do not have two FMA units (though others do), so we
prefer the AVX512VL implementation over the should-be-faster AVX512F
implementation on those machines. What's needed now is to read the PIROM in
order to determine at runtime whether the particular Skylake-X machine
actually has the second FMA unit or not, but until that happens, we just fall
back to the VL implementation for all Skylake-X.
```
![image](https://user-images.githubusercontent.com/10643/33815507-2c8ce3c8-de32-11e7-9b64-ef2b6e88dd37.png)
