### PR TITLE
Reboot should reboot instead of powering off.

### DIFF
--- a/contrib/crosvm/README.md
+++ b/contrib/crosvm/README.md
@@ -33,7 +33,7 @@ kernel:
   image: linuxkit/kernel:4.9.91
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 services:

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.4 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 services:

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 onboot:

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.40-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 onboot:

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 onboot:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/pkg/init/etc/inittab
+++ b/pkg/init/etc/inittab
@@ -6,4 +6,9 @@
 ::ctrlaltdel:/bin/rc.shutdown reboot
 
 # Stuff to do on shutdown
-::shutdown:/bin/rc.shutdown poweroff
+#
+# Use 'noop' so that rc.shutdown does not attempt to invoke its own shutdown
+# actions.  Instead, it will return after it invokes sync/umount.  This lets
+# init decide which shutdown action to run.  (So that it's possible to correctly
+# handle halt, reboot, or poweroff)
+::shutdown:/bin/rc.shutdown noop

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/logging/examples/logging.yml
+++ b/projects/logging/examples/logging.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 onboot:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 services:

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.136
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.107
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/008_config_4.16.x/test.yml
+++ b/test/cases/020_kernel/008_config_4.16.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.16.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.136
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: check

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.107
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: check

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: check

--- a/test/cases/020_kernel/018_kmod_4.16.x/test.yml
+++ b/test/cases/020_kernel/018_kmod_4.16.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.16.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/ca-certificates:v0.4
 onboot:

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
   - linuxkit/ca-certificates:v0.4

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.14.48
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 onboot:

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a14b7ef6115e6d56fe5bf7c40517b9e190dd4dfb
+  - linuxkit/init:fbcbbe3ace0b3e9455300017dd07625293a0d4d4
   - linuxkit/runc:v0.4
 onboot:
   - name: test-ns


### PR DESCRIPTION
When busybox's reboot processing occurs in init, it runs all SHUTDOWN
actions that are defined in inittab.  Once those are complete, it will
trigger either a halt, poweroff, or reboot, depending upon what signal
is received.  The mechanism that's used to shell out through inittab
does not allow us to pass through exactly which invocation was
requested.

Due to the way that rc.shutdown works, it invokes the poweroff action
for any and all SHUTDOWN callbacks, whether they're a reboot, poweroff,
or halt.  Instead of handling the reboot(2) syscall in rc.shutdown,
return after killing and unmounting and let busybox's init process
decide which reboot(2) action to use.

Signed-off-by: Krister Johansen <krister.johansen@oracle.com>

**- What I did**

Since the `::shutdown` action in inittab can be invoked for multiple different types of shutdowns, use a dummy argument to `rc.shutdown` that does not trigger a reboot or poweroff.  Let init decide once the unmount and kill are complete.

**- How I did it**

Modified how `::shutdown` is calling `rc.shutdown` in /etc/inittab.

**- How to verify it**

I verified this by invoking `reboot`, `poweroff`, and `halt` and validating that each triggered the desired action.

**- Description for the changelog**

Ensure that reboot triggers a reboot instead of a poweroff.