### PR TITLE
Bump moby tool to d9d2a91780b3

### DIFF
--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -13,6 +13,12 @@ Details of usage of the `vndr` tool and the format of `vendor.conf` can be found
 Once done, you must run the `vndr` tool to add the necessary files to the `vendor` directory.
 The easiest way to do this is in a container.
 
+Currently if updating `github.com/moby/tool` it is also necessary to
+update `src/cmd/linuxkit/build.go` manually after updating `vendor.conf`:
+
+    hash=$(awk '/^github.com\/moby\/tool/ { print $2 }' src/cmd/linuxkit/vendor.conf)
+    curl -fsSL -o src/cmd/linuxkit/build.go https://raw.githubusercontent.com/moby/tool/${hash}/cmd/moby/build.go
+
 ## Updating in a container
 
 To update all dependencies:

--- a/src/cmd/linuxkit/vendor.conf
+++ b/src/cmd/linuxkit/vendor.conf
@@ -24,7 +24,9 @@ github.com/jmespath/go-jmespath bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 github.com/mitchellh/go-ps 4fdf99ab29366514c69ccccddab5dc58b8d84062
 github.com/moby/datakit 97b3d230535397a813323902c23751e176481a86
 github.com/moby/hyperkit a12cd7250bcd8d689078e3e42ae4a7cf6a0cbaf3
-github.com/moby/tool 656bd87fd26b4cfc7da735939ce78cc7cb541181
+# When updating also:
+# curl -fsSL -o src/cmd/linuxkit/build.go https://raw.githubusercontent.com/moby/tool/«hash»/cmd/moby/build.go
+github.com/moby/tool d9d2a91780b34b92e669bbfa099f613bd9fad6bb
 github.com/moby/vpnkit 0e4293bb1058598c4b0a406ed171f52573ef414c
 github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
 github.com/opencontainers/image-spec v1.0.0

--- a/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/docker.go
+++ b/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/docker.go
@@ -4,7 +4,6 @@ package moby
 // and also using the Docker API not shelling out
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -81,25 +80,18 @@ func dockerCreate(image string) (string, error) {
 	return respBody.ID, nil
 }
 
-func dockerExport(container string) ([]byte, error) {
+func dockerExport(container string) (io.ReadCloser, error) {
 	log.Debugf("docker export: %s", container)
 	cli, err := dockerClient()
 	if err != nil {
-		return []byte{}, errors.New("could not initialize Docker API client")
+		return nil, errors.New("could not initialize Docker API client")
 	}
 	responseBody, err := cli.ContainerExport(context.Background(), container)
 	if err != nil {
-		return []byte{}, err
-	}
-	defer responseBody.Close()
-
-	output := bytes.NewBuffer(nil)
-	_, err = io.Copy(output, responseBody)
-	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
-	return output.Bytes(), nil
+	return responseBody, err
 }
 
 func dockerRm(container string) error {

--- a/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/image.go
+++ b/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/image.go
@@ -82,7 +82,7 @@ func tarPrefix(path string, tw tarWriter) error {
 }
 
 // ImageTar takes a Docker image and outputs it to a tar stream
-func ImageTar(ref *reference.Spec, prefix string, tw tarWriter, trust bool, pull bool, resolv string) error {
+func ImageTar(ref *reference.Spec, prefix string, tw tarWriter, trust bool, pull bool, resolv string) (e error) {
 	log.Debugf("image tar: %s %s", ref, prefix)
 	if prefix != "" && prefix[len(prefix)-1] != byte('/') {
 		return fmt.Errorf("prefix does not end with /: %s", prefix)
@@ -119,15 +119,17 @@ func ImageTar(ref *reference.Spec, prefix string, tw tarWriter, trust bool, pull
 	if err != nil {
 		return fmt.Errorf("Failed to docker export container from container %s: %v", container, err)
 	}
-	err = dockerRm(container)
-	if err != nil {
-		return fmt.Errorf("Failed to docker rm container %s: %v", container, err)
-	}
+	defer func() {
+		contents.Close()
+
+		if err := dockerRm(container); e == nil && err != nil {
+			e = fmt.Errorf("Failed to docker rm container %s: %v", container, err)
+		}
+	}()
 
 	// now we need to filter out some files from the resulting tar archive
 
-	r := bytes.NewReader(contents)
-	tr := tar.NewReader(r)
+	tr := tar.NewReader(contents)
 
 	for {
 		hdr, err := tr.Next()

--- a/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/linuxkit.go
+++ b/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/linuxkit.go
@@ -1,7 +1,6 @@
 package moby
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -18,13 +17,13 @@ kernel:
   image: linuxkit/kernel:4.9.39
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:00ab58c9681a0bf42b2e35134c1ccf1591ebb64d
+  - linuxkit/runc:f5960b83a8766ae083efc744fa63dbf877450e4f
 onboot:
   - name: mkimage
-    image: linuxkit/mkimage:e439d6108466186948ca7ea2a293fc6c1d1183fa
+    image: linuxkit/mkimage:a63b8ee4c5de335afc32ba850e0af319b25b96c0
   - name: poweroff
-    image: linuxkit/poweroff:bccfe1cb04fc7bb9f03613d2314f38abd2620f29
+    image: linuxkit/poweroff:3845c4d64d47a1ea367806be5547e44594b0fa91
 trust:
   org:
     - linuxkit
@@ -58,9 +57,21 @@ func ensureLinuxkitImage(name string) error {
 		return err
 	}
 	// TODO pass through --pull to here
-	buf := new(bytes.Buffer)
-	Build(m, buf, false, "")
-	image := buf.Bytes()
+	tf, err := ioutil.TempFile("", "")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tf.Name())
+	Build(m, tf, false, "")
+	if err := tf.Close(); err != nil {
+		return err
+	}
+
+	image, err := os.Open(tf.Name())
+	if err != nil {
+		return err
+	}
+	defer image.Close()
 	kernel, initrd, cmdline, err := tarToInitrd(image)
 	if err != nil {
 		return fmt.Errorf("Error converting to initrd: %v", err)


### PR DESCRIPTION
https://github.com/moby/tool/compare/656bd87fd26b...d9d2a91780b3

d9d2a91 Merge pull request #193 from ijc/bugfix-191
307f13b Defer dockerRm until we are finished with the contents
ebd7228 Merge pull request #191 from ijc/reduce-memory-via-tempfiles
3045a80 Stream `docker export` directly to consumer
9f44acf Generate intermediate image into a temp file
9558740 Add cpu and mem profiling options

Reduces the memory usage substantially.

While here make some notes about the need to update src/cmd/linuxkit/build.go
where people might see them.

Signed-off-by: Ian Campbell <ijc@docker.com>
