### PR TITLE
Only support long RSA and ed25519 ssh keys

### DIFF
--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -28,6 +28,10 @@ files:
     source: ~/.ssh/id_rsa.pub
     mode: "0600"
     optional: true
+  - path: root/.ssh/authorized_keys
+    source: ~/.ssh/id_ed25519.pub
+    mode: "0600"
+    optional: true
 trust:
   org:
     - linuxkit

--- a/pkg/sshd/usr/bin/ssh.sh
+++ b/pkg/sshd/usr/bin/ssh.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 KEYS=$(find /etc/ssh -name 'ssh_host_*_key')
-[ -z "$KEYS" ] && ssh-keygen -A >/dev/null 2>/dev/null
+[ -z "$KEYS" ] && \
+  ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N '' && \
+  ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key -N ''
 
 exec /usr/sbin/sshd -D -e


### PR DESCRIPTION
1. Support ed25519 ssh keys in example
2. Only generate ed25519 and 4096 bit RSA keys for sshd by default

dsa and ecdsa and short RSA keys are not recommended. You should
probably just switch to ed25519.

This only affects installs if you do not add your own keys.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![hippo-milk-pink-orig](https://user-images.githubusercontent.com/482364/40243740-ec6afe7a-5ab8-11e8-8202-d1f594cba8a4.jpg)
