### PR TITLE
Configure guest with 9P mount and vsock port when using existing VPNKit instance

### DIFF
--- a/src/cmd/linuxkit/run_hyperkit.go
+++ b/src/cmd/linuxkit/run_hyperkit.go
@@ -245,6 +245,10 @@ func runHyperKit(args []string) {
 			if len(netMode) > 2 {
 				vpnkitPortSocket = netMode[2]
 			}
+			// The guest will use this 9P mount to configure which ports to forward
+			h.Sockets9P = []hyperkit.Socket9P{{Path: vpnkitPortSocket, Tag: "port"}}
+			// VSOCK port 62373 is used to pass traffic from host->guest
+			h.VSockPorts = append(h.VSockPorts, 62373)
 		} else {
 			// Start new VPNKit instance
 			h.VPNKitSock = filepath.Join(*state, "vpnkit_eth.sock")


### PR DESCRIPTION
Signed-off-by: Emily Casey <ecasey@pivotal.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I added support for port forwarding when running hyperkit with an existing vpnkit instance

**- How I did it**
I set Sockets9P and VSockPorts on the hyperkit instance when starting with an existing vpnkit process

**- How to verify it**
Start vpnkit kit. `linuxkit run hyperkit` with the `-neworking vpnkit[,eth-socket-path[,port-socket-path]]` flag. In the guest use `vpnkit-expose-port` to configure a forwarded port. From the host send traffic to the configured host port and observe that it is forwarded to the guest port.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Supports port forwarding when running hyperkit with an existing vpnkit image

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1994518/36735008-28273dac-1ba3-11e8-926d-9eb91234b642.png)
