### PR TITLE
Add packages needed for iovisor/bcc

### DIFF
--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -22,6 +22,9 @@ busybox-initscripts
 ca-certificates
 cdrkit
 cifs-utils
+clang
+clang-dev
+clang-static
 cmake
 coreutils
 cryptsetup
@@ -38,6 +41,8 @@ ethtool
 expect
 findutils
 flex
+flex-dev
+fts-dev
 gcc
 gettext
 gettext-dev
@@ -60,12 +65,16 @@ libc-dev
 libc-utils
 libc6-compat
 libcap-ng-dev
+libedit-dev
 libelf-dev
 libressl-dev
 libseccomp-dev
 libtirpc-dev
 libtool
 linux-headers
+llvm
+llvm-dev
+llvm-static
 lsscsi
 make
 mpc1-dev
@@ -83,6 +92,7 @@ openssl
 openssl-dev
 patch
 pigz
+python
 python3
 qemu-aarch64
 qemu-arm

--- a/tools/alpine/packages.aarch64
+++ b/tools/alpine/packages.aarch64
@@ -1,2 +1,3 @@
 libunwind-dev
+luajit-dev
 qemu-system-aarch64

--- a/tools/alpine/packages.x86_64
+++ b/tools/alpine/packages.x86_64
@@ -1,5 +1,6 @@
 gummiboot
 libunwind-dev
+luajit-dev
 open-vm-tools
 ovmf
 syslinux

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:16423407969d02cf36c3ae6b76d4280701bbbfa6-arm64
+# linuxkit/alpine:d94c0b0b11d1d669e72745739a078676b48a2fc6-arm64
 # automatically generated list of installed packages
 abuild-3.2.0-r0
 alpine-baselayout-3.1.0-r0
@@ -31,6 +31,10 @@ ca-certificates-20171114-r3
 cdrkit-1.1.11-r2
 celt051-0.5.1.3-r0
 cifs-utils-6.8-r0
+clang-5.0.1-r1
+clang-dev-5.0.1-r1
+clang-libs-5.0.1-r1
+clang-static-5.0.1-r1
 cmake-3.11.1-r2
 cmake-bash-completion-3.11.1-r2
 coreutils-8.29-r2
@@ -62,7 +66,11 @@ file-5.32-r0
 findmnt-2.32-r0
 findutils-4.6.0-r1
 flex-2.6.4-r1
+flex-dev-2.6.4-r1
+flex-libs-2.6.4-r1
 fortify-headers-0.9-r0
+fts-1.2.7-r1
+fts-dev-1.2.7-r1
 g++-6.4.0-r8
 gc-7.6.4-r2
 gcc-6.4.0-r8
@@ -123,6 +131,7 @@ libcrypto1.0-1.0.2o-r1
 libcurl-7.60.0-r1
 libdrm-2.4.92-r0
 libedit-20170329.3.1-r3
+libedit-dev-20170329.3.1-r3
 libelf-0.8.13-r3
 libelf-dev-0.8.13-r3
 libepoxy-1.4.3-r1
@@ -182,8 +191,14 @@ libxdmcp-1.1.2-r4
 libxkbcommon-0.7.1-r1
 libxml2-2.9.8-r0
 linux-headers-4.4.6-r2
+llvm5-5.0.1-r4
+llvm5-dev-5.0.1-r4
+llvm5-libs-5.0.1-r4
+llvm5-static-5.0.1-r4
 lsscsi-0.28-r0
 lua5.3-libs-5.3.4-r5
+luajit-2.1.0_beta3-r4
+luajit-dev-2.1.0_beta3-r4
 lz4-libs-1.8.2-r0
 lzip-1.20-r0
 lzo-2.10-r2
@@ -231,6 +246,7 @@ pinentry-1.1.0-r0
 pixman-0.34.0-r5
 pkgconf-1.5.1-r0
 popt-1.16-r7
+python2-2.7.15-r0
 python3-3.6.4-r1
 qemu-2.12.0-r3
 qemu-aarch64-2.12.0-r3
@@ -278,7 +294,7 @@ util-linux-dev-2.32-r0
 vde2-libs-2.3.2-r9
 vim-8.1.0115-r0
 wayland-libs-server-1.15.0-r0
-wireguard-tools-0.0.20180625-r0
+wireguard-tools-0.0.20180708-r0
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r13
 wpa_supplicant-openrc-2.6-r13

--- a/tools/alpine/versions.s390x
+++ b/tools/alpine/versions.s390x
@@ -1,4 +1,4 @@
-# linuxkit/alpine:91e3f51daf5fe62369fd517e6490c4b34f28c447-s390x
+# linuxkit/alpine:1be091fe902a92cea4573b2d64c2757e1fb8b282-s390x
 # automatically generated list of installed packages
 abuild-3.2.0-r0
 alpine-baselayout-3.1.0-r0
@@ -31,6 +31,10 @@ ca-certificates-20171114-r3
 cdrkit-1.1.11-r2
 celt051-0.5.1.3-r0
 cifs-utils-6.8-r0
+clang-5.0.1-r1
+clang-dev-5.0.1-r1
+clang-libs-5.0.1-r1
+clang-static-5.0.1-r1
 cmake-3.11.1-r2
 cmake-bash-completion-3.11.1-r2
 coreutils-8.29-r2
@@ -62,7 +66,11 @@ file-5.32-r0
 findmnt-2.32-r0
 findutils-4.6.0-r1
 flex-2.6.4-r1
+flex-dev-2.6.4-r1
+flex-libs-2.6.4-r1
 fortify-headers-0.9-r0
+fts-1.2.7-r1
+fts-dev-1.2.7-r1
 g++-6.4.0-r8
 gc-7.6.4-r2
 gcc-6.4.0-r8
@@ -122,6 +130,7 @@ libcrypto1.0-1.0.2o-r1
 libcurl-7.60.0-r1
 libdrm-2.4.92-r0
 libedit-20170329.3.1-r3
+libedit-dev-20170329.3.1-r3
 libelf-0.8.13-r3
 libelf-dev-0.8.13-r3
 libepoxy-1.4.3-r1
@@ -177,6 +186,10 @@ libxdmcp-1.1.2-r4
 libxkbcommon-0.7.1-r1
 libxml2-2.9.8-r0
 linux-headers-4.4.6-r2
+llvm5-5.0.1-r4
+llvm5-dev-5.0.1-r4
+llvm5-libs-5.0.1-r4
+llvm5-static-5.0.1-r4
 lsscsi-0.28-r0
 lua5.3-libs-5.3.4-r5
 lz4-libs-1.8.2-r0
@@ -226,6 +239,7 @@ pinentry-1.1.0-r0
 pixman-0.34.0-r5
 pkgconf-1.5.1-r0
 popt-1.16-r7
+python2-2.7.15-r0
 python3-3.6.4-r1
 qemu-2.12.0-r3
 qemu-aarch64-2.12.0-r3
@@ -273,7 +287,7 @@ util-linux-dev-2.32-r0
 vde2-libs-2.3.2-r9
 vim-8.1.0115-r0
 wayland-libs-server-1.15.0-r0
-wireguard-tools-0.0.20180625-r0
+wireguard-tools-0.0.20180708-r0
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r13
 wpa_supplicant-openrc-2.6-r13

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc-amd64
+# linuxkit/alpine:cbf183a92cb4800c4129c2b9bb6e4d3eb3226330-amd64
 # automatically generated list of installed packages
 abuild-3.2.0-r0
 alpine-baselayout-3.1.0-r0
@@ -31,6 +31,10 @@ ca-certificates-20171114-r3
 cdrkit-1.1.11-r2
 celt051-0.5.1.3-r0
 cifs-utils-6.8-r0
+clang-5.0.1-r1
+clang-dev-5.0.1-r1
+clang-libs-5.0.1-r1
+clang-static-5.0.1-r1
 cmake-3.11.1-r2
 cmake-bash-completion-3.11.1-r2
 coreutils-8.29-r2
@@ -62,7 +66,11 @@ file-5.32-r0
 findmnt-2.32-r0
 findutils-4.6.0-r1
 flex-2.6.4-r1
+flex-dev-2.6.4-r1
+flex-libs-2.6.4-r1
 fortify-headers-0.9-r0
+fts-1.2.7-r1
+fts-dev-1.2.7-r1
 fuse-2.9.7-r1
 g++-6.4.0-r8
 gc-7.6.4-r2
@@ -127,6 +135,7 @@ libcrypto1.0-1.0.2o-r1
 libcurl-7.60.0-r1
 libdrm-2.4.92-r0
 libedit-20170329.3.1-r3
+libedit-dev-20170329.3.1-r3
 libelf-0.8.13-r3
 libelf-dev-0.8.13-r3
 libepoxy-1.4.3-r1
@@ -188,8 +197,14 @@ libxdmcp-1.1.2-r4
 libxkbcommon-0.7.1-r1
 libxml2-2.9.8-r0
 linux-headers-4.4.6-r2
+llvm5-5.0.1-r4
+llvm5-dev-5.0.1-r4
+llvm5-libs-5.0.1-r4
+llvm5-static-5.0.1-r4
 lsscsi-0.28-r0
 lua5.3-libs-5.3.4-r5
+luajit-2.1.0_beta3-r4
+luajit-dev-2.1.0_beta3-r4
 lz4-libs-1.8.2-r0
 lzip-1.20-r0
 lzo-2.10-r2
@@ -240,6 +255,7 @@ pinentry-1.1.0-r0
 pixman-0.34.0-r5
 pkgconf-1.5.1-r0
 popt-1.16-r7
+python2-2.7.15-r0
 python3-3.6.4-r1
 qemu-2.12.0-r3
 qemu-aarch64-2.12.0-r3
@@ -287,7 +303,7 @@ util-linux-dev-2.32-r0
 vde2-libs-2.3.2-r9
 vim-8.1.0115-r0
 wayland-libs-server-1.15.0-r0
-wireguard-tools-0.0.20180625-r0
+wireguard-tools-0.0.20180708-r0
 wireless-tools-30_pre9-r0
 wpa_supplicant-2.6-r13
 wpa_supplicant-openrc-2.6-r13


### PR DESCRIPTION
This adds most of the packages needed to add the iovisor/bcc tools to LinuxKit as per #3106.

`python` and `iperf` were omitted as I don't think they are essential. Also `luajit-dev` is not avail on s390x so the build of bcc might need to take that into account (/cc @
kmjohansen).

The new package is: `linuxkit/alpine:cbf183a92cb4800c4129c2b9bb6e4d3eb3226330` and the size increased by about 140MB to about 600MB on x86.

![image](https://user-images.githubusercontent.com/3338098/42605440-de464b2e-856f-11e8-8007-fee70a5e9f64.png)
