### PR TITLE
Fix support for arm kernel config tests

### DIFF
--- a/test/cases/020_kernel/000_config_4.4.x/test.sh
+++ b/test/cases/020_kernel/000_config_4.4.x/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # SUMMARY: Sanity check on the kernel config file
-# disabled for arm64: https://github.com/linuxkit/linuxkit/issues/2807
+# disabled for arm64, no 4.4 build
 # LABELS: amd64
 # REPEAT:
 

--- a/test/cases/020_kernel/001_config_4.9.x/test.sh
+++ b/test/cases/020_kernel/001_config_4.9.x/test.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # SUMMARY: Sanity check on the kernel config file
-# disabled for arm64: https://github.com/linuxkit/linuxkit/issues/2807
-# LABELS: amd64
+# LABELS:
 # REPEAT:
 
 set -e

--- a/test/cases/020_kernel/006_config_4.14.x/test.sh
+++ b/test/cases/020_kernel/006_config_4.14.x/test.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # SUMMARY: Sanity check on the kernel config file
-# disabled for arm64: https://github.com/linuxkit/linuxkit/issues/2807
-# LABELS: amd64
+# LABELS:
 # REPEAT:
 
 set -e

--- a/test/cases/020_kernel/007_config_4.15.x/test.sh
+++ b/test/cases/020_kernel/007_config_4.15.x/test.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # SUMMARY: Sanity check on the kernel config file
-# disabled for arm64: https://github.com/linuxkit/linuxkit/issues/2807
-# LABELS: amd64
+# LABELS:
 # REPEAT:
 
 set -e


### PR DESCRIPTION
**- What I did**

Fixes #2807 

Expands the check-kernel-config.sh script to handle `x86_64` specific configs, and (unfortunately) some cases where configs existed in `x86_64` kernels before `arm64`, which complicated things a bit. Let me know if there's a different way you'd prefer to handle the conditions here please!

**- How I did it**
* Looked at what was failing in #2807, plus new tests added in #2908
* Added conditional blocks in the script for `x86_64` specific checks, and some that were either architecture dependent or kernel version dependent (e.g. `CONFIG_RANDOMIZE_BASE` which is in `x86_64` 4.4 but not in `arm64` until 4.6)
* Also found/fixed an issue with `oprofilefs` failing on the `arm64` kernel checks

**- How to verify it**
- I performed these steps on both my local `x86_64` Macbook, and an `arm64` packet.net server.
- I had to build a local version of the `test-kernel-config` image (docker build in the `test/pkg/kernel-config` directory)
- modified the `test.yml`'s for each of the `linuxkit.kernel.config` tests to use my local image
- went into each kernel config test case, built the `test.yml` and ran it to confirm the tests still passed.

**- Description for the changelog**
- Enables kernel configuration tests for `arm64`

**- A picture of a cute animal (not mandatory but encouraged)**
![screen shot 2018-03-30 at 9 35 35 pm](https://user-images.githubusercontent.com/419708/38158437-514ab164-3462-11e8-8f6a-ed72fea54ddd.png)
