### PR TITLE
tests: Fix wireguard test shutdown

### DIFF
--- a/test/cases/040_packages/023_wireguard/check.sh
+++ b/test/cases/040_packages/023_wireguard/check.sh
@@ -20,8 +20,8 @@ fi
 # Nginx may not be up immediately as service startup is async
 for s in $(seq 1 10)
 do
-	wget -O - http://192.168.2.1/ && echo "success" > /tmp/ok && halt
+	wget -O - http://192.168.2.1/ && echo "success" > /tmp/ok && poweroff
 	sleep 1
 done
 
-poweroff -f
+poweroff


### PR DESCRIPTION
With PR #3030 the behaviour of poweroff/halt is changed. This
test relies on on-shutdown containers to be executed to display
the test result (service containers have their stdout redirected).
Use 'poweroff' (note, no '-f') to ensure that:
- the machine actually powers off
- the on-shutdown container is executed

Note, there are subtle differences between 'poweroff' and 'halt'
between hypervisors. With HyperKit, 'halt' actually works, but with
qemu/kvm, with 'halt' the process does not exit.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@gmail.com>

![image](https://user-images.githubusercontent.com/3338098/41191231-2ad5585e-6be4-11e8-9598-dfcaef1c40a4.png)
