### PR TITLE
Bump to containerd v1.0.1-rc.0

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:728e5fe9e6b818d9825b28826b929ae75a386e9e # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   # support metadata for optional config in /var/config

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 services:
   - name: getty
     image: linuxkit/getty:22e27189b6b354e1d5d38fc0536a5af3f2adb79f

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS1 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: rngd1

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 as alpine
+FROM linuxkit/alpine:99dec12a5e8524b7a262c6bdfcea733191354883 as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build
+FROM linuxkit/alpine:99dec12a5e8524b7a262c6bdfcea733191354883 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -16,7 +16,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS mirror
+FROM linuxkit/alpine:99dec12a5e8524b7a262c6bdfcea733191354883 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -11,7 +11,7 @@ RUN \
   make \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin
-ENV RUNC_COMMIT=74a17296470088de3805e138d3d87c62e613dfc4
+ENV RUNC_COMMIT=7f24b40cc5423969b4554ef04ba0b00e2b4ba010
 RUN mkdir -p $GOPATH/src/github.com/opencontainers && \
   cd $GOPATH/src/github.com/opencontainers && \
   git clone https://github.com/opencontainers/runc.git

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f # with runc, logwrite, startmemlogd
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5 # with runc, logwrite, startmemlogd
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bccfe1cb04fc7bb9f03613d2314f38abd2620f29

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bccfe1cb04fc7bb9f03613d2314f38abd2620f29

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bccfe1cb04fc7bb9f03613d2314f38abd2620f29

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bccfe1cb04fc7bb9f03613d2314f38abd2620f29

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bccfe1cb04fc7bb9f03613d2314f38abd2620f29

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bccfe1cb04fc7bb9f03613d2314f38abd2620f29

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bccfe1cb04fc7bb9f03613d2314f38abd2620f29

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bccfe1cb04fc7bb9f03613d2314f38abd2620f29

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 services:
   - name: acpid
     image: linuxkit/acpid:fa37afe931844fb834e1906ec244d13b031741b9

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.111
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:9c3668b834540d2e776d0bf4aff661b3bcc35616

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:9c3668b834540d2e776d0bf4aff661b3bcc35616

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:9c3668b834540d2e776d0bf4aff661b3bcc35616

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.111
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.111
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 trust:
   org:
     - linuxkit

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:4b1d7a8dab03c09855fb4b6060a42b2294674b47

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:59bd2ba406162087169e2dd0bbce0ab73bc31da1
+    image: linuxkit/test-containerd:bbec657082ed2126ccb7f0e8d2a2c5c30eefd3dc
   - name: poweroff
     image: linuxkit/poweroff:bccfe1cb04fc7bb9f03613d2314f38abd2620f29
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: extend
     image: linuxkit/extend:e550c16d8464cabeffdff80f27e6fa8278f06dbb

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:1a192d168adadec47afa860e3fc874fbc2a823ff

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:1a192d168adadec47afa860e3fc874fbc2a823ff

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: extend
     image: linuxkit/extend:e550c16d8464cabeffdff80f27e6fa8278f06dbb

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:1a192d168adadec47afa860e3fc874fbc2a823ff

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:e439d6108466186948ca7ea2a293fc6c1d1183fa

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:bccfe1cb04fc7bb9f03613d2314f38abd2620f29

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: dhcpcd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
+  - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS mirror
+FROM linuxkit/alpine:99dec12a5e8524b7a262c6bdfcea733191354883 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:81fc00e879cf56fa6f058f6c891b012bc867de7f
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
+  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -43,7 +43,7 @@ RUN go get -u github.com/LK4D4/vndr
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.0.0
+ENV CONTAINERD_COMMIT=v1.0.1-rc.0
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,10 +1,10 @@
-# linuxkit/alpine:9d29dc154440859d729ba864ffd67bb4c90e630d-arm64
+# linuxkit/alpine:7dedd0ef748530ece641d931b6f77aa2992d90e5-arm64
 # automatically generated list of installed packages
 abuild-3.1.0-r3
 alpine-baselayout-3.0.5-r2
 alpine-keys-2.1-r1
 alsa-lib-1.1.4.1-r2
-apk-tools-2.8.1-r2
+apk-tools-2.8.2-r0
 argp-standalone-1.3-r2
 attr-2.4.47-r6
 attr-dev-2.4.47-r6
@@ -115,7 +115,7 @@ libcap-2.25-r1
 libcap-ng-0.7.8-r1
 libcap-ng-dev-0.7.8-r1
 libcom_err-1.43.7-r0
-libcrypto1.0-1.0.2m-r0
+libcrypto1.0-1.0.2n-r0
 libcurl-7.57.0-r0
 libdrm-2.4.88-r0
 libedit-20170329.3.1-r3
@@ -160,7 +160,7 @@ libseccomp-2.3.2-r0
 libseccomp-dev-2.3.2-r0
 libsmartcols-2.31-r0
 libssh2-1.8.0-r2
-libssl1.0-1.0.2m-r0
+libssl1.0-1.0.2n-r0
 libstdc++-6.4.0-r5
 libtasn1-4.12-r2
 libtirpc-1.0.1-r2
@@ -204,11 +204,11 @@ open-iscsi-2.0.874-r0
 open-isns-lib-0.97-r2
 openntpd-6.2_p3-r0
 openrc-0.24.1-r4
-openssh-keygen-7.5_p1-r7
-openssh-server-7.5_p1-r7
-openssh-server-common-7.5_p1-r7
-openssl-1.0.2m-r0
-openssl-dev-1.0.2m-r0
+openssh-keygen-7.5_p1-r8
+openssh-server-7.5_p1-r8
+openssh-server-common-7.5_p1-r8
+openssl-1.0.2n-r0
+openssl-dev-1.0.2n-r0
 opus-1.2.1-r1
 p11-kit-0.23.2-r2
 patch-2.7.5-r1
@@ -234,7 +234,7 @@ qemu-system-x86_64-2.10.1-r2
 readline-7.0.003-r0
 rhash-libs-1.3.5-r1
 rpcbind-0.2.4-r0
-rsync-3.1.2-r6
+rsync-3.1.2-r7
 scanelf-1.2.2-r1
 sed-4.4-r1
 sfdisk-2.31-r0
@@ -266,7 +266,7 @@ vim-8.0.1359-r0
 wayland-libs-client-1.14.0-r2
 wayland-libs-cursor-1.14.0-r2
 wayland-libs-server-1.14.0-r2
-wireguard-tools-0.0.20171211-r0
+wireguard-tools-0.0.20171221-r0
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r8
 xfsprogs-4.14.0-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,10 +1,10 @@
-# linuxkit/alpine:4584958639b2378246371fe219f33b270667e22e-amd64
+# linuxkit/alpine:99dec12a5e8524b7a262c6bdfcea733191354883-amd64
 # automatically generated list of installed packages
 abuild-3.1.0-r3
 alpine-baselayout-3.0.5-r2
 alpine-keys-2.1-r1
 alsa-lib-1.1.4.1-r2
-apk-tools-2.8.1-r2
+apk-tools-2.8.2-r0
 argp-standalone-1.3-r2
 attr-2.4.47-r6
 attr-dev-2.4.47-r6
@@ -211,9 +211,9 @@ open-isns-lib-0.97-r2
 open-vm-tools-10.1.15-r0
 openntpd-6.2_p3-r0
 openrc-0.24.1-r4
-openssh-keygen-7.5_p1-r7
-openssh-server-7.5_p1-r7
-openssh-server-common-7.5_p1-r7
+openssh-keygen-7.5_p1-r8
+openssh-server-7.5_p1-r8
+openssh-server-common-7.5_p1-r8
 openssl-1.0.2n-r0
 openssl-dev-1.0.2n-r0
 opus-1.2.1-r1
@@ -241,7 +241,7 @@ qemu-system-x86_64-2.10.1-r2
 readline-7.0.003-r0
 rhash-libs-1.3.5-r1
 rpcbind-0.2.4-r0
-rsync-3.1.2-r6
+rsync-3.1.2-r7
 scanelf-1.2.2-r1
 sed-4.4-r1
 sfdisk-2.31-r0
@@ -274,7 +274,7 @@ vim-8.0.1359-r0
 wayland-libs-client-1.14.0-r2
 wayland-libs-cursor-1.14.0-r2
 wayland-libs-server-1.14.0-r2
-wireguard-tools-0.0.20171211-r0
+wireguard-tools-0.0.20171221-r0
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r8
 xfsprogs-4.14.0-r0


### PR DESCRIPTION
Entirely mechanical bump to [containerd v1.0.1-rc.0](https://github.com/containerd/containerd/releases/tag/v1.0.1-rc.0). I will track rc through to final release.

Fixes #2855.