### PR TITLE
Add cli option '--bridgeadapter' to 'linuxkit vbox run'

### DIFF
--- a/src/cmd/linuxkit/run_vbox.go
+++ b/src/cmd/linuxkit/run_vbox.go
@@ -52,6 +52,7 @@ func runVbox(args []string) {
 
 	// networking
 	networking := flags.String("networking", "nat", "Networking mode. null|nat|bridged|intnet|hostonly|generic|natnetwork[<devicename>]")
+	bridgeadapter := flags.String("bridgeadapter", "", "Bridge adapter interface to use if networking mode is bridged")
 
 	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
@@ -201,6 +202,12 @@ func runVbox(args []string) {
 	_, out, err = manage(vboxmanage, "modifyvm", name, "--nic1", *networking)
 	if err != nil {
 		log.Fatalf("modifyvm --nic error: %v\n%s", err, out)
+	}
+	if *networking == "bridged" {
+		_, out, err = manage(vboxmanage, "modifyvm", name, "--bridgeadapter1", *bridgeadapter)
+		if err != nil {
+			log.Fatalf("modifyvm --bridgeadapter error: %v\n%s", err, out)
+		}
 	}
 
 	_, out, err = manage(vboxmanage, "modifyvm", name, "--cableconnected1", "on")


### PR DESCRIPTION
Starting a virtualbox vm in bridged networking mode requires the host's
network interface to attach to the bridge being specified. This commit
adds command line option '--bridgeadapter iface' to 'linuxkit vbox run',
where 'iface' is the host's network interface to use in bridged mode.

Fixes: #2929

Signed-off-by: Olaf Bergner <olaf.bergner@gmx.de>

**- What I did**

Added command line option `--bridgeadapter` taking the name of a host network interface to use for bridged networking to `linuxkit run vbox`.

**- How I did it**

Added flag `bridgeadapter` to `run_vbox.go`.

**- How to verify it**

Run e.g. on Mac
```
linuxkit run vbox --iso --networking bridged --bridgeadapter en0 docker.iso
```
and observe in VirtualBox GUI that VM `docker` is started in bridged mode, **not** NAT mode.

**- Description for the changelog**

Add cli option `--bridgeadapter` to `linuxkit vbox run` to support specifying host network interface when running virtualbox vm in bridged mode.
