### PR TITLE
Move metadata to /run instead of /var

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -9,7 +9,7 @@ init:
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
-  # support metadata for optional config in /var/config
+  # support metadata for optional config in /run/config
   - name: metadata
     image: linuxkit/metadata:2af15c9f4b0e73515c219b7cc14e6e65e1d4fd6d
   - name: sysctl

--- a/blueprints/docker-for-mac/docker-ce.yml
+++ b/blueprints/docker-for-mac/docker-ce.yml
@@ -1,7 +1,7 @@
 services:
   # Run dockerd with the vpnkit userland proxy from the vpnkit-forwarder container.
   # Bind mounts /var/run to allow vsudd to connect to docker.sock, /var/vpnkit
-  # for vpnkit coordination and /var/config/docker for the configuration file.
+  # for vpnkit coordination and /run/config/docker for the configuration file.
   - name: docker-dfm
     image: docker:17.07.0-ce-dind
     capabilities:
@@ -16,7 +16,7 @@ services:
      - /lib/modules:/lib/modules
      - /var/vpnkit:/port # vpnkit control 9p mount
      - /var/run:/var/run
-     - /var/config/docker:/var/config/docker
+     - /run/config/docker:/var/config/docker
      - /usr/bin/vpnkit-expose-port:/usr/bin/vpnkit-expose-port # userland proxy
      - /usr/bin/vpnkit-iptables-wrapper:/usr/bin/iptables # iptables wrapper 
     command: [ "/usr/local/bin/docker-init", "/usr/local/bin/dockerd", "--",

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -12,11 +12,11 @@ instances before launch (it is immutable in most providers).
 The [metadata package](../pkg/metadata/) handles both metadata and
 userdata for a number of providers (see below).  It abstracts over
 the provider differences by exposing both metadata and userdata in
-a directory hierarchy under `/var/config`.  For example, sshd config
-files from the metadata are placed under `/var/config/ssh`.
+a directory hierarchy under `/run/config`.  For example, sshd config
+files from the metadata are placed under `/run/config/ssh`.
 
 Userdata is assumed to be a single string and the contents will be
-stored under `/var/config/userdata`.  If userdata is a JSON file, the
+stored under `/run/config/userdata`.  If userdata is a JSON file, the
 contents will be further processed, where different keys cause
 directories to be created and the directories are populated with files.
 For example, the following userdata file:
@@ -45,9 +45,9 @@ For example, the following userdata file:
 ```
 will generate the following files:
 ```
-/var/config/ssh/sshd_config
-/var/config/foo/bar
-/var/config/foo/baz
+/run/config/ssh/sshd_config
+/run/config/foo/bar
+/run/config/foo/baz
 ```
 
 The JSON file consists of a map from `name` to an entry object. Each entry object has the following fields:
@@ -83,20 +83,20 @@ Below is a list of supported providers and notes on what is supported. We will a
 GCP metadata is reached via a well known URL
 (`http://metadata.google.internal/`) and currently
 we extract the hostname and populate the
-`/var/config/ssh/authorized_keys` from metadata. In the future we'll
+`/run/config/ssh/authorized_keys` from metadata. In the future we'll
 add more complete SSH support.
 
 GCP userdata is extracted from `/computeMetadata/v1/instance/attributes/userdata`
-and made available in `/var/config/userdata`.
+and made available in `/run/config/userdata`.
 
 ## AWS
 
 AWS metadata is reached via the following URL
 (`http://169.254.169.254/latest/meta-data/`) and currently we extract the
-hostname and populate the `/var/config/ssh/authorized_keys` from metadata.
+hostname and populate the `/run/config/ssh/authorized_keys` from metadata.
 
 AWS userdata is extracted from `http://169.254.169.254/latest/user-data` and
-and made available in `/var/config/userdata`.
+and made available in `/run/config/userdata`.
 
 
 ## HyperKit

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -20,7 +20,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:ac5e8364e2e9aa8717a3295c51eb60b8c57373d5
     binds:
-     - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
+     - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx
     image: nginx:alpine
     capabilities:

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -24,7 +24,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:ac5e8364e2e9aa8717a3295c51eb60b8c57373d5
     binds:
-     - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
+     - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx
     image: nginx:alpine
     capabilities:

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -21,7 +21,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:ac5e8364e2e9aa8717a3295c51eb60b8c57373d5
     binds:
-     - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
+     - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx
     image: nginx:alpine
     capabilities:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -24,7 +24,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:ac5e8364e2e9aa8717a3295c51eb60b8c57373d5
     binds:
-     - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
+     - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx
     image: nginx:alpine
     capabilities:

--- a/pkg/metadata/main.go
+++ b/pkg/metadata/main.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// ConfigPath is where the data is extracted to
-	ConfigPath = "/var/config"
+	ConfigPath = "/run/config"
 
 	// Hostname is the filename in configPath where the hostname is stored
 	Hostname = "hostname"


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Moved metadata (and userdata) to `/run/config` instead of `/var/config`. Closes #2829 

Two questions to be addressed:

1. Is `/run/config` the right path? I chose it to match `/var/config`, but wonder if something else might need the space? Should it be `/run/metadata`? I prefer `/run/config`, but want to raise the question.
2. Is there anything in the docker-for-mac blueprint that expects it to be in `/var/config`? In the `docker-ce.yml` I updated the mount of data from `/var/config/docker:/var/config/docker` to `/run/config/docker:/var/config/docker`, so it should provide the data to docker where it expects, but not sure if anything else builds on the base system.

**- How I did it**

* Changed the `ConfigPath` var in [main.go](./pkg/metadata/main.go) . 
* No need to rewrite tests, as they pass in the target path as parameter
* Updated the doc
* Updated various consuming ymls

**- How to verify it**
Run it in an environment and see that metadata shows up where desired.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Metadata in `/run/config` instead of `/var/config` to avoid possible mount conflicts, and fit with runtime data.

**- A picture of a cute animal (not mandatory but encouraged)**