### PR TITLE
wireguard: update to 0.0.20180218

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -40,8 +40,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180202
-ENV WIREGUARD_SHA256=ee3415b482265ad9e8721aa746aaffdf311058a2d1a4d80e7b6d11bbbf71c722
+ENV WIREGUARD_VERSION=0.0.20180218
+ENV WIREGUARD_SHA256=4ac4c4e4ad4dc2cf9dcb831b0cf347567ccea675ca524528cf5a4d9dccb2fe52
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```

  * keygen-html: fix up copyright
  
  Copy and paste errors.
  
  * tools: do not collide types with libc clashes
  * tools: FreeBSD doesn't have EAI_NODATA
  * tools: fixup errno handling
  * tools: endian.h is not portable
  
  Fixes compilation and correctness several places.
  
  * tools: allow in-line comments
  
  You can now put a # comment anywhere in a line, in which case, it extends
  until the end of the line.
  
  * wg-quick: match from beginning rather than shift right
  
  This raises the proper error when providing interface names that are too long.
  
  * qemu: add support for powerpc
  
  Now that we have known PPC users, it's probably a good thing to ensure we
  don't introduce bugs, so PPC has been added to our CI on build.wireguard.com.
  
  * poly1305: fix up selftest counter
  
  Make sure we're using the right array length in the debug-mode-only
  self-tests.
  
  * netns: replace n0 ip with ip0, per custom
  
  Fixes up console output consistency.
  
  * qemu: more granular memleak detection
  
  This avoids us getting memory leak errors due to upstream's power management
  drivers leaking, or the like, when we're only interested in WireGuard memory
  leaks.
  
  * socket: free skb if there isn't an endpoint
  
  Fixes a memory leak.
  
  * allowedips: indicate to clang-analyzer that trie is non-null
  
  Hopefully future versions are slightly smarter...
  
  * blake2s: use union instead of casting
  
  Similarly fixes a clang-analyzer issue, as well as ensuring alignment.
  
  * tools: normalize strncpy/snprintf usage
  
  Correctness.
  
  * contrib: add embeddable wireguard library
  
  See: https://lists.zx2c4.com/pipermail/wireguard/2018-February/002387.html
  And: https://git.zx2c4.com/WireGuard/tree/contrib/examples/embeddable-wg-library/README
```