### PR TITLE
Bump rtf to f2409214ca3b719567aa15bb7b363f24876a4d98

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 
 PREFIX?=/usr/local/
 
-RTF_COMMIT=3e8ed35ca934259cb644c2492bf9b181954a07e1
+RTF_COMMIT=f2409214ca3b719567aa15bb7b363f24876a4d98
 RTF_CMD=github.com/linuxkit/rtf/cmd
 RTF_VERSION=0.0
 bin/rtf: tmp_rtf_bin.tar | bin

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To run the test suite:
 
 ```
 cd test
-rtf -x run
+rtf -v run -x
 ```
 
 This will run the tests and put the results in a the `_results` directory!
@@ -115,13 +115,13 @@ Run control is handled using labels and with pattern matching.
 To run add a label you may use:
 
 ```
-rtf -x -l slow run
+rtf -v -l slow run -x
 ```
 
 To run tests that match the pattern `linuxkit.examples` you would use the following command:
 
 ```
-rtf -x run linuxkit.examples
+rtf -v run -x linuxkit.examples
 ```
 
 ## Building your own customised image

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,7 +12,7 @@ To run the test suite:
 
 ```
 cd test
-rtf -x run
+rtf -v run -x
 ```
 
 This will run the tests and put the results in a the `_results` directory!
@@ -21,7 +21,7 @@ Run control is handled using labels and with pattern matching.
 To run add a label you may use:
 
 ```
-rtf -x -l slow run
+rtf -v -l slow run -x
 ```
 
 You can list the tests which will be run using:
@@ -35,7 +35,7 @@ Some tests may be marked as `SKIP` and `LABELS` column will typically provide an
 To run tests that match the pattern `linuxkit.build` you would use the following command:
 
 ```
-rtf -x run linuxkit.build
+rtf -v run -x linuxkit.build
 ```
 
 ### Writing new tests

--- a/test/Makefile
+++ b/test/Makefile
@@ -43,7 +43,7 @@ ltp: $(LINUXKIT) test-ltp.img.tar.gz
 ### ------
 
 test: gcp-hack
-	@rtf -l build -x run
+	@rtf -l build -v run -x
 
 test-pr: gcp-hack
-	@rtf -l build -x run
+	@rtf -l build -v run -x


### PR DESCRIPTION
Pulls in a bumper crop of updates from last year and some recent improvements:

    $ git log --oneline 3e8ed35ca934..f2409214ca3b | cat
    f240921 Merge pull request #38 from ijc/timestamp-precision
    f626ffe Preserve full precision in nanoseconds part of log timestamp
    29c89e8 Merge pull request #37 from rn/ps1
    600ea59 Update documentation with new powershell features
    9fed685 Add powershell test and group templates and a stub library
    3ada6bd Don't use '#!/bin/sh' in tests or group initialisers
    dd187b4 Add test cases for powershell scripts
    4892754 Add support for writing tests in powershell (on Windows)
    00cdd1f Add the ability to execute powershell scripts
    00906da Add TestFilePath to the Test struct
    e6fdcb7 Add GroupFilePath to the Group struct
    c590dbc Make group member names for Pre/Post test scripts clearer
    5ca3d4f Add setEnv test
    d178af2 Improve environment variable setting in executeScript
    9c7cc94 Merge pull request #35 from rn/circle
    d464092 Use container builds on CircleCI and stash artefacts
    9a09cd5 Move CircleCI config file to .circleci
    9429279 Merge pull request #33 from rn/poule
    4de1f2c Add poule config
    88dcc27 Merge pull request #32 from mor1/extra-extra
    bfabb8a flags: update README for `-x` now as a local flag
    3f574c7 flags: make `-x` work
    ba442d6 Merge pull request #31 from dave-tucker/fix-panic
    6c7f09b local: Fix panic when no pattern is supplied
    617e977 Merge pull request #30 from dnephin/add-latest-link
    5829b2b Merge pull request #29 from dnephin/fix-command-descriptions
    d09a317 Add a link to the latest directory within results.
    c9a9a2a Remove some duplication between commands.
    7904cc7 Remove unused flags, and move run flags to run command.
    94e56a7 Update command descriptions
    faedeef Merge pull request #28 from dave-tucker/prepost
    a5f92ae local: Fix panic in PostTest
    23fbbea Merge pull request #26 from dave-tucker/fix-osx-vers
    156281e sysinfo: Fix OSX version parsing

Signed-off-by: Ian Campbell <ijc@docker.com>