### PR TITLE
Add s390x support for linuxkit docker images

### DIFF
--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -19,6 +19,10 @@ ifeq ($(ARCH), aarch64)
 DEPS += packages.aarch64
 SUFFIX=-arm64
 endif
+ifeq ($(ARCH), s390x)
+DEPS += packages.s390x
+SUFFIX=-s390x
+endif
 
 default: push
 

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -46,7 +46,6 @@ gmp-dev
 gnupg
 go
 grep
-gummiboot
 hvtools
 installkernel
 iperf3
@@ -65,7 +64,6 @@ libressl-dev
 libseccomp-dev
 libtirpc-dev
 libtool
-libunwind-dev
 linux-headers
 lsscsi
 make

--- a/tools/alpine/packages.aarch64
+++ b/tools/alpine/packages.aarch64
@@ -1,1 +1,3 @@
+gummiboot
+libunwind-dev
 qemu-system-aarch64

--- a/tools/alpine/packages.s390x
+++ b/tools/alpine/packages.s390x
@@ -1,0 +1,1 @@
+qemu-system-s390x

--- a/tools/alpine/packages.x86_64
+++ b/tools/alpine/packages.x86_64
@@ -1,3 +1,5 @@
+gummiboot
+libunwind-dev
 open-vm-tools
 ovmf
 syslinux

--- a/tools/alpine/push-manifest.sh
+++ b/tools/alpine/push-manifest.sh
@@ -19,6 +19,7 @@ IMAGE=$2
 
 IMG_X86_64=$(head -1 versions.x86_64 | sed 's,[#| ]*,,')
 IMG_ARM64=$(head -1 versions.aarch64 | sed 's,[#| ]*,,')
+IMG_s390x=$(head -1 versions.s390x | sed 's,[#| ]*,,')
 # Extract the TAG from the x86_64 name and build the manifest target name
 TAG=$(echo "$IMG_X86_64" | sed 's,\-.*$,,' | cut -d':' -f2)
 TARGET="$ORG/$IMAGE:$TAG"
@@ -34,6 +35,10 @@ manifests:
   - image: $IMG_X86_64
     platform:
       architecture: amd64
+      os: linux
+  - image: $IMG_s390x
+    platform:
+      architecture: s390x
       os: linux
 EOF
 


### PR DESCRIPTION
Add support for s390 architecture for linuxkit/alpine and the
other docker images in tools and pkg.

Signed-off-by: Alice Frosi <alice@linux.vnet.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I updated `tools` to be able to build and push linuxkit/alpine docker image for s390 architecture
