### PR TITLE
Containerd v1.1.0

### DIFF
--- a/contrib/crosvm/README.md
+++ b/contrib/crosvm/README.md
@@ -33,9 +33,9 @@ kernel:
   image: linuxkit/kernel:4.9.91
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
 services:
   - name: getty
     image: linuxkit/getty:v0.3

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:4e2ea826aaefdd196c7473255654d06ad96c4c21 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   # support metadata for optional config in /run/config

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: dhcpcd

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:01069780f536da8eb7745df7478a97253403b63d

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
 services:
   - name: getty
     image: linuxkit/getty:b286a610ccbebc45251f3a9df3619d76318e2244

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
   - linuxkit/firmware:177575af191cf16e19c4989200e40f11422c3b32
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:01069780f536da8eb7745df7478a97253403b63d

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.34-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:01069780f536da8eb7745df7478a97253403b63d

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:01069780f536da8eb7745df7478a97253403b63d

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:v0.3
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:02d7e748614512ea099e8c76254e41bcea03ba8f as alpine
+FROM linuxkit/alpine:90571a1a9059f3bf33ca3431bc5396aa837a47d3 as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:02d7e748614512ea099e8c76254e41bcea03ba8f AS build
+FROM linuxkit/alpine:90571a1a9059f3bf33ca3431bc5396aa837a47d3 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -19,7 +19,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:02d7e748614512ea099e8c76254e41bcea03ba8f AS mirror
+FROM linuxkit/alpine:90571a1a9059f3bf33ca3431bc5396aa837a47d3 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
   - linuxkit/memlogd:9b5834189f598f43c507f6938077113906f51012
 onboot:

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:01069780f536da8eb7745df7478a97253403b63d

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:b51c3da02bc2fc9a53f699efc51f650ac17ffac8

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
 services:
   - name: acpid
     image: linuxkit/acpid:6c05004a07f4f9228aec89605d5c72b184695d2a

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.128
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.95
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/007_config_4.15.x/test.yml
+++ b/test/cases/020_kernel/007_config_4.15.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.15.18
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/008_config_4.16.x/test.yml
+++ b/test/cases/020_kernel/008_config_4.16.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.16.3
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.128
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.95
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check

--- a/test/cases/020_kernel/017_kmod_4.15.x/test.yml
+++ b/test/cases/020_kernel/017_kmod_4.15.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.15.18
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check

--- a/test/cases/020_kernel/018_kmod_4.16.x/test.yml
+++ b/test/cases/020_kernel/018_kmod_4.16.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.16.3
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:763e67d733342281f3bdc55d7208b9c442837afe
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:8b99385a8b21b238c0c9db0af102d5b54bbe324e
+    image: linuxkit/test-containerd:d63fd9049c8c614de81276ae62a99dab3af095e2
   - name: poweroff
     image: linuxkit/poweroff:5740687bf0a6a0480922c0f59b3a4ca77c866cae
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
   - linuxkit/ca-certificates:fb5c7bf842a330f5b47cdf71f950fe0c85f4a772
 onboot:
   - name: dhcpcd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.14.35
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
-  - linuxkit/containerd:100d0d046c5061d75ee43e4ac5017a759109cae4
+  - linuxkit/containerd:f197e7cbb2ede4370b75127c76de6f7b2e3d9873
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:02d7e748614512ea099e8c76254e41bcea03ba8f AS mirror
+FROM linuxkit/alpine:90571a1a9059f3bf33ca3431bc5396aa837a47d3 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:d0bf64f4cea42bea71e7d8f8832ba497bb822e89
+  - linuxkit/init:11929b0007b87384f7372e9265067479c4616586
   - linuxkit/runc:acba8886e4b1318457c711700f695a02fef9493d
 onboot:
   - name: test-ns

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -54,7 +54,7 @@ RUN go get -u github.com/LK4D4/vndr
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.1.0-rc.2
+ENV CONTAINERD_COMMIT=v1.1.0
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:e7546eaccb642adbc223d39ee7ca48d9b58dc2f1-arm64
+# linuxkit/alpine:14e0cf6d30dc39993ac7fb97439049e1cd69ccd5-arm64
 # automatically generated list of installed packages
 abuild-3.1.0-r3
 alpine-baselayout-3.0.5-r2
@@ -92,6 +92,7 @@ isl-0.18-r0
 jansson-2.10-r0
 jq-1.5-r4
 json-c-0.12.1-r1
+keyutils-1.5.10-r0
 keyutils-libs-1.5.10-r0
 kmod-24-r0
 krb5-conf-1.0-r1
@@ -268,7 +269,7 @@ vim-8.0.1359-r0
 wayland-libs-client-1.14.0-r2
 wayland-libs-cursor-1.14.0-r2
 wayland-libs-server-1.14.0-r2
-wireguard-tools-0.0.20180413-r3
+wireguard-tools-0.0.20180420-r3
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r8
 xfsprogs-4.14.0-r0

--- a/tools/alpine/versions.s390x
+++ b/tools/alpine/versions.s390x
@@ -1,4 +1,4 @@
-# linuxkit/alpine:b3cb5e3adbf689ab5f500759d5ba774f279e3adf-s390x
+# linuxkit/alpine:d91bd2b9c9f0303d520ad7249e23afeb7bdf9abc-s390x
 # automatically generated list of installed packages
 abuild-3.1.0-r3
 alpine-baselayout-3.0.5-r2
@@ -91,6 +91,7 @@ isl-0.18-r0
 jansson-2.10-r0
 jq-1.5-r4
 json-c-0.12.1-r1
+keyutils-1.5.10-r0
 keyutils-libs-1.5.10-r0
 kmod-24-r0
 krb5-conf-1.0-r1
@@ -262,7 +263,7 @@ vim-8.0.1359-r0
 wayland-libs-client-1.14.0-r2
 wayland-libs-cursor-1.14.0-r2
 wayland-libs-server-1.14.0-r2
-wireguard-tools-0.0.20180413-r3
+wireguard-tools-0.0.20180420-r3
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r8
 xfsprogs-4.14.0-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:02d7e748614512ea099e8c76254e41bcea03ba8f-amd64
+# linuxkit/alpine:90571a1a9059f3bf33ca3431bc5396aa837a47d3-amd64
 # automatically generated list of installed packages
 abuild-3.1.0-r3
 alpine-baselayout-3.0.5-r2
@@ -94,6 +94,7 @@ isl-0.18-r0
 jansson-2.10-r0
 jq-1.5-r4
 json-c-0.12.1-r1
+keyutils-1.5.10-r0
 keyutils-libs-1.5.10-r0
 kmod-24-r0
 krb5-conf-1.0-r1
@@ -276,7 +277,7 @@ vim-8.0.1359-r0
 wayland-libs-client-1.14.0-r2
 wayland-libs-cursor-1.14.0-r2
 wayland-libs-server-1.14.0-r2
-wireguard-tools-0.0.20180413-r3
+wireguard-tools-0.0.20180420-r3
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r8
 xfsprogs-4.14.0-r0


### PR DESCRIPTION
Containerd release: https://github.com/containerd/containerd/releases/tag/v1.1.0

All mechanical/scripted.

Rebuilding the alpine base image bumped wireguardtools from 0.0.20180413-r3 to 0.0.20180420-r3. I think that's fine -- no need to coordinate with kernel updates these days, but cc @zx2c4 @rn in case that's wrong.