### PR TITLE
Add CI info and dependency to packages doc

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -13,6 +13,18 @@ All LinuxKit packages are:
 - Derived from well-known (and signed) sources for repeatable builds.
 - Built with multi-stage builds to minimise their size.
 
+
+## CI and Package Builds
+When building and merging packages, it is important to note that our CI process builds packages. The targets `make ci` and `make ci-pr` execute `make -C pkg build`. These in turn execute `linuxkit pkg build` for each package under `pkg/`. This in turn will try to pull the image whose tag matches the tree hash or, failing that, to build it.
+
+We do not want the builds to happen with each CI run for two reasons:
+
+1. It is slower to do a package build than to just pull the latest image.
+2. If any of the steps of the build fails, e.g. a `curl` download that depends on an intermittent target, it can cause all of CI to fail.
+
+Thus, if, as a maintainer, you merge any commits into a `pkg/`, even if the change is documentation alone, please do a `linuxkit package push`.
+
+
 ## Package source
 
 A package source consists of a directory containing at least two files:
@@ -138,4 +150,3 @@ linuxkit pkg build -org=wombat -disable-content-trust -hash=foo push
 
 and this will create `wombat/<image>:foo-<arch>` and
 `wombat/<image>:foo` for use in your YAML files.
-


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated docs to indicate the CI dependency on packages building.

Helps prevent the issue raised [here](https://github.com/linuxkit/linuxkit/pull/2951#issuecomment-371283872) by @rn 

**- How I did it**
Typing a few paragraphs in markdown.

**- How to verify it**
Read it.

**- Description for the changelog**
Include detail on CI packages dependency.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![rabbit](https://i2-prod.mirror.co.uk/incoming/article8717308.ece/ALTERNATES/s810/Bunny-Rabbit-bunny-rabbit.jpg)