### PR TITLE
Add services.linuxkit warning to motd for sshd and getty

### DIFF
--- a/contrib/crosvm/README.md
+++ b/contrib/crosvm/README.md
@@ -38,7 +38,7 @@ init:
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
       - INSECURE=true
 trust:

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -18,7 +18,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:v0.4
   - name: sshd
-    image: linuxkit/sshd:v0.4
+    image: linuxkit/sshd:2c7e6e36bd0ffa2b3d950cf9128da89ba3375dbb
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -15,7 +15,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.4
   - name: sshd
-    image: linuxkit/sshd:v0.4
+    image: linuxkit/sshd:2c7e6e36bd0ffa2b3d950cf9128da89ba3375dbb
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -22,7 +22,7 @@ onboot:
 
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
       - INSECURE=true
   - name: rngd

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -52,7 +52,7 @@ services:
     image: linuxkit/acpid:v0.4
   # Enable getty for easier debugging
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
         - INSECURE=true
   # Run ntpd to keep time synchronised in the VM

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -18,7 +18,7 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -16,13 +16,13 @@ onboot:
     image: linuxkit/metadata:v0.4
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: rngd
     image: linuxkit/rngd:v0.4
   - name: sshd
-    image: linuxkit/sshd:v0.4
+    image: linuxkit/sshd:2c7e6e36bd0ffa2b3d950cf9128da89ba3375dbb
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -18,7 +18,7 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
     runtime:

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -12,7 +12,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: influxdb

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:72df922e49a363a4ad53d88cd1a8a3ae4d41086f
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -19,7 +19,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:v0.4
   - name: sshd
-    image: linuxkit/sshd:v0.4
+    image: linuxkit/sshd:2c7e6e36bd0ffa2b3d950cf9128da89ba3375dbb
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -24,11 +24,11 @@ services:
   - name: rngd
     image: linuxkit/rngd:v0.4
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: sshd
-    image: linuxkit/sshd:v0.4
+    image: linuxkit/sshd:2c7e6e36bd0ffa2b3d950cf9128da89ba3375dbb
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -13,7 +13,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   # Currently redis:4.0.6-alpine has trust issue with multi-arch

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:v0.4
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/rngd", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: rngd
@@ -22,7 +22,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.4
   - name: sshd
-    image: linuxkit/sshd:v0.4
+    image: linuxkit/sshd:2c7e6e36bd0ffa2b3d950cf9128da89ba3375dbb
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -24,7 +24,7 @@ onboot:
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: tss

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:v0.4
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -19,7 +19,7 @@ onboot:
     command: ["sh", "-c", "mkdir /host_var/vpnkit && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
 services:
   - name: sshd
-    image: linuxkit/sshd:v0.4
+    image: linuxkit/sshd:2c7e6e36bd0ffa2b3d950cf9128da89ba3375dbb
   - name: vpnkit-forwarder
     image: linuxkit/vpnkit-forwarder:v0.4
     binds:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -16,13 +16,13 @@ onboot:
     image: linuxkit/metadata:v0.4
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: rngd
     image: linuxkit/rngd:v0.4
   - name: sshd
-    image: linuxkit/sshd:v0.4
+    image: linuxkit/sshd:2c7e6e36bd0ffa2b3d950cf9128da89ba3375dbb
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -40,7 +40,7 @@ onboot:
           net: /run/netns/wg1
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
     net: /run/netns/wg1

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -18,7 +18,7 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: rngd

--- a/pkg/getty/etc/motd
+++ b/pkg/getty/etc/motd
@@ -2,3 +2,4 @@ Welcome to LinuxKit!
 
 NOTE: This system is namespaced.
 The namespace you are currently in may not be the root.
+System services are namespaced; to access, use `ctr -n linuxkit.service ...`

--- a/pkg/sshd/etc/motd
+++ b/pkg/sshd/etc/motd
@@ -2,3 +2,4 @@ Welcome to LinuxKit!
 
 NOTE: This system is namespaced.
 The namespace you are currently in may not be the root.
+System services are namespaced; to access, use `ctr -n linuxkit.service ...`

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
 trust:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/sysctl:v0.4
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -28,9 +28,9 @@ onboot:
      - /lib:/lib     # for ifconfig
 services:
   - name: sshd
-    image: linuxkit/sshd:v0.4
+    image: linuxkit/sshd:2c7e6e36bd0ffa2b3d950cf9128da89ba3375dbb
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
 files:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -13,7 +13,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.4
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
 trust:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -14,7 +14,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
     env:
      - INSECURE=true
   - name: rngd

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -12,7 +12,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:v0.4
+    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added warning to motd in `sshd` and `getty` that the system services are in `ctr -n services.linuxkit ` per the request on slack [here](https://dockercommunity.slack.com/archives/C51K0GDU7/p1528274549000187)

**- How I did it**
Modify the two `motd` files

**- How to verify it**
Run it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Useful increased messages for `motd` to reduce support costs

**- A picture of a cute animal (not mandatory but encouraged)**
![dolphin](https://www.xyzwallpaper.com/wp-content/uploads/2017/05/dolphin-jump-hd-image.jpg)
