### PR TITLE
Added InfluxDB OS an example

### DIFF
--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -1,0 +1,48 @@
+kernel:
+  image: linuxkit/kernel:4.14.21
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+init:
+  - linuxkit/init:d899eee3560a40aa3b4bdd67b3bb82703714b2b9
+  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
+  - linuxkit/ca-certificates:v0.2
+onboot:
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:v0.2
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+services:
+  - name: getty
+    image: linuxkit/getty:v0.2
+    env:
+     - INSECURE=true
+  - name: influxdb
+    image: influxdb:1.4
+    net: host
+    capabilities:
+      - CAP_NET_BIND_SERVICE
+      - CAP_DAC_OVERRIDE
+  - name: kapacitor
+    image: kapacitor:1.4
+    net: host
+    capabilities:
+      - all
+    env:
+      - KAPACITOR_INFLUXDB_0_URLS_0=http://influxdb:8086
+  - name: telegraf
+    image: telegraf:1.4
+    net: host
+    capabilities:
+      - all
+  - name: chronograf
+    image: chronograf:1.4
+    net: host
+    capabilities:
+      - CAP_NET_BIND_SERVICE
+      - CAP_DAC_OVERRIDE
+    env:
+      - INFLUXDB_URL=http://localhost:8086
+      - KAPACITOR_URL=http://localhost:9092
+trust:
+  org:
+    - linuxkit
+    - library


### PR DESCRIPTION
I tried to to build an OS with all the TICK stack
(https://www.influxdata.com/time-series-platform/): InfluxDB,
Chronograf, Kapacitor, Telegraf.

Very easy but I was curious to try it out after few months just reading
about linuxkit.

You can build the image with:

```
linuxkit build --format iso-bios examples/influxdb-os
```

And you can run it:

```
linuxkit run qemu -iso influxdb-os.iso -publish 8888:8888/tcp -publish
8086:8086/tcp
```

After that you can open your browser on `localhost:8888` to see
Chronograf (the dashboard up and running).

All the services are configurated to talk with each other.