### PR TITLE
Avoid writing to tty devices which don't actually exist.

### DIFF
--- a/pkg/init/etc/init.d/000-issue
+++ b/pkg/init/etc/init.d/000-issue
@@ -6,7 +6,9 @@ if [ -f /etc/issue ]; then
 		console=*)
 			fulltty=${opt#console=}
 			tty=${fulltty%,*}
-			cat /etc/issue >> /dev/$tty
+			if [ -c "/dev/$tty" ] ; then
+				cat /etc/issue >> "/dev/$tty"
+			fi
 		esac
 	done
 fi


### PR DESCRIPTION
    $ git diff linuxkit.yml
    diff --git a/linuxkit.yml b/linuxkit.yml
    index e2ec829db..21b84e4ad 100644
    --- a/linuxkit.yml
    +++ b/linuxkit.yml
    @@ -1,6 +1,6 @@
     kernel:
       image: linuxkit/kernel:4.14.32
    -  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
    +  cmdline: "console=ttyS0 console=foobar"
     init:
       - linuxkit/init:v0.3
       - linuxkit/runc:v0.3
    $ linuxkit  build linuxkit.yml
    [...]
    $ linuxkit run linuxkit
    [...]
    getty: cmdline has console=foobar but /dev/foobar is not a character device; not starting getty for foobar

    linuxkit-2ae2c420a11c login: root (automatic login)

    Welcome to LinuxKit!

    NOTE: This system is namespaced.
    The namespace you are currently in may not be the root.
    (ns: getty) linuxkit-2ae2c420a11c:~# ls -l /proc/1/root/dev/foobar
    -rw-r--r--    1 root     root           311 Apr  9 13:19 /proc/1/root/dev/foobar
    (ns: getty) linuxkit-2ae2c420a11c:~# cat /proc/1/root/dev/foobar

    Welcome to LinuxKit

                            ##         .
                      ## ## ##        ==
                   ## ## ## ## ##    ===
               /"""""""""""""""""\___/ ===
              {                       /  ===-
               \______ O           __/
                 \    \         __/
                  \____\_______/

Also added quotes around $tty for good measure.

Signed-off-by: Ian Campbell <ijc@docker.com>

(this seems to have been like this forever so not urgent and hence I didn't rebuild the package nor intend to bump the hashes).