### PR TITLE
Binfmt fixes

### DIFF
--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -17,7 +17,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:v0.4
   - name: binfmt
-    image: linuxkit/binfmt:v0.4
+    image: linuxkit/binfmt:0f73915a3fe365615a10a811f5b83303f48949d5
   # Format and mount the disk image in /var/lib/docker
   - name: format
     image: linuxkit/format:v0.4

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,8 +1,9 @@
-FROM linuxkit/alpine:1b05307ae8152e3d38f79e297b0632697a30c65c AS qemu
-RUN apk add \
-    qemu-aarch64 \
-    qemu-arm \
-    qemu-ppc64le
+# Use Debian stretch until https://bugs.alpinelinux.org/issues/8131 is resolved.
+FROM debian@sha256:de3eac83cd481c04c5d6c7344cd7327625a1d8b2540e82a8231b5675cef0ae5f AS qemu
+RUN apt-get update && apt-get install -y qemu-user-static && \
+    mv /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64 && \
+    mv /usr/bin/qemu-arm-static /usr/bin/qemu-arm && \
+    mv /usr/bin/qemu-ppc64le-static /usr/bin/qemu-ppc64le
 
 FROM linuxkit/alpine:1b05307ae8152e3d38f79e297b0632697a30c65c AS mirror
 

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -12,13 +12,10 @@ ENV GOPATH=/go PATH=$PATH:/go/bin
 COPY main.go /go/src/binfmt/
 RUN go-compile.sh /go/src/binfmt
 
-RUN mkdir /binfmt_misc
-
 FROM scratch
 ENTRYPOINT []
 WORKDIR /
 COPY --from=qemu usr/bin/qemu-* usr/bin/
 COPY --from=mirror /go/bin/binfmt usr/bin/binfmt
-COPY --from=mirror /binfmt_misc /binfmt_misc/
 COPY etc/binfmt.d/00_linuxkit.conf etc/binfmt.d/00_linuxkit.conf
-CMD ["/usr/bin/binfmt", "-dir", "/etc/binfmt.d/", "-mount", "/binfmt_misc"]
+CMD ["/usr/bin/binfmt"]

--- a/pkg/binfmt/build.yml
+++ b/pkg/binfmt/build.yml
@@ -1,9 +1,10 @@
 image: binfmt
+network: true
 arches:
   - amd64
 config:
-  binds:
-  - /proc/sys/fs/binfmt_misc:/binfmt_misc
+  capabilities:
+    - CAP_SYS_ADMIN
   readonly: true
   net: new
   ipc: new

--- a/pkg/binfmt/main.go
+++ b/pkg/binfmt/main.go
@@ -69,6 +69,11 @@ func binfmt(line []byte) error {
 func main() {
 	flag.Parse()
 
+	if err := syscall.Mount("binfmt_misc", mount, "binfmt_misc", 0, ""); err != nil {
+		log.Fatalf("Cannot mount binfmt_misc filesystem at %s: %v", mount, err)
+	}
+	defer syscall.Unmount(mount, 0)
+
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		log.Fatalf("Cannot read directory %s: %s", dir, err)

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:v0.4
 onboot:
   - name: binfmt
-    image: linuxkit/binfmt:v0.4
+    image: linuxkit/binfmt:0f73915a3fe365615a10a811f5b83303f48949d5
   - name: test
     image: alpine:3.7
     binds:


### PR DESCRIPTION
Rather than bind mounting binfmt_misc filesystem, mount a copy.
    
For some reason, bind mounting does not always seem to work,
sometimes the filesystem is empty. Mounting a fresh copy seems
a better solution, and simplifies things. The container does
need `CAP_SYS_ADMIN` but only on boot.

also cherry pick #3071 to use Debian for qemu as Alpine currently broken for networking.

fix #2710

