### PR TITLE
tests: Use poweroff instead of halt for wireguard test

### DIFF
--- a/test/cases/040_packages/023_wireguard/check.sh
+++ b/test/cases/040_packages/023_wireguard/check.sh
@@ -24,4 +24,4 @@ do
 	sleep 1
 done
 
-halt
+poweroff -f


### PR DESCRIPTION
The proposed change in https://github.com/linuxkit/linuxkit/pull/3030
seems to timeout on the wireguard test. Try 'poweroff -f' instead
of 'halt' to stop the test VM.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

![ant](https://user-images.githubusercontent.com/3338098/40783922-dea5fc0e-64db-11e8-9791-578289eaa3bf.jpg)
