### PR TITLE
Update kernel to 4.9.95

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -171,7 +171,7 @@ RUN printf "KERNEL_SOURCE=${KERNEL_SOURCE}\n" > /out/kernel-source-info
 
 # perf
 # Skip for 4.4.x (the compile is broken and tedious to fix) and 4.9.x (the
-# compile broke with 4.9.94)
+# compile broke with 4.9.95)
 RUN if [ "${KERNEL_SERIES}" != "4.4.x" ] && [ "${KERNEL_SERIES}" != "4.9.x" ]; then \
        mkdir -p /build/perf && \
        make -C tools/perf LDFLAGS=-static O=/build/perf && \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -223,7 +223,7 @@ $(eval $(call kernel,4.15.18,4.15.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.35,4.14.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.35,4.14.x,,-dbg))
 $(eval $(call kernel,4.14.34,4.14.x,-rt,))
-$(eval $(call kernel,4.9.94,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.95,4.9.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.4.128,4.4.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.94 Kernel Configuration
+# Linux/x86 4.9.95 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From fec790ff65963758fe94e7595323a4f7ce893537 Mon Sep 17 00:00:00 2001
+From 521c5861bffc6f4389b7a4b3c2aa46f6af7788f7 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()
@@ -146,5 +146,5 @@ index 43899e0d6fa1..c3b180254f91 100644
  
  int is_printable_array(char *p, unsigned int len);
 -- 
-2.16.3
+2.16.0
 

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 21fd7b8d98fbd8234db3a9e93f8076a56962fe38 Mon Sep 17 00:00:00 2001
+From d95769a2299661f2e14c6e25b720cce6fab2f9c7 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable
@@ -66,5 +66,5 @@ index 95f0884aae02..f3ed3c963c71 100644
  	while ((jr = jit_get_next_entry(jd))) {
  		switch(jr->prefix.id) {
 -- 
-2.16.3
+2.16.0
 

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From d95a84d8e75727b5f40b77c3b442e4e4781a666a Mon Sep 17 00:00:00 2001
+From ed64e0e06adb3e6ac804c67bca01ac02084773f3 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets
@@ -1787,5 +1787,5 @@ index 000000000000..331d3759f5cb
 +MODULE_DESCRIPTION("Hyper-V Sockets");
 +MODULE_LICENSE("Dual BSD/GPL");
 -- 
-2.16.3
+2.16.0
 

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From e7411a23194d517aa3032efd3bf8d2c4df8fbabf Mon Sep 17 00:00:00 2001
+From 4cb61b9fc8f71af8f1fa1ac8f3f7b8280efd9064 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs
@@ -14,7 +14,7 @@ Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/hv/channel_mgmt.c b/drivers/hv/channel_mgmt.c
-index d8bc4b910192..8df02f3ca0b2 100644
+index 9360cdce740e..d838074e9add 100644
 --- a/drivers/hv/channel_mgmt.c
 +++ b/drivers/hv/channel_mgmt.c
 @@ -192,7 +192,6 @@ static u16 hv_get_dev_type(const struct vmbus_channel *channel)
@@ -26,5 +26,5 @@ index d8bc4b910192..8df02f3ca0b2 100644
  }
  
 -- 
-2.16.3
+2.16.0
 

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 1a00c61e9337af29dbf2958bff25f6f93c26e965 Mon Sep 17 00:00:00 2001
+From 9e361d2cc762624f728876e9c729ff9a93860e20 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host
@@ -44,5 +44,5 @@ index bcd06306f3e8..e7707747f56d 100644
  	}
  
 -- 
-2.16.3
+2.16.0
 

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From f11cab58352b8fa2d08804be5dd933cf1d9a0099 Mon Sep 17 00:00:00 2001
+From aceced86c6e317bff7c085811ac49ce09b5d2fdf Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.
@@ -101,5 +101,5 @@ index a6707133c297..5c95ba1e2ecf 100644
  	return 0;
  }
 -- 
-2.16.3
+2.16.0
 

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From d4d724c68837b751ba48784e7ce984fb27491bd6 Mon Sep 17 00:00:00 2001
+From 74d5b7e925ffa4d537367ab94027562edccf8695 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host
@@ -44,5 +44,5 @@ index 5c95ba1e2ecf..eee238cc60bd 100644
  	rc = hvutil_transport_send(hvt, vss_msg, sizeof(*vss_msg), NULL);
  	if (rc) {
 -- 
-2.16.3
+2.16.0
 

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From 66bf5add7020079a45f5adcacd2ed2427e0f02b5 Mon Sep 17 00:00:00 2001
+From 2d295aa2f2a60368220ffe672f45e7a33b166010 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to
@@ -34,7 +34,7 @@ Origin: git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
  6 files changed, 154 insertions(+), 106 deletions(-)
 
 diff --git a/drivers/hv/channel_mgmt.c b/drivers/hv/channel_mgmt.c
-index 8df02f3ca0b2..e7949b64bfbc 100644
+index d838074e9add..095dd37367de 100644
 --- a/drivers/hv/channel_mgmt.c
 +++ b/drivers/hv/channel_mgmt.c
 @@ -202,33 +202,34 @@ static u16 hv_get_dev_type(const struct vmbus_channel *channel)
@@ -488,5 +488,5 @@ index c9af8369b4f7..7df9eb8f0cf7 100644
  void hv_event_tasklet_disable(struct vmbus_channel *channel);
  void hv_event_tasklet_enable(struct vmbus_channel *channel);
 -- 
-2.16.3
+2.16.0
 

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 45440e7eb9144ad10169a1cb1e6451f7227698e2 Mon Sep 17 00:00:00 2001
+From c80664ca424405e74aaf0580502417dbc8c1349f Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.
@@ -114,5 +114,5 @@ index f3797c07be10..89440c2eb346 100644
  					hb_srv_version & 0xFFFF);
  			}
 -- 
-2.16.3
+2.16.0
 

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From 579f4302847860593b46aaecefd8ab5cd614fe58 Mon Sep 17 00:00:00 2001
+From 69711c925c3af1eee629d742f5affadaf99de9c4 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot
@@ -28,7 +28,7 @@ Origin: git@github.com:dcui/linux.git
  1 file changed, 11 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hv/channel_mgmt.c b/drivers/hv/channel_mgmt.c
-index e7949b64bfbc..2fe024e86209 100644
+index 095dd37367de..effac8042dc6 100644
 --- a/drivers/hv/channel_mgmt.c
 +++ b/drivers/hv/channel_mgmt.c
 @@ -388,8 +388,17 @@ void hv_event_tasklet_enable(struct vmbus_channel *channel)
@@ -52,5 +52,5 @@ index e7949b64bfbc..2fe024e86209 100644
  
  void hv_process_channel_removal(struct vmbus_channel *channel, u32 relid)
 -- 
-2.16.3
+2.16.0
 

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From a4edc49571f0bab17936fbee5917b379307a5ea5 Mon Sep 17 00:00:00 2001
+From 7e4d299735527e57005eb4726aca80a7523db425 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in
@@ -56,5 +56,5 @@ index 1606e7f08f4b..1caed01954f6 100644
  	vmbus_teardown_gpadl(newchannel, newchannel->ringbuffer_gpadlhandle);
  	kfree(open_info);
 -- 
-2.16.3
+2.16.0
 

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 8ba11bc96b7b2c05c6ed27b925f0eaf90f87bf11 Mon Sep 17 00:00:00 2001
+From 1c9c81c5dfffac2a248f616b83b1125e08b6e1b6 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on
@@ -69,7 +69,7 @@ index 1caed01954f6..5bbcc964dbf7 100644
  	channel->sc_creation_callback = NULL;
  	/* Stop callback and cancel the timer asap */
 diff --git a/drivers/hv/channel_mgmt.c b/drivers/hv/channel_mgmt.c
-index 2fe024e86209..b2bdcfb49144 100644
+index effac8042dc6..5470eeaf3f45 100644
 --- a/drivers/hv/channel_mgmt.c
 +++ b/drivers/hv/channel_mgmt.c
 @@ -375,6 +375,30 @@ static void vmbus_release_relid(u32 relid)
@@ -173,5 +173,5 @@ index 7df9eb8f0cf7..a87757cf277b 100644
  
  void vmbus_setevent(struct vmbus_channel *channel);
 -- 
-2.16.3
+2.16.0
 

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.94
+  image: linuxkit/kernel:4.9.95
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89

--- a/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.94 AS ksrc
+FROM linuxkit/kernel:4.9.95 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:f3cd219615428b2bd943411723eb28875275fae7 AS build

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.94
+docker pull linuxkit/kernel:4.9.95
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.94
+  image: linuxkit/kernel:4.9.95
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89


### PR DESCRIPTION
I've also recompiled arm64 and all x86_64 kernels to pick up the `-rt` kernels from https://github.com/linuxkit/linuxkit/pull/3010 and the WireGuard update from https://github.com/linuxkit/linuxkit/pull/3011. For s390x I plan to pick up the wireguard update with the next 4.14.x/4.16.x kernel update.

![image](https://user-images.githubusercontent.com/3338098/39125881-7044e92e-46f8-11e8-96a4-2c6685d10428.png)
