### PR TITLE
Stash kernel source and WireGuard source in the package

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -132,7 +132,7 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
     ([ -n "${DEBUG}" ] && cp vmlinux /out || true)
 
 # WireGuard
-RUN curl -sSL -o /wireguard.tar.xz "${WIREGUARD_URL}" && \
+RUN curl -fsSL -o /wireguard.tar.xz "${WIREGUARD_URL}" && \
     echo "${WIREGUARD_SHA256}  /wireguard.tar.xz" | sha256sum -c - && \
     cp /wireguard.tar.xz /out/src/ && \
     tar -C / --one-top-level=wireguard --strip-components=2 -xJf /wireguard.tar.xz "WireGuard-${WIREGUARD_VERSION}/src" && \
@@ -189,7 +189,7 @@ ENV UCODE_URL=https://downloadmirror.intel.com/27776/eng/microcode-20180425.tgz
 RUN set -e && \
     if [ $(uname -m) == x86_64 ]; then \
         cd /ucode && \
-        curl -sSL -o microcode.tar.gz ${UCODE_URL} && \
+        curl -fsSL -o microcode.tar.gz ${UCODE_URL} && \
         md5sum -c intel-ucode-md5sums && \
         tar xf microcode.tar.gz && \
         rm -f intel-ucode/list && \

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -84,6 +84,11 @@ RUN set -e && \
         done; \
     fi
 
+RUN mkdir -p /out/src
+
+# Save kernel source
+RUN tar cJf /out/src/linux.tar.xz /linux
+
 # Kernel config
 RUN case $(uname -m) in \
     x86_64) \
@@ -109,7 +114,6 @@ RUN case $(uname -m) in \
     make oldconfig && \
     if [ -z "${EXTRA}" ] && [ -z "${DEBUG}" ]; then diff .config ${KERNEL_DEF_CONF}; fi
 
-RUN mkdir /out
 
 # Kernel
 RUN make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
@@ -130,6 +134,7 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)" KCFLAGS="-fno-pie" && \
 # WireGuard
 RUN curl -sSL -o /wireguard.tar.xz "${WIREGUARD_URL}" && \
     echo "${WIREGUARD_SHA256}  /wireguard.tar.xz" | sha256sum -c - && \
+    cp /wireguard.tar.xz /out/src/ && \
     tar -C / --one-top-level=wireguard --strip-components=2 -xJf /wireguard.tar.xz "WireGuard-${WIREGUARD_VERSION}/src" && \
     make -j "$(getconf _NPROCESSORS_ONLN)" M="/wireguard" modules
 


### PR DESCRIPTION
The main commit is:
```
    While we can re-create the kernel source code we don't have it
    handily available in one place. This commit stashes the kernel
    and the WireGuard source as /src/linux.tar.xz and
    /src/wireguard.tar.xz in the kernel package.

    This increases the size of the hub image by around 100MB.
```
In addition, I also added `-f` to the `curl` invocations which were missing it.

![image](https://user-images.githubusercontent.com/3338098/41054990-eb54134c-69b7-11e8-95f2-e08f6fad12af.png)
