### PR TITLE
Add '.log' as file extension to 'pkg/logwrite' files

### DIFF
--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -22,7 +22,7 @@ services:
      - INSECURE=true
 # A service which generates log messages for testing
   - name: write-to-the-logs
-    image: alpine
+    image: alpine:3.8
     command: ["/bin/sh", "-c", "while /bin/true; do echo hello $(date); sleep 1; done" ]
   - name: write-and-rotate-logs
     image: linuxkit/logwrite:v0.5

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -25,7 +25,7 @@ services:
     image: alpine:3.8
     command: ["/bin/sh", "-c", "while /bin/true; do echo hello $(date); sleep 1; done" ]
   - name: write-and-rotate-logs
-    image: linuxkit/logwrite:v0.5
+    image: linuxkit/logwrite:d9778c0d538094d398cf0cbfc89277aeca67f1be
   - name: kmsg
     image: linuxkit/kmsg:v0.5
 trust:

--- a/test/cases/040_packages/030_logwrite/check.sh
+++ b/test/cases/040_packages/030_logwrite/check.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 for i in $(seq 1 20); do
-	if [ -e /var/log/fill-the-logs.out.0 ]; then
+	if [ -e /var/log/fill-the-logs.out.log.0 ]; then
 		printf "logwrite test suite PASSED\n" > /dev/console
 		/sbin/poweroff -f
 	fi

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -13,7 +13,7 @@ services:
     image: alpine
     command: ["/bin/sh", "-c", "while /bin/true; do echo hello $(date); done" ]
   - name: write-and-rotate-logs
-    image: linuxkit/logwrite:v0.5
+    image: linuxkit/logwrite:d9778c0d538094d398cf0cbfc89277aeca67f1be
     command: ["/usr/bin/logwrite", "-max-log-size", "1024"]
   - name: check-the-logs
     image: alpine:3.8

--- a/test/cases/040_packages/031_kmsg/check.sh
+++ b/test/cases/040_packages/031_kmsg/check.sh
@@ -2,7 +2,7 @@
 
 for i in $(seq 1 20); do
 	# Look for a common kernel log message
-	if grep "SCSI subsystem initialized" /var/log/kmsg.out 2>/dev/null; then
+	if grep "SCSI subsystem initialized" /var/log/kmsg.out.log 2>/dev/null; then
 		printf "kmsg test suite PASSED\n" > /dev/console
 		/sbin/poweroff -f
 	fi
@@ -10,6 +10,6 @@ for i in $(seq 1 20); do
 done
 
 printf "kmsg test suite FAILED\n" > /dev/console
-echo "contents of /var/log/kmsg.out:" > /dev/console
-cat /var/log/kmsg.out > /dev/console
+echo "contents of /var/log/kmsg.out.log:" > /dev/console
+cat /var/log/kmsg.out.log > /dev/console
 /sbin/poweroff -f

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -11,7 +11,7 @@ services:
   - name: kmsg
     image: linuxkit/kmsg:v0.5
   - name: write-and-rotate-logs
-    image: linuxkit/logwrite:v0.5
+    image: linuxkit/logwrite:d9778c0d538094d398cf0cbfc89277aeca67f1be
   - name: check-the-logs
     image: alpine:3.8
     binds:


### PR DESCRIPTION
Without this change, logfiles just use the log name provided by init, typically `<name>.err` and `name.out`. This PR adds `.log` as generic extension to all log files.

While at it, I also simplified the logwrite code a tiny bit and fixed up the test and example.

/cc @djs55 

![olinguito](https://user-images.githubusercontent.com/3338098/42586213-8543f610-852f-11e8-871f-8a097278dba8.jpg)
