### PR TITLE
Improve error message for new packages

### DIFF
--- a/src/cmd/linuxkit/pkglib/git.go
+++ b/src/cmd/linuxkit/pkglib/git.go
@@ -89,6 +89,10 @@ func (g git) treeHash(pkg, commit string) (string, error) {
 		return "", err
 	}
 
+	if out == "" {
+		return "", fmt.Errorf("Package %s is not in git", pkg)
+	}
+
 	matches := treeHashRe.FindStringSubmatch(out)
 	if len(matches) != 2 {
 		return "", fmt.Errorf("Unable to parse ls-tree output: %q", out)


### PR DESCRIPTION
When I tried to use `linuxkit pkg build` for the first time on a new package, it showed `Unable to parse ls-tree output: ""` error, which I could not parse before I looked at the code. Hopefully, this change would make it easier for people to use the tool for the first time on a new package.