### PR TITLE
wireguard: upgrade to 0.0.20180420

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180413
-ENV WIREGUARD_SHA256="419ef147c729db4442b9c2bb5ce4f76ae0807bd820d60d1dce17311885e97251"
+ENV WIREGUARD_VERSION=0.0.20180420
+ENV WIREGUARD_SHA256="b58cd2acf9e8d3fe9044c06c0056bd74da1f5673a456f011d36eee3f6fb1da16"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```

  * wg-quick: account for specified fwmark in auto routing mode
  
  If we're doing automatic routing with default routes, but the config has
  also specified an explicit fwmark, then use that explicit fwmark, even
  if it's conflicting, since the administrator has explicitly opted into
  using it. Also, when shutting down the interface, we only now remove the
  fancy rules if we're in automatic routing mode with default routes.
  
  * send: account for route-based MTU
  
  It might be that a particular route has a different MTU than the
  interface, via `ip route add ... dev wg0 mtu 1281`, for example. In this
  case, it's important that we don't accidently pad beyond the end of the
  MTU. We accomplish that in this patch by carrying forward the MTU from
  the dst if it exists. We also add a unit test for this issue.
  
  * send: simplify skb_padding with nice macro
  * blake2s: remove unused helper
  * compat: remove unused dev_recursion_level backport
  
  Cleanups.
  
  * poly1305: do not place constants in different sections
  
  We're referencing these constants as one contiguous blob, so if there's
  any merging that goes on with other constants elsewhere (such as the
  kernel's current poly1305 implementation that we hope to replace), then
  these will be reordered and have the wrong values.
```