### PR TITLE
Some kernel builds need openssl binary for key generation

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add \
     installkernel \
     kmod \
     libelf-dev \
+    libressl \
     libressl-dev \
     linux-headers \
     mpc1-dev \


### PR DESCRIPTION
For example kernel module signatures if you do not provide a key. So add
to the dependencies for kernel builds.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![lapwing](https://user-images.githubusercontent.com/482364/38872007-271a314e-424a-11e8-9b35-5d513858c5ee.jpg)
