### PR TITLE
A minor update/hint to the docker-for-mac example documentation.

### DIFF
--- a/examples/docker-for-mac.md
+++ b/examples/docker-for-mac.md
@@ -19,6 +19,21 @@ To run the VM with a 4G disk:
 linuxkit run hyperkit -networking=vpnkit -vsock-ports=2376 -disk size=4096M -data-file ./metadata.json docker-for-mac
 ```
 
+Where the file `./metadata.json` should contain the desired docker daemon
+configuration, for example:
+
+```
+{
+  "docker": {
+    "entries": {
+      "daemon.json": {
+        "content": "{\n  \"debug\" : true,\n  \"experimental\" : true\n}\n"
+      }
+    }
+  }
+}
+```
+
 In another terminal you should now be able to access docker via the
 socket `guest.00000947` in the state directory
 (`docker-for-mac-state/` by default):


### PR DESCRIPTION
Signed-off-by: functor <meehow@gmail.com>

Just a minor update to the docker-for-mac example documentation that makes it work and be self-contained. Might save some time for people who are just experimenting and don't know yet about the metadata functionality etc.