### PR TITLE
Non-existent target check is marked phony

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -71,7 +71,7 @@ endif
 
 KERNEL_VERSIONS=
 
-.PHONY: check build push
+.PHONY: fetch build push
 # Targets:
 # fetch: Downloads the kernel sources into ./sources
 # build: Builds all kernels


### PR DESCRIPTION
The non-existent target "check" is marked phony, this looks like a typo. 

The typo is mostly harmless, even without this change the "fetch" target is still created and it's prerequisites are added correctly.

**- Description for the changelog**
Removes ".PHONY" on non-existent target.

**- A picture of a cute animal (not mandatory but encouraged)**
![a27xnm7h3nk01](https://user-images.githubusercontent.com/965243/37219788-596a4d54-2379-11e8-93a6-32e1aa3f7724.jpg)
