### PR TITLE
wireguard: upgrade to 0.0.20180625

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180613
-ENV WIREGUARD_SHA256="c120cdedc3967dcb4ad5c1c7eadd2a1b04ef5dbf2fe60cc8e7c0db337bcda7dc"
+ENV WIREGUARD_VERSION=0.0.20180625
+ENV WIREGUARD_SHA256="d9bedeb22b1f83d48581608a6521fea1d429fbeb8809419d08703ef2ec570020"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```

  * receive: don't toggle bh
  
  The last snapshot caused a big performance regression, which we partially
  revert here. This general matter, though, will be revisited in the future,
  perhaps by switching to NAPI.
  
  * main: test poly1305 before chacha20poly1305
  * poly1305: give linker the correct constant data section size
  
  While the default bfd linker did the right thing, gold would sometimes merge
  section incorrectly because of an incorrect section length field, resulting in
  wrong calculations.
  
  * simd: add missing header
  
  Fixes a compile error on a few odd kernels.
  
  * global: fix a few typos
  * manpages: eliminate whitespace at the end of the line
  * tools: fix misspelling of strchrnul in comment
  
  Cosmetic fixups.
  
  * global: use ktime boottime instead of jiffies
  * global: use fast boottime instead of normal boottime
  * compat: more robust ktime backport
  
  We now use the equivalent of clock_gettime(CLOCK_BOOTTIME) for doing age
  checks on time-limited objects, such as ephemeral keys, so that on systems
  where we don't clear before sleep (like Android), we make sure to invalidate
  the objects after the proper amount of time, taking into account time spent
  asleep.
  
  * wg-quick: android: prevent outgoing handshake packets from being dropped
  
  Recent android phones block outgoing packets using iptables while the system
  is asleep. This makes sense for most services, but not for a tunnel device
  itself, so we work around this by inserting our own iptables rule.
```