### PR TITLE
Kernel update to 4.15.11/4.14.28/4.9.88/4.4.122

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -1,6 +1,6 @@
 # This is an example for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.2 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:d899eee3560a40aa3b4bdd67b3bb82703714b2b9

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/packet.arm64.yml
+++ b/examples/packet.arm64.yml
@@ -5,7 +5,7 @@
 # for arm64 then the 'ucode' line in the kernel section can be left
 # out.
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyAMA0"
   ucode: ""
 onboot:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -218,22 +218,22 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,4.15.10,4.15.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.27,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.27,4.14.x,,-dbg))
+$(eval $(call kernel,4.15.11,4.15.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.28,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.28,4.14.x,,-dbg))
 $(eval $(call kernel,4.14.24,4.14.x,-rt,))
-$(eval $(call kernel,4.9.87,4.9.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.4.121,4.4.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.88,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.4.122,4.4.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,4.15.10,4.15.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.27,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.15.11,4.15.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.28,4.14.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.24,4.14.x,-rt,))
-$(eval $(call kernel,4.9.87,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.88,4.9.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),s390x)
-$(eval $(call kernel,4.15.10,4.15.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.27,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.15.11,4.15.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.28,4.14.x,$(EXTRA),$(DEBUG)))
 endif
 
 # Target for kernel config

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.27 Kernel Configuration
+# Linux/arm64 4.14.28 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-s390x
+++ b/kernel/config-4.14.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.14.27 Kernel Configuration
+# Linux/s390 4.14.28 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.27 Kernel Configuration
+# Linux/x86 4.14.28 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.15.x-aarch64
+++ b/kernel/config-4.15.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.15.10 Kernel Configuration
+# Linux/arm64 4.15.11 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.15.x-s390x
+++ b/kernel/config-4.15.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.15.10 Kernel Configuration
+# Linux/s390 4.15.11 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.15.x-x86_64
+++ b/kernel/config-4.15.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.15.10 Kernel Configuration
+# Linux/x86 4.15.11 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.121 Kernel Configuration
+# Linux/x86 4.4.122 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-aarch64
+++ b/kernel/config-4.9.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.9.87 Kernel Configuration
+# Linux/arm64 4.9.88 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.87 Kernel Configuration
+# Linux/x86 4.9.88 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 32882258de04031a9e6e9fd7e887ba4cb44f8d43 Mon Sep 17 00:00:00 2001
+From 9e6fb8fa75239b9806b4242297c80cc7c310cb10 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 01/19] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,4 +1,4 @@
-From ad4ef30200f12aa261487865d26cf53dd773621f Mon Sep 17 00:00:00 2001
+From 3b2d530710e5be30e256d5aa1ebae0703ab38da6 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
 Subject: [PATCH 02/19] hyper-v: trace vmbus_on_msg_dpc()

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,4 +1,4 @@
-From 0230ea645a34c80d17837a7434070b285b72c85b Mon Sep 17 00:00:00 2001
+From dd95b7b338da2bab4991d5f0b56fa2774886a562 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
 Subject: [PATCH 03/19] hyper-v: trace vmbus_on_message()

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,4 +1,4 @@
-From b22271be9d0d1e5253b3843655e399028af17b4a Mon Sep 17 00:00:00 2001
+From b99df6af791f4f2ec66697a7dfff2af34870ff2e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
 Subject: [PATCH 04/19] hyper-v: trace vmbus_onoffer()

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,4 +1,4 @@
-From 770e1985657043b375f5290f08b2d7ab30f23d0b Mon Sep 17 00:00:00 2001
+From 2187f51e26e56dc580ac19ccd63b57f368eb2b6a Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
 Subject: [PATCH 05/19] hyper-v: trace vmbus_onoffer_rescind()

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,4 +1,4 @@
-From f294264e85111fa6717db328ffe6ad17e457a861 Mon Sep 17 00:00:00 2001
+From 2710d816e5254612a92e928f855799cb700ae4f8 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
 Subject: [PATCH 06/19] hyper-v: trace vmbus_onopen_result()

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,4 +1,4 @@
-From be90af98b5f2e485ea5fa03c0b8dca65363efdb7 Mon Sep 17 00:00:00 2001
+From b6b44fa770e22a9d7746c7f8efab180925a1d35b Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
 Subject: [PATCH 07/19] hyper-v: trace vmbus_ongpadl_created()

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,4 +1,4 @@
-From e9c3c69420c92bec6e76b3d80a2fccbe4949f5a5 Mon Sep 17 00:00:00 2001
+From 7f6baef301fc0f4cf6e30484073ea4386575d3e4 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
 Subject: [PATCH 08/19] hyper-v: trace vmbus_ongpadl_torndown()

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,4 +1,4 @@
-From eebe8dc4835d1e8d64efe5c52bcce7fcc5ebdf68 Mon Sep 17 00:00:00 2001
+From 0fca0d45b7ce47dd3c19fde841daa1ba934bb6ff Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
 Subject: [PATCH 09/19] hyper-v: trace vmbus_onversion_response()

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,4 +1,4 @@
-From 06fd7944807e7757daf0d892fa91039ed7aca3ba Mon Sep 17 00:00:00 2001
+From 53b28d61e855cb8b432021544d75fa7bb2c2eb20 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
 Subject: [PATCH 10/19] hyper-v: trace vmbus_request_offers()

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,4 +1,4 @@
-From e1cd073f78523f60d516b1c4d820706197ef55dd Mon Sep 17 00:00:00 2001
+From fdb1d52d99c85bfee9f075a6b916dd5cab5b7201 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
 Subject: [PATCH 11/19] hyper-v: trace vmbus_open()

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,4 +1,4 @@
-From 19d12a26608ba3690674980530865374601fe929 Mon Sep 17 00:00:00 2001
+From b3687399ac3979384b967ac9b4369bf06669a8c9 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
 Subject: [PATCH 12/19] hyper-v: trace vmbus_close_internal()

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,4 +1,4 @@
-From d6518b0c258f8d9c80df7bae959db7b357bf3666 Mon Sep 17 00:00:00 2001
+From 8378185cbad396f933b97e13ba03793e3cb1b5b1 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
 Subject: [PATCH 13/19] hyper-v: trace vmbus_establish_gpadl()

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,4 +1,4 @@
-From 8accf518f221dfc7d093bff53d40c76c2a4fea7f Mon Sep 17 00:00:00 2001
+From d0d9bd3f1d426e25098c14671fac766d557c951e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
 Subject: [PATCH 14/19] hyper-v: trace vmbus_teardown_gpadl()

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,4 +1,4 @@
-From 1a5e660a3c6b31b01442815e36581ae930db5b18 Mon Sep 17 00:00:00 2001
+From e7c4b06f8552556f3ef3538257ff631d71e4d691 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
 Subject: [PATCH 15/19] hyper-v: trace vmbus_negotiate_version()

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,4 +1,4 @@
-From 54e520cf838ab5298fc68242e52ce6429f0ba22f Mon Sep 17 00:00:00 2001
+From a8d841250cf5d87864833b44931f053b828e4053 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
 Subject: [PATCH 16/19] hyper-v: trace vmbus_release_relid()

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,4 +1,4 @@
-From d58b3cc08abcfd6bac3df3bd2a1902bf2e84fdd0 Mon Sep 17 00:00:00 2001
+From aba183386c58ef438f297c636e9cce2aab466e5d Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
 Subject: [PATCH 17/19] hyper-v: trace vmbus_send_tl_connect_request()

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,4 +1,4 @@
-From cadcba05f4caea37893151fa5acb85adffa17a4b Mon Sep 17 00:00:00 2001
+From 87f64fbb47f44c9e05e1a01052fd3bb74579190c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
 Subject: [PATCH 18/19] hyper-v: trace channel events

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From 9e06e0b24b86d260ae98ddc5f85330b069e45ba5 Mon Sep 17 00:00:00 2001
+From dce0d5fd0fee3486847ce4dd58c73b210668fc62 Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH 19/19] serial: forbid 8250 on s390

--- a/kernel/patches-4.15.x/0001-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.15.x/0001-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From 61dd4919cb8dc425fab54b1a4327c953195af1bd Mon Sep 17 00:00:00 2001
+From e1f267325f956405e2e8004e45833d3dfcea84ae Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH] serial: forbid 8250 on s390

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 318dfe6fb39533df22142c38730039d78df3f59e Mon Sep 17 00:00:00 2001
+From 51034cb762c585aabddb2fb7bab4a25de91851c5 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From fa54d00da4106b5159b15e3da2ad7d4114329dc9 Mon Sep 17 00:00:00 2001
+From 5ed21ae24d8c240b9049c2f33c7fa41bddd6b0ee Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 6de8bc3ac6127b61231ac74d6b6333770804f18d Mon Sep 17 00:00:00 2001
+From b9ec1c4fae27c873d10d4cfa8d391aca5eaefe31 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 6098294c09c266baf0e91ae50bbb49f3d1c7a6a7 Mon Sep 17 00:00:00 2001
+From 8dcabcc699cc5a01dcf7e172c369d8f4b75cc98d Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From ea7f9f835aeb13fc163ace51cef88fe7c1e24918 Mon Sep 17 00:00:00 2001
+From 7fc8017d994465c4359ca75f9dc34aa301c35950 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From 7802eeaf5441e315d38b5e72c5474a1b9fed8ecc Mon Sep 17 00:00:00 2001
+From 88fe64e4b36adb34935bd28528053593daef333a Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From 7b8efc472c447799f341a50ef397c33790019953 Mon Sep 17 00:00:00 2001
+From dd7f171e675f58361f88e4cdeba9492bdb2340c1 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From fcad395c35919f092a43306cfdffa81f1557f322 Mon Sep 17 00:00:00 2001
+From 8822d73230ebe55bdd501ece757a82b4ccfceb1e Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 8f498d05d6dc69c50b76fd785917b340aed5ecf2 Mon Sep 17 00:00:00 2001
+From 1ae45baa9406320b4a3b13e53ebd17a66169f296 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From abf2f8df3c66b842768c4271100a59ad90614376 Mon Sep 17 00:00:00 2001
+From 1b1925f3637b673e1bc08eda5490b94d9a887564 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From db9330a4c6bc7f827e45571bad2b8782f7b31ac3 Mon Sep 17 00:00:00 2001
+From 20785f80a4e42edac8cb26e590433a5c89b5c5aa Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 8c4bd0b3024e24ba1bc8fe13b993ab8a59732c78 Mon Sep 17 00:00:00 2001
+From aa854816a2157f63db8efe5a74ac991f935cd0d4 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a # with runc, logwrite, startmemlogd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.121
+  image: linuxkit/kernel:4.4.122
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.87
+  image: linuxkit/kernel:4.9.88
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/007_config_4.15.x/test.yml
+++ b/test/cases/020_kernel/007_config_4.15.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.15.10
+  image: linuxkit/kernel:4.15.11
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.4.121 AS ksrc
+FROM linuxkit/kernel:4.4.122 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.4.121
+docker pull linuxkit/kernel:4.4.122
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.121
+  image: linuxkit/kernel:4.4.122
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.87 AS ksrc
+FROM linuxkit/kernel:4.9.88 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.87
+docker pull linuxkit/kernel:4.9.88
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.87
+  image: linuxkit/kernel:4.9.88
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
+++ b/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.14.27 AS ksrc
+FROM linuxkit/kernel:4.14.28 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.sh
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.14.27
+docker pull linuxkit/kernel:4.14.28
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/017_kmod_4.15.x/Dockerfile
+++ b/test/cases/020_kernel/017_kmod_4.15.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.15.10 AS ksrc
+FROM linuxkit/kernel:4.15.11 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/017_kmod_4.15.x/test.sh
+++ b/test/cases/020_kernel/017_kmod_4.15.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.15.10
+docker pull linuxkit/kernel:4.15.11
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/017_kmod_4.15.x/test.yml
+++ b/test/cases/020_kernel/017_kmod_4.15.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.15.10
+  image: linuxkit/kernel:4.15.11
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.121
+  image: linuxkit/kernel:4.4.122
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.87
+  image: linuxkit/kernel:4.9.88
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.14.27
+  image: linuxkit/kernel:4.14.28
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a


### PR DESCRIPTION
At least the 4.14.x kernel seems pretty straightforward bug fixes and nothing to too concerning.

arm64/s390x/x86 kernels build and pushed

![image](https://user-images.githubusercontent.com/3338098/37658813-4d580a26-2c46-11e8-835c-07f8b4d91f96.png)
