### PR TITLE
Add s390 console to examples

### DIFF
--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.14.23
-  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
   - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -28,7 +28,7 @@ services:
   - name: ntpd
     image: linuxkit/openntpd:v0.2
   - name: docker
-    image: docker:17.07.0-ce-dind
+    image: docker:17.09.0-ce-dind
     capabilities:
      - all
     net: host

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.14.23
-  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
   - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.14.23
-  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
   - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.14.23
-  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
   - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -2,7 +2,7 @@
 # connect: nc localhost 6379
 kernel:
   image: linuxkit/kernel:4.14.23
-  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
   - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.14.23
-  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
   - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,6 +1,6 @@
 kernel:
   image: linuxkit/kernel:4.14.23
-  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
   - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731


### PR DESCRIPTION
On z platform, the kernel console is ttysclp0

Signed-off-by: Alice Frosi <alice@linux.vnet.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I added the s390 console to `examples`
