### PR TITLE
Add support for driver (and CPU) firmware

### DIFF
--- a/docs/platform-packet.md
+++ b/docs/platform-packet.md
@@ -34,6 +34,13 @@ an additional YAML for [arm64](../examples/packet.arm64.yml) servers
 which provide both access to the serial console and via ssh and
 configures bonding for network devices via metadata (if supported).
 
+For x86_64 builds for Intel servers we strongly recommend adding
+`ucode: intel-ucode.cpio` to the kernel section in the YAML. This
+updates the Intel CPU microcode to the latest by prepending it to the
+generated initrd file. The `ucode` entry is only recommended when
+booting on baremetal. It should be omitted (but is harmless) when
+building images to boot in VMs.
+
 **Note**: The update of the iPXE configuration sometimes may take some
 time and the first boot may fail. Hitting return on the console to
 retry the boot typically fixes this.

--- a/examples/packet.arm64.yml
+++ b/examples/packet.arm64.yml
@@ -1,3 +1,13 @@
+# This YAML snippet is to be used in conjunction with packet.yml to
+# build a arm64 image for packet.net. It adds a modprobe of the NIC
+# driver and overrides the kernel section to disable prepending the
+# Intel CPU microcode to the initrd. If writing a YAML specifically
+# for arm64 then the 'ucode' line in the kernel section can be left
+# out.
+kernel:
+  image: linuxkit/kernel:4.9.76
+  cmdline: "console=ttyAMA0"
+  ucode: ""
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:1a192d168adadec47afa860e3fc874fbc2a823ff

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -7,6 +7,7 @@ init:
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff
   - linuxkit/containerd:1b6b8a5884e17b26e2725cb82c436841070fca95
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
+  - linuxkit/firmware:8fc7d7702589b67e5b1aa72bb61cc72b47a048aa
 onboot:
   - name: rngd1
     image: linuxkit/rngd:94e01a4b16fadb053455cdc2269c4eb0b39199cd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,6 +1,7 @@
 kernel:
   image: linuxkit/kernel:4.9.76
-  cmdline: "console=ttyS1 console=ttyAMA0"
+  cmdline: console=ttyS1
+  ucode: intel-ucode.cpio
 init:
   - linuxkit/init:f7a3d03face99e933626533a3381ae4476fbc8de
   - linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff

--- a/pkg/firmware-all/Dockerfile
+++ b/pkg/firmware-all/Dockerfile
@@ -1,0 +1,19 @@
+FROM linuxkit/alpine:34518265c6cb63ff02074549cc5b64bef40c336f AS build
+RUN apk add --no-cache git
+
+# Make sure you also update the FW_COMMIT in ../firmware/Dockerfile
+ENV FW_URL=git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
+ENV FW_COMMIT=65b1c68c63f974d72610db38dfae49861117cae2
+
+RUN mkdir -p /out/lib && \
+    cd /out/lib && \
+    git clone ${FW_URL} firmware && \
+    cd firmware && \
+    git checkout ${FW_COMMIT} && \
+    rm -rf .git 
+
+FROM scratch
+WORKDIR /
+ENTRYPOINT []
+COPY --from=build /out/lib/ /lib/
+    

--- a/pkg/firmware-all/README.md
+++ b/pkg/firmware-all/README.md
@@ -1,0 +1,8 @@
+The `firmware-all` package contains all firmware binaries from the
+[Linux firmware
+repository](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/). It
+is quite large.
+
+For use with the LinuxKit kernel we recommend using the
+[`firmware`](../firmware/) package, which only contains the firmware
+binaries for which drivers are enabled.

--- a/pkg/firmware-all/build.yml
+++ b/pkg/firmware-all/build.yml
@@ -1,0 +1,2 @@
+image: firmware-all
+network: true

--- a/pkg/firmware/Dockerfile
+++ b/pkg/firmware/Dockerfile
@@ -1,0 +1,44 @@
+# Make modules from a recentish kernel available
+FROM linuxkit/kernel:4.14.12 AS kernel
+
+FROM linuxkit/alpine:34518265c6cb63ff02074549cc5b64bef40c336f AS build
+RUN apk add --no-cache git kmod
+
+# Clone the firmware repository
+# Make sure you also update the FW_COMMIT in ../firmware-all/Dockerfile
+ENV FW_URL=git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
+ENV FW_COMMIT=65b1c68c63f974d72610db38dfae49861117cae2
+WORKDIR /
+RUN git clone ${FW_URL} && \
+    cd /linux-firmware && \
+    git checkout ${FW_COMMIT}
+
+# Copy files we always need/want: Licenses, docs and AMD CPU microcode
+WORKDIR /linux-firmware
+RUN set -e && \
+    mkdir -p /out/lib/firmware && \
+    cp README WHENCE /out/lib/firmware && \
+    cp GPL-? LICENSE.* LICENCE.* /out/lib/firmware && \
+    case $(uname -m) in \
+    x86_64) \
+        cp -r amd-ucode /out/lib/firmware; \
+        ;; \
+    esac
+
+# Extract kernel modules for
+WORKDIR /
+COPY --from=kernel /kernel.tar /kernel.tar
+RUN tar xf /kernel.tar
+
+# Copy files required by the modules
+RUN set -e && \
+    for fw in $(find /lib/modules -name \*.ko -exec modinfo --field=firmware {} \;); do \
+        mkdir -p "/out/lib/firmware/$fw" && \
+        cp "/linux-firmware/$fw" "/out/lib/firmware/$fw"; \
+    done
+
+FROM scratch
+WORKDIR /
+ENTRYPOINT []
+COPY --from=build /out/lib/ /lib/
+

--- a/pkg/firmware/README.md
+++ b/pkg/firmware/README.md
@@ -1,0 +1,12 @@
+The `firmware` package contains updated firmware files required by any
+driver compiled as a module. Based on the modules included in a recent
+LinuxKit kernel, copy the required firmware binaries as reported by
+'modinfo'. We deliberately do *not* pick the latest version here to
+prevent it being updated on kernel updates. Firmware revisions do not
+change very often and we expect older and newer kernels to work with a
+range of firmware binaries.
+
+Note: The current mechanism only handles firmware blobs required by
+modules and ignores firmware blobs required by drivers compiled into
+the kernel. However, with the LinuxKit kernels we typically compile
+all hardware drivers as modules.

--- a/pkg/firmware/build.yml
+++ b/pkg/firmware/build.yml
@@ -1,0 +1,2 @@
+image: firmware
+network: true

--- a/src/cmd/linuxkit/vendor.conf
+++ b/src/cmd/linuxkit/vendor.conf
@@ -26,7 +26,7 @@ github.com/moby/datakit 97b3d230535397a813323902c23751e176481a86
 github.com/moby/hyperkit a12cd7250bcd8d689078e3e42ae4a7cf6a0cbaf3
 # When updating also:
 # curl -fsSL -o src/cmd/linuxkit/build.go https://raw.githubusercontent.com/moby/tool/«hash»/cmd/moby/build.go
-github.com/moby/tool f816553d2fc58638f6904fddedd13c36d237b498
+github.com/moby/tool 57b6e2ab947104d47fd60e5af0e34d0edeb9421c
 github.com/moby/vpnkit 0e4293bb1058598c4b0a406ed171f52573ef414c
 github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
 github.com/opencontainers/image-spec v1.0.0

--- a/src/cmd/linuxkit/vendor/github.com/moby/tool/src/initrd/initrd.go
+++ b/src/cmd/linuxkit/vendor/github.com/moby/tool/src/initrd/initrd.go
@@ -110,13 +110,13 @@ func CopyTar(w *Writer, r *tar.Reader) (written int64, err error) {
 	}
 }
 
-// CopySplitTar copies a tar stream into an initrd, but splits out kernel and cmdline
-func CopySplitTar(w *Writer, r *tar.Reader) (kernel []byte, cmdline string, err error) {
+// CopySplitTar copies a tar stream into an initrd, but splits out kernel, cmdline, and ucode
+func CopySplitTar(w *Writer, r *tar.Reader) (kernel []byte, cmdline string, ucode []byte, err error) {
 	for {
 		var thdr *tar.Header
 		thdr, err = r.Next()
 		if err == io.EOF {
-			return kernel, cmdline, nil
+			return kernel, cmdline, ucode, nil
 		}
 		if err != nil {
 			return
@@ -134,6 +134,11 @@ func CopySplitTar(w *Writer, r *tar.Reader) (kernel []byte, cmdline string, err 
 				return
 			}
 			cmdline = string(buf)
+		case "boot/ucode.cpio":
+			ucode, err = ioutil.ReadAll(r)
+			if err != nil {
+				return
+			}
 		case "boot":
 			// skip this entry
 		default:

--- a/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/config.go
+++ b/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/config.go
@@ -36,6 +36,7 @@ type KernelConfig struct {
 	Cmdline string  `yaml:"cmdline,omitempty" json:"cmdline,omitempty"`
 	Binary  string  `yaml:"binary,omitempty" json:"binary,omitempty"`
 	Tar     *string `yaml:"tar,omitempty" json:"tar,omitempty"`
+	UCode   *string `yaml:"ucode,omitempty" json:"ucode,omitempty"`
 
 	ref *reference.Spec
 }
@@ -288,6 +289,9 @@ func AppendConfig(m0, m1 Moby) (Moby, error) {
 	}
 	if m1.Kernel.Tar != nil {
 		moby.Kernel.Tar = m1.Kernel.Tar
+	}
+	if m1.Kernel.UCode != nil {
+		moby.Kernel.UCode = m1.Kernel.UCode
 	}
 	if m1.Kernel.ref != nil {
 		moby.Kernel.ref = m1.Kernel.ref

--- a/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/linuxkit.go
+++ b/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/linuxkit.go
@@ -72,7 +72,7 @@ func ensureLinuxkitImage(name string) error {
 		return err
 	}
 	defer image.Close()
-	kernel, initrd, cmdline, err := tarToInitrd(image)
+	kernel, initrd, cmdline, _, err := tarToInitrd(image)
 	if err != nil {
 		return fmt.Errorf("Error converting to initrd: %v", err)
 	}

--- a/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/schema.go
+++ b/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/schema.go
@@ -13,7 +13,8 @@ var schema = string(`
         "image": {"type": "string"},
         "cmdline": {"type": "string"},
         "binary": {"type": "string"},
-        "tar": {"type": "string"}
+        "tar": {"type": "string"},
+        "ucode": {"type": "string"}
       }
     },
     "file": {


### PR DESCRIPTION
This adds two new packages: `firmware` and `firmware-all`. The former only contains firmware blobs required by the driver modules included in a LinuxKit kernel (plus license files and the AMD CPU microde) while the latter contains a snapshot of the `linux-firmware` repository. `firmware` should be sufficient for use with LinuxKit kernels, while `firmware-all` may be used with custom or other distro's kernels.

Repositories are set up and packages pushed/signed. This should now be good for review.

resolves #2714

![shark-smile](https://user-images.githubusercontent.com/3338098/35006921-d5c71272-faef-11e7-9cb0-7721d7818045.jpg)

