### PR TITLE
Allow choice of qemu binary and acceleration

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -167,6 +167,7 @@ func runQemu(args []string) {
 
 	// Backend configuration
 	qemuContainerized := flags.Bool("containerized", false, "Run qemu in a container")
+	qemuCmd := flags.String("qemu", "", "Path to the qemu binary (otherwise look in $PATH)")
 
 	// Generate UUID, so that /sys/class/dmi/id/product_uuid is populated
 	vmUUID := uuid.New()
@@ -311,6 +312,7 @@ func runQemu(args []string) {
 		Memory:         *mem,
 		KVM:            *enableKVM,
 		Containerized:  *qemuContainerized,
+		QemuBinPath:    *qemuCmd,
 		PublishedPorts: publishFlags,
 		NetdevConfig:   netdevConfig,
 		UUID:           vmUUID,
@@ -591,6 +593,13 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 }
 
 func discoverBackend(config QemuConfig) QemuConfig {
+	if config.QemuImgPath != "" && config.Containerized {
+		log.Fatal("-qemu and -containerized can't be used together.")
+	}
+	if config.QemuImgPath != "" {
+		return config
+	}
+
 	qemuBinPath := "qemu-system-" + config.Arch
 	qemuImgPath := "qemu-img"
 

--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -38,7 +38,7 @@ type QemuConfig struct {
 	Arch           string
 	CPUs           string
 	Memory         string
-	KVM            bool
+	Accel          string
 	Containerized  bool
 	QemuBinPath    string
 	QemuImgPath    string
@@ -56,7 +56,8 @@ const (
 )
 
 var (
-	defaultArch string
+	defaultArch  string
+	defaultAccel string
 )
 
 func init() {
@@ -66,24 +67,17 @@ func init() {
 	case "amd64":
 		defaultArch = "x86_64"
 	}
+	switch {
+	case haveKVM():
+		defaultAccel = "kvm:tcg"
+	case runtime.GOOS == "darwin":
+		defaultAccel = "hvf:tcg"
+	}
 }
 
 func haveKVM() bool {
 	_, err := os.Stat("/dev/kvm")
 	return !os.IsNotExist(err)
-}
-
-func envOverrideBool(env string, b *bool) {
-	val := os.Getenv(env)
-	if val == "" {
-		return
-	}
-
-	var err error
-	*b, err = strconv.ParseBool(val)
-	if err != nil {
-		log.Fatal("Unable to parse %q=%q as a boolean", env, val)
-	}
 }
 
 func retrieveMAC(statePath string) net.HardwareAddr {
@@ -160,7 +154,7 @@ func runQemu(args []string) {
 	fw := flags.String("fw", "", "Path to OVMF firmware for UEFI boot")
 
 	// VM configuration
-	enableKVM := flags.Bool("kvm", haveKVM(), "Enable KVM acceleration")
+	accel := flags.String("accel", defaultAccel, "Choose acceleration mode. Use 'tcg' to disable it.")
 	arch := flags.String("arch", defaultArch, "Type of architecture to use, e.g. x86_64, aarch64")
 	cpus := flags.String("cpus", "1", "Number of CPUs")
 	mem := flags.String("mem", "1024", "Amount of memory in MB")
@@ -185,8 +179,8 @@ func runQemu(args []string) {
 
 	// These envvars override the corresponding command line
 	// options. So this must remain after the `flags.Parse` above.
-	envOverrideBool("LINUXKIT_QEMU_KVM", enableKVM)
-	envOverrideBool("LINUXKIT_QEMU_CONTAINERIZED", qemuContainerized)
+	*accel = getStringValue("LINUXKIT_QEMU_ACCEL", *accel, "")
+	*qemuContainerized = getBoolValue("LINUXKIT_QEMU_CONTAINERIZED", *qemuContainerized)
 
 	if len(remArgs) == 0 {
 		fmt.Println("Please specify the path to the image to boot")
@@ -310,7 +304,7 @@ func runQemu(args []string) {
 		Arch:           *arch,
 		CPUs:           *cpus,
 		Memory:         *mem,
-		KVM:            *enableKVM,
+		Accel:          *accel,
 		Containerized:  *qemuContainerized,
 		QemuBinPath:    *qemuCmd,
 		PublishedPorts: publishFlags,
@@ -429,7 +423,7 @@ func runQemuContainer(config QemuConfig) error {
 		dockerArgs = append(dockerArgs, "--tty")
 	}
 
-	if config.KVM {
+	if strings.Contains(config.Accel, "kvm") {
 		dockerArgs = append(dockerArgs, "--device", "/dev/kvm")
 	}
 
@@ -491,6 +485,7 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 	qemuArgs = append(qemuArgs, "-m", config.Memory)
 	qemuArgs = append(qemuArgs, "-uuid", config.UUID.String())
 	qemuArgs = append(qemuArgs, "-pidfile", filepath.Join(config.StatePath, "qemu.pid"))
+
 	// Need to specify the vcpu type when running qemu on arm64 platform, for security reason,
 	// the vcpu should be "host" instead of other names such as "cortex-a53"...
 	if config.Arch == "aarch64" {
@@ -501,12 +496,27 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 		}
 	}
 
-	if config.KVM {
-		qemuArgs = append(qemuArgs, "-enable-kvm")
+	// goArch is the GOARCH equivalent of config.Arch
+	var goArch string
+	switch config.Arch {
+	case "aarch64":
+		goArch = "arm64"
+	case "x86_64":
+		goArch = "amd64"
+	default:
+		log.Fatalf("%s is an unsupported architecture.")
+	}
+
+	if goArch != runtime.GOARCH {
+		log.Infof("Disable acceleration as %s != %s", config.Arch, runtime.GOARCH)
+		config.Accel = ""
+	}
+
+	if config.Accel != "" {
 		if config.Arch == "aarch64" {
-			qemuArgs = append(qemuArgs, "-machine", "virt,gic_version=host")
+			qemuArgs = append(qemuArgs, "-machine", fmt.Sprintf("virt,gic_version=host,accel=%s", config.Accel))
 		} else {
-			qemuArgs = append(qemuArgs, "-machine", "q35,accel=kvm:tcg")
+			qemuArgs = append(qemuArgs, "-machine", fmt.Sprintf("q35,accel=%s", config.Accel))
 		}
 	} else {
 		if config.Arch == "aarch64" {


### PR DESCRIPTION
There are more acceleration backend in the pipeline for qemu. Allow to select the qemu binary being used (makes it easier to select master builds) and the acceleration option.

For example:
```
linuxkit run qemu -qemu ~/src/repos/virt/qemu/x86_64-softmmu/qemu-system-x86_64 -accel hvf minimal
```
boots with a qemu master build on macOS with Hypervisor Framework Acceleration.

Note this also changes the `LINUXKIT_QEMU_KVM` env variable to `LINUXKIT_QEMU_ACCEL`

![turtle](https://user-images.githubusercontent.com/3338098/35690971-30d12118-076f-11e8-80f9-ec3c5ed61a74.jpg)
