### PR TITLE
wireguard: upgrade to 0.0.20180708

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180625
-ENV WIREGUARD_SHA256="d9bedeb22b1f83d48581608a6521fea1d429fbeb8809419d08703ef2ec570020"
+ENV WIREGUARD_VERSION=0.0.20180708
+ENV WIREGUARD_SHA256="5e38d554f7d1e3a64e3a5319ca1a3b790c84ed89c896586c490a93ac1f953a91"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * device: print daddr not saddr in missing peer error
  * receive: style
  
  Debug messages now make sense again.
  
  * selftest: ratelimiter: improve chance of success via retry
  * qemu: bump default kernel version
  * qemu: decide debug kernel based on KERNEL_VERSION
  
  Some improvements to our testing infrastructure.
  
  * receive: use NAPI on the receive path
  
  This is a big change that should both improve preemption latency (by not
  disabling it unconditionally) and vastly improve rx performance on most
  systems by using NAPI. The main purpose of this snapshot is to test out this
  technique.
```