### PR TITLE
pkg/init/cmd/service: plumb containerd namespace

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:728e5fe9e6b818d9825b28826b929ae75a386e9e # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
 services:

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS1 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
 onboot:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
 onboot:

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
 onboot:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/pkg/init/cmd/service/start.go
+++ b/pkg/init/cmd/service/start.go
@@ -11,12 +11,11 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
-	"github.com/containerd/containerd/namespaces"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	log "github.com/sirupsen/logrus"
 )
 
-func startCmd(args []string) {
+func startCmd(ctx context.Context, args []string) {
 	invoked := filepath.Base(os.Args[0])
 	flags := flag.NewFlagSet("start", flag.ExitOnError)
 	flags.Usage = func() {
@@ -48,7 +47,7 @@ func startCmd(args []string) {
 		"service": service,
 	})
 
-	id, pid, msg, err := start(service, *sock, *path, *dumpSpec)
+	id, pid, msg, err := start(ctx, service, *sock, *path, *dumpSpec)
 	if err != nil {
 		log.WithError(err).Fatal(msg)
 	}
@@ -74,7 +73,7 @@ func (c *logio) Close() error {
 	return nil
 }
 
-func start(service, sock, basePath, dumpSpec string) (string, uint32, string, error) {
+func start(ctx context.Context, service, sock, basePath, dumpSpec string) (string, uint32, string, error) {
 	path := filepath.Join(basePath, service)
 
 	runtimeConfig := getRuntimeConfig(path)
@@ -89,8 +88,6 @@ func start(service, sock, basePath, dumpSpec string) (string, uint32, string, er
 	if err != nil {
 		return "", 0, "creating containerd client", err
 	}
-
-	ctx := namespaces.WithNamespace(context.Background(), "default")
 
 	var spec *specs.Spec
 	specf, err := os.Open(filepath.Join(path, "config.json"))

--- a/pkg/init/cmd/service/system_init.go
+++ b/pkg/init/cmd/service/system_init.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/namespaces"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -52,7 +51,7 @@ func cleanupTask(ctx context.Context, ctr containerd.Container) error {
 	}
 }
 
-func systemInitCmd(args []string) {
+func systemInitCmd(ctx context.Context, args []string) {
 	invoked := filepath.Base(os.Args[0])
 	flags := flag.NewFlagSet("system-init", flag.ExitOnError)
 	flags.Usage = func() {
@@ -108,8 +107,6 @@ func systemInitCmd(args []string) {
 		log.WithError(err).Fatal("creating containerd client")
 	}
 
-	ctx := namespaces.WithNamespace(context.Background(), "default")
-
 	ctrs, err := client.Containers(ctx)
 	if err != nil {
 		log.WithError(err).Fatal("listing containers")
@@ -140,7 +137,7 @@ func systemInitCmd(args []string) {
 		return
 	}
 	for _, file := range files {
-		if id, pid, msg, err := start(file.Name(), *sock, *path, ""); err != nil {
+		if id, pid, msg, err := start(ctx, file.Name(), *sock, *path, ""); err != nil {
 			log.WithError(err).Error(msg)
 		} else {
 			log.Debugf("Started %s pid %d", id, pid)

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed # with runc, logwrite, startmemlogd
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55 # with runc, logwrite, startmemlogd
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
 onboot:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
 services:

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.109
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.11
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.109
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: check

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: check

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.11
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.109
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 trust:
   org:

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 trust:
   org:

--- a/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.11
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.74
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
 onboot:

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:5a577d070817b4f17821657823082651baafd4ed
+  - linuxkit/init:fb1e34662dc92a45f8e92c91adbee094e22feb55
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: test-ns


### PR DESCRIPTION
This PR correctly plumbs a single context to propagate the containerd
namespace to the necessary commands. Services launched with containerd
after this change will now be in a default namespace of
`services.linuxkit`.

A top-level flag is added to the service command,
`--containerd-namespace` which can be used to change, if needed.

Signed-off-by: Stephen J Day <stephen.day@docker.com>