### PR TITLE
Update authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -24,6 +24,7 @@ David Sheets <david.sheets@docker.com> <sheets@alum.mit.edu>
 Ian Campbell <ian.campbell@docker.com> <ijc25@users.noreply.github.com>
 Ian Campbell <ian.campbell@docker.com> <ijc@docker.com>
 Ian Campbell <ian.campbell@docker.com> <ijc@users.noreply.github.com>
+Ian Campbell <ian.campbell@docker.com> <ijc@lxdeb01.marist.edu>
 Isaac Rodman <isaac@eyz.us> <isaac.rodman@healthtrio.com>
 Isaac Rodman <isaac@eyz.us>
 Istvan Szukacs <l1x@users.noreply.github.com>
@@ -35,6 +36,7 @@ Ken Cochrane <ken.cochrane@docker.com> <KenCochrane@gmail.com>
 Magnus Skjegstad <magnus.skjegstad@docker.com> <magnus@skjegstad.com>
 Marten Cassel <marten.cassel@gmail.com> <mcpop28@hotmail.com>
 Mindy Preston <mindy.preston@docker.com> <meetup@yomimono.org>
+MinJae Kwon <mingrammer@gmail.com>
 Nathan Dautenhahn <ndd@seas.upenn.edu> <ndd@cis.upenn.edu>
 Nathan LeClaire <nathan.leclaire@docker.com> <nathan.leclaire@gmail.com>
 Nathan LeClaire <nathan.leclaire@docker.com> <nathanleclaire@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -50,6 +50,7 @@ Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>
 Justin Cormack <justin.cormack@docker.com>
 Justin Ko <justin.ko@oracle.com>
 Ken Cochrane <ken.cochrane@docker.com>
+Krister Johansen <krister.johansen@oracle.com>
 Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>
 Liqdfire <liqdfire@gmail.com>
 Lorenzo Fontana <lo@linux.com>
@@ -66,6 +67,7 @@ Matt Johnson <matjohn2@cisco.com>
 Michel Courtine <michel.courtine@docker.com>
 Mickaël Salaün <mic@digikod.net>
 Mindy Preston <mindy.preston@docker.com>
+MinJae Kwon <mingrammer@gmail.com>
 Natanael Copa <natanael.copa@docker.com>
 Nathan Dautenhahn <ndd@seas.upenn.edu>
 Nathan LeClaire <nathan.leclaire@docker.com>
@@ -93,6 +95,7 @@ Sotiris Salloumis <sotiris.salloumis@gmail.com>
 Stefan Bourlon <stefan.bourlon@ca.com>
 Stephen J Day <stephen.day@docker.com>
 Steve Hiehn <shiehn@pivotal.io>
+Sukchan Lee <acetcom@gmail.com>
 Theo Koulouris <theo.koulouris@hpe.com>
 Thomas Conte <thomas@conte.com>
 Thomas Gazagnaire <thomas.gazagnaire@docker.com>


### PR DESCRIPTION
Also add another alias for @ijc

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@gmail.com>

![image](https://user-images.githubusercontent.com/3338098/41252186-4d9a42ce-6db4-11e8-9b5b-f90fadbe242a.png)
