### PR TITLE
containerd v1.1.0-rc.2

### DIFF
--- a/contrib/crosvm/README.md
+++ b/contrib/crosvm/README.md
@@ -33,9 +33,9 @@ kernel:
   image: linuxkit/kernel:4.9.91
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
 services:
   - name: getty
     image: linuxkit/getty:v0.3

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.3 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   # support metadata for optional config in /run/config

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: dhcpcd

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
 services:
   - name: getty
     image: linuxkit/getty:v0.3

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
   - linuxkit/firmware:v0.3
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.29-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:f3cd219615428b2bd943411723eb28875275fae7 as alpine
+FROM linuxkit/alpine:02d7e748614512ea099e8c76254e41bcea03ba8f as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/containerd/etc/containerd/config.toml
+++ b/pkg/containerd/etc/containerd/config.toml
@@ -1,7 +1,6 @@
 state = "/run/containerd"
 root = "/var/lib/containerd"
-snapshotter = "io.containerd.snapshotter.v1.overlayfs"
-differ = "io.containerd.differ.v1.base-diff"
+disabled_plugins = ["cri"]
 
 [grpc]
   address = "/run/containerd/containerd.sock"

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,10 +1,13 @@
-FROM linuxkit/alpine:f3cd219615428b2bd943411723eb28875275fae7 AS build
+FROM linuxkit/alpine:02d7e748614512ea099e8c76254e41bcea03ba8f AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
 RUN LDFLAGS=-static CFLAGS=-Werror make usermode-helper
 
-RUN apk add --no-cache go musl-dev
+# containerd v1.1.x requires go1.10 which is currently a separate package in
+# Alpine 3.7 Use the same version here for consistency and because we use the
+# containerd client library.
+RUN apk add --no-cache go1.10 musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin
 
 COPY cmd /go/src/cmd
@@ -16,7 +19,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:f3cd219615428b2bd943411723eb28875275fae7 AS mirror
+FROM linuxkit/alpine:02d7e748614512ea099e8c76254e41bcea03ba8f AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/init/cmd/service/runc.go
+++ b/pkg/init/cmd/service/runc.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/containerd/containerd/sys"
+	"github.com/opencontainers/runc/libcontainer/system"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -49,7 +49,7 @@ func runcInit(rootPath, serviceType string) int {
 	}
 
 	// need to set ourselves as a child subreaper or we cannot wait for runc as reparents to init
-	if err := sys.SetSubreaper(1); err != nil {
+	if err := system.SetSubreaper(1); err != nil {
 		log.Fatalf("Cannot set as subreaper: %v", err)
 	}
 

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -1,10 +1,12 @@
-FROM linuxkit/alpine:f3cd219615428b2bd943411723eb28875275fae7 as alpine
+FROM linuxkit/alpine:02d7e748614512ea099e8c76254e41bcea03ba8f as alpine
+# containerd v1.1.x requires go1.10 which is currently a separate package in Alpine 3.7
+# Use the same version of go for consistency.
 RUN \
   apk add \
   bash \
   gcc \
   git \
-  go \
+  go1.10 \
   libc-dev \
   libseccomp-dev \
   linux-headers \

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:v0.3 # with runc, logwrite, startmemlogd
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89 # with runc, logwrite, startmemlogd
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.3

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
 services:
   - name: acpid
     image: linuxkit/acpid:v0.3

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.128
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:12d9e1153ea4eec2ddb155ab2a782faca5f503e0

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.94
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:12d9e1153ea4eec2ddb155ab2a782faca5f503e0

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:12d9e1153ea4eec2ddb155ab2a782faca5f503e0

--- a/test/cases/020_kernel/007_config_4.15.x/test.yml
+++ b/test/cases/020_kernel/007_config_4.15.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.15.17
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:12d9e1153ea4eec2ddb155ab2a782faca5f503e0

--- a/test/cases/020_kernel/008_config_4.16.x/test.yml
+++ b/test/cases/020_kernel/008_config_4.16.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.16.2
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:12d9e1153ea4eec2ddb155ab2a782faca5f503e0

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.128
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.94
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/017_kmod_4.15.x/test.yml
+++ b/test/cases/020_kernel/017_kmod_4.15.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.15.17
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/018_kmod_4.16.x/test.yml
+++ b/test/cases/020_kernel/018_kmod_4.16.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.16.2
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 trust:
   org:
     - linuxkit

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: test
     image: alpine:3.7

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:v0.3

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:v0.3
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:9769b24f2093104dcb837906e3fd6ea34dba55d1
+    image: linuxkit/test-containerd:8b99385a8b21b238c0c9db0af102d5b54bbe324e
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format
     image: linuxkit/format:v0.3

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: extend
     image: linuxkit/extend:v0.3

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:v0.3

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:v0.3

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format
     image: linuxkit/format:v0.3

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: extend
     image: linuxkit/extend:v0.3

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format
     image: linuxkit/format:v0.3

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format
     image: linuxkit/format:v0.3

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format
     image: linuxkit/format:v0.3

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:v0.3

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format
     image: linuxkit/format:v0.3

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format
     image: linuxkit/format:v0.3

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format
     image: linuxkit/format:v0.3

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:v0.3

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.3

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: dhcpcd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.14.34
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
-  - linuxkit/containerd:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
+  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -3,6 +3,7 @@ RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)
 # xfsprogs is required for xfs test (mkfs.xfs)
+# containerd v1.1.x requires go1.10 which is currently a separate package in Alpine 3.7
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
     busybox \
@@ -10,7 +11,7 @@ RUN apk add --no-cache --initdb -p /out \
     btrfs-progs-dev \
     gcc \
     git \
-    go \
+    go1.10 \
     libc-dev \
     linux-headers \
     make \

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:f3cd219615428b2bd943411723eb28875275fae7 AS mirror
+FROM linuxkit/alpine:02d7e748614512ea099e8c76254e41bcea03ba8f AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.3
-  - linuxkit/runc:v0.3
+  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -43,7 +43,8 @@ RUN mv /etc/apk/repositories /etc/apk/repositories.upstream && echo "/mirror" > 
 
 # add Go validation tools
 COPY go-compile.sh /go/bin/
-RUN apk add --no-cache git go musl-dev
+# containerd v1.1.x requires go1.10 which is currently a separate package in Alpine 3.7
+RUN apk add --no-cache git go1.10 musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin
 RUN go get -u github.com/golang/lint/golint
 RUN go get -u github.com/gordonklaus/ineffassign
@@ -53,13 +54,13 @@ RUN go get -u github.com/LK4D4/vndr
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.0.3
+ENV CONTAINERD_COMMIT=v1.1.0-rc.2
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \
   cd $GOPATH/src/github.com/containerd/containerd && \
   git checkout $CONTAINERD_COMMIT
-RUN apk add --no-cache btrfs-progs-dev gcc libc-dev linux-headers make
+RUN apk add --no-cache btrfs-progs-dev gcc libc-dev linux-headers make libseccomp-dev
 RUN cd $GOPATH/src/github.com/containerd/containerd && \
   make binaries EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"' BUILD_TAGS="static_build"
 

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -45,6 +45,7 @@ git
 gmp-dev
 gnupg
 go
+go1.10
 grep
 hvtools
 installkernel

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,10 +1,10 @@
-# linuxkit/alpine:6d019c0ba6b9a9238b5c03ac8a85aecaac217711-arm64
+# linuxkit/alpine:e7546eaccb642adbc223d39ee7ca48d9b58dc2f1-arm64
 # automatically generated list of installed packages
 abuild-3.1.0-r3
 alpine-baselayout-3.0.5-r2
 alpine-keys-2.1-r1
 alsa-lib-1.1.4.1-r2
-apk-tools-2.9.1-r0
+apk-tools-2.9.1-r2
 argp-standalone-1.3-r2
 attr-2.4.47-r6
 attr-dev-2.4.47-r6
@@ -77,6 +77,7 @@ gmp-dev-6.1.2-r1
 gnupg-2.2.3-r0
 gnutls-3.6.1-r0
 go-1.9.4-r0
+go1.10-1.10-r0
 grep-3.1-r0
 guile-2.0.14-r0
 guile-libs-2.0.14-r0
@@ -115,7 +116,7 @@ libcap-2.25-r1
 libcap-ng-0.7.8-r1
 libcap-ng-dev-0.7.8-r1
 libcom_err-1.43.7-r0
-libcrypto1.0-1.0.2n-r0
+libcrypto1.0-1.0.2o-r0
 libcurl-7.59.0-r0
 libdrm-2.4.88-r0
 libedit-20170329.3.1-r3
@@ -160,7 +161,7 @@ libseccomp-2.3.2-r1
 libseccomp-dev-2.3.2-r1
 libsmartcols-2.31-r0
 libssh2-1.8.0-r2
-libssl1.0-1.0.2n-r0
+libssl1.0-1.0.2o-r0
 libstdc++-6.4.0-r5
 libtasn1-4.12-r3
 libtirpc-1.0.1-r2
@@ -207,8 +208,8 @@ openrc-0.24.1-r4
 openssh-keygen-7.5_p1-r8
 openssh-server-7.5_p1-r8
 openssh-server-common-7.5_p1-r8
-openssl-1.0.2n-r0
-openssl-dev-1.0.2n-r0
+openssl-1.0.2o-r0
+openssl-dev-1.0.2o-r0
 opus-1.2.1-r1
 p11-kit-0.23.2-r2
 patch-2.7.5-r2
@@ -216,7 +217,7 @@ pax-utils-1.2.2-r1
 pcre-8.41-r1
 pcre2-10.30-r0
 pcsc-lite-libs-1.8.22-r0
-perl-5.26.1-r1
+perl-5.26.2-r0
 pigz-2.3.4-r2
 pinentry-1.0.0-r0
 pixman-0.34.0-r3
@@ -267,7 +268,7 @@ vim-8.0.1359-r0
 wayland-libs-client-1.14.0-r2
 wayland-libs-cursor-1.14.0-r2
 wayland-libs-server-1.14.0-r2
-wireguard-tools-0.0.20180304-r2
+wireguard-tools-0.0.20180413-r3
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r8
 xfsprogs-4.14.0-r0

--- a/tools/alpine/versions.s390x
+++ b/tools/alpine/versions.s390x
@@ -1,10 +1,10 @@
-# linuxkit/alpine:0c1aa378a52a20b52a091f6b2cc345e01cc79271-s390x
+# linuxkit/alpine:b3cb5e3adbf689ab5f500759d5ba774f279e3adf-s390x
 # automatically generated list of installed packages
 abuild-3.1.0-r3
 alpine-baselayout-3.0.5-r2
 alpine-keys-2.1-r1
 alsa-lib-1.1.4.1-r2
-apk-tools-2.9.1-r0
+apk-tools-2.9.1-r2
 argp-standalone-1.3-r2
 attr-2.4.47-r6
 attr-dev-2.4.47-r6
@@ -77,6 +77,7 @@ gmp-dev-6.1.2-r1
 gnupg-2.2.3-r0
 gnutls-3.6.1-r0
 go-1.9.4-r0
+go1.10-1.10-r0
 grep-3.1-r0
 guile-2.0.14-r0
 guile-libs-2.0.14-r0
@@ -210,7 +211,7 @@ pax-utils-1.2.2-r1
 pcre-8.41-r1
 pcre2-10.30-r0
 pcsc-lite-libs-1.8.22-r0
-perl-5.26.1-r1
+perl-5.26.2-r0
 pigz-2.3.4-r2
 pinentry-1.0.0-r0
 pixman-0.34.0-r3
@@ -261,7 +262,7 @@ vim-8.0.1359-r0
 wayland-libs-client-1.14.0-r2
 wayland-libs-cursor-1.14.0-r2
 wayland-libs-server-1.14.0-r2
-wireguard-tools-0.0.20180304-r2
+wireguard-tools-0.0.20180413-r3
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r8
 xfsprogs-4.14.0-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,10 +1,10 @@
-# linuxkit/alpine:f3cd219615428b2bd943411723eb28875275fae7-amd64
+# linuxkit/alpine:02d7e748614512ea099e8c76254e41bcea03ba8f-amd64
 # automatically generated list of installed packages
 abuild-3.1.0-r3
 alpine-baselayout-3.0.5-r2
 alpine-keys-2.1-r1
 alsa-lib-1.1.4.1-r2
-apk-tools-2.9.1-r0
+apk-tools-2.9.1-r2
 argp-standalone-1.3-r2
 attr-2.4.47-r6
 attr-dev-2.4.47-r6
@@ -78,6 +78,7 @@ gmp-dev-6.1.2-r1
 gnupg-2.2.3-r0
 gnutls-3.6.1-r0
 go-1.9.4-r0
+go1.10-1.10-r0
 grep-3.1-r0
 guile-2.0.14-r0
 guile-libs-2.0.14-r0
@@ -224,7 +225,7 @@ pax-utils-1.2.2-r1
 pcre-8.41-r1
 pcre2-10.30-r0
 pcsc-lite-libs-1.8.22-r0
-perl-5.26.1-r1
+perl-5.26.2-r0
 pigz-2.3.4-r2
 pinentry-1.0.0-r0
 pixman-0.34.0-r3
@@ -275,7 +276,7 @@ vim-8.0.1359-r0
 wayland-libs-client-1.14.0-r2
 wayland-libs-cursor-1.14.0-r2
 wayland-libs-server-1.14.0-r2
-wireguard-tools-0.0.20180304-r2
+wireguard-tools-0.0.20180413-r3
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r8
 xfsprogs-4.14.0-r0


### PR DESCRIPTION
https://github.com/containerd/containerd/releases/tag/v1.1.0-rc.2

Mostly fairly standard but the newer containerd requires go 1.10 which is available in alpine as a separate go1.10 package so add that to the mirror and use it for containerd + runc + init (runc just for consistency, init uses containerd libraries so it requires 1.10 too).

When we bump to alpine 3.8 we will need to remember to undo this part to go back to the default go package.