### PR TITLE
Subcommand serve should parse flags.

### DIFF
--- a/src/cmd/linuxkit/serve.go
+++ b/src/cmd/linuxkit/serve.go
@@ -28,6 +28,7 @@ func serve(args []string) {
 	}
 	portFlag := flags.String("port", ":8080", "Local port to serve on")
 	dirFlag := flags.String("directory", ".", "Directory to serve")
+	flags.Parse(args)
 
 	http.Handle("/", http.FileServer(http.Dir(*dirFlag)))
 	log.Fatal(http.ListenAndServe(*portFlag, logRequest(http.DefaultServeMux)))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
Fixes "serve" sub-command to parse command line arguments.


**- A picture of a cute animal (not mandatory but encouraged)**
