### PR TITLE
Fix some issues highlighted by go vet

### DIFF
--- a/blueprints/docker-for-mac/base.yml
+++ b/blueprints/docker-for-mac/base.yml
@@ -4,14 +4,14 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:728e5fe9e6b818d9825b28826b929ae75a386e9e # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   # support metadata for optional config in /run/config
   - name: metadata
-    image: linuxkit/metadata:2af15c9f4b0e73515c219b7cc14e6e65e1d4fd6d
+    image: linuxkit/metadata:8e45cb18b0cb309a6aff514dd1be1ac6b5f59f06
   - name: sysctl
     image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
   - name: sysfs
@@ -22,7 +22,7 @@ onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib"]
   # make a swap file on the mounted disk
   - name: swap

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:2af15c9f4b0e73515c219b7cc14e6e65e1d4fd6d
+    image: linuxkit/metadata:8e45cb18b0cb309a6aff514dd1be1ac6b5f59f06
 services:
   - name: rngd
     image: linuxkit/rngd:94e01a4b16fadb053455cdc2269c4eb0b39199cd

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
@@ -17,7 +17,7 @@ onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 
 services:

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
@@ -14,7 +14,7 @@ onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:2af15c9f4b0e73515c219b7cc14e6e65e1d4fd6d
+    image: linuxkit/metadata:8e45cb18b0cb309a6aff514dd1be1ac6b5f59f06
 services:
   - name: getty
     image: linuxkit/getty:22e27189b6b354e1d5d38fc0536a5af3f2adb79f

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 services:

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:2af15c9f4b0e73515c219b7cc14e6e65e1d4fd6d
+    image: linuxkit/metadata:8e45cb18b0cb309a6aff514dd1be1ac6b5f59f06
     command: ["/usr/bin/metadata", "openstack"]
 services:
   - name: rngd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS1 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:2af15c9f4b0e73515c219b7cc14e6e65e1d4fd6d
+    image: linuxkit/metadata:8e45cb18b0cb309a6aff514dd1be1ac6b5f59f06
     command: ["/usr/bin/metadata", "packet"]
 services:
   - name: rngd

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
@@ -15,7 +15,7 @@ onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/external"]
   - name: swap
     image: linuxkit/swap:b3d5db11b14168874a01b5ea4398186321be836f

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:

--- a/examples/vsudd.yml
+++ b/examples/vsudd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:0d59a6cc03412289ef4313f2491ec666c1715cc9
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:2af15c9f4b0e73515c219b7cc14e6e65e1d4fd6d
+    image: linuxkit/metadata:8e45cb18b0cb309a6aff514dd1be1ac6b5f59f06
 services:
   - name: getty
     image: linuxkit/getty:22e27189b6b354e1d5d38fc0536a5af3f2adb79f

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/pkg/init/cmd/rc.init/main.go
+++ b/pkg/init/cmd/rc.init/main.go
@@ -281,7 +281,7 @@ func rlimit(resource int, cur, max uint64) {
 	lim := unix.Rlimit{Cur: cur, Max: max}
 	err := unix.Setrlimit(resource, &lim)
 	if err != nil {
-		log.Printf("Failed to set rlimit %s: %v", resource, err)
+		log.Printf("Failed to set rlimit %d: %v", resource, err)
 	}
 }
 

--- a/pkg/metadata/main.go
+++ b/pkg/metadata/main.go
@@ -165,7 +165,7 @@ func writeConfigFiles(target string, current Entry) {
 	if isFile(current) {
 		filemode, err := parseFileMode(current.Perm, 0644)
 		if err != nil {
-			log.Printf("Failed to parse permission %s: %s", current, err)
+			log.Printf("Failed to parse permission %+v: %s", current, err)
 			return
 		}
 		if err := ioutil.WriteFile(target, []byte(*current.Content), filemode); err != nil {
@@ -175,7 +175,7 @@ func writeConfigFiles(target string, current Entry) {
 	} else if isDirectory(current) {
 		filemode, err := parseFileMode(current.Perm, 0755)
 		if err != nil {
-			log.Printf("Failed to parse permission %s: %s", current, err)
+			log.Printf("Failed to parse permission %+v: %s", current, err)
 			return
 		}
 		if err := os.MkdirAll(target, filemode); err != nil {

--- a/pkg/mount/mountie.go
+++ b/pkg/mount/mountie.go
@@ -180,13 +180,13 @@ func makeDevLinks() error {
 				// udev makes these relative links, copy that behaviour.
 				tgtpath := filepath.Join("..", "..", name)
 				if err := os.Symlink(tgtpath, sympath); err != nil {
-					log.Printf("Failed to create %q: %v", err)
+					log.Printf("Failed to create %q: %v", sympath, err)
 					continue
 				}
 			case "TYPE":
 				// uninteresting
 			default:
-				log.Printf("unused %q blkid property %q", name, key, match[0])
+				log.Printf("unused %q blkid property %q in %q", name, key, match[0])
 			}
 		}
 	}

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
@@ -17,7 +17,7 @@ onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
@@ -17,7 +17,7 @@ onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5 # with runc, logwrite, startmemlogd
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de # with runc, logwrite, startmemlogd
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/src/cmd/linuxkit/run_packet.go
+++ b/src/cmd/linuxkit/run_packet.go
@@ -291,7 +291,7 @@ func validateHTTPURL(url string) error {
 		return err
 	}
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("Got a non 200- or 300- HTTP response code: %s", resp)
+		return fmt.Errorf("Got a non 200- or 300- HTTP response code: %s", resp.Status)
 	}
 	return nil
 }

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 services:

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.111
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.111
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: check

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: check

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.111
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 trust:
   org:

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 trust:
   org:

--- a/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
@@ -14,7 +14,7 @@ onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
@@ -15,7 +15,7 @@ onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
     image: linuxkit/test-containerd:bbec657082ed2126ccb7f0e8d2a2c5c30eefd3dc

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: extend
     image: linuxkit/extend:e550c16d8464cabeffdff80f27e6fa8278f06dbb
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: modprobe
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: modprobe
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/extend:e550c16d8464cabeffdff80f27e6fa8278f06dbb
     command: ["/usr/bin/extend", "-type", "btrfs"]
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
     command: ["/usr/bin/format", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: extend
     image: linuxkit/extend:e550c16d8464cabeffdff80f27e6fa8278f06dbb
     command: ["/usr/bin/extend", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
     command: ["/usr/bin/format"]
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
     command: ["/usr/bin/format", "-label", "docker"]
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
     command: ["/usr/bin/format", "@DEVICE@"]
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "-device", "@DEVICE@1", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: modprobe
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
     command: ["/usr/bin/format", "-type", "xfs" ]
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: format
@@ -12,10 +12,10 @@ onboot:
     image: linuxkit/format:5a1140cb65e733f26de727fa684fef1326e9d5ab
     command: ["/usr/bin/format", "-label", "foo"]
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: mount
-    image: linuxkit/mount:b346ec277b7074e5c9986128a879c10a1d18742b
+    image: linuxkit/mount:3c37d46558c794e8535daa805e7037cb8e82c141
     command: ["/usr/bin/mountie", "-label", "foo", "/var/foo"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.9.76
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
 onboot:

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:7c405a03c8467b3aa7999d2a729aeb5d3fa7dae5
+  - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
 onboot:
   - name: test-ns


### PR DESCRIPTION
This fixes most of the issues at https://goreportcard.com/report/github.com/linuxkit/linuxkit#go_vet.

There remaining ones are all `error: net.UnixAddr composite literal uses unkeyed fields (vet)` to things under `projects/logging/pkg/memlogd/cmd/...`, which is a) under projects (hence not to be worried about overmuch) and b) pretty bogus since they are `net.UnixAddr{socketPath, "unix"}` which seems to me to be a pretty reasonable construct even without the field names.

The individual commit messages include the specific warnings being fixed.