### PR TITLE
Use NOTARY_AUTH instead of the expect gymnastics 

### DIFF
--- a/src/cmd/linuxkit/pkglib/manifest_push_script.go
+++ b/src/cmd/linuxkit/pkglib/manifest_push_script.go
@@ -67,49 +67,13 @@ fi
 SHA256=$(echo "$OUT" | cut -d' ' -f2 | cut -d':' -f2)
 LEN=$(echo "$OUT" | cut -d' ' -f3)
 
-# Notary requires a PTY for username/password so use expect for that.
+# notary 0.6.0 accepts authentication as base64-encoded "username:password"
+export NOTARY_AUTH=$(echo "$USER:$PASS" | base64)
 export NOTARY_DELEGATION_PASSPHRASE="$DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE"
-NOTARY_CMD="notary -s https://notary.docker.io -d $HOME/.docker/trust addhash \
-             -p docker.io/$REPO $TAG $LEN --sha256 $SHA256 \
-             -r targets/releases"
 
-echo '
-spawn '"$NOTARY_CMD"'
-set pid [exp_pid]
-set timeout 60
-expect {
-    timeout {
-        puts "Expected username prompt"
-        exec kill -9 $pid
-        exit 1
-    }
-    "username: " {
-        send "'"$USER"'\n"
-    }
-}
-expect {
-    timeout {
-        puts "Expected password prompt"
-        exec kill -9 $pid
-        exit 1
-    }
-    "password: " {
-        send "'"$PASS"'\n"
-    }
-}
-expect {
-    timeout {
-        puts "Expected password prompt"
-        exec kill -9 $pid
-        exit 1
-    }
-    eof {
-    }
-}
-set waitval [wait -i $spawn_id]
-set exval [lindex $waitval 3]
-exit $exval
-' | expect -f -
+notary -s https://notary.docker.io -d $HOME/.docker/trust addhash \
+       -p docker.io/$REPO $TAG $LEN --sha256 $SHA256 \
+       -r targets/releases
 
 echo
 echo "New signed multi-arch image: $REPO:$TAG"


### PR DESCRIPTION
`notary` 0.6.0 allows passing credentials via the `NOTARY_AUTH` env variable. Previously we had jump through hoops via an expect script to feed the credentials to `notary`.

![image](https://user-images.githubusercontent.com/3338098/38258994-d7b5fa32-375b-11e8-9478-73a7728e6372.png)
