### PR TITLE
Script to generate s390 kernel configs

### DIFF
--- a/contrib/kernel-config-s390/create_kernel_conf.sh
+++ b/contrib/kernel-config-s390/create_kernel_conf.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+if [ -z "$GOPATH" ]; then
+	>&2 echo "You need to set the GOPATH"
+	exit 1
+fi
+
+DIR=$GOPATH/src/github.com/linuxkit/linuxkit
+KERNEL_DIR=$DIR/kernel
+CONTRIB=$DIR/contrib/kernel-config-s390
+DOCKER_IMG=linuxkit/kconfig
+set -x
+set -e
+
+cd $KERNEL_DIR
+
+for v in sources/*.tar.xz
+do
+    KERNEL_VER=$(echo "$v" |sed -e 's/^\(sources\/linux-\)//' | sed -e 's/\.[0-9]*\.tar\.xz$//')
+    # Trying to stick as close as possible to x86 and arm configuration
+    [ -e config-$KERNEL_VER.x-aarch64 ] || continue
+    $DIR/scripts/kconfig-split.py config-$KERNEL_VER.x-aarch64 config-$KERNEL_VER.x-x86_64
+    mv split-common split-common-$KERNEL_VER.x
+done
+docker run -ti --rm  -v $KERNEL_DIR:/src -v $CONTRIB:/entry $DOCKER_IMG -c /entry/entrypoint.sh

--- a/contrib/kernel-config-s390/entrypoint.sh
+++ b/contrib/kernel-config-s390/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+
+KER=$(ls | grep linux-)
+
+for LINUX in $KER
+do
+	VERSION=$(echo "$LINUX" | sed -e 's/^\(linux-\)//')
+	FAMILY=$(echo "$VERSION" | sed -e 's/\.[0-9]*$//').x
+	cd $LINUX
+    cp /src/split-common-$FAMILY arch/s390/configs/linuxkit_defconfig
+	echo "--------- Kernel $VERSION --------------------"
+    make defconfig
+    
+    # Common configuration from x86 and arm
+    [ -e /src/split-common-$FAMILY ] || continue
+    make linuxkit_defconfig
+
+    cp .config /src/config-$FAMILY-s390x
+	echo "----------------------------------------------"
+	cd ..
+done


### PR DESCRIPTION
The script generates the kernel configs for s390 based on the
kernel configs for x86 and arm.

The configs are generated inside a docker container from the image
linuxkit/kconfig.

Signed-off-by: Alice Frosi <alice@linux.vnet.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did** 
Add script `create_kernel_conf.sh` to generate s390 kernel configs.  

