### PR TITLE
Use microcode-20171117 in kernel build as microcode-20180108 is no longer available

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -158,7 +158,7 @@ RUN if [ "${KERNEL_SERIES}" != "4.4.x" ]; then \
      fi
 
 # Download Intel ucode and create a CPIO archive for it
-ENV UCODE_URL=https://downloadmirror.intel.com/27431/eng/microcode-20180108.tgz
+ENV UCODE_URL=https://downloadmirror.intel.com/27337/eng/microcode-20171117.tgz
 RUN set -e && \
     if [ $(uname -m) == x86_64 ]; then \
         cd /ucode && \

--- a/kernel/ucode/intel-ucode-md5sums
+++ b/kernel/ucode/intel-ucode-md5sums
@@ -1,1 +1,1 @@
-871df55f0ab010ee384dabfc424f2c12  microcode.tar.gz
+b294245d1f7f6c20f01edba53185f258  microcode.tar.gz


### PR DESCRIPTION

Signed-off-by: Emily Casey <ecasey@pivotal.io>
Signed-off-by: Steve Hiehn <shiehn@pivotal.io>

**- What I did**
I changed the downloaded version of microcode to 20171117 because the link to download version 20180108 was returning a 404. 20180108 must have been made unavailable because the intel site currently reports 20171117 as the latest version https://downloadcenter.intel.com/download/27337?v=t.

**- How I did it**
I Changed the UCODE_URL to point at the microcode-20171117.tgz and changed the expected md5.

**- How to verify it**
`docker build` the kernel image

**- Description for the changelog**
Downgraded to Intel microcode version 20171117

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1994518/35595441-c11ded0a-05e4-11e8-9580-434b525bd15d.png)
