### PR TITLE
Update tools for s390x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: default
 VERSION="v0.2+"
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:8235f703735672509a16fb626d25c6ffb0d1c21d
+GO_COMPILE=linuxkit/go-compile:7392985c6f55aba61201514174b45ba755fb386e
 
 LINUXKIT?=bin/linuxkit
 GOOS?=$(shell uname -s | tr '[:upper:]' '[:lower:]')

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -28,7 +28,7 @@ docker run -it --rm \
 -v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:8235f703735672509a16fb626d25c6ffb0d1c21d
+linuxkit/go-compile:7392985c6f55aba61201514174b45ba755fb386e
 ```
 
 To update a single dependency:
@@ -38,7 +38,7 @@ docker run -it --rm \
 -v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:8235f703735672509a16fb626d25c6ffb0d1c21d
+linuxkit/go-compile:7392985c6f55aba61201514174b45ba755fb386e
 github.com/docker/docker
 ```
 

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:8ad3a04b70f1e93e6159143e3792e379a9b0519d-amd64
+# linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee-amd64
 # automatically generated list of installed packages
 abuild-3.1.0-r3
 alpine-baselayout-3.0.5-r2
@@ -275,7 +275,7 @@ vim-8.0.1359-r0
 wayland-libs-client-1.14.0-r2
 wayland-libs-cursor-1.14.0-r2
 wayland-libs-server-1.14.0-r2
-wireguard-tools-0.0.20180218-r0
+wireguard-tools-0.0.20180304-r0
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r8
 xfsprogs-4.14.0-r0

--- a/tools/go-compile/Dockerfile
+++ b/tools/go-compile/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/tools/mkimage-dynamic-vhd/build.yml
+++ b/tools/mkimage-dynamic-vhd/build.yml
@@ -1,1 +1,4 @@
 image: mkimage-dynamic-vhd
+arches:
+  - amd64
+  - arm64

--- a/tools/mkimage-gcp/build.yml
+++ b/tools/mkimage-gcp/build.yml
@@ -1,1 +1,3 @@
 image: mkimage-gcp
+arches:
+  - amd64

--- a/tools/mkimage-iso-bios/Dockerfile
+++ b/tools/mkimage-iso-bios/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-iso-efi/Dockerfile
+++ b/tools/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS grub-build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS grub-build
 
 RUN apk add \
   automake \
@@ -39,7 +39,7 @@ RUN mkdir /grub-lib && \
     ;; \
   esac
 
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS make-img
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS make-img
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-iso-efi/build.yml
+++ b/tools/mkimage-iso-efi/build.yml
@@ -1,2 +1,5 @@
 image: mkimage-iso-efi
 network: true
+arches:
+  - amd64
+  - arm64

--- a/tools/mkimage-qcow2-efi/Dockerfile
+++ b/tools/mkimage-qcow2-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS grub-build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS grub-build
 
 RUN apk add \
   automake \
@@ -40,7 +40,7 @@ RUN mkdir /grub-lib && \
     ;; \
   esac
 
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS make-img
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS make-img
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-qcow2-efi/build.yml
+++ b/tools/mkimage-qcow2-efi/build.yml
@@ -1,2 +1,5 @@
 image: mkimage-qcow2-efi
 network: true
+arches:
+  - amd64
+  - arm64

--- a/tools/mkimage-raw-bios/Dockerfile
+++ b/tools/mkimage-raw-bios/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-raw-bios/build.yml
+++ b/tools/mkimage-raw-bios/build.yml
@@ -1,2 +1,3 @@
 image: mkimage-raw-bios
-arches: ["amd64"]
+arches:
+  - amd64

--- a/tools/mkimage-raw-efi/Dockerfile
+++ b/tools/mkimage-raw-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS grub-build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS grub-build
 
 RUN apk add \
   automake \
@@ -40,7 +40,7 @@ RUN mkdir /grub-lib && \
     ;; \
   esac
 
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS make-img
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS make-img
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-raw-efi/build.yml
+++ b/tools/mkimage-raw-efi/build.yml
@@ -1,2 +1,5 @@
 image: mkimage-raw-efi
 network: true
+arches:
+  - amd64
+  - arm64

--- a/tools/mkimage-rpi3/Dockerfile
+++ b/tools/mkimage-rpi3/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 as build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee as build
 RUN apk add \
     bc \
     dtc \

--- a/tools/mkimage-vhd/build.yml
+++ b/tools/mkimage-vhd/build.yml
@@ -1,1 +1,4 @@
 image: mkimage-vhd
+arches:
+  - amd64
+  - arm64

--- a/tools/mkimage-vmdk/build.yml
+++ b/tools/mkimage-vmdk/build.yml
@@ -1,1 +1,4 @@
 image: mkimage-vmdk
+arches:
+  - amd64
+  - arm64

--- a/tools/qemu/Dockerfile
+++ b/tools/qemu/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \


### PR DESCRIPTION
- Update tools/alpine
- Disable s390x for all `./tools` packages apart from `go-compile`
- Update to latest `go-compile`

All packages already build and pushed.

WIP: #2949

![image](https://user-images.githubusercontent.com/3338098/37355648-27e6cfda-26dc-11e8-8ed9-bc86f02779d4.png)
