### PR TITLE
wireguard: upgrade to 0.0.20180524

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180519
-ENV WIREGUARD_SHA256="8846b3006c3f7e079bb38a4c985ccc2981e259f56c927b4cf47cbc1420e1c462"
+ENV WIREGUARD_VERSION=0.0.20180524
+ENV WIREGUARD_SHA256="57614239c1f1a99a367f2c816153acda5bffada66a3b8e3b8215f1625784abc9"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * allowedips: set pointer to null before freeing
  * ncat-client-server: do not always call sudo and use env bash
  * qemu: bump default kernel for gcc 8.1
  * compat: work around qcom 4.9 backports
  
  The usual fixes.
  
  * tools: fix OpenBSD build
  * tools: always pass -v as first argument to install
  
  Portability changes.
  
  * wg-quick: darwin: rename namefile environment variable
  * wg-quick: darwin: do not remove routes when no real interface
  * wg-quick: freebsd: add new implementation
  * wg-quick: openbsd: add new implementation
  * wg-quick: support FreeBSD/Darwin search path
  * wg-quick: better bash completion for non-renaming OSes
  * wg-quick: allow enumeration of socket files
  
  We now support OpenBSD and FreeBSD, in addition to macOS.
```