### PR TITLE
Add code of conduct link to Github recommended location

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+LinuxKit applies the [Docker code of conduct](https://github.com/docker/code-of-conduct).
+
+For further information, see also the [contributing guide](CONTRIBUTING.md) and the [maintainers file](MAINTAINERS).


### PR DESCRIPTION
See recommendations at https://help.github.com/articles/adding-a-code-of-conduct-to-your-project/

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

See also #2848

![animal rave](https://user-images.githubusercontent.com/482364/35218525-e5490cac-ff66-11e7-9f47-f6ebe0ff70cb.jpg)
