### PR TITLE
Add /run to binds and use newer yml label format

### DIFF
--- a/pkg/metadata/Dockerfile
+++ b/pkg/metadata/Dockerfile
@@ -6,7 +6,7 @@ ENV GOPATH=/go PATH=$PATH:/go/bin
 COPY .  /go/src/metadata/
 RUN go-compile.sh /go/src/metadata
 
-RUN mkdir -p out/tmp out/var out/dev out/etc out/etc/ssl/certs
+RUN mkdir -p out/tmp out/var out/run out/dev out/etc out/etc/ssl/certs
 
 FROM scratch
 ENTRYPOINT []
@@ -15,4 +15,3 @@ WORKDIR /
 COPY --from=mirror /go/bin/metadata /usr/bin/metadata
 COPY --from=mirror /out/ /
 CMD ["/usr/bin/metadata"]
-LABEL org.mobyproject.config='{"binds": ["/dev:/dev", "/var:/var", "/sys:/sys", "/etc/resolv.conf:/etc/resolv.conf", "/etc/ssl/certs:/etc/ssl/certs"], "tmpfs": ["/tmp"], "readonly": true, "capabilities": ["CAP_SYS_ADMIN", "CAP_NET_ADMIN"]}'

--- a/pkg/metadata/build.yml
+++ b/pkg/metadata/build.yml
@@ -1,1 +1,15 @@
 image: metadata
+config:
+  binds:
+    - /dev:/dev
+    - /var:/var
+    - /run:/run
+    - /sys:/sys
+    - /etc/resolv.conf:/etc/resolv.conf
+    - /etc/ssl/certs:/etc/ssl/certs
+  tmpfs:
+    - /tmp
+  readonly: true
+  capabilities:
+    - CAP_SYS_ADMIN
+    - CAP_NET_ADMIN


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the labeling and binds for `linuxkit/metadata`

**- How I did it**
Moved the label to the new `build.yml` config (with thanks to @justincormack for the help) and added mounts for `/run`

**- How to verify it**
Run it. Now metadata shows up correctly.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix binds for metadata under `/run`.


**- A picture of a cute animal (not mandatory but encouraged)**
