### PR TITLE
Update moby tool vendoring

### DIFF
--- a/src/cmd/linuxkit/vendor.conf
+++ b/src/cmd/linuxkit/vendor.conf
@@ -26,7 +26,7 @@ github.com/moby/datakit 97b3d230535397a813323902c23751e176481a86
 github.com/moby/hyperkit a285521725f44f3d10ca1042c2c07d3a6e24bed8
 # When updating also:
 # curl -fsSL -o src/cmd/linuxkit/build.go https://raw.githubusercontent.com/moby/tool/«hash»/cmd/moby/build.go
-github.com/moby/tool 749585dd13ad043087556c8a341c1dc99041639f
+github.com/moby/tool f1ae82c9eb338241cccd62443263498ae0461c2c
 github.com/moby/vpnkit 0e4293bb1058598c4b0a406ed171f52573ef414c
 github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
 github.com/opencontainers/image-spec v1.0.0

--- a/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/config.go
+++ b/src/cmd/linuxkit/vendor/github.com/moby/tool/src/moby/config.go
@@ -785,7 +785,8 @@ func ConfigInspectToOCI(yaml *Image, inspect types.ImageInspect, idMap map[strin
 		}
 		src := parts[0]
 		dest := parts[1]
-		opts := []string{"rw", "rbind", "rprivate"}
+		// default to rshared if not specified
+		opts := []string{"rw", "rbind", "rshared"}
 		if len(parts) == 3 {
 			opts = append(strings.Split(parts[2], ","), "rbind")
 		}


### PR DESCRIPTION
This only includes https://github.com/moby/tool/pull/210 which
makes bind mounts into containers rshared not rprivate by default,
which makes debug easier as you can see them from the host.

Signed-off-by: Justin Cormack <justin@specialbusservice.com>

![img_20180328_082500-2](https://user-images.githubusercontent.com/482364/38325467-f31d491c-383a-11e8-9699-0d025fcfc9eb.jpg)
