### PR TITLE
Preparation for v0.5 release

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -32,6 +32,7 @@ Jeff Wu <jeff.wu.junfei@gmail.com> <JeffWuBJ@users.noreply.github.com>
 Jeremy Yallop <yallop@docker.com> <yallop@gmail.com>
 Justin Cormack <justin.cormack@docker.com> <justin.cormack@unikernel.com>
 Justin Cormack <justin.cormack@docker.com> <justin@specialbusservice.com>
+Justin Barrick <jbarrick@cloudflare.com>
 Ken Cochrane <ken.cochrane@docker.com> <KenCochrane@gmail.com>
 Magnus Skjegstad <magnus.skjegstad@docker.com> <magnus@skjegstad.com>
 Marten Cassel <marten.cassel@gmail.com> <mcpop28@hotmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,12 +3,14 @@
 
 Ajeet Singh Raina, Docker Captain, {Code} Catalysts, Dell EMC R&D <ajeetraina@gmail.com>
 Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
+Alan Raison <alanraison@users.noreply.github.com>
 Alex Johnson <hello@alex-johnson.net>
 Alice Frosi <alice@linux.vnet.ibm.com>
 Amir Chaudhry <amir.chaudhry@docker.com>
 Anil Madhavapeddy <anil.madhavapeddy@docker.com>
 Avi Deitcher <avi@deitcher.net>
 Bill Kerr <bill@generalbill.com>
+Brice Figureau <brice-puppet@daysofwonder.com>
 Carlton-Semple <carlton.semple@ibm.com>
 Craig Ingram <cingram@heroku.com>
 Damiano Donati <damiano.donati@gmail.com>
@@ -47,6 +49,7 @@ Jes Ferrier <jes.ferrier@gmail.com>
 Jesse Adametz <jesseadametz@gmail.com>
 John Albietz <inthecloud247@gmail.com>
 Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>
+Justin Barrick <jbarrick@cloudflare.com>
 Justin Cormack <justin.cormack@docker.com>
 Justin Ko <justin.ko@oracle.com>
 Ken Cochrane <ken.cochrane@docker.com>
@@ -60,6 +63,7 @@ Magnus Skjegstad <magnus.skjegstad@docker.com>
 Marco Mariani <marco.mariani@alterway.fr>
 Marcus van Dam <marcus@marcusvandam.nl>
 marten <marten.cassel@gmail.com>
+Mathieu Champlon <mathieu.champlon@docker.com>
 Mathieu Pasquet <mathieu.pasquet@alterway.fr>
 Matt Bajor <matt.bajor@workday.com>
 Matt Bentley <matt.bentley@docker.com>
@@ -76,6 +80,7 @@ Niclas Mietz <niclas@mietz.io>
 Nico Di Rocco <dirocco.nico@gmail.com>
 Olaf Bergner <olaf.bergner@gmx.de>
 Olaf Flebbe <of@oflebbe.de>
+Patrik Cyvoct <patrik@ptrk.io>
 Phil Estes <estesp@linux.vnet.ibm.com>
 Pierre Gayvallet <pierre.gayvallet@docker.com>
 Pratik Mallya <mallya@us.ibm.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [v0.5] - 2018-07-10
+### Added
+- New logging support with log rotation.
+- Scaleway provider.
+- Support for v4.17.x kernels.
+- Kernel source are not included in the kernel packages.
+- Improved documentation about debugging LinuxKit.
+
+### Changed
+- Switched to Alpine Linux 3.8 as the base.
+- `containerd` updated to v1.1.1.
+- `pkg/cadvisor` updated to v0.30.2
+- `pkg/node_exporter` updated to 0.16.0
+- WireGuard updated to 0.0.20180708.
+- Linux firmware binaries update to latest.
+- Improved support for building on Windows.
+- Improved support for AWS/GCP metadata.
+- Better handling of reboot/poweroff.
+
+### Removed
+- Support for v4.16.x. kernels as they have been EOLed.
+
+
 ## [v0.4] - 2018-05-12
 ### Added
 - Support for v4.16.x kernels.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION="v0.4+"
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:a8031514cbd017cd10207de56be3434b9d7c6fd7
+GO_COMPILE=linuxkit/go-compile:49a2e8f8672ca95ad0159eebcc631773503465c1
 
 ifeq ($(OS),Windows_NT)
 LINUXKIT?=bin/linuxkit.exe

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION="v0.4+"
+VERSION="v0.5"
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
 GO_COMPILE=linuxkit/go-compile:49a2e8f8672ca95ad0159eebcc631773503465c1

--- a/contrib/crosvm/README.md
+++ b/contrib/crosvm/README.md
@@ -33,12 +33,12 @@ kernel:
   image: linuxkit/kernel:4.9.91
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
       - INSECURE=true
 trust:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -182,13 +182,29 @@ Next, we update the LinuxKit packages. This is really the core of the
 release. The other steps above are just there to ensure consistency
 across packages.
 
+
 ```sh
 cd $LK_ROOT/pkg
 ../scripts/update-component-sha.sh --image linuxkit/alpine:$LK_ALPINE
 
 git commit -a -s -m "pkgs: Update packages to latest alpine base"
 git push $LK_REMOTE rel_$LK_RELEASE
+```
 
+Most of the packages are build from `linuxkit/alpine` and source code
+in the `linuxkit` repository, but some packages wrap external
+tools. The time of a release is a good opportunity to check if there
+have been updates. Specifically:
+
+- `pkg/cadvisor`: Check for [new releases](https://github.com/google/cadvisor/releases).
+- `pkg/firmware` and `pkg/firmware-all`: Use latest commit from [here](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git).
+- `pkg/node_exporter`: Check for [new releases](https://github.com/prometheus/node_exporter/releases).
+- `example/docker.yml`: Check [docker hub](https://hub.docker.com/r/library/docker/tags/) for the latest `dind` tags.
+
+The build/push the packages:
+
+```sh
+cd $LK_ROOT/pkg
 make OPTIONS="-release $LK_RELEASE" push
 ```
 

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -28,7 +28,7 @@ docker run -it --rm \
 -v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:a8031514cbd017cd10207de56be3434b9d7c6fd7
+linuxkit/go-compile:49a2e8f8672ca95ad0159eebcc631773503465c1
 ```
 
 To update a single dependency:
@@ -38,7 +38,7 @@ docker run -it --rm \
 -v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint /go/bin/vndr \
-linuxkit/go-compile:a8031514cbd017cd10207de56be3434b9d7c6fd7
+linuxkit/go-compile:49a2e8f8672ca95ad0159eebcc631773503465c1
 github.com/docker/docker
 ```
 

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:7d885acd45923cc3406a40dc4fa4be24903e3cd2
+    image: linuxkit/metadata:v0.5
 services:
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: sshd
-    image: linuxkit/sshd:ae16b868747913bad83ad1b5823669eff1563013
+    image: linuxkit/sshd:v0.5
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
 services:
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
   - name: sshd
-    image: linuxkit/sshd:ae16b868747913bad83ad1b5823669eff1563013
+    image: linuxkit/sshd:v0.5
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,33 +2,33 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: sysfs
-    image: linuxkit/sysfs:6d1b016e1a7834ccc72bd4570fadd22933665ec8
+    image: linuxkit/sysfs:v0.5
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
       - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: ntpd
-    image: linuxkit/openntpd:2f13536030a04f93cfaa02f816fe24f536c9943c
+    image: linuxkit/openntpd:v0.5
 
   - name: docker
     image: docker:17.10.0-ce-dind
@@ -46,7 +46,7 @@ services:
       - /etc/docker/daemon.json:/etc/docker/daemon.json
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: cadvisor
-    image: linuxkit/cadvisor:9d0f7fc85a4cf50ee3fa68c83e89593f1db80d24
+    image: linuxkit/cadvisor:v0.5
 files:
   - path: var/lib/docker
     directory: true

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -3,30 +3,30 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/vpnkit-expose-port:9899eef84d0a881b6a5ca5a4b4bb71e382435cb5 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/vpnkit-expose-port:v0.5 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   # support metadata for optional config in /run/config
   - name: metadata
-    image: linuxkit/metadata:7d885acd45923cc3406a40dc4fa4be24903e3cd2
+    image: linuxkit/metadata:v0.5
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: sysfs
-    image: linuxkit/sysfs:6d1b016e1a7834ccc72bd4570fadd22933665ec8
+    image: linuxkit/sysfs:v0.5
   - name: binfmt
-    image: linuxkit/binfmt:b0d833f5ecd26d6cb991622b1234afd9a0f6ee31
+    image: linuxkit/binfmt:v0.5
   # Format and mount the disk image in /var/lib/docker
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib"]
   # make a swap file on the mounted disk
   - name: swap
-    image: linuxkit/swap:e73f719b467e3dcb1eec85f1f1fd5d32fe1140bf
+    image: linuxkit/swap:v0.5
     command: ["/swap.sh", "--path", "/var/lib/swap", "--size", "1024M"]
   # mount-vpnkit mounts the 9p share used by vpnkit to coordinate port forwarding
   - name: mount-vpnkit
@@ -44,41 +44,41 @@ onboot:
         - /var:/host_var
     command: ["sh", "-c", "mv -v /host_var/log /host_var/lib && ln -vs /var/lib/log /host_var/log"]
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   # Enable acpi to shutdown on power events
   - name: acpid
-    image: linuxkit/acpid:80b486a60dd0d55233e560db1ff096b1d5b35bbd
+    image: linuxkit/acpid:v0.5
   # Enable getty for easier debugging
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
         - INSECURE=true
   # Run ntpd to keep time synchronised in the VM
   - name: ntpd
-    image: linuxkit/openntpd:2f13536030a04f93cfaa02f816fe24f536c9943c
+    image: linuxkit/openntpd:v0.5
   # VSOCK to unix domain socket forwarding. Forwards guest /var/run/docker.sock
   # to a socket on the host.
   - name: vsudd
-    image: linuxkit/vsudd:4d2a600d4dcefed5195a6908a1aaf0e16d48ad0c
+    image: linuxkit/vsudd:v0.5
     binds:
         - /var/run:/var/run
     command: ["/vsudd", "-inport", "2376:unix:/var/run/docker.sock"]
   # vpnkit-forwarder forwards network traffic to/from the host via VSOCK port 62373. 
   # It needs access to the vpnkit 9P coordination share 
   - name: vpnkit-forwarder
-    image: linuxkit/vpnkit-forwarder:e474ea69ccc48157b6b8053a9a5814af46b58707
+    image: linuxkit/vpnkit-forwarder:v0.5
     binds:
         - /var/vpnkit:/port
     net: host
     command: ["/vpnkit-forwarder", "-vsockPort", "62373"]
   # Monitor for image deletes and invoke a TRIM on the container filesystem
   - name: trim-after-delete
-    image: linuxkit/trim-after-delete:1a8531c662ad4cde6f795cab9db3e622b3cf655e
+    image: linuxkit/trim-after-delete:v0.5
   # When the host resumes from sleep, force a clock resync
   - name: host-timesync-daemon
-    image: linuxkit/host-timesync-daemon:a54caae030f4086e482b103100f954b27a02aadd
+    image: linuxkit/host-timesync-daemon:v0.5
   # Run dockerd with the vpnkit userland proxy from the vpnkit-forwarder container.
   # Bind mounts /var/run to allow vsudd to connect to docker.sock, /var/vpnkit
   # for vpnkit coordination and /run/config/docker for the configuration file.

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,31 +2,31 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: sysfs
-    image: linuxkit/sysfs:6d1b016e1a7834ccc72bd4570fadd22933665ec8
+    image: linuxkit/sysfs:v0.5
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
   - name: ntpd
-    image: linuxkit/openntpd:2f13536030a04f93cfaa02f816fe24f536c9943c
+    image: linuxkit/openntpd:v0.5
   - name: docker
     image: docker:18.05.0-ce-dind
     capabilities:

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -28,7 +28,7 @@ services:
   - name: ntpd
     image: linuxkit/openntpd:2f13536030a04f93cfaa02f816fe24f536c9943c
   - name: docker
-    image: docker:17.09.0-ce-dind
+    image: docker:18.05.0-ce-dind
     capabilities:
      - all
     net: host

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,27 +2,27 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:7d885acd45923cc3406a40dc4fa4be24903e3cd2
+    image: linuxkit/metadata:v0.5
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: sshd
-    image: linuxkit/sshd:ae16b868747913bad83ad1b5823669eff1563013
+    image: linuxkit/sshd:v0.5
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,24 +2,24 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,15 +2,15 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 onshutdown:
   - name: shutdown
@@ -18,7 +18,7 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
     runtime:
@@ -30,7 +30,7 @@ services:
           destination: writeable-host-etc
           options: ["rw", "lowerdir=/etc", "upperdir=/run/hostetc/upper", "workdir=/run/hostetc/work"]
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,17 +2,17 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: influxdb

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,21 +3,21 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
-  - linuxkit/memlogd:19e58ab6ae2c6be1751260aa60e91c441eda1294
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
+  - linuxkit/memlogd:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
 # Inside the getty type `/proc/1/root/usr/bin/logread -F` to follow the log
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
 # A service which generates log messages for testing
@@ -25,9 +25,9 @@ services:
     image: alpine
     command: ["/bin/sh", "-c", "while /bin/true; do echo hello $(date); sleep 1; done" ]
   - name: write-and-rotate-logs
-    image: linuxkit/logwrite:7859c102a963828fd9c5aa3837db9600483220c7
+    image: linuxkit/logwrite:v0.5
   - name: kmsg
-    image: linuxkit/kmsg:3dfa0d5b4027ecc16089f27fbcffa15d6aa5438e
+    image: linuxkit/kmsg:v0.5
 trust:
   org:
     - linuxkit

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
 trust:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
   - name: node_exporter
-    image: linuxkit/node_exporter:be55316c1843b237a77d09ea8f57462c0f8dbbdd
+    image: linuxkit/node_exporter:v0.5
 trust:
   org:
     - linuxkit

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,24 +2,24 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:7d885acd45923cc3406a40dc4fa4be24903e3cd2
+    image: linuxkit/metadata:v0.5
     command: ["/usr/bin/metadata", "openstack"]
 services:
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: sshd
-    image: linuxkit/sshd:ae16b868747913bad83ad1b5823669eff1563013
+    image: linuxkit/sshd:v0.5
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/packet.arm64.yml
+++ b/examples/packet.arm64.yml
@@ -10,5 +10,5 @@ kernel:
   ucode: ""
 onboot:
   - name: modprobe
-    image: linuxkit/modprobe:e1f78caa4c3a64a239ffb23c81622b4104cba5a0
+    image: linuxkit/modprobe:v0.5
     command: ["modprobe", "nicvf"]

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,32 +3,32 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
-  - linuxkit/firmware:eac78cc21acd33a871d8b5f64a17c574cebb4c73
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
+  - linuxkit/firmware:v0.5
 onboot:
   - name: rngd1
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
     command: ["/sbin/rngd", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:7d885acd45923cc3406a40dc4fa4be24903e3cd2
+    image: linuxkit/metadata:v0.5
     command: ["/usr/bin/metadata", "packet"]
 services:
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: sshd
-    image: linuxkit/sshd:ae16b868747913bad83ad1b5823669eff1563013
+    image: linuxkit/sshd:v0.5
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,16 +4,16 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   # Currently redis:4.0.6-alpine has trust issue with multi-arch

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,24 +2,24 @@ kernel:
   image: linuxkit/kernel:4.14.54-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
   - name: open-vm-tools
-    image: linuxkit/open-vm-tools:b36c4f55b86a28939e4eb726fc8999f842b0a213
+    image: linuxkit/open-vm-tools:v0.5
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -2,28 +2,28 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: rngd1
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
     command: ["/sbin/rngd", "-1"]
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:7d885acd45923cc3406a40dc4fa4be24903e3cd2
+    image: linuxkit/metadata:v0.5
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
 trust:
   org:
     - linuxkit

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,27 +2,27 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: rngd1
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
     command: ["/sbin/rngd", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
   - name: sshd
-    image: linuxkit/sshd:ae16b868747913bad83ad1b5823669eff1563013
+    image: linuxkit/sshd:v0.5
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,33 +2,33 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/external"]
   - name: swap
-    image: linuxkit/swap:e73f719b467e3dcb1eec85f1f1fd5d32fe1140bf
+    image: linuxkit/swap:v0.5
     # to use unencrypted swap, use:
     # command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G"]
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
 trust:
   org:
     - linuxkit

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,25 +2,25 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: tss
-    image: linuxkit/tss:1be95ab914493a11929930b8900bde812be0dcaa
+    image: linuxkit/tss:v0.5
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,22 +2,22 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,12 +2,12 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: mount-vpnkit
     image: alpine:3.8
@@ -19,9 +19,9 @@ onboot:
     command: ["sh", "-c", "mkdir /host_var/vpnkit && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
 services:
   - name: sshd
-    image: linuxkit/sshd:ae16b868747913bad83ad1b5823669eff1563013
+    image: linuxkit/sshd:v0.5
   - name: vpnkit-forwarder
-    image: linuxkit/vpnkit-forwarder:e474ea69ccc48157b6b8053a9a5814af46b58707
+    image: linuxkit/vpnkit-forwarder:v0.5
     binds:
         - /var/vpnkit:/port
     net: host

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: vsudd
-    image: linuxkit/vsudd:4d2a600d4dcefed5195a6908a1aaf0e16d48ad0c
+    image: linuxkit/vsudd:v0.5
     binds:
         - /run/containerd/containerd.sock:/run/containerd/containerd.sock
     command: ["/vsudd",

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,27 +2,27 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:7d885acd45923cc3406a40dc4fa4be24903e3cd2
+    image: linuxkit/metadata:v0.5
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: sshd
-    image: linuxkit/sshd:ae16b868747913bad83ad1b5823669eff1563013
+    image: linuxkit/sshd:v0.5
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,18 +2,18 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:dd18c95e8add1dde51864d221efc02290a8ee7d0
+    image: linuxkit/ip:v0.5
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -26,7 +26,7 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:dd18c95e8add1dde51864d221efc02290a8ee7d0
+    image: linuxkit/ip:v0.5
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -40,12 +40,12 @@ onboot:
           net: /run/netns/wg1
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
     net: /run/netns/wg1
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: nginx
     image: nginx:1.13.8-alpine
     net: /run/netns/wg0

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,15 +2,15 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 onshutdown:
   - name: shutdown
@@ -18,11 +18,11 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/pkg/acpid/Dockerfile
+++ b/pkg/acpid/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -6,7 +6,7 @@ RUN apk add --no-cache --initdb -p /out \
     busybox
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror2
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror2
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     busybox-initscripts

--- a/pkg/auditd/Dockerfile
+++ b/pkg/auditd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --initdb -p /out alpine-baselayout apk-tools audit busybox tini

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y qemu-user-static && \
     mv /usr/bin/qemu-arm-static /usr/bin/qemu-arm && \
     mv /usr/bin/qemu-ppc64le-static /usr/bin/qemu-ppc64le
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/ca-certificates/Dockerfile
+++ b/pkg/ca-certificates/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 as alpine
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc as alpine
 
 RUN apk add ca-certificates
 

--- a/pkg/cadvisor/Dockerfile
+++ b/pkg/cadvisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 as build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc as build
 
 RUN apk add --no-cache bash go git musl-dev linux-headers make
 
@@ -16,7 +16,7 @@ RUN go get -d ${GITREPO} \
     && mv cadvisor /usr/bin/
 
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/cadvisor/Dockerfile
+++ b/pkg/cadvisor/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache bash go git musl-dev linux-headers make
 
 ENV GOPATH=/go PATH=$PATH:/go/bin
 ENV GITREPO=github.com/google/cadvisor
-ENV COMMIT=v0.28.1
+ENV COMMIT=v0.30.2
 
 ADD /static.patch /tmp/
 

--- a/pkg/dhcpcd/Dockerfile
+++ b/pkg/dhcpcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/extend/Dockerfile
+++ b/pkg/extend/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -15,7 +15,7 @@ RUN apk add --no-cache --initdb -p /out \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/firmware-all/Dockerfile
+++ b/pkg/firmware-all/Dockerfile
@@ -3,7 +3,7 @@ RUN apk add --no-cache git
 
 # Make sure you also update the FW_COMMIT in ../firmware/Dockerfile
 ENV FW_URL=git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
-ENV FW_COMMIT=65b1c68c63f974d72610db38dfae49861117cae2
+ENV FW_COMMIT=d1147327232ec4616a66ab898df84f9700c816c1
 
 RUN mkdir -p /out/lib && \
     cd /out/lib && \

--- a/pkg/firmware-all/Dockerfile
+++ b/pkg/firmware-all/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 RUN apk add --no-cache git
 
 # Make sure you also update the FW_COMMIT in ../firmware/Dockerfile

--- a/pkg/firmware/Dockerfile
+++ b/pkg/firmware/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache git kmod
 # Clone the firmware repository
 # Make sure you also update the FW_COMMIT in ../firmware-all/Dockerfile
 ENV FW_URL=git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
-ENV FW_COMMIT=65b1c68c63f974d72610db38dfae49861117cae2
+ENV FW_COMMIT=d1147327232ec4616a66ab898df84f9700c816c1
 WORKDIR /
 RUN git clone ${FW_URL} && \
     cd /linux-firmware && \

--- a/pkg/firmware/Dockerfile
+++ b/pkg/firmware/Dockerfile
@@ -1,7 +1,7 @@
 # Make modules from a recentish kernel available
 FROM linuxkit/kernel:4.14.28 AS kernel
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 RUN apk add --no-cache git kmod
 
 # Clone the firmware repository

--- a/pkg/format/Dockerfile
+++ b/pkg/format/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -15,7 +15,7 @@ RUN apk add --no-cache --initdb -p /out \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/getty/Dockerfile
+++ b/pkg/getty/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/host-timesync-daemon/Dockerfile
+++ b/pkg/host-timesync-daemon/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN apk add --no-cache go musl-dev git
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/ip/Dockerfile
+++ b/pkg/ip/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add curl
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/kmsg/Dockerfile
+++ b/pkg/kmsg/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN apk add --no-cache go musl-dev linux-headers
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/logwrite/Dockerfile
+++ b/pkg/logwrite/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/memlogd/Dockerfile
+++ b/pkg/memlogd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/metadata/Dockerfile
+++ b/pkg/metadata/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN apk add --no-cache go musl-dev linux-headers
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/mkimage/Dockerfile
+++ b/pkg/mkimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/modprobe/Dockerfile
+++ b/pkg/modprobe/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/mount/Dockerfile
+++ b/pkg/mount/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -9,7 +9,7 @@ RUN apk add --no-cache --initdb -p /out \
     && true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/node_exporter/Dockerfile
+++ b/pkg/node_exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 as build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc as build
 
 RUN apk add --no-cache go git musl-dev make
 

--- a/pkg/node_exporter/Dockerfile
+++ b/pkg/node_exporter/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache go git musl-dev make
 
 ENV GOPATH=/go PATH=$PATH:/go/bin
 ENV GITREPO=github.com/prometheus/node_exporter
-ENV COMMIT=v0.15.1
+ENV COMMIT=v0.16.0
 
 RUN go get -d ${GITREPO} \
     && cd /go/src/${GITREPO} \

--- a/pkg/open-vm-tools/Dockerfile
+++ b/pkg/open-vm-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/openntpd/Dockerfile
+++ b/pkg/openntpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/qemu-ga/Dockerfile
+++ b/pkg/qemu-ga/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN mkdir -p /out/var/run
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN apk add --no-cache go gcc musl-dev linux-headers
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 as alpine
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc as alpine
 RUN \
   apk add \
   bash \

--- a/pkg/sshd/Dockerfile
+++ b/pkg/sshd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/swap/Dockerfile
+++ b/pkg/swap/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/pkg/sysctl/Dockerfile
+++ b/pkg/sysctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/sysfs/Dockerfile
+++ b/pkg/sysfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN apk add --no-cache go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/pkg/trim-after-delete/Dockerfile
+++ b/pkg/trim-after-delete/Dockerfile
@@ -1,5 +1,5 @@
 # We need the `fstrim` binary:
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/pkg/tss/Dockerfile
+++ b/pkg/tss/Dockerfile
@@ -24,8 +24,8 @@ COPY src/glibc_stubs/ /usr/src/glibc_stubs
 WORKDIR /usr/src/glibc_stubs
 RUN make && make install
 
-RUN git clone https://git.code.sf.net/p/trousers/trousers /usr/src/trousers-trousers && cd /usr/src/trousers-trousers && git checkout $TROUSERS_COMMIT
-RUN git clone https://git.code.sf.net/p/trousers/tpm-tools /usr/src/trousers-tpm-tools && cd /usr/src/trousers-tpm-tools && git checkout $TPM_TOOLS_COMMIT
+RUN git clone https://github.com/linuxkit/mirror-trousers.git /usr/src/trousers-trousers && cd /usr/src/trousers-trousers && git checkout $TROUSERS_COMMIT
+RUN git clone https://github.com/linuxkit/mirror-tpm-tools.git /usr/src/trousers-tpm-tools && cd /usr/src/trousers-tpm-tools && git checkout $TPM_TOOLS_COMMIT
 WORKDIR /usr/src/trousers-trousers
 RUN sh bootstrap.sh && \
     ./configure --prefix=/ --sysconfdir=/etc LDFLAGS="-L/out/lib/ -lgetpwent_r" && \

--- a/pkg/tss/Dockerfile
+++ b/pkg/tss/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 
 ENV TROUSERS_COMMIT de57f069ef2297d6a6b3a0353e217a5a2f66e444
 ENV TPM_TOOLS_COMMIT bdf9f1bc8f63cd6fc370c2deb58d03ac55079e84

--- a/pkg/vpnkit-expose-port/Dockerfile
+++ b/pkg/vpnkit-expose-port/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/pkg/vpnkit-forwarder/Dockerfile
+++ b/pkg/vpnkit-forwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/pkg/vsudd/Dockerfile
+++ b/pkg/vsudd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
+  - linuxkit/init:v0.5
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,28 +2,28 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: sysfs
-    image: linuxkit/sysfs:6d1b016e1a7834ccc72bd4570fadd22933665ec8
+    image: linuxkit/sysfs:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: ntpd
-    image: linuxkit/openntpd:2f13536030a04f93cfaa02f816fe24f536c9943c
+    image: linuxkit/openntpd:v0.5
   - name: docker
     image: docker:17.07.0-ce-dind
     capabilities:

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,28 +2,28 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: sysfs
-    image: linuxkit/sysfs:6d1b016e1a7834ccc72bd4570fadd22933665ec8
+    image: linuxkit/sysfs:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: ntpd
-    image: linuxkit/openntpd:2f13536030a04f93cfaa02f816fe24f536c9943c
+    image: linuxkit/openntpd:v0.5
   - name: docker
     image: docker:17.07.0-ce-dind
     capabilities:

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
+  - linuxkit/init:v0.5
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,16 +2,16 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
 trust:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
   - samoht/fdd
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
 files:
   - path: etc/init.d/020-fdd-init
     mode: "0700"

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,12 +2,12 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcp-client
     image: miragesdk/dhcp-client:22aa9d527820534295a8cd59901c0c5197af6585
     net: host
@@ -28,9 +28,9 @@ onboot:
      - /lib:/lib     # for ifconfig
 services:
   - name: sshd
-    image: linuxkit/sshd:ae16b868747913bad83ad1b5823669eff1563013
+    image: linuxkit/sshd:v0.5
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
 files:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,18 +2,18 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
 services:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
 trust:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/src/cmd/linuxkit/main.go
+++ b/src/cmd/linuxkit/main.go
@@ -19,17 +19,17 @@ func init() {
 	// This allows us to overwrite the hashes locally without having
 	// to re-vendor the 'github.com/moby/tool' when we update 'mkimage-*'
 	imgs := map[string]string{
-		"iso-bios":    "linuxkit/mkimage-iso-bios:fea1990f9703f24fc3c71ecd33695b60ca11043c",
-		"iso-efi":     "linuxkit/mkimage-iso-efi:6948ef717ff8b0ca5831ff6b281404ae7f61d36c",
-		"raw-bios":    "linuxkit/mkimage-raw-bios:89577baee3bf6e4b7c6669e9e7d16181a0aefbbf",
-		"raw-efi":     "linuxkit/mkimage-raw-efi:276b61f502a7e4667e4a343df15e379f451e4cc3",
-		"squashfs":    "linuxkit/mkimage-squashfs:3c5db8c90dfa828f9cfcf90f050c1db5ef177420",
+		"iso-bios":    "linuxkit/mkimage-iso-bios:fd0092700bc19ea36cc8dccccc9799b7847b4909",
+		"iso-efi":     "linuxkit/mkimage-iso-efi:79148c60bbf2a9526d976d708840492d85b0c576",
+		"raw-bios":    "linuxkit/mkimage-raw-bios:0ff04de5d11a88b0712cdc85b2ee5f0b966ffccf",
+		"raw-efi":     "linuxkit/mkimage-raw-efi:084f159cb44dc6c22351a70f1c1a043857be4e12",
+		"squashfs":    "linuxkit/mkimage-squashfs:36f3fa106cfb7f8b818a828d7aebb27f946c9526",
 		"gcp":         "linuxkit/mkimage-gcp:e6cdcf859ab06134c0c37a64ed5f886ec8dae1a1",
-		"qcow2-efi":   "linuxkit/mkimage-qcow2-efi:fa3756a291319d0250a9eac1471296d8e4cae0f8",
+		"qcow2-efi":   "linuxkit/mkimage-qcow2-efi:0eb853459785fad0b518d8edad3b7434add6ad96",
 		"vhd":         "linuxkit/mkimage-vhd:3820219e5c350fe8ab2ec6a217272ae82f4b9242",
 		"dynamic-vhd": "linuxkit/mkimage-dynamic-vhd:743ac9959fe6d3912ebd78b4fd490b117c53f1a6",
 		"vmdk":        "linuxkit/mkimage-vmdk:cee81a3ed9c44ae446ef7ebff8c42c1e77b3e1b5",
-		"rpi3":        "linuxkit/mkimage-rpi3:c0645c61c71f7233a4a7cde2afecf41011668417",
+		"rpi3":        "linuxkit/mkimage-rpi3:be740259f3b49bfe46f5322e22709c3af2111b33",
 	}
 	if err := moby.UpdateOutputImages(imgs); err != nil {
 		log.Fatalf("Failed to register mkimage-*. %v", err)

--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -20,7 +20,7 @@ import (
 
 // QemuImg is the version of qemu container
 const (
-	QemuImg       = "linuxkit/qemu:4e47c416a9176029a45514d1fd911c0e995a0b84"
+	QemuImg       = "linuxkit/qemu:5d89b7a57b638eba986df318c97fa9d5905135a5"
 	defaultFWPath = "/usr/share/ovmf/bios.bin"
 )
 

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org:

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,12 +2,12 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
 services:
   - name: acpid
-    image: linuxkit/acpid:80b486a60dd0d55233e560db1ff096b1d5b35bbd
+    image: linuxkit/acpid:v0.5
 trust:
   org:
     - linuxkit

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.139
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:a780a39198cf98e2b93b773b36f9fc40a278edd0

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -6,9 +6,9 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:0c214d1854b7d98e29ec9ea618befd5529b627ae
+    image: linuxkit/test-kernel-config:a780a39198cf98e2b93b773b36f9fc40a278edd0
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.111
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:a780a39198cf98e2b93b773b36f9fc40a278edd0

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -6,9 +6,9 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:0c214d1854b7d98e29ec9ea618befd5529b627ae
+    image: linuxkit/test-kernel-config:a780a39198cf98e2b93b773b36f9fc40a278edd0
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -6,9 +6,9 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:0c214d1854b7d98e29ec9ea618befd5529b627ae
+    image: linuxkit/test-kernel-config:a780a39198cf98e2b93b773b36f9fc40a278edd0
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:a780a39198cf98e2b93b773b36f9fc40a278edd0

--- a/test/cases/020_kernel/009_config_4.17.x/test.yml
+++ b/test/cases/020_kernel/009_config_4.17.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.17.5
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:a780a39198cf98e2b93b773b36f9fc40a278edd0

--- a/test/cases/020_kernel/009_config_4.17.x/test.yml
+++ b/test/cases/020_kernel/009_config_4.17.x/test.yml
@@ -6,9 +6,9 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:0c214d1854b7d98e29ec9ea618befd5529b627ae
+    image: linuxkit/test-kernel-config:a780a39198cf98e2b93b773b36f9fc40a278edd0
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.4.139
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -13,7 +13,7 @@ onboot:
     capabilities:
      - all
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.111
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -13,7 +13,7 @@ onboot:
     capabilities:
      - all
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -13,7 +13,7 @@ onboot:
     capabilities:
      - all
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/019_kmod_4.17.x/test.yml
+++ b/test/cases/020_kernel/019_kmod_4.17.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.17.5
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/019_kmod_4.17.x/test.yml
+++ b/test/cases/020_kernel/019_kmod_4.17.x/test.yml
@@ -13,7 +13,7 @@ onboot:
     capabilities:
      - all
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/cases/020_kernel/110_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/010_echo-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/010_echo-short-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/011_echo-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/011_echo-short-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/012_echo-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/012_echo-short-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/015_echo-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/015_echo-long-1con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/016_echo-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/016_echo-long-10con-single/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/017_echo-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/017_echo-long-5con-multi/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/100_mix/010_veth-unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/010_veth-unix-domain-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "mix"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/100_mix/011_veth-unix-domain-echo-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/011_veth-unix-domain-echo-reverse/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-reverse"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/100_mix/012_veth-ipv4-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/012_veth-ipv4-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv4"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/100_mix/013_veth-ipv6-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/013_veth-ipv6-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv6"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/100_mix/014_veth-tcp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/014_veth-tcp-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-tcp"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/100_mix/015_veth-udp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/015_veth-udp-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-udp"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/100_mix/020_unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/020_unix-domain-echo/test.yml
@@ -1,10 +1,10 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:945ef91db90f7c953a64ca8804b33040ede743ab
+    image: linuxkit/test-ns:d11ee39370e09038da0e8ca0dcc2f277f3cc22ef
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-unix"]
     mounts: # for runc
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 trust:
   org:
     - linuxkit

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,25 +2,25 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: sysfs
-    image: linuxkit/sysfs:6d1b016e1a7834ccc72bd4570fadd22933665ec8
+    image: linuxkit/sysfs:v0.5
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd
-    image: linuxkit/rngd:68dbb9f121634e7fcf538ab1c54f3eb2e2430e85
+    image: linuxkit/rngd:v0.5
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
   - name: docker
     image: docker:17.07.0-ce-dind
     capabilities:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -34,7 +34,7 @@ services:
      - /run:/var/run
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: test-docker-bench
-    image: linuxkit/test-docker-bench:b534dfb6b498fa4e21a3d5b814661022591d4595
+    image: linuxkit/test-docker-bench:401fed45d409a8547cb27fd107994b933aedaba4
     ipc: host
     pid: host
     net: host

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: test
     image: alpine:3.8

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -12,7 +12,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: binfmt
-    image: linuxkit/binfmt:b0d833f5ecd26d6cb991622b1234afd9a0f6ee31
+    image: linuxkit/binfmt:v0.5
   - name: test
     image: alpine:3.8
     binds:

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -14,7 +14,7 @@ onboot:
       - /proc/sys/fs/binfmt_misc:/binfmt_misc
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -13,7 +13,7 @@ onboot:
       - /etc:/host-etc
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
     image: linuxkit/test-containerd:1d1c9e9cb43617debe693b42608f014b118515e5

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -20,7 +20,7 @@ onboot:
   - name: test
     image: linuxkit/test-containerd:1d1c9e9cb43617debe693b42608f014b118515e5
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -15,7 +15,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -16,7 +16,7 @@ onboot:
       - /var/lib/docker:/var/lib/docker
     command: ["touch", "/var/lib/docker/bar"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org: 

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: extend
-    image: linuxkit/extend:87bb27ba1cd275e98214d2c8edc600b2a836730f
+    image: linuxkit/extend:v0.5
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -17,7 +17,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -20,7 +20,7 @@ onboot:
       - /var/lib/docker:/var/lib/docker
     command: ["touch", "/var/lib/docker/bar"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org: 

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,17 +2,17 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: modprobe
-    image: linuxkit/modprobe:e1f78caa4c3a64a239ffb23c81622b4104cba5a0
+    image: linuxkit/modprobe:v0.5
     command: ["modprobe", "btrfs"]
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -21,7 +21,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,17 +2,17 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: modprobe
-    image: linuxkit/modprobe:e1f78caa4c3a64a239ffb23c81622b4104cba5a0
+    image: linuxkit/modprobe:v0.5
     command: ["modprobe", "btrfs"]
   - name: extend
-    image: linuxkit/extend:87bb27ba1cd275e98214d2c8edc600b2a836730f
+    image: linuxkit/extend:v0.5
     command: ["/usr/bin/extend", "-type", "btrfs"]
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -17,7 +17,7 @@ onboot:
       - /var/lib/docker:/var/lib/docker
     command: ["touch", "/var/lib/docker/bar"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 trust:
   org: 

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: extend
-    image: linuxkit/extend:87bb27ba1cd275e98214d2c8edc600b2a836730f
+    image: linuxkit/extend:v0.5
     command: ["/usr/bin/extend", "-type", "xfs"]
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format"]
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format", "-label", "docker"]
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format", "@DEVICE@"]
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "-device", "@DEVICE@1", "/var/lib/docker"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -21,7 +21,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,17 +2,17 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: modprobe
-    image: linuxkit/modprobe:e1f78caa4c3a64a239ffb23c81622b4104cba5a0
+    image: linuxkit/modprobe:v0.5
     command: ["modprobe", "btrfs"]
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -18,7 +18,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format", "-type", "xfs" ]
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -26,7 +26,7 @@ onboot:
       - CAP_SYS_ADMIN
       - CAP_MKNOD
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,23 +2,23 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format", "-verbose", "-type", "ext4", "/dev/sda"]
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format", "-verbose", "-type", "ext4", "/dev/sdb"]
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format", "-verbose", "-type", "xfs", "/dev/sda"]
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format", "-verbose", "-force", "-type", "xfs", "/dev/sdb"]
   - name: test
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     binds:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,20 +2,20 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format", "-label", "docker"]
   - name: format
-    image: linuxkit/format:c5e3200c3eeaed2652314869c08197098fd1f843
+    image: linuxkit/format:v0.5
     command: ["/usr/bin/format", "-label", "foo"]
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "-label", "docker", "/var/lib/docker"]
   - name: mount
-    image: linuxkit/mount:6b25743397b520924de11f96e3eeb613aa04a507
+    image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "-label", "foo", "/var/foo"]
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -25,7 +25,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,17 +2,17 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:3763a7fc3fddedc185bbd6f7f583f729e57fbeda
+    image: linuxkit/getty:v0.5
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -8,7 +8,7 @@ onboot:
   - name: mkimage
     image: linuxkit/mkimage:11ae974e84cf99de5c1bac927f67f235845a3df4
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: mkimage
-    image: linuxkit/mkimage:11ae974e84cf99de5c1bac927f67f235845a3df4
+    image: linuxkit/mkimage:v0.5
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
 trust:

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
 onboot:
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
 trust:
   org:
     - linuxkit

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -16,7 +16,7 @@ onboot:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "10"]
 files:
   - path: check.sh

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:6f96e509c7383b31dfdd2c3e9fa01c6ab3e4c586
+    image: linuxkit/sysctl:v0.5
   - name: test
     image: alpine:3.8
     net: host

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
-  - linuxkit/ca-certificates:ce2692e89d2be341b0d3caa0b0aa01b37d5d0694
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:dd18c95e8add1dde51864d221efc02290a8ee7d0
+    image: linuxkit/ip:v0.5
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -24,7 +24,7 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:dd18c95e8add1dde51864d221efc02290a8ee7d0
+    image: linuxkit/ip:v0.5
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -2,18 +2,18 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:6cc1442112980c889230b6449df09d5b48de6854
-  - linuxkit/runc:v0.4
-  - linuxkit/containerd:f2bc1bda1ab18146967fa1a149800aaf14bee81b
-  - linuxkit/ca-certificates:v0.4
-  - linuxkit/memlogd:883f0d46e7d3ae2d787e8acb496da115a4707cbc
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
+  - linuxkit/memlogd:v0.5
 services:
 # A service which generates logs of log messages
   - name: fill-the-logs
     image: alpine
     command: ["/bin/sh", "-c", "while /bin/true; do echo hello $(date); done" ]
   - name: write-and-rotate-logs
-    image: linuxkit/logwrite:7859c102a963828fd9c5aa3837db9600483220c7
+    image: linuxkit/logwrite:v0.5
     command: ["/usr/bin/logwrite", "-max-log-size", "1024"]
   - name: check-the-logs
     image: alpine:3.8

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:6cc1442112980c889230b6449df09d5b48de6854
-  - linuxkit/runc:v0.4
-  - linuxkit/containerd:f2bc1bda1ab18146967fa1a149800aaf14bee81b
-  - linuxkit/ca-certificates:v0.4
-  - linuxkit/memlogd:883f0d46e7d3ae2d787e8acb496da115a4707cbc
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
+  - linuxkit/ca-certificates:v0.5
+  - linuxkit/memlogd:v0.5
 services:
   - name: kmsg
-    image: linuxkit/kmsg:3dfa0d5b4027ecc16089f27fbcffa15d6aa5438e
+    image: linuxkit/kmsg:v0.5
   - name: write-and-rotate-logs
-    image: linuxkit/logwrite:7859c102a963828fd9c5aa3837db9600483220c7
+    image: linuxkit/logwrite:v0.5
   - name: check-the-logs
     image: alpine:3.8
     binds:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -11,7 +11,7 @@ onboot:
     binds:
      - /etc/ltp/baseline:/etc/ltp/baseline
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
 files:
   - path: /etc/ltp/baseline
     contents: "100"

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -12,9 +12,9 @@ onboot:
     image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
-    image: linuxkit/test-kernel-config:0c214d1854b7d98e29ec9ea618befd5529b627ae
+    image: linuxkit/test-kernel-config:a780a39198cf98e2b93b773b36f9fc40a278edd0
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,12 +4,12 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
-  - linuxkit/containerd:9924cc405996bc43a61e050e70284372d2cb09b8
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/containerd:v0.5
 onboot:
   - name: dhcpcd
-    image: linuxkit/dhcpcd:0aa201ad1a4c134f0ed6ab2cec23602d5ee73d7f
+    image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:a780a39198cf98e2b93b773b36f9fc40a278edd0

--- a/test/pkg/docker-bench/Dockerfile
+++ b/test/pkg/docker-bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \

--- a/test/pkg/kernel-config/Dockerfile
+++ b/test/pkg/kernel-config/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl bash

--- a/test/pkg/ns/Dockerfile
+++ b/test/pkg/ns/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
@@ -8,7 +8,7 @@ RUN apk add --no-cache --initdb -p /out \
     musl
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 RUN apk add --no-cache \
     build-base \
     git \

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -14,7 +14,7 @@ onboot:
     - type: cgroup
       options: ["rw"]
   - name: poweroff
-    image: linuxkit/poweroff:37021954220a932951eca5de5a856865e48cfc00
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
     command: ["/bin/sh", "/poweroff.sh", "3"]
 trust:
   org:

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:317b039710f39b0263981cff25cf873043baf561
-  - linuxkit/runc:01b4f0706d999f9065ef44492689e43d0bcd83c5
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>

--- a/test/pkg/poweroff/Dockerfile
+++ b/test/pkg/poweroff/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache

--- a/test/pkg/virtsock/Dockerfile
+++ b/test/pkg/virtsock/Dockerfile
@@ -1,10 +1,10 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     tini
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 
 RUN apk add --no-cache go musl-dev git make
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/tools/go-compile/Dockerfile
+++ b/tools/go-compile/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/tools/mkimage-iso-bios/Dockerfile
+++ b/tools/mkimage-iso-bios/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-iso-efi/Dockerfile
+++ b/tools/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS grub-build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS grub-build
 
 RUN apk add \
   automake \
@@ -39,7 +39,7 @@ RUN mkdir /grub-lib && \
     ;; \
   esac
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS make-img
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS make-img
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-qcow2-efi/Dockerfile
+++ b/tools/mkimage-qcow2-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS grub-build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS grub-build
 
 RUN apk add \
   automake \
@@ -40,7 +40,7 @@ RUN mkdir /grub-lib && \
     ;; \
   esac
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS make-img
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS make-img
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-raw-bios/Dockerfile
+++ b/tools/mkimage-raw-bios/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-raw-efi/Dockerfile
+++ b/tools/mkimage-raw-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS grub-build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS grub-build
 
 RUN apk add \
   automake \
@@ -40,7 +40,7 @@ RUN mkdir /grub-lib && \
     ;; \
   esac
 
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS make-img
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS make-img
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/mkimage-rpi3/Dockerfile
+++ b/tools/mkimage-rpi3/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 as build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc as build
 RUN apk add \
     bc \
     dtc \

--- a/tools/mkimage-squashfs/Dockerfile
+++ b/tools/mkimage-squashfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc
 
 RUN \
   apk update && apk upgrade && \

--- a/tools/qemu/Dockerfile
+++ b/tools/qemu/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:6264e5b39af8eb1da7ffa4c05a7ccc597da01197 AS mirror
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \


### PR DESCRIPTION
This updates everything to the latest alpine base and all the packages were build and pushed with the v0.5 release tag.

Updated `cadvisor`, `node_exporter` and `firmware`/`firmware-all` to the latest version and added a note to `releasing.md` to do so as part of the next releases (resolves #3099).

The `pkg/tss` build was getting really annoying with sf.net timing out, so mirrored the `tpm-tools` and `trousers` repository to `linuxkit/mirror-tpkm-tools` and `linuxkit/mirror-trousers` for more reliable builds (resolves #3097).

Once this is merged the repository is locked till the version in `./Makefile` is bumped to `v0.5+`

![snake](https://user-images.githubusercontent.com/3338098/42537471-d9f7275c-848c-11e8-991a-de4528f0ed92.jpg)
