### PR TITLE
Get architecture name from Docker image

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -30,7 +30,7 @@ RUN apk add \
     zlib-dev
 
 # libunwind-dev pkg is missed from arm64 now, below statement will be removed if the pkg is available.
-RUN [ $(uname -m) == x86_64 ] && apk add libunwind-dev || true
+RUN [ $(apk --print-arch) == x86_64 ] && apk add libunwind-dev || true
 
 ARG KERNEL_VERSION
 ARG KERNEL_SERIES
@@ -84,7 +84,7 @@ RUN set -e && \
     fi
 
 # Kernel config
-RUN case $(uname -m) in \
+RUN case $(apk --print-arch) in \
     x86_64) \
         KERNEL_DEF_CONF=/linux/arch/x86/configs/x86_64_defconfig; \
         ;; \
@@ -95,9 +95,9 @@ RUN case $(uname -m) in \
         KERNEL_DEF_CONF=/linux/arch/s390/defconfig; \
         ;; \
     esac  && \
-    cp /config-${KERNEL_SERIES}-$(uname -m) ${KERNEL_DEF_CONF}; \
-    if [ -n "${EXTRA}" ] && [ -f "/config-${KERNEL_SERIES}-$(uname -m)${EXTRA}" ]; then \
-        cat /config-${KERNEL_SERIES}-$(uname -m)${EXTRA} >> ${KERNEL_DEF_CONF}; \
+    cp /config-${KERNEL_SERIES}-$(apk --print-arch) ${KERNEL_DEF_CONF}; \
+    if [ -n "${EXTRA}" ] && [ -f "/config-${KERNEL_SERIES}-$(apk --print-arch)${EXTRA}" ]; then \
+        cat /config-${KERNEL_SERIES}-$(apk --print-arch)${EXTRA} >> ${KERNEL_DEF_CONF}; \
     fi; \
     sed -i "s/CONFIG_LOCALVERSION=\"-linuxkit\"/CONFIG_LOCALVERSION=\"-linuxkit${EXTRA}${DEBUG}\"/" ${KERNEL_DEF_CONF}; \
     if [ -n "${DEBUG}" ]; then \
@@ -112,7 +112,7 @@ RUN mkdir /out
 
 # Kernel
 RUN make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
-    case $(uname -m) in \
+    case $(apk --print-arch) in \
     x86_64) \
         cp arch/x86_64/boot/bzImage /out/kernel; \
         ;; \
@@ -139,7 +139,7 @@ RUN make INSTALL_MOD_PATH=/tmp/kernel-modules modules_install && \
       cd /tmp/kernel-modules/lib/modules/$DVER && \
       rm build source && \
       ln -s /usr/src/linux-headers-$DVER build ) && \
-    case $(uname -m) in \
+    case $(apk --print-arch) in \
     aarch64) \
         make INSTALL_DTBS_PATH=/tmp/kernel-modules/boot/dtb dtbs_install; \
         ;; \
@@ -179,7 +179,7 @@ RUN if [ "${KERNEL_SERIES}" != "4.4.x" ]; then \
 # Download Intel ucode and create a CPIO archive for it
 ENV UCODE_URL=https://downloadmirror.intel.com/27337/eng/microcode-20171117.tgz
 RUN set -e && \
-    if [ $(uname -m) == x86_64 ]; then \
+    if [ $(apk --print-arch) == x86_64 ]; then \
         cd /ucode && \
         curl -sSL -o microcode.tar.gz ${UCODE_URL} && \
         md5sum -c intel-ucode-md5sums && \


### PR DESCRIPTION
Since the `build` process will run within the docker daemon, so it's
safer to get the Arch name based on the images in which the build
process is running while not depend on the host kernel.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Change the arch name fetch method
**- How I did it**
Using the `apk --print-arch` provided by the docker image instead of the host
**- How to verify it**
`make build_` kernel
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
