### PR TITLE
pkg: build: do not infer a release if not pushing

### DIFF
--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -82,7 +82,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 		return fmt.Errorf("Unknown arch %q", arch)
 	}
 
-	if p.git != nil && bo.release == "" {
+	if p.git != nil && bo.push && bo.release == "" {
 		r, err := p.git.commitTag("HEAD")
 		if err != nil {
 			return err


### PR DESCRIPTION
If you happen to be exactly on a tag then:

    $ linuxkit pkg build --dev pkg/init
    Building "ijc/init:dev"
    Cannot release "v0.3" if not pushing

Do not try and infer a release if not pushing so this is possible again.

The subsequent check for `bo.release != "" && !bo.push` remains since the
caller could have used `WithRelease` but not `WithPush`. Our CLI never does
this, but a hypothetical other user of the library might.

Signed-off-by: Ian Campbell <ijc@docker.com>

