### PR TITLE
This commit adds the functionality to run the qemu container detached

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -366,6 +366,11 @@ func runQemuLocal(config QemuConfig) error {
 		}
 	}
 
+	// Detached mode is only supported in a container.
+	if config.Detached == true {
+		return fmt.Errorf("Detached mode is only supported when running in a container, not locally")
+	}
+
 	qemuCmd := exec.Command(config.QemuBinPath, args...)
 	// If verbosity is enabled print out the full path/arguments
 	log.Debugf("%v\n", qemuCmd.Args)

--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -40,6 +40,7 @@ type QemuConfig struct {
 	Memory         string
 	Accel          string
 	Containerized  bool
+	Detached       bool
 	QemuBinPath    string
 	QemuImgPath    string
 	PublishedPorts []string
@@ -162,6 +163,7 @@ func runQemu(args []string) {
 	// Backend configuration
 	qemuContainerized := flags.Bool("containerized", false, "Run qemu in a container")
 	qemuCmd := flags.String("qemu", "", "Path to the qemu binary (otherwise look in $PATH)")
+	qemuDetached := flags.Bool("detached", false, "Set qemu container to run in the background")
 
 	// Generate UUID, so that /sys/class/dmi/id/product_uuid is populated
 	vmUUID := uuid.New()
@@ -306,6 +308,7 @@ func runQemu(args []string) {
 		Memory:         *mem,
 		Accel:          *accel,
 		Containerized:  *qemuContainerized,
+		Detached:       *qemuDetached,
 		QemuBinPath:    *qemuCmd,
 		PublishedPorts: publishFlags,
 		NetdevConfig:   netdevConfig,
@@ -425,6 +428,10 @@ func runQemuContainer(config QemuConfig) error {
 
 	if strings.Contains(config.Accel, "kvm") {
 		dockerArgs = append(dockerArgs, "--device", "/dev/kvm")
+	}
+
+	if config.Detached == true {
+		dockerArgs = append(dockerArgs, "-d")
 	}
 
 	if config.PublishedPorts != nil && len(config.PublishedPorts) > 0 {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This PR adds the functionality to allow the user to run the qemu container detached via a flag `-detached`  under `linuxkit run qemu`. I have added this flag as we are building tooling around Linuxkit and want to have the option for the container to not have a tty
**- How I did it**
I added the detached to the qemuconfig struct that gets passed to down to the docker args

**- How to verify it**
I have run all the tests included in the readme and have been able to run the container in the background successfully

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

This PR adds the functionality to allow the user to run the qemu container detached via a flag `-detached`  under `linuxkit run qemu`
**- A picture of a cute animal (not mandatory but encouraged)**
