### PR TITLE
wireguard: update to 0.0.20180118

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -39,8 +39,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20171221
-ENV WIREGUARD_SHA256=2b97697e9b271ba8836a04120a287b824648124f21d5309170ec51c1f86ac5ed
+ENV WIREGUARD_VERSION=0.0.20180118
+ENV WIREGUARD_SHA256=463f3b402deb66b7ceac8df2d50944f32683933356455d6c1c7453926db3a8a3
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
* receive: treat packet checking as irrelevant for timers

Small simplification to the state machine, as discussed with Mathias
Hall-Andersen.

* socket: check for null socket before fishing out sport
* wg-quick: ifnames have max len of 15
* tools: plug memleak in config error path

Important bug fixes.

* external-tests: add python implementation

Piotr Lizonczyk has contributed a test vector written in Python.

* poly1305: remove indirect calls

From Samuel Neves, we now are in a better position to mitigate speculative
execution attacks.

* curve25519: modularize implementation
* curve25519: import 32-bit fiat-crypto implementation
* curve25519: import 64-bit hacl-star implementation
* curve25519: resolve symbol clash between fe types
* curve25519: wire up new impls and remove donna
* tools: import new curve25519 implementations
* contrib: keygen-html: update curve25519 implementation

Two of our Curve25519 implementations now use formally verified C. Read this
mailing list post for more information:
https://lists.zx2c4.com/pipermail/wireguard/2018-January/002304.html

![image](https://user-images.githubusercontent.com/10643/35147690-c0ed51aa-fd0f-11e7-8fb4-8f39b3bbe849.png)