### PR TITLE
Change support for foreign kernels

### DIFF
--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -22,20 +22,10 @@ containing the `perf` utility for debugging and performance tracing.
 The perf package is called `kernel-perf` and is tagged the same way as
 the kernel packages.
 
-In addition to the official kernel images, LinuxKit offers the ability
-to build bootable Linux images with kernels from various
-distributions. We mostly offer this mostly for testing
-purposes. "Foreign" kernel images are created by re-packing the native
-kernel packages into hub images. The hub images are typically tagged
-with the kernel version.
-
-In summary, LinuxKit offers a choice of the following kernels:
-- [linuxkit/kernel](https://hub.docker.com/r/linuxkit/kernel/): Official LinuxKit kernels.
-- [linuxkit/kernel-mainline](https://hub.docker.com/r/linuxkit/kernel-mainline/): Mainline [kernel.org](http://kernel.org) kernels from the [Ubuntu Mainline PPA](http://kernel.ubuntu.com/~kernel-ppa/mainline/).
-- [linuxkit/kernel-ubuntu](https://hub.docker.com/r/linuxkit/kernel-ubuntu/): Selected Ubuntu kernels.
-- [linuxkit/kernel-debian](https://hub.docker.com/r/linuxkit/kernel-debian/): Selected Debian kernels.
-- [linuxkit/kernel-centos](https://hub.docker.com/r/linuxkit/kernel-centos/): Selected CentOS kernels.
-- [linuxkit/kernel-fedora](https://hub.docker.com/r/linuxkit/kernel-fedora/): Selected Fedora kernels.
+In addition to the official images, there are also some
+[scripts](../scripts/kernels) which repackage kernels packages from
+some Linux distributions into LinuxKit kernel packages. These are
+mostly provided for testing purposes.
 
 
 ## Loading kernel modules

--- a/scripts/kernels/Dockerfile.deb
+++ b/scripts/kernels/Dockerfile.deb
@@ -1,4 +1,4 @@
-FROM alpine:3.5 AS extract
+FROM alpine:3.7 AS extract
 
 ARG DEB_URLS
 
@@ -20,7 +20,7 @@ RUN cp -a boot/System.map-* /out/System.map
 RUN tar cf /out/kernel.tar lib
 RUN tar cf /out/kernel-dev.tar usr || true
 
-FROM linuxkit/toybox-media:b396a375852e5dffc002389d95e0658c8de72914@sha256:a317cc378946ee48cc011cdfc5aa08f0229f5bf10ff70e3690d8f60b36700033
+FROM scratch
 WORKDIR /
 ENTRYPOINT []
 CMD []

--- a/scripts/kernels/Dockerfile.rpm
+++ b/scripts/kernels/Dockerfile.rpm
@@ -1,4 +1,4 @@
-FROM alpine:3.5 AS extract
+FROM alpine:3.7 AS extract
 
 ARG RPM_URLS
 
@@ -21,7 +21,7 @@ RUN cp -a boot/System.map-* /out/System.map || mv lib/modules/*/System.map /out/
 RUN tar cf /out/kernel.tar lib
 RUN tar cf /out/kernel-dev.tar usr || true
 
-FROM linuxkit/toybox-media:b396a375852e5dffc002389d95e0658c8de72914@sha256:a317cc378946ee48cc011cdfc5aa08f0229f5bf10ff70e3690d8f60b36700033
+FROM scratch
 WORKDIR /
 ENTRYPOINT []
 CMD []

--- a/scripts/kernels/README.md
+++ b/scripts/kernels/README.md
@@ -1,0 +1,31 @@
+# Using "foreign" kernels
+
+This directory contains a number of scripts to re-package other
+distributions kernels into a LinuxKit kernel package. The scripts
+download the relevant `rpm`s or `deb`s and create a local docker image
+which can be used in LinuxKit. You can optionally push the package to
+hub, if you like.
+
+All scripts take slightly different command line arguments (which
+could be improved) as each distribution uses different naming
+conventions and repository layouts.
+
+## Example
+
+To build a package using the `4.14.11` from the mainline [ppa
+repository](http://kernel.ubuntu.com/~kernel-ppa/mainline), first
+build the package:
+
+```sh
+./mainline.sh foobar/kernel-mainline v4.14.11 041411 201801022143
+```
+
+Here `v4.14.11` is the sub-directory of the [ppa
+repository](http://kernel.ubuntu.com/~kernel-ppa/mainline), `041411`
+seems to be another version used in the name of the `deb`s, and
+`201801022143` is the date. You can find the names by browsing the
+[ppa repository](http://kernel.ubuntu.com/~kernel-ppa/mainline).
+
+
+The result is a local image `foobar/kernel-mainline:4.14.11`, which
+can be used in a YAML file like a normal LinuxKit kernel image.

--- a/scripts/kernels/mainline.sh
+++ b/scripts/kernels/mainline.sh
@@ -1,57 +1,31 @@
 #! /bin/sh
 
-REPO="linuxkit/kernel-mainline"
+if [ "$#" -ne 4 ]; then
+    echo "Usage: $0 <org/repo> <base url> <kernel version> <version> <date>"
+    echo
+    echo "Example:"
+    echo "$0 foobar/kernel-mainline v4.14.11 041411 201801022143"
+    echo
+    echo "This will create a local LinuxKit kernel package:"
+    echo "foobar/kernel-mainline:4.14.11"
+    echo "which you can then push to hub or just use locally"
+    exit 1
+fi
+
+REPO=$1
+VER=$2
+VER1=$3
+DATE=$4
 BASE_URL=http://kernel.ubuntu.com/~kernel-ppa/mainline
+ARCH=amd64
+# Strip leading 'v'
+KVER=${VER:1}
+URL="${BASE_URL}/${VER}"
 
-TAGS=$(curl --silent -f -lSL https://registry.hub.docker.com/v1/repositories/${REPO}/tags)
+KERNEL_DEB="${URL}/linux-image-${KVER}-${VER1}-generic_${KVER}-${VER1}.${DATE}_${ARCH}.deb"
+HEADERS_DEB="${URL}/linux-headers-${KVER}-${VER1}-generic_${KVER}-${VER1}.${DATE}_${ARCH}.deb"
+HEADERS_ALL_DEB="${URL}/linux-headers-${KVER}-${VER1}_${KVER}-${VER1}.${DATE}_all.deb"
 
-build_image() {
-    VERSION=$1
-    KDIR=$2
-    ARCH=amd64
+DEB_URLS="${KERNEL_DEB} ${HEADERS_DEB} ${HEADERS_ALL_DEB}"
 
-    LINKS=$(curl -s ${BASE_URL}/${KDIR}/ | \
-                sed -n 's/.*href="\([^"]*\).*/\1/p')
-
-    IMAGE=$(echo $LINKS | \
-            grep -o "linux-image[^ ]\+-generic[^ ]\+${ARCH}.deb" | head -1)
-    [ -z "${IMAGE}" ] && return 1
-    HDR_GEN=$(echo $LINKS | grep -o "linux-headers[^ ]\+_all.deb" | head -1)
-    [ -z "${HDR_GEN}" ] && return 1
-    HDR_ARCH=$(echo $LINKS | \
-               grep -o "linux-headers[^ ]\+-generic[^ ]\+${ARCH}.deb" | head -1)
-    [ -z "${HDR_ARCH}" ] && return 1
-
-    DEB_URL=${BASE_URL}/${KDIR}/${IMAGE}
-    HDR_GEN_URL=${BASE_URL}/${KDIR}/${HDR_GEN}
-    HDR_ARCH_URL=${BASE_URL}/${KDIR}/${HDR_ARCH}
-    echo "Trying to fetch ${VERSION} from ${DEB_URL}"
-
-    docker build -t ${REPO}:${VERSION} -f Dockerfile.deb --no-cache \
-           --build-arg DEB_URLS="${DEB_URL} ${HDR_GEN_URL} ${HDR_ARCH_URL}" .
-}
-
-LINKS=$(curl -s ${BASE_URL}/ | sed -n 's/.*href="\([^"]*\).*/\1/p')
-# Extract all kernel versions (drop RCs, ckt(?) and other links)
-VERSIONS=$(echo $LINKS | grep -o "v[0-9]\+\.[0-9]\+\.[0-9]\+[^ ]*" | \
-           grep -ve '-rc' | grep -ve '-ckt' | uniq)
-
-# Extract 3.16.x and 4.x.x
-THREES=$(echo $VERSIONS | grep -o "v3\.16\.[0-9]\+[^ ]*")
-FOURS=$(echo $VERSIONS | grep -o "v4\.[0-9]\+\.[0-9]\+[^ ]*")
-KDIRS="${THREES} ${FOURS}"
-
-for KDIR in $KDIRS; do
-    # Strip the Ubuntu release name for the tag and also the 'v' like with
-    # the other kernel packages
-    VERSION=$(echo $KDIR | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+")
-    if echo $TAGS | grep -q "\"${VERSION}\""; then
-        echo "${REPO}:${VERSION} exists"
-        continue
-    fi
-    build_image ${VERSION} ${KDIR} && \
-        DOCKER_CONTENT_TRUST=1 docker push ${REPO}:${VERSION}
-
-    docker rmi ${REPO}:${VERSION}
-    docker system prune -f
-done
+docker build -t "${REPO}:${KVER}" -f Dockerfile.deb --no-cache --build-arg DEB_URLS="${DEB_URLS}" .


### PR DESCRIPTION
We used to periodically build linuxkit packages for kernels from other distributions. This was a manual process, so didn't happen very often. This PR abandons  this approach and instead rewrites the scripts so that users can build their own LinuxKit kernel packages from `centos`, `fedora`, `debian`, and `ubuntu` kernels.  There is also a script to re-package the mainline PPA kernels.

Once this gets merged, I'll remove the docker hub repos.

resolves #2763

![bieber-ratte](https://user-images.githubusercontent.com/3338098/34613722-b1d6195c-f226-11e7-9a73-6296a1668662.jpg)
