### PR TITLE
Complete initial s390x support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 
 PREFIX?=/usr/local/
 
-RTF_COMMIT=f2409214ca3b719567aa15bb7b363f24876a4d98
+RTF_COMMIT=171155c375706f2616f0b9c96afe2240e15d1de1
 RTF_CMD=github.com/linuxkit/rtf/cmd
 RTF_VERSION=0.0
 bin/rtf: tmp_rtf_bin.tar | bin

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.2
+    image: linuxkit/metadata:09272c373fa10b9a09f2c9fe380bffb4402f98f6
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: sshd
-    image: linuxkit/sshd:v0.2
+    image: linuxkit/sshd:b24724013759bbcb084600d1157735ccfc9aa615
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
   - name: sshd
-    image: linuxkit/sshd:v0.2
+    image: linuxkit/sshd:b24724013759bbcb084600d1157735ccfc9aa615
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,33 +2,33 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: sysfs
-    image: linuxkit/sysfs:v0.2
+    image: linuxkit/sysfs:f7fc4dfbdc7e09f8aab0063699d9a75932b08c3f
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
       - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: ntpd
-    image: linuxkit/openntpd:v0.2
+    image: linuxkit/openntpd:e3cd26ff2974f2d93c88c28efacf69e15bcdb983
 
   - name: docker
     image: docker:17.10.0-ce-dind
@@ -46,7 +46,7 @@ services:
       - /etc/docker/daemon.json:/etc/docker/daemon.json
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: cadvisor
-    image: linuxkit/cadvisor:v0.2
+    image: linuxkit/cadvisor:5adb222abfcc3e7f21287045d7192aaf9198b80e
 files:
   - path: var/lib/docker
     directory: true

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -3,30 +3,30 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/vpnkit-expose-port:v0.2 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/vpnkit-expose-port:3f60b78f78bfb83c14dd459ff7a3f58dacb33ad0 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   # support metadata for optional config in /run/config
   - name: metadata
-    image: linuxkit/metadata:v0.2
+    image: linuxkit/metadata:09272c373fa10b9a09f2c9fe380bffb4402f98f6
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: sysfs
-    image: linuxkit/sysfs:v0.2
+    image: linuxkit/sysfs:f7fc4dfbdc7e09f8aab0063699d9a75932b08c3f
   - name: binfmt
-    image: linuxkit/binfmt:v0.2
+    image: linuxkit/binfmt:98398d827e80b56e487d2ae94ed86a0006acb702
   # Format and mount the disk image in /var/lib/docker
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib"]
   # make a swap file on the mounted disk
   - name: swap
-    image: linuxkit/swap:v0.2
+    image: linuxkit/swap:83b2f6d8c1e8196b68215a62269da4b79002aad0
     command: ["/swap.sh", "--path", "/var/lib/swap", "--size", "1024M"]
   # mount-vpnkit mounts the 9p share used by vpnkit to coordinate port forwarding
   - name: mount-vpnkit
@@ -44,41 +44,41 @@ onboot:
         - /var:/host_var
     command: ["sh", "-c", "mv -v /host_var/log /host_var/lib && ln -vs /var/lib/log /host_var/log"]
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   # Enable acpi to shutdown on power events
   - name: acpid
-    image: linuxkit/acpid:v0.2
+    image: linuxkit/acpid:a1399f824db917488d048c5e23ca3cec6e5317d8
   # Enable getty for easier debugging
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
         - INSECURE=true
   # Run ntpd to keep time synchronised in the VM
   - name: ntpd
-    image: linuxkit/openntpd:v0.2
+    image: linuxkit/openntpd:e3cd26ff2974f2d93c88c28efacf69e15bcdb983
   # VSOCK to unix domain socket forwarding. Forwards guest /var/run/docker.sock
   # to a socket on the host.
   - name: vsudd
-    image: linuxkit/vsudd:v0.2
+    image: linuxkit/vsudd:3559f24480e165e0719479146953b461a3e1b99e
     binds:
         - /var/run:/var/run
     command: ["/vsudd", "-inport", "2376:unix:/var/run/docker.sock"]
   # vpnkit-forwarder forwards network traffic to/from the host via VSOCK port 62373. 
   # It needs access to the vpnkit 9P coordination share 
   - name: vpnkit-forwarder
-    image: linuxkit/vpnkit-forwarder:v0.2
+    image: linuxkit/vpnkit-forwarder:9dad2e9fb848d6452232deb01e08beda7ba00d21
     binds:
         - /var/vpnkit:/port
     net: host
     command: ["/vpnkit-forwarder", "-vsockPort", "62373"]
   # Monitor for image deletes and invoke a TRIM on the container filesystem
   - name: trim-after-delete
-    image: linuxkit/trim-after-delete:v0.2
+    image: linuxkit/trim-after-delete:ab0873798bf27deb5024569e46dfe30bebda9713
   # When the host resumes from sleep, force a clock resync
   - name: host-timesync-daemon
-    image: linuxkit/host-timesync-daemon:v0.2
+    image: linuxkit/host-timesync-daemon:10177f45d9384fa4cc61571ae8bb3bffbb3eba3c
   # Run dockerd with the vpnkit userland proxy from the vpnkit-forwarder container.
   # Bind mounts /var/run to allow vsudd to connect to docker.sock, /var/vpnkit
   # for vpnkit coordination and /run/config/docker for the configuration file.

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,31 +2,31 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: sysfs
-    image: linuxkit/sysfs:v0.2
+    image: linuxkit/sysfs:f7fc4dfbdc7e09f8aab0063699d9a75932b08c3f
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
   - name: ntpd
-    image: linuxkit/openntpd:v0.2
+    image: linuxkit/openntpd:e3cd26ff2974f2d93c88c28efacf69e15bcdb983
   - name: docker
     image: docker:17.09.0-ce-dind
     capabilities:

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,27 +2,27 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.2
+    image: linuxkit/metadata:09272c373fa10b9a09f2c9fe380bffb4402f98f6
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: sshd
-    image: linuxkit/sshd:v0.2
+    image: linuxkit/sshd:b24724013759bbcb084600d1157735ccfc9aa615
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,24 +2,24 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,15 +2,15 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 onshutdown:
   - name: shutdown
@@ -18,7 +18,7 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
     runtime:
@@ -30,7 +30,7 @@ services:
           destination: writeable-host-etc
           options: ["rw", "lowerdir=/etc", "upperdir=/run/hostetc/upper", "workdir=/run/hostetc/work"]
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,17 +2,17 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d899eee3560a40aa3b4bdd67b3bb82703714b2b9
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: influxdb

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
   - name: node_exporter
-    image: linuxkit/node_exporter:v0.2
+    image: linuxkit/node_exporter:4e469ba415316c03136d5645642782554cb293e7
 trust:
   org:
     - linuxkit

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,24 +2,24 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.2
+    image: linuxkit/metadata:09272c373fa10b9a09f2c9fe380bffb4402f98f6
     command: ["/usr/bin/metadata", "openstack"]
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: sshd
-    image: linuxkit/sshd:v0.2
+    image: linuxkit/sshd:b24724013759bbcb084600d1157735ccfc9aa615
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/packet.arm64.yml
+++ b/examples/packet.arm64.yml
@@ -10,5 +10,5 @@ kernel:
   ucode: ""
 onboot:
   - name: modprobe
-    image: linuxkit/modprobe:v0.2
+    image: linuxkit/modprobe:67d9b334e4d84f480158e0a4974f547a469489a0
     command: ["modprobe", "nicvf"]

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,32 +3,32 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
-  - linuxkit/firmware:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
+  - linuxkit/firmware:33b2483a7e2cc54cc4a58dbe9c3662f7f067f70d
 onboot:
   - name: rngd1
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
     command: ["/sbin/rngd", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.2
+    image: linuxkit/metadata:09272c373fa10b9a09f2c9fe380bffb4402f98f6
     command: ["/usr/bin/metadata", "packet"]
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: sshd
-    image: linuxkit/sshd:v0.2
+    image: linuxkit/sshd:b24724013759bbcb084600d1157735ccfc9aa615
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,16 +4,16 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   # Currently redis:4.0.6-alpine has trust issue with multi-arch

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,24 +2,24 @@ kernel:
   image: linuxkit/kernel:4.14.18-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:d899eee3560a40aa3b4bdd67b3bb82703714b2b9
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
   - name: open-vm-tools
-    image: linuxkit/open-vm-tools:v0.2
+    image: linuxkit/open-vm-tools:fd0b0bc2c57da0ed069a423fb5a3494499fb1ac0
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,27 +2,27 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: rngd1
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
     command: ["/sbin/rngd", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
   - name: sshd
-    image: linuxkit/sshd:v0.2
+    image: linuxkit/sshd:b24724013759bbcb084600d1157735ccfc9aa615
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,33 +2,33 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/external"]
   - name: swap
-    image: linuxkit/swap:v0.2
+    image: linuxkit/swap:83b2f6d8c1e8196b68215a62269da4b79002aad0
     # to use unencrypted swap, use:
     # command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G"]
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
 trust:
   org:
     - linuxkit

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,25 +2,25 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: tss
-    image: linuxkit/tss:v0.2
+    image: linuxkit/tss:4ed60eeeeb9c26a3172e8b2c654ec257c6c9b220
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,22 +2,22 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,12 +2,12 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: mount-vpnkit
     image: alpine:3.7
@@ -19,9 +19,9 @@ onboot:
     command: ["sh", "-c", "mkdir /host_var/vpnkit && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
 services:
   - name: sshd
-    image: linuxkit/sshd:v0.2
+    image: linuxkit/sshd:b24724013759bbcb084600d1157735ccfc9aa615
   - name: vpnkit-forwarder
-    image: linuxkit/vpnkit-forwarder:v0.2
+    image: linuxkit/vpnkit-forwarder:9dad2e9fb848d6452232deb01e08beda7ba00d21
     binds:
         - /var/vpnkit:/port
     net: host

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: vsudd
-    image: linuxkit/vsudd:v0.2
+    image: linuxkit/vsudd:3559f24480e165e0719479146953b461a3e1b99e
     binds:
         - /run/containerd/containerd.sock:/run/containerd/containerd.sock
     command: ["/vsudd",

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,27 +2,27 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.2
+    image: linuxkit/metadata:09272c373fa10b9a09f2c9fe380bffb4402f98f6
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: sshd
-    image: linuxkit/sshd:v0.2
+    image: linuxkit/sshd:b24724013759bbcb084600d1157735ccfc9aa615
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,18 +2,18 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:v0.2
+    image: linuxkit/ip:14cd8bfc3a62e759ee6c925d697171ba18a91d70
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -26,7 +26,7 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:v0.2
+    image: linuxkit/ip:14cd8bfc3a62e759ee6c925d697171ba18a91d70
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -40,12 +40,12 @@ onboot:
           net: /run/netns/wg1
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
     net: /run/netns/wg1
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: nginx
     image: nginx:1.13.8-alpine
     net: /run/netns/wg0

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,15 +2,15 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 onshutdown:
   - name: shutdown
@@ -18,11 +18,11 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/pkg/acpid/Dockerfile
+++ b/pkg/acpid/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -6,7 +6,7 @@ RUN apk add --no-cache --initdb -p /out \
     busybox
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror2
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror2
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     busybox-initscripts

--- a/pkg/auditd/Dockerfile
+++ b/pkg/auditd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --initdb -p /out alpine-baselayout apk-tools audit busybox tini

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,10 +1,10 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS qemu
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS qemu
 RUN apk add \
     qemu-aarch64 \
     qemu-arm \
     qemu-ppc64le
 
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/ca-certificates/Dockerfile
+++ b/pkg/ca-certificates/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 as alpine
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee as alpine
 
 RUN apk add ca-certificates
 

--- a/pkg/cadvisor/Dockerfile
+++ b/pkg/cadvisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 as build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee as build
 
 RUN apk add --no-cache bash go git musl-dev linux-headers make
 
@@ -16,7 +16,7 @@ RUN go get -d ${GITREPO} \
     && mv cadvisor /usr/bin/
 
 
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/cadvisor/build.yml
+++ b/pkg/cadvisor/build.yml
@@ -1,2 +1,5 @@
 image: cadvisor
 network: true
+arches:
+  - amd64
+  - arm64

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:b1a36f0dd41e60142dd84dab7cd333ce7da1d1f8 as alpine
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/dhcpcd/Dockerfile
+++ b/pkg/dhcpcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/extend/Dockerfile
+++ b/pkg/extend/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -15,7 +15,7 @@ RUN apk add --no-cache --initdb -p /out \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/firmware-all/Dockerfile
+++ b/pkg/firmware-all/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS build
 RUN apk add --no-cache git
 
 # Make sure you also update the FW_COMMIT in ../firmware/Dockerfile

--- a/pkg/firmware/Dockerfile
+++ b/pkg/firmware/Dockerfile
@@ -1,5 +1,5 @@
 # Make modules from a recentish kernel available
-FROM linuxkit/kernel:4.14.12 AS kernel
+FROM linuxkit/kernel:4.14.28 AS kernel
 
 FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS build
 RUN apk add --no-cache git kmod

--- a/pkg/firmware/Dockerfile
+++ b/pkg/firmware/Dockerfile
@@ -1,7 +1,7 @@
 # Make modules from a recentish kernel available
 FROM linuxkit/kernel:4.14.12 AS kernel
 
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS build
 RUN apk add --no-cache git kmod
 
 # Clone the firmware repository

--- a/pkg/format/Dockerfile
+++ b/pkg/format/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -15,7 +15,7 @@ RUN apk add --no-cache --initdb -p /out \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/getty/Dockerfile
+++ b/pkg/getty/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/host-timesync-daemon/Dockerfile
+++ b/pkg/host-timesync-daemon/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN apk add --no-cache go musl-dev git
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:b1a36f0dd41e60142dd84dab7cd333ce7da1d1f8 AS build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -16,7 +16,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:b1a36f0dd41e60142dd84dab7cd333ce7da1d1f8 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/ip/Dockerfile
+++ b/pkg/ip/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add curl
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/metadata/Dockerfile
+++ b/pkg/metadata/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN apk add --no-cache go musl-dev linux-headers
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/mkimage/Dockerfile
+++ b/pkg/mkimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/modprobe/Dockerfile
+++ b/pkg/modprobe/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/mount/Dockerfile
+++ b/pkg/mount/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -9,7 +9,7 @@ RUN apk add --no-cache --initdb -p /out \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/node_exporter/Dockerfile
+++ b/pkg/node_exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 as build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee as build
 
 RUN apk add --no-cache go git musl-dev make
 

--- a/pkg/open-vm-tools/Dockerfile
+++ b/pkg/open-vm-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/openntpd/Dockerfile
+++ b/pkg/openntpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/qemu-ga/Dockerfile
+++ b/pkg/qemu-ga/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS build
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN mkdir -p /out/var/run
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN apk add --no-cache go gcc musl-dev linux-headers
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -3,6 +3,9 @@ FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 RUN apk add --no-cache go gcc musl-dev linux-headers
 ENV GOPATH=/go PATH=$PATH:/go/bin
 
+# see https://github.com/golang/go/issues/23672
+ENV CGO_CFLAGS_ALLOW=(-mrdrnd|-mrdseed)
+
 COPY cmd/rngd/ /go/src/rngd/
 RUN REQUIRE_CGO=1 go-compile.sh /go/src/rngd
 

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 as alpine
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee as alpine
 RUN \
   apk add \
   bash \

--- a/pkg/sshd/Dockerfile
+++ b/pkg/sshd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/swap/Dockerfile
+++ b/pkg/swap/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/sysctl/Dockerfile
+++ b/pkg/sysctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/sysfs/Dockerfile
+++ b/pkg/sysfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/trim-after-delete/Dockerfile
+++ b/pkg/trim-after-delete/Dockerfile
@@ -1,5 +1,5 @@
 # We need the `fstrim` binary:
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/tss/Dockerfile
+++ b/pkg/tss/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS build
 
 ENV TROUSERS_COMMIT de57f069ef2297d6a6b3a0353e217a5a2f66e444
 ENV TPM_TOOLS_COMMIT bdf9f1bc8f63cd6fc370c2deb58d03ac55079e84

--- a/pkg/vpnkit-expose-port/Dockerfile
+++ b/pkg/vpnkit-expose-port/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS build
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS build
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/pkg/vpnkit-forwarder/Dockerfile
+++ b/pkg/vpnkit-forwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/pkg/vsudd/Dockerfile
+++ b/pkg/vsudd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,28 +2,28 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: sysfs
-    image: linuxkit/sysfs:v0.2
+    image: linuxkit/sysfs:f7fc4dfbdc7e09f8aab0063699d9a75932b08c3f
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: ntpd
-    image: linuxkit/openntpd:v0.2
+    image: linuxkit/openntpd:e3cd26ff2974f2d93c88c28efacf69e15bcdb983
   - name: docker
     image: docker:17.07.0-ce-dind
     capabilities:

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,28 +2,28 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: sysfs
-    image: linuxkit/sysfs:v0.2
+    image: linuxkit/sysfs:f7fc4dfbdc7e09f8aab0063699d9a75932b08c3f
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: ntpd
-    image: linuxkit/openntpd:v0.2
+    image: linuxkit/openntpd:e3cd26ff2974f2d93c88c28efacf69e15bcdb983
   - name: docker
     image: docker:17.07.0-ce-dind
     capabilities:

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a # with runc, logwrite, startmemlogd
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72 # with runc, logwrite, startmemlogd
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,16 +2,16 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
 trust:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
   - samoht/fdd
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
 files:
   - path: etc/init.d/020-fdd-init
     mode: "0700"

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,12 +2,12 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcp-client
     image: miragesdk/dhcp-client:22aa9d527820534295a8cd59901c0c5197af6585
     net: host
@@ -28,9 +28,9 @@ onboot:
      - /lib:/lib     # for ifconfig
 services:
   - name: sshd
-    image: linuxkit/sshd:v0.2
+    image: linuxkit/sshd:b24724013759bbcb084600d1157735ccfc9aa615
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
 files:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,18 +2,18 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
 services:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
 trust:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/src/cmd/linuxkit/vendor.conf
+++ b/src/cmd/linuxkit/vendor.conf
@@ -26,7 +26,7 @@ github.com/moby/datakit 97b3d230535397a813323902c23751e176481a86
 github.com/moby/hyperkit a285521725f44f3d10ca1042c2c07d3a6e24bed8
 # When updating also:
 # curl -fsSL -o src/cmd/linuxkit/build.go https://raw.githubusercontent.com/moby/tool/«hash»/cmd/moby/build.go
-github.com/moby/tool c9d52b57874b36a474206a867d9bc3ea7bacaffe
+github.com/moby/tool 749585dd13ad043087556c8a341c1dc99041639f
 github.com/moby/vpnkit 0e4293bb1058598c4b0a406ed171f52573ef414c
 github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
 github.com/opencontainers/image-spec v1.0.0

--- a/src/cmd/linuxkit/vendor/github.com/moby/tool/README.md
+++ b/src/cmd/linuxkit/vendor/github.com/moby/tool/README.md
@@ -2,13 +2,9 @@
 
 [Moby Project](https://mobyproject.org)
 
-The Moby Project is an open framework to assemble specialized container systems without reinventing the wheel.
+The Moby Project is an open framework created by Docker to assemble specialized container systems without reinventing the wheel.
 
-Moby is an open framework created by Docker to assemble specialized container systems without reinventing the wheel. It provides a “lego set” of dozens of standard components and a framework for assembling them into custom platforms. At the core of Moby is a framework to assemble specialized container systems which provides:
-
-* Components
-* Tools
-* Assemblies
+At the core of Moby is a framework which provides a “lego set” of dozens of standard components and tools for assembling them into custom platforms.
 
 For more information, please visit the [Moby Project home page](https://mobyproject.org).
 

--- a/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/output.go
+++ b/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/output.go
@@ -14,16 +14,16 @@ import (
 )
 
 const (
-	isoBios    = "linuxkit/mkimage-iso-bios:3315508388e62f7a599fa5c2d5318e78017ef553"
-	isoEfi     = "linuxkit/mkimage-iso-efi:6afada67184c7f68add9562375c662a4559eaa18"
-	rawBios    = "linuxkit/mkimage-raw-bios:31e7ef4ed982bad6ab9ff1f1185514492c325571"
-	rawEfi     = "linuxkit/mkimage-raw-efi:82db3af46d299be160590fb1633bbfebc891a927"
-	gcp        = "linuxkit/mkimage-gcp:df4f46fbcabcfef84af2ff34ff1ef7e7673bc329"
-	vhd        = "linuxkit/mkimage-vhd:796acfc515c22afb8f32d6b5c4bdd456b7f79d8c"
-	vmdk       = "linuxkit/mkimage-vmdk:deb9018d06dbb9da29464a4320187ce7e4ae1856"
-	dynamicvhd = "linuxkit/mkimage-dynamic-vhd:172fb196713a4aff677b88422026512600b1ca55"
-	rpi3       = "linuxkit/mkimage-rpi3:553c6c2d13b7d54f6b73b3b0c1c15f2e47ffb0df"
-	qcow2Efi   = "linuxkit/mkimage-qcow2-efi:9bc3de981188da099eaf44cc467f5bbb29c13033"
+	isoBios    = "linuxkit/mkimage-iso-bios:8c1020d428e78cbe6fa9da023b94d2cb7994cfb9"
+	isoEfi     = "linuxkit/mkimage-iso-efi:d1990ff78a7b15e6f1f368378f2120f55dcf30ab"
+	rawBios    = "linuxkit/mkimage-raw-bios:fa0da669c33543bb04966338aa3091cff9f88398"
+	rawEfi     = "linuxkit/mkimage-raw-efi:eb489af91687d2f8c0456c7058784c0ecba2107c"
+	gcp        = "linuxkit/mkimage-gcp:e6cdcf859ab06134c0c37a64ed5f886ec8dae1a1"
+	vhd        = "linuxkit/mkimage-vhd:3820219e5c350fe8ab2ec6a217272ae82f4b9242"
+	vmdk       = "linuxkit/mkimage-vmdk:cee81a3ed9c44ae446ef7ebff8c42c1e77b3e1b5"
+	dynamicvhd = "linuxkit/mkimage-dynamic-vhd:743ac9959fe6d3912ebd78b4fd490b117c53f1a6"
+	rpi3       = "linuxkit/mkimage-rpi3:e76686a5b4fad750bd857bfa239d777d4ab21d6f"
+	qcow2Efi   = "linuxkit/mkimage-qcow2-efi:193ea2d93bbb437552cf58549f166e738d517c24"
 )
 
 var outFuns = map[string]func(string, io.Reader, int) error{

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,12 +2,12 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
 services:
   - name: acpid
-    image: linuxkit/acpid:v0.2
+    image: linuxkit/acpid:a1399f824db917488d048c5e23ca3cec6e5317d8
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.123
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1

--- a/test/cases/020_kernel/007_config_4.15.x/test.yml
+++ b/test/cases/020_kernel/007_config_4.15.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.15.12
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.123
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/017_kmod_4.15.x/test.yml
+++ b/test/cases/020_kernel/017_kmod_4.15.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.15.12
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/000_kernel-4.4.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.123
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/001_kernel-4.9.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
+++ b/test/cases/020_kernel/110_namespace/006_kernel-4.14.x/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 trust:
   org:
     - linuxkit

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,25 +2,25 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: sysfs
-    image: linuxkit/sysfs:v0.2
+    image: linuxkit/sysfs:f7fc4dfbdc7e09f8aab0063699d9a75932b08c3f
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.2
+    image: linuxkit/rngd:8bcfb9a90470161a04f25e58407852a3d1ad499a
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
   - name: docker
     image: docker:17.07.0-ce-dind
     capabilities:

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: binfmt
-    image: linuxkit/binfmt:v0.2
+    image: linuxkit/binfmt:98398d827e80b56e487d2ae94ed86a0006acb702
   - name: test
     image: alpine:3.7
     binds:

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
     image: linuxkit/test-containerd:0c99fe453549483a8706b369521393b61ef9c896

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: extend
-    image: linuxkit/extend:v0.2
+    image: linuxkit/extend:e824c312be97f73b27a91ae1b9462cf97953f8ca
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,17 +2,17 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: modprobe
-    image: linuxkit/modprobe:v0.2
+    image: linuxkit/modprobe:67d9b334e4d84f480158e0a4974f547a469489a0
     command: ["modprobe", "btrfs"]
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,17 +2,17 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: modprobe
-    image: linuxkit/modprobe:v0.2
+    image: linuxkit/modprobe:67d9b334e4d84f480158e0a4974f547a469489a0
     command: ["modprobe", "btrfs"]
   - name: extend
-    image: linuxkit/extend:v0.2
+    image: linuxkit/extend:e824c312be97f73b27a91ae1b9462cf97953f8ca
     command: ["/usr/bin/extend", "-type", "btrfs"]
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: extend
-    image: linuxkit/extend:v0.2
+    image: linuxkit/extend:e824c312be97f73b27a91ae1b9462cf97953f8ca
     command: ["/usr/bin/extend", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format"]
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format", "-label", "docker"]
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format", "@DEVICE@"]
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "-device", "@DEVICE@1", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,17 +2,17 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: modprobe
-    image: linuxkit/modprobe:v0.2
+    image: linuxkit/modprobe:67d9b334e4d84f480158e0a4974f547a469489a0
     command: ["modprobe", "btrfs"]
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format", "-type", "xfs" ]
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format", "-verbose", "-type", "ext4", "/dev/sda"]
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format", "-verbose", "-type", "ext4", "/dev/sdb"]
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format", "-verbose", "-type", "xfs", "/dev/sda"]
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format", "-verbose", "-force", "-type", "xfs", "/dev/sdb"]
   - name: test
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     binds:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format", "-label", "docker"]
   - name: format
-    image: linuxkit/format:v0.2
+    image: linuxkit/format:a0a0469c74e3c5617d2fdffb6c38e402133fb680
     command: ["/usr/bin/format", "-label", "foo"]
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: mount
-    image: linuxkit/mount:v0.2
+    image: linuxkit/mount:03795dccf510edfc14aeb0ab5e87cd9f7da3586a
     command: ["/usr/bin/mountie", "-label", "foo", "/var/foo"]
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,17 +2,17 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.2
+    image: linuxkit/getty:9e2c184fdd708720d47e663f03ad137c074d4f21
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: mkimage
-    image: linuxkit/mkimage:v0.2
+    image: linuxkit/mkimage:dccd1028bc96b91702236be8bbacb04477aacc4c
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d
 trust:

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:v0.2
+    image: linuxkit/sysctl:e7106b5e3db64a9ec21eb1479727627ecf52137d
   - name: test
     image: alpine:3.7
     net: host

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
+  - linuxkit/ca-certificates:04a6dc9e5c901ee128c353f690bd97aeb7d97ae8
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:v0.2
+    image: linuxkit/ip:14cd8bfc3a62e759ee6c925d697171ba18a91d70
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -24,7 +24,7 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:v0.2
+    image: linuxkit/ip:14cd8bfc3a62e759ee6c925d697171ba18a91d70
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,12 +4,12 @@ kernel:
   image: linuxkit/kernel:4.14.29
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
-  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
+  - linuxkit/containerd:d03b69c7d23fdae0fec1b6e62a72d362992135df
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.2
+    image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b212cfeb4bb6330e0a7547d8010fe2e8489b677a
-  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/init:7af4e32f31f04d6c63d457c502d2f69344db7d72
+  - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>


### PR DESCRIPTION
- Update `moby/tool`
- Update all package to the latest `linuxkit/alpine` (which has s390x support)
- Update firmware package to use a newer kernel package with s390x support
- Disable `cadvisor` for s390x. There was a compile error
- Fix x86 `rngd` compilation (need to add some CFLAGS to the whitelist) resolves https://github.com/linuxkit/linuxkit/issues/2967
- Update all YAMLs to latest version

resolves https://github.com/linuxkit/linuxkit/issues/2949

Note, there is another issue with s390x: https://github.com/linuxkit/linuxkit/issues/2968

![image](https://user-images.githubusercontent.com/3338098/37864322-aa0fb284-2f64-11e8-870c-0860b76e141e.png)
