### PR TITLE
Update kernel config test

### DIFF
--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1
+    image: linuxkit/test-kernel-config:a3eb5aa39ed8e426cc2b33606820edc59301ae4d
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1
+    image: linuxkit/test-kernel-config:a3eb5aa39ed8e426cc2b33606820edc59301ae4d
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1
+    image: linuxkit/test-kernel-config:a3eb5aa39ed8e426cc2b33606820edc59301ae4d
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/007_config_4.15.x/test.yml
+++ b/test/cases/020_kernel/007_config_4.15.x/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:e4b01b68b225d694a60f8b335258bd2144971239
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1
+    image: linuxkit/test-kernel-config:a3eb5aa39ed8e426cc2b33606820edc59301ae4d
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/dhcpcd:8b23f047ffa4d657a2c7dd465e69cc13721c4165
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:f658811da20f069f71a863ba9469b4a2ae8910e1
+    image: linuxkit/test-kernel-config:a3eb5aa39ed8e426cc2b33606820edc59301ae4d
   - name: poweroff
     image: linuxkit/poweroff:f9a0a5e52fd2a97908bda33db2afffafe4a6a67d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/pkg/kernel-config/Dockerfile
+++ b/test/pkg/kernel-config/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:cba395fbc278daee841106801aba1e1bd7e0f2f7 AS mirror
+FROM linuxkit/alpine:96ad1eb5ec262b4cd0eef574cdc0b225b502d9ee AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl bash

--- a/test/pkg/kernel-config/build.yml
+++ b/test/pkg/kernel-config/build.yml
@@ -1,2 +1,5 @@
 image: test-kernel-config
 network: true
+arches:
+  - amd64
+  - arm64


### PR DESCRIPTION
https://github.com/linuxkit/linuxkit/pull/2976 fixed the kernel config test for arm64. This PR updates the test to use the new package.

While at it also update it to the latest alpine abse image and restrict the build of the package to arm64 and amd64 (as these currently are the only arches which are supported)

![image](https://user-images.githubusercontent.com/3338098/38163450-36281bbc-34ec-11e8-8e72-269ebde27a5c.png)
