### PR TITLE
wireguard: update to 0.0.20180304

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -41,8 +41,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180218
-ENV WIREGUARD_SHA256=4ac4c4e4ad4dc2cf9dcb831b0cf347567ccea675ca524528cf5a4d9dccb2fe52
+ENV WIREGUARD_VERSION=0.0.20180304
+ENV WIREGUARD_SHA256=efb1652f0da67fb2731040439b6abb820a5e2f1bc177aa15c5dce68ea3327787
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * queueing: skb_reset: mark as xnet
  
  This allows cgroups to classify packets.
  
  * contrib: embedded-wg-library: add ability to add and del interfaces
  * contrib: embedded-wg-library: add key generation functions
  
  The embeddable library gains a few extra tricks, for people implementing
  plugins for various network managers.
  
  * crypto: read only after init
  * allowedips: fix comment style
  * messages: MESSAGE_TOTAL is unused
  * global: in gnu code, use un-underscored asm
  * noise: fix function prototype
  
  Small cleanups.
  
  * compat: workaround netlink refcount bug
  
  An upstream refcounting bug meant that in certain situations it became
  impossible to unload the module. So, we work around it in the compat code. The
  problem has been fixed in 4.16.
  
  * contrib: keygen-html: rewrite in pure javascript
  * Revert "contrib: keygen-html: rewrite in pure javascript"
  
  We nearly moved away from emscripten'ing the fiat32 code, but the resultant
  floating point javascript was just too terrifying.
  
  * Kconfig: require DST_CACHE explicitly
  
  Required for certain frankenkernels.
  
  * compat: use correct -include path
  
  Fixes certain out-of-tree build systems.
  
  * noise: align static_identity keys
  
  Gives us better alignment of private keys.
  
  * wg-quick: if resolvconf/interface-order exists, use it
  * wg-quick: if resolvconf/run/iface exists, use it
  
  Better compatibility with Debian's resolvconf.
  
  * contrib: add extract-handshakes kprobe example
  
  Small utility for extracting ephemeral key data from the kernel's memory. More
  information can be found here:
  https://lists.zx2c4.com/pipermail/wireguard/2018-February/002439.html
```