### PR TITLE
kernel: Don't compile -rt kernels on s390x

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -233,7 +233,6 @@ $(eval $(call kernel,4.14.29,4.14.x,-rt,))
 else ifeq ($(ARCH),s390x)
 $(eval $(call kernel,4.15.15,4.15.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.32,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.29,4.14.x,-rt,))
 endif
 
 # Target for kernel config


### PR DESCRIPTION
Looks like commit 9a88a5e98601 ("Upgrade -rt patches to
v4.14.29-rt25") accidentally added compiling -rt kernels
for s390x. Remove it.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@gmail.com>

![image](https://user-images.githubusercontent.com/3338098/38336869-3286ee3a-385b-11e8-85f5-7fc68fb65680.png)
