### PR TITLE
Kernel update to 4.15.12/4.14.29/4.9.89/4.4.123 + Hyper-V SCSI fixes

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -1,6 +1,6 @@
 # This is an example for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.2 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:d899eee3560a40aa3b4bdd67b3bb82703714b2b9

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/packet.arm64.yml
+++ b/examples/packet.arm64.yml
@@ -5,7 +5,7 @@
 # for arm64 then the 'ucode' line in the kernel section can be left
 # out.
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyAMA0"
   ucode: ""
 onboot:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -218,22 +218,22 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,4.15.11,4.15.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.28,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.28,4.14.x,,-dbg))
+$(eval $(call kernel,4.15.12,4.15.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.29,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.29,4.14.x,,-dbg))
 $(eval $(call kernel,4.14.24,4.14.x,-rt,))
-$(eval $(call kernel,4.9.88,4.9.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.4.122,4.4.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.89,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.4.123,4.4.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,4.15.11,4.15.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.28,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.15.12,4.15.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.29,4.14.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.24,4.14.x,-rt,))
-$(eval $(call kernel,4.9.88,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.89,4.9.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),s390x)
-$(eval $(call kernel,4.15.11,4.15.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.28,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.15.12,4.15.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.29,4.14.x,$(EXTRA),$(DEBUG)))
 endif
 
 # Target for kernel config

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.28 Kernel Configuration
+# Linux/arm64 4.14.29 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-s390x
+++ b/kernel/config-4.14.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.14.28 Kernel Configuration
+# Linux/s390 4.14.29 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.28 Kernel Configuration
+# Linux/x86 4.14.29 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.15.x-aarch64
+++ b/kernel/config-4.15.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.15.11 Kernel Configuration
+# Linux/arm64 4.15.12 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.15.x-s390x
+++ b/kernel/config-4.15.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.15.11 Kernel Configuration
+# Linux/s390 4.15.12 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.15.x-x86_64
+++ b/kernel/config-4.15.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.15.11 Kernel Configuration
+# Linux/x86 4.15.12 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.122 Kernel Configuration
+# Linux/x86 4.4.123 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-aarch64
+++ b/kernel/config-4.9.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.9.88 Kernel Configuration
+# Linux/arm64 4.9.89 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.88 Kernel Configuration
+# Linux/x86 4.9.89 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,7 +1,7 @@
 From f2dfc3322844833fff0e355605881c7057a6ff34 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
-Subject: [PATCH 01/19] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB
+Subject: [PATCH 01/21] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB
  (page size)
 
 Signed-off-by: Cheng-mean Liu <soccerl@microsoft.com>

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 9e6fb8fa75239b9806b4242297c80cc7c310cb10 Mon Sep 17 00:00:00 2001
+From f2dfc3322844833fff0e355605881c7057a6ff34 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 01/19] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB
@@ -24,5 +24,5 @@ index 3f03567631cb..e63c201ed1ef 100644
  
  enum ars_masks {
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,4 +1,4 @@
-From 3b2d530710e5be30e256d5aa1ebae0703ab38da6 Mon Sep 17 00:00:00 2001
+From 39acaefe663f3f9baf52bfe8353cdb185ec6e391 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
 Subject: [PATCH 02/19] hyper-v: trace vmbus_on_msg_dpc()
@@ -107,5 +107,5 @@ index 2cd134dd94d2..9687e462fd43 100644
  		WARN_ONCE(1, "unknown msgtype=%d\n", hdr->msgtype);
  		goto msg_handled;
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,7 +1,7 @@
 From 39acaefe663f3f9baf52bfe8353cdb185ec6e391 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
-Subject: [PATCH 02/19] hyper-v: trace vmbus_on_msg_dpc()
+Subject: [PATCH 02/21] hyper-v: trace vmbus_on_msg_dpc()
 
 Add tracing subsystem to Hyper-V VMBus module and add tracepoint
 to vmbus_on_msg_dpc() which is called when we receive a message from host.

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,7 +1,7 @@
 From 597a62a851affc0eb02402f5cfdd9d07f1e7ae87 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
-Subject: [PATCH 03/19] hyper-v: trace vmbus_on_message()
+Subject: [PATCH 03/21] hyper-v: trace vmbus_on_message()
 
 Add tracepoint to vmbus_on_message() which is called when we start
 processing a blocking from work context.

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,4 +1,4 @@
-From dd95b7b338da2bab4991d5f0b56fa2774886a562 Mon Sep 17 00:00:00 2001
+From 597a62a851affc0eb02402f5cfdd9d07f1e7ae87 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
 Subject: [PATCH 03/19] hyper-v: trace vmbus_on_message()
@@ -45,5 +45,5 @@ index 9c2772922c76..d432aba5df8a 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,7 +1,7 @@
 From 8db9f715df104300b0df6f6709e82ef4f9aa26a5 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
-Subject: [PATCH 04/19] hyper-v: trace vmbus_onoffer()
+Subject: [PATCH 04/21] hyper-v: trace vmbus_onoffer()
 
 Add tracepoint to CHANNELMSG_OFFERCHANNEL handler.
 

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,4 +1,4 @@
-From b99df6af791f4f2ec66697a7dfff2af34870ff2e Mon Sep 17 00:00:00 2001
+From 8db9f715df104300b0df6f6709e82ef4f9aa26a5 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
 Subject: [PATCH 04/19] hyper-v: trace vmbus_onoffer()
@@ -76,5 +76,5 @@ index d432aba5df8a..488b873b563e 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,4 +1,4 @@
-From 2187f51e26e56dc580ac19ccd63b57f368eb2b6a Mon Sep 17 00:00:00 2001
+From 0c6347ab475d34df2815cea98f0ebaa2fe5f6e3b Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
 Subject: [PATCH 05/19] hyper-v: trace vmbus_onoffer_rescind()
@@ -47,5 +47,5 @@ index 488b873b563e..dbbed1d1f327 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,7 +1,7 @@
 From 0c6347ab475d34df2815cea98f0ebaa2fe5f6e3b Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
-Subject: [PATCH 05/19] hyper-v: trace vmbus_onoffer_rescind()
+Subject: [PATCH 05/21] hyper-v: trace vmbus_onoffer_rescind()
 
 Add tracepoint to CHANNELMSG_RESCIND_CHANNELOFFER handler.
 

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,7 +1,7 @@
 From 11ba0cc0131faac0d5e1e9ec30a5545156c2e636 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
-Subject: [PATCH 06/19] hyper-v: trace vmbus_onopen_result()
+Subject: [PATCH 06/21] hyper-v: trace vmbus_onopen_result()
 
 Add tracepoint to CHANNELMSG_OPENCHANNEL_RESULT handler.
 

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,4 +1,4 @@
-From 2710d816e5254612a92e928f855799cb700ae4f8 Mon Sep 17 00:00:00 2001
+From 11ba0cc0131faac0d5e1e9ec30a5545156c2e636 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
 Subject: [PATCH 06/19] hyper-v: trace vmbus_onopen_result()
@@ -56,5 +56,5 @@ index dbbed1d1f327..9757c19d1c08 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,4 +1,4 @@
-From b6b44fa770e22a9d7746c7f8efab180925a1d35b Mon Sep 17 00:00:00 2001
+From 46a7efc184320188f4b867c84777b5fcd564783c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
 Subject: [PATCH 07/19] hyper-v: trace vmbus_ongpadl_created()
@@ -56,5 +56,5 @@ index 9757c19d1c08..20734b7b341b 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,7 +1,7 @@
 From 46a7efc184320188f4b867c84777b5fcd564783c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
-Subject: [PATCH 07/19] hyper-v: trace vmbus_ongpadl_created()
+Subject: [PATCH 07/21] hyper-v: trace vmbus_ongpadl_created()
 
 Add tracepoint to CHANNELMSG_GPADL_CREATED handler.
 

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,4 +1,4 @@
-From 7f6baef301fc0f4cf6e30484073ea4386575d3e4 Mon Sep 17 00:00:00 2001
+From 92412b339cf3f5aad7a2423349451db5fcfac9fd Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
 Subject: [PATCH 08/19] hyper-v: trace vmbus_ongpadl_torndown()
@@ -47,5 +47,5 @@ index 20734b7b341b..84c08cdf7235 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,7 +1,7 @@
 From 92412b339cf3f5aad7a2423349451db5fcfac9fd Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
-Subject: [PATCH 08/19] hyper-v: trace vmbus_ongpadl_torndown()
+Subject: [PATCH 08/21] hyper-v: trace vmbus_ongpadl_torndown()
 
 Add tracepoint to CHANNELMSG_GPADL_TORNDOWN handler.
 

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,7 +1,7 @@
 From f887dce3b758deb4dece07f8e3ea2a00f80cdc31 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
-Subject: [PATCH 09/19] hyper-v: trace vmbus_onversion_response()
+Subject: [PATCH 09/21] hyper-v: trace vmbus_onversion_response()
 
 Add tracepoint to CHANNELMSG_VERSION_RESPONSE handler.
 

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,4 +1,4 @@
-From 0fca0d45b7ce47dd3c19fde841daa1ba934bb6ff Mon Sep 17 00:00:00 2001
+From f887dce3b758deb4dece07f8e3ea2a00f80cdc31 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
 Subject: [PATCH 09/19] hyper-v: trace vmbus_onversion_response()
@@ -51,5 +51,5 @@ index 84c08cdf7235..2a046547107f 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,7 +1,7 @@
 From e44a4b4f6301dcdb3d790efe097e4bb23c68d9c0 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
-Subject: [PATCH 10/19] hyper-v: trace vmbus_request_offers()
+Subject: [PATCH 10/21] hyper-v: trace vmbus_request_offers()
 
 Add tracepoint to CHANNELMSG_REQUESTOFFERS sender.
 

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,4 +1,4 @@
-From 53b28d61e855cb8b432021544d75fa7bb2c2eb20 Mon Sep 17 00:00:00 2001
+From e44a4b4f6301dcdb3d790efe097e4bb23c68d9c0 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
 Subject: [PATCH 10/19] hyper-v: trace vmbus_request_offers()
@@ -51,5 +51,5 @@ index 2a046547107f..566ac0f2fe56 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,4 +1,4 @@
-From fdb1d52d99c85bfee9f075a6b916dd5cab5b7201 Mon Sep 17 00:00:00 2001
+From 2a62f25b008f45a8eb264146ae40d4658ee4d6d8 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
 Subject: [PATCH 11/19] hyper-v: trace vmbus_open()
@@ -66,5 +66,5 @@ index 566ac0f2fe56..38fedb803bd8 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,7 +1,7 @@
 From 2a62f25b008f45a8eb264146ae40d4658ee4d6d8 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
-Subject: [PATCH 11/19] hyper-v: trace vmbus_open()
+Subject: [PATCH 11/21] hyper-v: trace vmbus_open()
 
 Add tracepoint to CHANNELMSG_OPENCHANNEL sender.
 

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,7 +1,7 @@
 From e69671031bc85350f16fcc0f73d162758fa9af6b Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
-Subject: [PATCH 12/19] hyper-v: trace vmbus_close_internal()
+Subject: [PATCH 12/21] hyper-v: trace vmbus_close_internal()
 
 Add tracepoint to CHANNELMSG_CLOSECHANNEL sender.
 

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,4 +1,4 @@
-From b3687399ac3979384b967ac9b4369bf06669a8c9 Mon Sep 17 00:00:00 2001
+From e69671031bc85350f16fcc0f73d162758fa9af6b Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
 Subject: [PATCH 12/19] hyper-v: trace vmbus_close_internal()
@@ -54,5 +54,5 @@ index 38fedb803bd8..302bd4e964f0 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,7 +1,7 @@
 From 5023216570a427cf25fb782219054eae334346ed Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
-Subject: [PATCH 13/19] hyper-v: trace vmbus_establish_gpadl()
+Subject: [PATCH 13/21] hyper-v: trace vmbus_establish_gpadl()
 
 Add tracepoint to CHANNELMSG_GPADL_HEADER/CHANNELMSG_GPADL_BODY sender.
 

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,4 +1,4 @@
-From 8378185cbad396f933b97e13ba03793e3cb1b5b1 Mon Sep 17 00:00:00 2001
+From 5023216570a427cf25fb782219054eae334346ed Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
 Subject: [PATCH 13/19] hyper-v: trace vmbus_establish_gpadl()
@@ -92,5 +92,5 @@ index 302bd4e964f0..978e70bdc7c5 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,7 +1,7 @@
 From d00717f5e5c55048a95ba543e5e4f3ce6c57906f Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
-Subject: [PATCH 14/19] hyper-v: trace vmbus_teardown_gpadl()
+Subject: [PATCH 14/21] hyper-v: trace vmbus_teardown_gpadl()
 
 Add tracepoint to CHANNELMSG_GPADL_TEARDOWN sender.
 

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,4 +1,4 @@
-From d0d9bd3f1d426e25098c14671fac766d557c951e Mon Sep 17 00:00:00 2001
+From d00717f5e5c55048a95ba543e5e4f3ce6c57906f Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
 Subject: [PATCH 14/19] hyper-v: trace vmbus_teardown_gpadl()
@@ -57,5 +57,5 @@ index 978e70bdc7c5..cd33a52ef27f 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,4 +1,4 @@
-From e7c4b06f8552556f3ef3538257ff631d71e4d691 Mon Sep 17 00:00:00 2001
+From d9d5329a9ecce6afa0fc25a0f560c473ae52de4a Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
 Subject: [PATCH 15/19] hyper-v: trace vmbus_negotiate_version()
@@ -66,5 +66,5 @@ index cd33a52ef27f..f06284d64a8c 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,7 +1,7 @@
 From d9d5329a9ecce6afa0fc25a0f560c473ae52de4a Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
-Subject: [PATCH 15/19] hyper-v: trace vmbus_negotiate_version()
+Subject: [PATCH 15/21] hyper-v: trace vmbus_negotiate_version()
 
 Add tracepoint to CHANNELMSG_INITIATE_CONTACT sender.
 

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,4 +1,4 @@
-From a8d841250cf5d87864833b44931f053b828e4053 Mon Sep 17 00:00:00 2001
+From 03890ec76a01397d8fba82ca606d77873e0504ce Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
 Subject: [PATCH 16/19] hyper-v: trace vmbus_release_relid()
@@ -64,5 +64,5 @@ index f06284d64a8c..f0e437c3522f 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,7 +1,7 @@
 From 03890ec76a01397d8fba82ca606d77873e0504ce Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
-Subject: [PATCH 16/19] hyper-v: trace vmbus_release_relid()
+Subject: [PATCH 16/21] hyper-v: trace vmbus_release_relid()
 
 Add tracepoint to CHANNELMSG_RELID_RELEASED sender.
 

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,4 +1,4 @@
-From aba183386c58ef438f297c636e9cce2aab466e5d Mon Sep 17 00:00:00 2001
+From 540f25fed2376bfb7e4d2f144c7b453b9eb4660a Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
 Subject: [PATCH 17/19] hyper-v: trace vmbus_send_tl_connect_request()
@@ -70,5 +70,5 @@ index f0e437c3522f..5382d9630306 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,7 +1,7 @@
 From 540f25fed2376bfb7e4d2f144c7b453b9eb4660a Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
-Subject: [PATCH 17/19] hyper-v: trace vmbus_send_tl_connect_request()
+Subject: [PATCH 17/21] hyper-v: trace vmbus_send_tl_connect_request()
 
 Add tracepoint to CHANNELMSG_TL_CONNECT_REQUEST sender.
 

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,7 +1,7 @@
 From b3776f6e8c1b0ab39c222cbe473ae42399a52783 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
-Subject: [PATCH 18/19] hyper-v: trace channel events
+Subject: [PATCH 18/21] hyper-v: trace channel events
 
 Added an additional set of trace points for when channel gets notified
 or signals host.

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,4 +1,4 @@
-From 87f64fbb47f44c9e05e1a01052fd3bb74579190c Mon Sep 17 00:00:00 2001
+From b3776f6e8c1b0ab39c222cbe473ae42399a52783 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
 Subject: [PATCH 18/19] hyper-v: trace channel events
@@ -97,5 +97,5 @@ index 9687e462fd43..27d5efd696ad 100644
  			case HV_CALL_ISR:
  				vmbus_channel_isr(channel);
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From dce0d5fd0fee3486847ce4dd58c73b210668fc62 Mon Sep 17 00:00:00 2001
+From 661a5c31d4ca7222b9576b43508fcb22df5adc2f Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH 19/19] serial: forbid 8250 on s390
@@ -31,5 +31,5 @@ index a5c0ef1e7695..16b1496e6105 100644
  	---help---
  	  This selects whether you want to include the driver for the standard
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,7 +1,7 @@
 From 661a5c31d4ca7222b9576b43508fcb22df5adc2f Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
-Subject: [PATCH 19/19] serial: forbid 8250 on s390
+Subject: [PATCH 19/21] serial: forbid 8250 on s390
 
 Using "make kvmconfig" results in a potentially unusable linux image
 on s390.  The reason is that both the (default on s390) sclp consoles

--- a/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
+++ b/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
@@ -1,0 +1,132 @@
+From 4ba99b3191f3fb7aebd9c2c3374828391ccb878c Mon Sep 17 00:00:00 2001
+From: Cathy Avery <cavery@redhat.com>
+Date: Tue, 31 Oct 2017 08:52:06 -0400
+Subject: [PATCH 20/21] scsi: storvsc: Allow only one remove lun work item to
+ be issued per lun
+
+When running multipath on a VM if all available paths go down the driver
+can schedule large amounts of storvsc_remove_lun work items to the same
+lun. In response to the failing paths typically storvsc responds by
+taking host->scan_mutex and issuing a TUR per lun. If there has been
+heavy IO to the failed device all the failed IOs are returned from the
+host. A remove lun work item is issued per failed IO. If the outstanding
+TURs have not been completed in a timely manner the scan_mutex is never
+released or released too late. Consequently the many remove lun work
+items are not completed as scsi_remove_device also tries to take
+host->scan_mutex.  This results in dragging the VM down and sometimes
+completely.
+
+This patch only allows one remove lun to be issued to a particular lun
+while it is an instantiated member of the scsi stack.
+
+Signed-off-by: Cathy Avery <cavery@redhat.com>
+Reviewed-by: Christoph Hellwig <hch@lst.de>
+Reviewed-by: Long Li <longli@microsoft.com>
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+(cherry picked from commit 436ad941335386c5fc7faa915a8fbdfe8c908084)
+---
+ drivers/scsi/storvsc_drv.c | 27 ++++++++++++++++++++++-----
+ 1 file changed, 22 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/scsi/storvsc_drv.c b/drivers/scsi/storvsc_drv.c
+index a3e480e7a257..f0ce2193eff7 100644
+--- a/drivers/scsi/storvsc_drv.c
++++ b/drivers/scsi/storvsc_drv.c
+@@ -486,6 +486,7 @@ struct hv_host_device {
+ 	unsigned int port;
+ 	unsigned char path;
+ 	unsigned char target;
++	struct workqueue_struct *handle_error_wq;
+ };
+ 
+ struct storvsc_scan_work {
+@@ -922,6 +923,7 @@ static void storvsc_handle_error(struct vmscsi_request *vm_srb,
+ {
+ 	struct storvsc_scan_work *wrk;
+ 	void (*process_err_fn)(struct work_struct *work);
++	struct hv_host_device *host_dev = shost_priv(host);
+ 	bool do_work = false;
+ 
+ 	switch (SRB_STATUS(vm_srb->srb_status)) {
+@@ -989,7 +991,7 @@ static void storvsc_handle_error(struct vmscsi_request *vm_srb,
+ 	wrk->lun = vm_srb->lun;
+ 	wrk->tgt_id = vm_srb->target_id;
+ 	INIT_WORK(&wrk->work, process_err_fn);
+-	schedule_work(&wrk->work);
++	queue_work(host_dev->handle_error_wq, &wrk->work);
+ }
+ 
+ 
+@@ -1804,10 +1806,19 @@ static int storvsc_probe(struct hv_device *device,
+ 	if (stor_device->num_sc != 0)
+ 		host->nr_hw_queues = stor_device->num_sc + 1;
+ 
++	/*
++	 * Set the error handler work queue.
++	 */
++	host_dev->handle_error_wq =
++			alloc_ordered_workqueue("storvsc_error_wq_%d",
++						WQ_MEM_RECLAIM,
++						host->host_no);
++	if (!host_dev->handle_error_wq)
++		goto err_out2;
+ 	/* Register the HBA and start the scsi bus scan */
+ 	ret = scsi_add_host(host, &device->device);
+ 	if (ret != 0)
+-		goto err_out2;
++		goto err_out3;
+ 
+ 	if (!dev_is_ide) {
+ 		scsi_scan_host(host);
+@@ -1816,7 +1827,7 @@ static int storvsc_probe(struct hv_device *device,
+ 			 device->dev_instance.b[4]);
+ 		ret = scsi_add_device(host, 0, target, 0);
+ 		if (ret)
+-			goto err_out3;
++			goto err_out4;
+ 	}
+ #if IS_ENABLED(CONFIG_SCSI_FC_ATTRS)
+ 	if (host->transportt == fc_transport_template) {
+@@ -1827,17 +1838,21 @@ static int storvsc_probe(struct hv_device *device,
+ 		fc_host_node_name(host) = stor_device->node_name;
+ 		fc_host_port_name(host) = stor_device->port_name;
+ 		stor_device->rport = fc_remote_port_add(host, 0, &ids);
++
+ 		if (!stor_device->rport) {
+ 			ret = -ENOMEM;
+-			goto err_out3;
++			goto err_out4;
+ 		}
+ 	}
+ #endif
+ 	return 0;
+ 
+-err_out3:
++err_out4:
+ 	scsi_remove_host(host);
+ 
++err_out3:
++	destroy_workqueue(host_dev->handle_error_wq);
++
+ err_out2:
+ 	/*
+ 	 * Once we have connected with the host, we would need to
+@@ -1861,6 +1876,7 @@ static int storvsc_remove(struct hv_device *dev)
+ {
+ 	struct storvsc_device *stor_device = hv_get_drvdata(dev);
+ 	struct Scsi_Host *host = stor_device->host;
++	struct hv_host_device *host_dev = shost_priv(host);
+ 
+ #if IS_ENABLED(CONFIG_SCSI_FC_ATTRS)
+ 	if (host->transportt == fc_transport_template) {
+@@ -1868,6 +1884,7 @@ static int storvsc_remove(struct hv_device *dev)
+ 		fc_remove_host(host);
+ 	}
+ #endif
++	destroy_workqueue(host_dev->handle_error_wq);
+ 	scsi_remove_host(host);
+ 	storvsc_dev_remove(dev);
+ 	scsi_host_put(host);
+-- 
+2.11.1
+

--- a/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
+++ b/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
@@ -1,0 +1,110 @@
+From 7586e0a49a7cc84f0b0ef766804837c81fe0cdd5 Mon Sep 17 00:00:00 2001
+From: Long Li <longli@microsoft.com>
+Date: Tue, 31 Oct 2017 14:58:08 -0700
+Subject: [PATCH 21/21] scsi: storvsc: Avoid excessive host scan on controller
+ change
+
+When there are multiple disks attached to the same SCSI controller, the
+host may send several VSTOR_OPERATION_REMOVE_DEVICE or
+VSTOR_OPERATION_ENUMERATE_BUS messages in a row, to indicate there is a
+change on the SCSI controller. In response, storvsc rescans the SCSI
+host.
+
+There is no need to do multiple scans on the same host. Fix the code to
+do only one scan.
+
+[mkp: applied by hand]
+
+Signed-off-by: Long Li <longli@microsoft.com>
+Tested-by: Cathy Avery <cavery@redhat.com>
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+(cherry picked from commit c58cc70fde299866bc261296166d26a87b4fa7ef)
+---
+ drivers/scsi/storvsc_drv.c | 26 +++++++++++---------------
+ 1 file changed, 11 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/scsi/storvsc_drv.c b/drivers/scsi/storvsc_drv.c
+index f0ce2193eff7..a892a5020c30 100644
+--- a/drivers/scsi/storvsc_drv.c
++++ b/drivers/scsi/storvsc_drv.c
+@@ -487,6 +487,8 @@ struct hv_host_device {
+ 	unsigned char path;
+ 	unsigned char target;
+ 	struct workqueue_struct *handle_error_wq;
++	struct work_struct host_scan_work;
++	struct Scsi_Host *host;
+ };
+ 
+ struct storvsc_scan_work {
+@@ -515,13 +517,12 @@ static void storvsc_device_scan(struct work_struct *work)
+ 
+ static void storvsc_host_scan(struct work_struct *work)
+ {
+-	struct storvsc_scan_work *wrk;
+ 	struct Scsi_Host *host;
+ 	struct scsi_device *sdev;
++	struct hv_host_device *host_device =
++		container_of(work, struct hv_host_device, host_scan_work);
+ 
+-	wrk = container_of(work, struct storvsc_scan_work, work);
+-	host = wrk->host;
+-
++	host = host_device->host;
+ 	/*
+ 	 * Before scanning the host, first check to see if any of the
+ 	 * currrently known devices have been hot removed. We issue a
+@@ -541,8 +542,6 @@ static void storvsc_host_scan(struct work_struct *work)
+ 	 * Now scan the host to discover LUNs that may have been added.
+ 	 */
+ 	scsi_scan_host(host);
+-
+-	kfree(wrk);
+ }
+ 
+ static void storvsc_remove_lun(struct work_struct *work)
+@@ -1119,8 +1118,7 @@ static void storvsc_on_receive(struct storvsc_device *stor_device,
+ 			     struct vstor_packet *vstor_packet,
+ 			     struct storvsc_cmd_request *request)
+ {
+-	struct storvsc_scan_work *work;
+-
++	struct hv_host_device *host_dev;
+ 	switch (vstor_packet->operation) {
+ 	case VSTOR_OPERATION_COMPLETE_IO:
+ 		storvsc_on_io_completion(stor_device, vstor_packet, request);
+@@ -1128,13 +1126,9 @@ static void storvsc_on_receive(struct storvsc_device *stor_device,
+ 
+ 	case VSTOR_OPERATION_REMOVE_DEVICE:
+ 	case VSTOR_OPERATION_ENUMERATE_BUS:
+-		work = kmalloc(sizeof(struct storvsc_scan_work), GFP_ATOMIC);
+-		if (!work)
+-			return;
+-
+-		INIT_WORK(&work->work, storvsc_host_scan);
+-		work->host = stor_device->host;
+-		schedule_work(&work->work);
++		host_dev = shost_priv(stor_device->host);
++		queue_work(
++			host_dev->handle_error_wq, &host_dev->host_scan_work);
+ 		break;
+ 
+ 	case VSTOR_OPERATION_FCHBA_DATA:
+@@ -1747,6 +1741,7 @@ static int storvsc_probe(struct hv_device *device,
+ 
+ 	host_dev->port = host->host_no;
+ 	host_dev->dev = device;
++	host_dev->host = host;
+ 
+ 
+ 	stor_device = kzalloc(sizeof(struct storvsc_device), GFP_KERNEL);
+@@ -1815,6 +1810,7 @@ static int storvsc_probe(struct hv_device *device,
+ 						host->host_no);
+ 	if (!host_dev->handle_error_wq)
+ 		goto err_out2;
++	INIT_WORK(&host_dev->host_scan_work, storvsc_host_scan);
+ 	/* Register the HBA and start the scsi bus scan */
+ 	ret = scsi_add_host(host, &device->device);
+ 	if (ret != 0)
+-- 
+2.11.1
+

--- a/kernel/patches-4.15.x/0001-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.15.x/0001-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From e1f267325f956405e2e8004e45833d3dfcea84ae Mon Sep 17 00:00:00 2001
+From 38779a8c70a41e599b0a8c5e187feb0e6bb9a589 Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH] serial: forbid 8250 on s390
@@ -31,5 +31,5 @@ index a5c0ef1e7695..16b1496e6105 100644
  	---help---
  	  This selects whether you want to include the driver for the standard
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 51034cb762c585aabddb2fb7bab4a25de91851c5 Mon Sep 17 00:00:00 2001
+From 3df181871d3998b60ead402386625dd9ced0978d Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()
@@ -146,5 +146,5 @@ index 43899e0d6fa1..c3b180254f91 100644
  
  int is_printable_array(char *p, unsigned int len);
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 5ed21ae24d8c240b9049c2f33c7fa41bddd6b0ee Mon Sep 17 00:00:00 2001
+From 085e1b3a8433471aa8db070fe682875e27edeb5a Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable
@@ -66,5 +66,5 @@ index 95f0884aae02..f3ed3c963c71 100644
  	while ((jr = jit_get_next_entry(jd))) {
  		switch(jr->prefix.id) {
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From b9ec1c4fae27c873d10d4cfa8d391aca5eaefe31 Mon Sep 17 00:00:00 2001
+From b59ddcff5004b135df4a2dbc8872b980e694c555 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets
@@ -1787,5 +1787,5 @@ index 000000000000..331d3759f5cb
 +MODULE_DESCRIPTION("Hyper-V Sockets");
 +MODULE_LICENSE("Dual BSD/GPL");
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 8dcabcc699cc5a01dcf7e172c369d8f4b75cc98d Mon Sep 17 00:00:00 2001
+From 24b0cb36bcf8d7ab539a84c89975911020eda978 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs
@@ -26,5 +26,5 @@ index d8bc4b910192..8df02f3ca0b2 100644
  }
  
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 7fc8017d994465c4359ca75f9dc34aa301c35950 Mon Sep 17 00:00:00 2001
+From daf1c9fbb8a50c9e65c3719804a18b3310555acd Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host
@@ -44,5 +44,5 @@ index bcd06306f3e8..e7707747f56d 100644
  	}
  
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From 88fe64e4b36adb34935bd28528053593daef333a Mon Sep 17 00:00:00 2001
+From bdd6c6a2208c8afae5a8ff0442b4dc90b24fb6f9 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.
@@ -101,5 +101,5 @@ index a6707133c297..5c95ba1e2ecf 100644
  	return 0;
  }
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From dd7f171e675f58361f88e4cdeba9492bdb2340c1 Mon Sep 17 00:00:00 2001
+From cbdf366165ac60ca7ca84f8ba14d33594f661375 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host
@@ -44,5 +44,5 @@ index 5c95ba1e2ecf..eee238cc60bd 100644
  	rc = hvutil_transport_send(hvt, vss_msg, sizeof(*vss_msg), NULL);
  	if (rc) {
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From 8822d73230ebe55bdd501ece757a82b4ccfceb1e Mon Sep 17 00:00:00 2001
+From 0ba28ee78672a16d5ea5ef036d7e928568629e3c Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to
@@ -488,5 +488,5 @@ index c9af8369b4f7..7df9eb8f0cf7 100644
  void hv_event_tasklet_disable(struct vmbus_channel *channel);
  void hv_event_tasklet_enable(struct vmbus_channel *channel);
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 1ae45baa9406320b4a3b13e53ebd17a66169f296 Mon Sep 17 00:00:00 2001
+From d9e7acb44bf39ef20d126e5cf3c9b020c0939b46 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.
@@ -114,5 +114,5 @@ index f3797c07be10..89440c2eb346 100644
  					hb_srv_version & 0xFFFF);
  			}
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From 1b1925f3637b673e1bc08eda5490b94d9a887564 Mon Sep 17 00:00:00 2001
+From df074b06d86ee023e7949f2066c6acad5cb32501 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot
@@ -52,5 +52,5 @@ index e7949b64bfbc..2fe024e86209 100644
  
  void hv_process_channel_removal(struct vmbus_channel *channel, u32 relid)
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 20785f80a4e42edac8cb26e590433a5c89b5c5aa Mon Sep 17 00:00:00 2001
+From dea4a36da7a089aef2dd720ddb560eac02a32939 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in
@@ -56,5 +56,5 @@ index 1606e7f08f4b..1caed01954f6 100644
  	vmbus_teardown_gpadl(newchannel, newchannel->ringbuffer_gpadlhandle);
  	kfree(open_info);
 -- 
-2.16.0
+2.11.1
 

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From aa854816a2157f63db8efe5a74ac991f935cd0d4 Mon Sep 17 00:00:00 2001
+From e87904df07737c1f0d91cdfa81e26dca8120296a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on
@@ -173,5 +173,5 @@ index 7df9eb8f0cf7..a87757cf277b 100644
  
  void vmbus_setevent(struct vmbus_channel *channel);
 -- 
-2.16.0
+2.11.1
 

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a # with runc, logwrite, startmemlogd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.122
+  image: linuxkit/kernel:4.4.123
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.88
+  image: linuxkit/kernel:4.9.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/007_config_4.15.x/test.yml
+++ b/test/cases/020_kernel/007_config_4.15.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.15.11
+  image: linuxkit/kernel:4.15.12
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.4.122 AS ksrc
+FROM linuxkit/kernel:4.4.123 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.4.122
+docker pull linuxkit/kernel:4.4.123
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.122
+  image: linuxkit/kernel:4.4.123
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.88 AS ksrc
+FROM linuxkit/kernel:4.9.89 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.88
+docker pull linuxkit/kernel:4.9.89
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.88
+  image: linuxkit/kernel:4.9.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
+++ b/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.14.28 AS ksrc
+FROM linuxkit/kernel:4.14.29 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.sh
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.14.28
+docker pull linuxkit/kernel:4.14.29
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/017_kmod_4.15.x/Dockerfile
+++ b/test/cases/020_kernel/017_kmod_4.15.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.15.11 AS ksrc
+FROM linuxkit/kernel:4.15.12 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:d307c8a386fa3f32cddda9409b9687e191cdd6f1 AS build

--- a/test/cases/020_kernel/017_kmod_4.15.x/test.sh
+++ b/test/cases/020_kernel/017_kmod_4.15.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.15.11
+docker pull linuxkit/kernel:4.15.12
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/017_kmod_4.15.x/test.yml
+++ b/test/cases/020_kernel/017_kmod_4.15.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.15.11
+  image: linuxkit/kernel:4.15.12
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.122
+  image: linuxkit/kernel:4.4.123
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.88
+  image: linuxkit/kernel:4.9.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.14.28
+  image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a


### PR DESCRIPTION
Regular kernel update plus backport for two Hyper-V SCSI driver patches which may help with some LCOW issue around hot-unplugging devices (they certainly don't hurt)

![image](https://user-images.githubusercontent.com/3338098/37801925-56626a40-2e20-11e8-9a4c-6029419c5a08.png)

