### PR TITLE
Update kernels to 4.15.2/4.14.18

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add \
     mpc1-dev \
     mpfr-dev \
     ncurses-dev \
+    patch \
     sed \
     squashfs-tools \
     tar \
@@ -67,7 +68,7 @@ RUN set -e && \
     if [ -d /patches-${KERNEL_SERIES} ]; then \
         for patch in /patches-${KERNEL_SERIES}/*.patch; do \
             echo "Applying $patch"; \
-            patch -p1 < "$patch"; \
+            patch -t -F0 -N -u -p1 < "$patch"; \
         done; \
     fi
 

--- a/kernel/Dockerfile.kconfig
+++ b/kernel/Dockerfile.kconfig
@@ -6,6 +6,7 @@ RUN apk add \
     diffutils \
     libarchive-tools \
     ncurses-dev \
+    patch \
     xz
 
 ARG KERNEL_VERSIONS
@@ -30,7 +31,7 @@ RUN set -e && \
             if [ -d /patches-${SERIES} ]; then \
                for patch in /patches-${SERIES}/*.patch; do \
                    echo "Applying $patch" && \
-                   patch -p1 < "$patch"; \
+                   patch -t -F0 -N -u -p1 < "$patch"; \
                done; \
             fi && \
         mv /config-${SERIES}-x86_64 arch/x86/configs/x86_64_defconfig && \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -204,9 +204,9 @@ endef
 # Build Targets
 # Debug targets only for latest stable and LTS stable
 #
-$(eval $(call kernel,4.15.1,4.15.x,$(EXTRA)))
-$(eval $(call kernel,4.14.17,4.14.x,$(EXTRA)))
-$(eval $(call kernel,4.14.17,4.14.x,-dbg))
+$(eval $(call kernel,4.15.2,4.15.x,$(EXTRA)))
+$(eval $(call kernel,4.14.18,4.14.x,$(EXTRA)))
+$(eval $(call kernel,4.14.18,4.14.x,-dbg))
 $(eval $(call kernel,4.9.80,4.9.x,$(EXTRA)))
 $(eval $(call kernel,4.9.80,4.9.x,-dbg))
 $(eval $(call kernel,4.4.115,4.4.x,$(EXTRA)))

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.17 Kernel Configuration
+# Linux/arm64 4.14.18 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.17 Kernel Configuration
+# Linux/x86 4.14.18 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.15.x-aarch64
+++ b/kernel/config-4.15.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.15.1 Kernel Configuration
+# Linux/arm64 4.15.2 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.15.x-x86_64
+++ b/kernel/config-4.15.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.15.1 Kernel Configuration
+# Linux/x86 4.15.2 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From a629d501c42e00b7c1e37ab8d8f32e303cd89f7a Mon Sep 17 00:00:00 2001
+From 68f097990b84f65ddf63e483f59f7a33810dbeda Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB (page

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.17
+  image: linuxkit/kernel:4.14.18
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6061875ba11fd9c563fda6234b103ed9997ff782

--- a/test/cases/020_kernel/007_config_4.15.x/test.yml
+++ b/test/cases/020_kernel/007_config_4.15.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.15.1
+  image: linuxkit/kernel:4.15.2
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6061875ba11fd9c563fda6234b103ed9997ff782

--- a/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
+++ b/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.14.17 AS ksrc
+FROM linuxkit/kernel:4.14.18 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.17
+  image: linuxkit/kernel:4.14.18
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6061875ba11fd9c563fda6234b103ed9997ff782

--- a/test/cases/020_kernel/017_kmod_4.15.x/Dockerfile
+++ b/test/cases/020_kernel/017_kmod_4.15.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.15.1 AS ksrc
+FROM linuxkit/kernel:4.15.2 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/017_kmod_4.15.x/test.yml
+++ b/test/cases/020_kernel/017_kmod_4.15.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.15.1
+  image: linuxkit/kernel:4.15.2
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6061875ba11fd9c563fda6234b103ed9997ff782

--- a/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.17
+  image: linuxkit/kernel:4.14.18
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:6061875ba11fd9c563fda6234b103ed9997ff782


### PR DESCRIPTION
These kernels include significant changes to spectre mitigation but may require a micro-code update which has not yet been released.

Also improve the application of kernel patches to disable fuzzing (resolves #2906)

x86 kernels already build, arm64 kernels still building

![baby-penguin](https://user-images.githubusercontent.com/3338098/35977161-2e1eacae-0cda-11e8-9671-80810a34886d.jpg)
