### PR TITLE
Workaround DNS issue with qemu-user-static on alpine by using Debian in the first stage #2710

### DIFF
--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,8 +1,9 @@
-FROM linuxkit/alpine:1b05307ae8152e3d38f79e297b0632697a30c65c AS qemu
-RUN apk add \
-    qemu-aarch64 \
-    qemu-arm \
-    qemu-ppc64le
+# Use Debian stretch until https://bugs.alpinelinux.org/issues/8131 is resolved.
+FROM debian@sha256:de3eac83cd481c04c5d6c7344cd7327625a1d8b2540e82a8231b5675cef0ae5f AS qemu
+RUN apt-get update && apt-get install -y qemu-user-static && \
+    mv /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64 && \
+    mv /usr/bin/qemu-arm-static /usr/bin/qemu-arm && \
+    mv /usr/bin/qemu-ppc64le-static /usr/bin/qemu-ppc64le
 
 FROM linuxkit/alpine:1b05307ae8152e3d38f79e297b0632697a30c65c AS mirror
 


### PR DESCRIPTION
Fixes #2710 

DNS lookups fail in qemu-user when it is built on Alpine: https://bugs.alpinelinux.org/issues/8131

Until this is resolved, we fetch the binaries from Debian and use those instead. The final stage
of the Dockerfile is still based on scratch.

We can revert this once the Alpine issue is fixed.

Signed-off-by: Justin Barrick <jbarrick@cloudflare.com>