### PR TITLE
wireguard: upgrade to 0.0.20180413

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -41,8 +41,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180304
-ENV WIREGUARD_SHA256=efb1652f0da67fb2731040439b6abb820a5e2f1bc177aa15c5dce68ea3327787
+ENV WIREGUARD_VERSION=0.0.20180413
+ENV WIREGUARD_SHA256="419ef147c729db4442b9c2bb5ce4f76ae0807bd820d60d1dce17311885e97251"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * wg-quick.8: fix typo
  * wg-quick: hide errors on save
  
  This fixes a small regression in the resolvconf save handling on Debian.
  
  * compat: stable kernels are now receiving b87b619
  * compat: silence warning on frankenkernels
  * compat: support OpenSUSE 15
  
  Usual set of fixes for weird kernels.
  
  * curve25519: use precomp implementation instead of sandy2x
  * curve25519: use cmov instead of xor for cswap
  * curve25519: memzero in batches
  * curve25519: precomp const correctness
  
  Rather than using sandy2x, which requires use of the vector registers and simd
  instructions (and therefore thermal throttling and register save/restores), we
  instead use BMI2 and ADX instructions to achieve better performance, using:
    - https://eprint.iacr.org/2017/264
    - https://github.com/armfazh/rfc7748_precomputed
  
  * curve25519: add self tests from wycheproof
  * chacha20poly1305: add self tests from wycheproof
  
  Wycheproof now provides sneaky test vectors, so we've imported them into our
  self-tests to mitigate regressions. More info can be found at:
    - https://github.com/google/wycheproof
```