### PR TITLE
Extend kernel config test

### DIFF
--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:80bb1cd57205e47b5976f7fa4fb036384d012a1d
+    image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:80bb1cd57205e47b5976f7fa4fb036384d012a1d
+    image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:80bb1cd57205e47b5976f7fa4fb036384d012a1d
+    image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/007_config_4.15.x/test.yml
+++ b/test/cases/020_kernel/007_config_4.15.x/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:80bb1cd57205e47b5976f7fa4fb036384d012a1d
+    image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.2
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:80bb1cd57205e47b5976f7fa4fb036384d012a1d
+    image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/pkg/kernel-config/check-kernel-config.sh
+++ b/test/pkg/kernel-config/check-kernel-config.sh
@@ -41,6 +41,11 @@ echo $UNZIPPED_CONFIG | grep -q CONFIG_PANIC_ON_OOPS=y || fail "CONFIG_PANIC_ON_
 echo $UNZIPPED_CONFIG | grep -q CONFIG_SYN_COOKIES=y || fail "CONFIG_SYN_COOKIES=y"
 echo $UNZIPPED_CONFIG | grep -q CONFIG_LEGACY_VSYSCALL_NONE=y || fail "CONFIG_LEGACY_VSYSCALL_NONE=y"
 echo $UNZIPPED_CONFIG | grep -q CONFIG_RANDOMIZE_BASE=y || fail "CONFIG_RANDOMIZE_BASE=y"
+echo $UNZIPPED_CONFIG | grep -q CONFIG_PAGE_TABLE_ISOLATION=y || fail "CONFIG_PAGE_TABLE_ISOLATION=y"
+echo $UNZIPPED_CONFIG | grep -q CONFIG_RETPOLINE=y || fail "CONFIG_RETPOLINE=y"
+echo $UNZIPPED_CONFIG | grep -q CONFIG_GENERIC_CPU_VULNERABILITIES=y || fail "CONFIG_GENERIC_CPU_VULNERABILITIES=y"
+echo $UNZIPPED_CONFIG | grep -q CONFIG_BPF_JIT_ALWAYS_ON=y || fail "CONFIG_BPF_JIT_ALWAYS_ON=y"
+
 
 # Conditional on kernel version
 if [ "$kernelMajor" -ge 4 -a "$kernelMinor" -ge 5 ]; then
@@ -86,6 +91,7 @@ echo $UNZIPPED_CONFIG | grep -q 'CONFIG_HIBERNATION is not set' || fail "CONFIG_
 echo $UNZIPPED_CONFIG | grep -q 'CONFIG_LEGACY_PTYS is not set' || fail "CONFIG_LEGACY_PTYS is not set"
 echo $UNZIPPED_CONFIG | grep -q 'CONFIG_X86_X32 is not set' || fail "CONFIG_X86_X32 is not set"
 echo $UNZIPPED_CONFIG | grep -q 'CONFIG_MODIFY_LDT_SYSCALL is not set' || fail "CONFIG_MODIFY_LDT_SYSCALL is not set"
+echo $UNZIPPED_CONFIG | grep -q 'CONFIG_SCSI_PROC_FS is not set' || fail "CONFIG_SCSI_PROC_FS is not set"
 
 # modprobe
 for mod in \


### PR DESCRIPTION
This commit adds tests for KPTI, retpoline, bpf_jit_always_on, and
disabled scsi proc fs configs.

Closes #2890

Signed-off-by: Craig Ingram <cingram@heroku.com>

The test.yml's will need to be updated with a new build of the linuxkit/test-kernel-config image, which (I think) I need someone else to build/push first. 

**- What I did**
I reviewed the checks added to the kernel configs for the past few months, in particular focusing on the Meltdown/Spectre mitigation checks, and added them to the `check-kernel-config.sh` script. 

**- How I did it**
Followed the pattern for other checks, and then ran the tests with the latest kernels using a local version of the `test-kernel-config` image to verify everything passed.

**- How to verify it**
* I had to build a local version of the test-kernel-config image (docker build in the `test/pkg/kernel-config` directory)
* modified the test.yml's for each of the linuxkit.kernel.config tests to use my local image 
* went into each kernel config test case, built the test.yml and ran it to confirm the tests still passed.

**- Description for the changelog**
Kernel configuration check tests for KPTI, Retpoline, BPF JIT Always On enabled, and SCSI proc FS disabled


**- A picture of a cute animal (not mandatory but encouraged)**
![screen shot 2018-02-07 at 4 47 46 pm](https://user-images.githubusercontent.com/419708/35943340-ab852538-0c26-11e8-96fb-3d0dfcc7941a.png)
Olive my goldendoodle ❤️ 