### PR TITLE
wireguard: upgrade to 0.0.20180531

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180524
-ENV WIREGUARD_SHA256="57614239c1f1a99a367f2c816153acda5bffada66a3b8e3b8215f1625784abc9"
+ENV WIREGUARD_VERSION=0.0.20180531
+ENV WIREGUARD_SHA256="ff653095cc0e4c491ab6cd095ddf5d1db207f48f947fb92873a73220363f423c"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * compat: don't clash with get_random_u32 backports
  
  This should allow running on recent Qualcomm msm8998 kernels.
  
  * wg-quick: determine IPs when saving interface
  * wg-quick: darwin: add multiple IP addresses
  * wg-quick: freebsd: configure as p2p link
  * wg-quick: darwin: set DNS servers after delay on route change
  
  Usual set of wg-quick changes, since the recent cross platform additions.
  
  * curve25519: x86_64: satisfy sparse
  * curve25519: x86_64: make symbol static
  * crypto: consistent constification
  
  Small cleanups in the crypto primitives.
  
  * chacha20poly1305: split up into separate files
  * chacha20poly1305: combine stack variables into union
  * chacha20poly1305: test scattergather functions too
  * chacha20poly1305: test for authtag failure
  
  We've reorganized our chapoly implementation and added lots of new tests as
  well. The generic C chacha should be slightly faster in the process.
  
  * poly1305: mips: compute S on fly
  
  Small speedup on MIPS.
  
  * device: do not assume dst is always valid
  
  Fixes a crash when forwarding packets from devices that use flow offloading.
  
  * tools: constanter time encoding
  
  Not essential, but nice to have.
```