### PR TITLE
Add support for userdata on GCP plus custom name

### DIFF
--- a/src/cmd/linuxkit/gcp.go
+++ b/src/cmd/linuxkit/gcp.go
@@ -182,7 +182,7 @@ func (g GCPClient) DeleteImage(name string) error {
 }
 
 // CreateInstance creates and starts an instance on GCP
-func (g GCPClient) CreateInstance(name, image, zone, machineType string, disks Disks, nested, replace bool) error {
+func (g GCPClient) CreateInstance(name, image, zone, machineType string, disks Disks, data *string, nested, replace bool) error {
 	if replace {
 		if err := g.DeleteInstance(name, zone, true); err != nil {
 			return err
@@ -261,6 +261,10 @@ func (g GCPClient) CreateInstance(name, image, zone, machineType string, disks D
 				{
 					Key:   "ssh-keys",
 					Value: sshKey,
+				},
+				{
+					Key:   "userdata",
+					Value: data,
 				},
 			},
 		},


### PR DESCRIPTION
This was missing in the linuxkit CLI, even though we support it in the
metadata package.

Also add support to set a name different from the image name, so you can run multiple machines from one image easily.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![hippo poop](https://user-images.githubusercontent.com/482364/41069670-ccf7b304-69a3-11e8-8fc0-438e62a6836e.jpg)
Image from [Hippos Poop So Much That Sometimes All the Fish Die](https://www.theatlantic.com/science/archive/2018/05/hippos-poop-so-much-that-sometimes-all-the-fish-die/560486/)