### PR TITLE
wireguard: upgrade to 0.0.20180519

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180513
-ENV WIREGUARD_SHA256="28a15c59f6710851587ebca76a335f1aaaa077aad052732e0959f2bae9ba8d5c"
+ENV WIREGUARD_VERSION=0.0.20180519
+ENV WIREGUARD_SHA256="8846b3006c3f7e079bb38a4c985ccc2981e259f56c927b4cf47cbc1420e1c462"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * chacha20poly1305: add mips32 implementation
  
  "The OpenWRT Commit" - this significantly speeds up performance on cheap
  plastic MIPS routers, and presumably the remaining MIPS32r2 super computers
  out there.
  
  * timers: reinitialize state on init
  * timers: round up instead of down in slack_time
  * timers: remove slack_time
  * timers: clear send_keepalive timer on sending handshake response
  * timers: no need to clear keepalive in persistent keepalive
  
  Andrew He and I have helped simplify the timers and remove some old warts,
  making the whole system a bit easier to analyze.
  
  * tools: fix errno propagation and messages
  
  Error messages are now more coherent.
  
  * wg-quick: use invoking shell in auto rooting
  
  Rather than letting sudo use bash from PATH, we now have it use whatever bash
  is currently executing the script.
  
  * device: remove allowedips before individual peers
  
  This avoids an O(n^2) traversal in favor of an O(n) one. Before systems with
  many peers would grind when deleting the interface.
  
  * dns-hatchet: update paths
  
  Our reorganizing of the wg-quick bash paths was not sync'd with this patch,
  resulting in some trivial problems for Fedora and OpenSUSE.
  
  * compat: backport for OpenSUSE 15
  
  Usual compat fixes.
  
  * wg-quick: add darwin implementation
  
  We released a Darwin implementation of wg-quick(8), to be used with the new
  wireguard-go snapshot.
  
  * wg-quick: darwin: ensure socket directory exists
  * wg-quick: darwin: remove v6 routes after shutdown
  * wg-quick: darwin: bash correctness
  * wg-quick: darwin: restore DNS on down
  * wg-quick: darwin: use bash from environment and require bash 4+
  * wg-quick: darwin: sometimes there are no network services
  * wg-quick: darwin: avoid routing loop if no default
  * wg-quick: darwin: networksetup does not like missing stdio
  * wg-quick: darwin: reorder functions
  * wg-quick: darwin: simpler inclusion check
  
  After a pretty intense first few days of the new macOS port, we've fixed a few
  bugs and improved functionality of wg-quick(8).
  
  * ncat-client-server: add wg-quick variant
  
  We now have client-quick.sh that does the same as client.sh except it builds a
  file for wg-quick(8), which can then be used in `wg-quick up demo`.
```