### PR TITLE
Remove the containerd config from the example

### DIFF
--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -34,25 +34,6 @@ services:
     binds:
      - /etc/resolv.conf:/etc/resolv.conf
 files:
-  - path: etc/containerd/config.toml
-    contents: |
-      state = "/run/containerd"
-      root = "/var/lib/containerd"
-      snapshotter = "io.containerd.snapshotter.v1.overlayfs"
-      differ = "io.containerd.differ.v1.base-diff"
-      subreaper = false
-
-      [grpc]
-      address = "/run/containerd/containerd.sock"
-      uid = 0
-      gid = 0
-
-      [debug]
-      address = "/run/containerd/debug.sock"
-      level = "info"
-
-      [metrics]
-      address = ":13337"
   - path: etc/linuxkit-config
     metadata: yaml
 trust:


### PR DESCRIPTION
It is very out of date and misleading. It was mainly there to
show Prometheus metrics.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![wolf](https://user-images.githubusercontent.com/482364/39880374-84e1c66a-5475-11e8-9beb-fada8bedb3ce.jpg)
