### PR TITLE
Memorizer: remove kasan poison on boot

### DIFF
--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -1,6 +1,6 @@
 kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
-  cmdline: "console=ttyS0 page_poison=1"
+  cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.4
   - linuxkit/runc:v0.4


### PR DESCRIPTION


Signed-off-by: Nathan Dautenhahn <ndd@cis.upenn.edu>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Originally, Memorizer kernel fed inputs to add boot printouts from a debug tool, however, it creates unnecessary output. Remove the kernel boot option parameter.

**- How I did it**

Modify line in memorizer.yml

**- How to verify it**

Rebuild and launch with 16+GB of ram using Qemu.

**- Description for the changelog**

Remove poison parameter in Memorizer configuration
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**