### PR TITLE
wireguard: upgrade to 0.0.20180613

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180531
-ENV WIREGUARD_SHA256="ff653095cc0e4c491ab6cd095ddf5d1db207f48f947fb92873a73220363f423c"
+ENV WIREGUARD_VERSION=0.0.20180613
+ENV WIREGUARD_SHA256="c120cdedc3967dcb4ad5c1c7eadd2a1b04ef5dbf2fe60cc8e7c0db337bcda7dc"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * wg-quick: android: change name of intent
  * wg-quick: android: delay setting users until end
  
  `ndc users add` eventually invokes SOCK_DESTROY on user sockets, causing
  them to reconnect. By delaying this until after routes are set, we
  ensure that the sockets reconnect using the tunnel, rather than the old
  route. This fixes push notifications on Android.
  
  * chacha20: add missing include to header
  
  Fixes a compile error on some kernels.
  
  * tools: encoding: add missing static array constraints
  
  Makes static analyzers happier.
  
  * tools: support getentropy(3)
  
  This lets us take advantage of both recent glibc calls as well as the long
  standing getentropy functions on the BSDs.
  
  * chacha20poly1305: use slow crypto on -rt kernels
  
  In rt kernels, spinlocks call schedule(), which means preemption can't
  be disabled. The FPU disables preemption. Hence, we can either
  restructure things to move the calls to kernel_fpu_begin/end to be
  really close to the actual crypto routines, or we can do the slower
  lazier solution of just not using the FPU at all on -rt kernels. This
  patch goes with the latter lazy solution. The reason why we don't
  place the calls to kernel_fpu_begin/end close to the crypto routines
  in the first place is that they're very expensive, as it usually
  involves a call to XSAVE. So on sane kernels, we benefit from only
  having to call it once.
```