### PR TITLE
pkg/sysctl fixes: support commented KV lines, additional seperator and comment character, no post-crit KV set skips

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -13,7 +13,7 @@ onboot:
   - name: metadata
     image: linuxkit/metadata:2af15c9f4b0e73515c219b7cc14e6e65e1d4fd6d
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: sysfs
     image: linuxkit/sysfs:1284b4a7061a5cc426425f0fb00748192505a05f
   - name: binfmt

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
 services:
   - name: rngd
     image: linuxkit/rngd:94e01a4b16fadb053455cdc2269c4eb0b39199cd

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: sysfs
     image: linuxkit/sysfs:1284b4a7061a5cc426425f0fb00748192505a05f
   - name: format

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/rngd:94e01a4b16fadb053455cdc2269c4eb0b39199cd
     command: ["/sbin/rngd", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: rngd1
     image: linuxkit/rngd:94e01a4b16fadb053455cdc2269c4eb0b39199cd
     command: ["/sbin/rngd", "-1"]

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
 services:
   - name: getty
     image: linuxkit/getty:22e27189b6b354e1d5d38fc0536a5af3f2adb79f

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: sysfs
     image: linuxkit/sysfs:1284b4a7061a5cc426425f0fb00748192505a05f
   - name: dhcpcd

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: sysfs
     image: linuxkit/sysfs:1284b4a7061a5cc426425f0fb00748192505a05f
   - name: dhcpcd

--- a/projects/etcd/etcd.yml
+++ b/projects/etcd/etcd.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: format
     image: linuxkit/format:e945016ec780a788a71dcddc81497d54d3b14bc7
   - name: mount

--- a/projects/etcd/prom-us-central1-f.yml
+++ b/projects/etcd/prom-us-central1-f.yml
@@ -8,7 +8,7 @@ init:
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -9,7 +9,7 @@ init:
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -9,7 +9,7 @@ init:
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -9,7 +9,7 @@ init:
   - samoht/fdd
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
 services:
   - name: getty
     image: linuxkit/getty:22e27189b6b354e1d5d38fc0536a5af3f2adb79f

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcp-client
     image: miragesdk/dhcp-client:22aa9d527820534295a8cd59901c0c5197af6585
     net: host

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
 services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/projects/swarmd/swarmd.yml
+++ b/projects/swarmd/swarmd.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
     binds:
      - /etc/sysctl.d/01-swarmd.conf:/etc/sysctl.d/01-swarmd.conf
   - name: dhcpcd

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -8,7 +8,7 @@ init:
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: sysfs
     image: linuxkit/sysfs:1284b4a7061a5cc426425f0fb00748192505a05f
   - name: format

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: format
     image: linuxkit/format:e945016ec780a788a71dcddc81497d54d3b14bc7
   - name: mount

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:db575765635dab6dd1164fce5a39782e0f646b84
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: test
     image: alpine:3.7
     net: host


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Correctly ignoring all commented KV lines, not only lines without equal signs
- Removing all whitespace in KVs (such as tabs as well) instead of only single spaces
- Added semicolon as a new comment prefix
- Added forward slash as separator character
- KV set fails are now logged as warnings with a prefix `WARN:`, and do not skip the rest of the KVs from being attempted (no silent fails/skips)

**- How I did it**
- Trimming the KV line and checking for hash (or semicolon) as first character and skipping line earlier in code block.
- Using `TrimSpace` to trim any whitespace, not only single space characters.
- Logging sysctl KV set error with `log.Println` instead of failing on first error with `log.Fatal`, so the rest of the KV sets can be attempted (instead of skipping them silently)

**- How to verify it**
- Lines such as the following now aren't attempted to be set: `#a.b.c=xyz`
- Lines such as the following are now skipped as comments `;a.b.c=xyz`
- Keys can be composed of periods `a.b.c=xyz`
- Keys can be composed of forward slashes `a/b/c=xyz`
- Disable IPv6 via cmdline `ipv6.disable=1` in kernel, and now `pkg/sysctl` won't skip the KV sets after `net.ipv6.conf.all.accept_redirects = 0`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
pkg/sysctl fixes: support commented KV lines, additional seperator and comment character, no post-crit KV set skips

**- A picture of a cute animal (not mandatory but encouraged)**
![media-20171119](https://user-images.githubusercontent.com/4591181/34342255-24b26c28-e967-11e7-8506-5127ec30266e.jpg)
