### PR TITLE
Kernel update to 4.14.7/4.9.70/4.4.106

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -1,6 +1,6 @@
 # This is a blueprint for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:728e5fe9e6b818d9825b28826b929ae75a386e9e # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS1 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=tty0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -102,6 +102,14 @@ build_$(2)$(3): Dockerfile Makefile $(wildcard patches-$(2)/*) $(wildcard config
 			$(LABELS) \
 			--no-cache -t $(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) .
 
+forcebuild_$(2)$(3): Dockerfile Makefile $(wildcard patches-$(2)/*) $(wildcard config-$(2)*) config-dbg | sources
+	docker build \
+		--build-arg KERNEL_VERSION=$(1) \
+		--build-arg KERNEL_SERIES=$(2) \
+		--build-arg EXTRA=$(3) \
+		$(LABELS) \
+		--no-cache -t $(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) .
+
 push_$(2)$(3): build_$(2)$(3)
 	@if [ x"$(DIRTY)" !=  x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
 	docker pull $(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) || \
@@ -111,11 +119,21 @@ push_$(2)$(3): build_$(2)$(3)
 		 $(PUSH_MANIFEST) $(ORG)/$(IMAGE):$(1)$(3)-$(TAG) $(DOCKER_CONTENT_TRUST) && \
 		 $(PUSH_MANIFEST) $(ORG)/$(IMAGE):$(1)$(3) $(DOCKER_CONTENT_TRUST))
 
+forcepush_$(2)$(3): forcebuild_$(2)$(3)
+	@if [ x"$(DIRTY)" !=  x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+	docker push $(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) && \
+	 docker tag $(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) $(ORG)/$(IMAGE):$(1)$(3)$(SUFFIX) && \
+	 docker push $(ORG)/$(IMAGE):$(1)$(3)$(SUFFIX) && \
+	 $(PUSH_MANIFEST) $(ORG)/$(IMAGE):$(1)$(3)-$(TAG) $(DOCKER_CONTENT_TRUST) && \
+	 $(PUSH_MANIFEST) $(ORG)/$(IMAGE):$(1)$(3) $(DOCKER_CONTENT_TRUST)
+
 show-tag_$(2)$(3):
 	@echo $(ORG)/$(IMAGE):$(1)$(3)-$(TAG)
 
 build: build_$(2)$(3)
+forcebuild: forcebuild_$(2)$(3)
 push: push_$(2)$(3)
+forcepush: forcepush_$(2)$(3)
 show-tags: show-tag_$(2)$(3)
 fetch: sources/linux-$(1).tar.xz
 
@@ -133,6 +151,11 @@ build_perf_$(2)$(3): build_$(2)$(3)
 			--build-arg IMAGE=$(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) \
 			--no-cache --network=none $(LABEL) -t $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG)$(SUFFIX) .
 
+forcebuild_perf_$(2)$(3): build_$(2)$(3)
+	 DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile.perf \
+		--build-arg IMAGE=$(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) \
+		--no-cache --network=none $(LABEL) -t $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG)$(SUFFIX) .
+
 push_perf_$(2)$(3): build_perf_$(2)$(3)
 	@if [ x"$(DIRTY)" != x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
 	docker pull $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG)$(SUFFIX) || \
@@ -142,8 +165,18 @@ push_perf_$(2)$(3): build_perf_$(2)$(3)
 		 $(PUSH_MANIFEST) $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG) $(DOCKER_CONTENT_TRUST) && \
 		 $(PUSH_MANIFEST) $(ORG)/$(IMAGE_PERF):$(1)$(3) $(DOCKER_CONTENT_TRUST))
 
+forcepush_perf_$(2)$(3): forcebuild_perf_$(2)$(3)
+	@if [ x"$(DIRTY)" != x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+	docker push $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG)$(SUFFIX) && \
+	docker tag $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG)$(SUFFIX) $(ORG)/$(IMAGE_PERF):$(1)$(3)$(SUFFIX) && \
+	docker push $(ORG)/$(IMAGE_PERF):$(1)$(3)$(SUFFIX) && \
+	$(PUSH_MANIFEST) $(ORG)/$(IMAGE_PERF):$(1)$(3)-$(TAG) $(DOCKER_CONTENT_TRUST) && \
+	$(PUSH_MANIFEST) $(ORG)/$(IMAGE_PERF):$(1)$(3) $(DOCKER_CONTENT_TRUST)
+
 build: build_perf_$(2)$(3)
+forcebuild: forcebuild_perf_$(2)$(3)
 push: push_perf_$(2)$(3)
+forcepush: forcepush_perf_$(2)$(3)
 endif
 
 ifneq ($(3), -dbg)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -204,11 +204,11 @@ endef
 # Build Targets
 # Debug targets only for latest stable and LTS stable
 #
-$(eval $(call kernel,4.14.6,4.14.x,$(EXTRA)))
-$(eval $(call kernel,4.14.6,4.14.x,-dbg))
-$(eval $(call kernel,4.9.69,4.9.x,$(EXTRA)))
-$(eval $(call kernel,4.9.69,4.9.x,-dbg))
-$(eval $(call kernel,4.4.105,4.4.x,$(EXTRA)))
+$(eval $(call kernel,4.14.7,4.14.x,$(EXTRA)))
+$(eval $(call kernel,4.14.7,4.14.x,-dbg))
+$(eval $(call kernel,4.9.70,4.9.x,$(EXTRA)))
+$(eval $(call kernel,4.9.70,4.9.x,-dbg))
+$(eval $(call kernel,4.4.106,4.4.x,$(EXTRA)))
 
 # Target for kernel config
 kconfig: | sources

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.6 Kernel Configuration
+# Linux/arm64 4.14.7 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.6 Kernel Configuration
+# Linux/x86 4.14.7 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.4.x-aarch64
+++ b/kernel/config-4.4.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.4.105 Kernel Configuration
+# Linux/arm64 4.4.106 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.105 Kernel Configuration
+# Linux/x86 4.4.106 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-aarch64
+++ b/kernel/config-4.9.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.9.69 Kernel Configuration
+# Linux/arm64 4.9.70 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.69 Kernel Configuration
+# Linux/x86 4.9.70 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 8378047ded55eba03eff0193507292b607106d44 Mon Sep 17 00:00:00 2001
+From 6609bcceff41b236a7bac382f31c32b722c861b4 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB (page
@@ -24,5 +24,5 @@ index 3f03567631cb..e63c201ed1ef 100644
  
  enum ars_masks {
 -- 
-2.15.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 970bf929ebe31e250b5fd1f0ca4bb7a82e26e68a Mon Sep 17 00:00:00 2001
+From 83cc3adf460a9bbea17baa9e6c495988a84034ad Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()
@@ -146,5 +146,5 @@ index 43899e0d6fa1..c3b180254f91 100644
  
  int is_printable_array(char *p, unsigned int len);
 -- 
-2.15.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 568099189cd487c00d4056798d17ba04ae61a596 Mon Sep 17 00:00:00 2001
+From 0021c8fb28a83fa4c61f30b4ef22358f2effbed6 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable
@@ -66,5 +66,5 @@ index 95f0884aae02..f3ed3c963c71 100644
  	while ((jr = jit_get_next_entry(jd))) {
  		switch(jr->prefix.id) {
 -- 
-2.15.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From d5cf4b3128afbfaaf8ccfa71bee64c6f708ad740 Mon Sep 17 00:00:00 2001
+From efea47108405d3a80ccb22c15a10a1a0bbbd51e5 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets
@@ -1787,5 +1787,5 @@ index 000000000000..331d3759f5cb
 +MODULE_DESCRIPTION("Hyper-V Sockets");
 +MODULE_LICENSE("Dual BSD/GPL");
 -- 
-2.15.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 437343f228ba87a0fec31ed0b420b1d25a024b67 Mon Sep 17 00:00:00 2001
+From a7d3eb77302c36c84f9a23372e27752830120414 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs
@@ -26,5 +26,5 @@ index d8bc4b910192..8df02f3ca0b2 100644
  }
  
 -- 
-2.15.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 74042fcd3c918554ca1a97f690563004d5fd901f Mon Sep 17 00:00:00 2001
+From 67c0eb9c20e98f633fb7ae12b46fcef8256a2483 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host
@@ -44,5 +44,5 @@ index bcd06306f3e8..e7707747f56d 100644
  	}
  
 -- 
-2.15.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From 56c3ad1db7e327686edeed91b5e7472395218301 Mon Sep 17 00:00:00 2001
+From 596d4b9ad2b8a1a14de8dd71b11c30fb9ee476b6 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.
@@ -101,5 +101,5 @@ index a76e3db0d01f..b1446d51ef45 100644
  	return 0;
  }
 -- 
-2.15.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From f1779f9bc179da66525dcb7312d5bd594711800a Mon Sep 17 00:00:00 2001
+From 2cfda6eac2e1597529c8047ddc81b2f9acb8521d Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host
@@ -44,5 +44,5 @@ index b1446d51ef45..4e543dbb731a 100644
  	rc = hvutil_transport_send(hvt, vss_msg, sizeof(*vss_msg), NULL);
  	if (rc) {
 -- 
-2.15.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From ce9b9b737f3aa97959a1e2e3a132f80acafe61ee Mon Sep 17 00:00:00 2001
+From ce256433a38cddf67f26bb0003bf2508b519388a Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to
@@ -488,5 +488,5 @@ index c9af8369b4f7..7df9eb8f0cf7 100644
  void hv_event_tasklet_disable(struct vmbus_channel *channel);
  void hv_event_tasklet_enable(struct vmbus_channel *channel);
 -- 
-2.15.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 7fe8497816d43f5e4cb456e85f9fe3012fd1758d Mon Sep 17 00:00:00 2001
+From 919ed3a9c042a7fd014110aa6ec9b0b4dfedb749 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.
@@ -114,5 +114,5 @@ index f3797c07be10..89440c2eb346 100644
  					hb_srv_version & 0xFFFF);
  			}
 -- 
-2.15.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From ef2f4172ca605810df2ab306927163e3b495079e Mon Sep 17 00:00:00 2001
+From ecd9adcba4da55f85247cd1ca6507e4f4786eb34 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot
@@ -52,5 +52,5 @@ index e7949b64bfbc..2fe024e86209 100644
  
  void hv_process_channel_removal(struct vmbus_channel *channel, u32 relid)
 -- 
-2.15.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 09224dcba98468c7db8fc2d3cbb6fc12f5c6cf11 Mon Sep 17 00:00:00 2001
+From 25dc167a82ccf312e6b3bac682637acefc53262f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in
@@ -56,5 +56,5 @@ index 1606e7f08f4b..1caed01954f6 100644
  	vmbus_teardown_gpadl(newchannel, newchannel->ringbuffer_gpadlhandle);
  	kfree(open_info);
 -- 
-2.15.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 92e5e152a6b89ab808e2b546a58cf04f18694873 Mon Sep 17 00:00:00 2001
+From 283bd035d158afe9b99d7842c4f9e42e026c19eb Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on
@@ -173,5 +173,5 @@ index 7df9eb8f0cf7..a87757cf277b 100644
  
  void vmbus_setevent(struct vmbus_channel *channel);
 -- 
-2.15.0
+2.11.1
 

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4 # with runc, logwrite, startmemlogd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.105
+  image: linuxkit/kernel:4.4.106
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.6
+  image: linuxkit/kernel:4.14.7
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.4.105 AS ksrc
+FROM linuxkit/kernel:4.4.106 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.69
+docker pull linuxkit/kernel:4.9.70
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.105
+  image: linuxkit/kernel:4.4.106
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.69 AS ksrc
+FROM linuxkit/kernel:4.9.70 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.69
+docker pull linuxkit/kernel:4.9.70
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
+++ b/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.14.6 AS ksrc
+FROM linuxkit/kernel:4.14.7 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.sh
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.69
+docker pull linuxkit/kernel:4.9.70
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.6
+  image: linuxkit/kernel:4.14.7
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.105
+  image: linuxkit/kernel:4.4.106
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.6
+  image: linuxkit/kernel:4.14.7
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.9.69
+  image: linuxkit/kernel:4.9.70
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4


### PR DESCRIPTION
Mechanic update of kernels, except I also rolled in a change to the kernel build to add `forcepush` and `forcebuild` targets. I was meant to add that a while, but I had screwed up a push of the 4.14.7 x86 kernel package and needed a force push, which is now there.

![boobies](https://user-images.githubusercontent.com/3338098/34117960-3f1e5db2-e415-11e7-9313-e6fd4c2406cf.jpg)

