### PR TITLE
Add s390x support for Linuxkit binary and tools

### DIFF
--- a/scripts/push-manifest.sh
+++ b/scripts/push-manifest.sh
@@ -45,7 +45,7 @@ esac
 # Push manifest list
 OUT=$(manifest-tool $MT_ARGS push from-args \
                     --ignore-missing \
-                    --platforms linux/amd64,linux/arm64 \
+                    --platforms linux/amd64,linux/arm64,linux/s390x \
                     --template "$TARGET"-ARCH \
                     --target "$TARGET")
 

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -76,7 +76,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 
 	var suffix string
 	switch arch {
-	case "amd64", "arm64":
+	case "amd64", "arm64", "s390x":
 		suffix = "-" + arch
 	default:
 		return fmt.Errorf("Unknown arch %q", arch)

--- a/src/cmd/linuxkit/pkglib/manifest_push_script.go
+++ b/src/cmd/linuxkit/pkglib/manifest_push_script.go
@@ -48,7 +48,7 @@ esac
 # Push manifest list
 OUT=$(manifest-tool $MT_ARGS push from-args \
                     --ignore-missing \
-                    --platforms linux/amd64,linux/arm64 \
+                    --platforms linux/amd64,linux/arm64,linux/s390x \
                     --template "$TARGET"-ARCH \
                     --target "$TARGET")
 

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -58,7 +58,7 @@ func NewFromCLI(fs *flag.FlagSet, args ...string) (Pkg, error) {
 	// Defaults
 	pi := pkgInfo{
 		Org:                 "linuxkit",
-		Arches:              []string{"amd64", "arm64"},
+		Arches:              []string{"amd64", "arm64", "s390x"},
 		GitRepo:             "https://github.com/linuxkit/linuxkit",
 		Network:             false,
 		DisableContentTrust: false,


### PR DESCRIPTION
This PR adds the basic support for s390 architecture on linuxkit
command.

Signed-off-by: Alice Frosi <alice@linux.vnet.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add basic support for s390 systems:
- s390-specific flags to run qemu on s390 architecture

**- How I did it**
Update qemu flag in `src/cmd/linuxkit/`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
