### PR TITLE
Bump to containerd v1.0.2-rc.0

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.2 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   # support metadata for optional config in /run/config

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.2

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
 services:
   - name: getty
     image: linuxkit/getty:v0.2

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
   - linuxkit/firmware:v0.2
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.2

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.2

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.2

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 as alpine
+FROM linuxkit/alpine:4d6cfc5de9c29ad5cb633db9638660ba22d2fea5 as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS build
+FROM linuxkit/alpine:4d6cfc5de9c29ad5cb633db9638660ba22d2fea5 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -16,7 +16,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:4d6cfc5de9c29ad5cb633db9638660ba22d2fea5 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -11,7 +11,7 @@ RUN \
   make \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin
-ENV RUNC_COMMIT=7f24b40cc5423969b4554ef04ba0b00e2b4ba010
+ENV RUNC_COMMIT=9f9c96235cc97674e935002fc3d78361b696a69e
 RUN mkdir -p $GOPATH/src/github.com/opencontainers && \
   cd $GOPATH/src/github.com/opencontainers && \
   git clone https://github.com/opencontainers/runc.git

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:v0.2 # with runc, logwrite, startmemlogd
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e # with runc, logwrite, startmemlogd
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.2

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.2

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.2

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
 services:
   - name: acpid
     image: linuxkit/acpid:v0.2

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.113
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:80bb1cd57205e47b5976f7fa4fb036384d012a1d

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:80bb1cd57205e47b5976f7fa4fb036384d012a1d

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.15
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:80bb1cd57205e47b5976f7fa4fb036384d012a1d

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.113
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.15
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.113
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.15
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 trust:
   org:
     - linuxkit

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:v0.2

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:v0.2
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:152ffeb88c134ddf5544810965f5932e37299f2e
+    image: linuxkit/test-containerd:5eb051de579648ae22d8a38076743d2a0d1411b0
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.2

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: format
     image: linuxkit/format:v0.2

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: extend
     image: linuxkit/extend:v0.2

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:v0.2

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:v0.2

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: format
     image: linuxkit/format:v0.2

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: extend
     image: linuxkit/extend:v0.2

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: format
     image: linuxkit/format:v0.2

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: format
     image: linuxkit/format:v0.2

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: format
     image: linuxkit/format:v0.2

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:v0.2

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: format
     image: linuxkit/format:v0.2

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: format
     image: linuxkit/format:v0.2

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: format
     image: linuxkit/format:v0.2

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:v0.2

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.2

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
   - linuxkit/ca-certificates:v0.2
 onboot:
   - name: dhcpcd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.9.78
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
-  - linuxkit/containerd:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.2

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:4d6cfc5de9c29ad5cb633db9638660ba22d2fea5 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.2
-  - linuxkit/runc:v0.2
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -43,7 +43,7 @@ RUN go get -u github.com/LK4D4/vndr
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.0.1
+ENV CONTAINERD_COMMIT=v1.0.2-rc.0
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:4da19976a059bc710eeff8d8daa8a2d3a48b851b-arm64
+# linuxkit/alpine:7c82197bb5138e34a0f6a387c0fc52e123e599ab-arm64
 # automatically generated list of installed packages
 abuild-3.1.0-r3
 alpine-baselayout-3.0.5-r2
@@ -25,7 +25,7 @@ btrfs-progs-4.13.2-r0
 btrfs-progs-dev-4.13.2-r0
 btrfs-progs-libs-4.13.2-r0
 build-base-0.5-r0
-busybox-1.27.2-r7
+busybox-1.27.2-r8
 busybox-initscripts-3.1-r2
 bzip2-1.0.6-r6
 ca-certificates-20171114-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7-amd64
+# linuxkit/alpine:4d6cfc5de9c29ad5cb633db9638660ba22d2fea5-amd64
 # automatically generated list of installed packages
 abuild-3.1.0-r3
 alpine-baselayout-3.0.5-r2
@@ -25,7 +25,7 @@ btrfs-progs-4.13.2-r0
 btrfs-progs-dev-4.13.2-r0
 btrfs-progs-libs-4.13.2-r0
 build-base-0.5-r0
-busybox-1.27.2-r7
+busybox-1.27.2-r8
 busybox-initscripts-3.1-r2
 bzip2-1.0.6-r6
 ca-certificates-20171114-r0


### PR DESCRIPTION
  
    https://github.com/containerd/containerd/releases/tag/v1.0.2-rc.0
    
    $ git log --oneline --no-merges v1.0.1..v1.0.2-rc.0
    a67e9d27 release: prepare 1.0.2-rc.0
    91c3b8bf content/testsuite: pass context to hold lease
    c910b470 content/testsuite: ensure unique content per test
    45e7aa52 Update copy to discard over truncate
    d7a0e702 Add resume content test cases
    5c21576e Fix duplicate directories entries on metadata change
    af4455b3 vendor: update go-runc to reduce gc pressure
    f042dc58 cmd/containerd-shim: aggressive memory reclamation
    8cf32d34 cmd/containerd-shim, reaper: reduce channel allocation
    367eddb4 archive, cio, cmd, linux: use buffer pools
    852f989a Update runc to 9f9c96235cc97674e935002fc3d78361b69
    a03fb1bd Fix NPE in dialer
    d04746b4 Update metadata image store to be initialized once
    5a67161d Update namespace empty check to use buckets
