### PR TITLE
Update linuxkit/alpine for test cases

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -113,7 +113,7 @@ cd $LK_ROOT/tools
 ../scripts/update-component-sha.sh --image linuxkit/alpine:$LK_ALPINE
 git checkout alpine/versions.aarch64 alpine/versions.s390x
 
-git commit -a -s -m "tools: Update to latest alpine base"
+git commit -a -s -m "tools: Update to the latest linuxkit/alpine"
 git push $LK_REMOTE rel_$LK_RELEASE
 
 make forcepush
@@ -151,7 +151,7 @@ Next, we update the test packages to the updated alpine base on the `x86_64` sys
 cd $LK_ROOT/test/pkg
 ../../scripts/update-component-sha.sh --image linuxkit/alpine:$LK_ALPINE
 
-git commit -a -s -m "tests: Update packages to latest alpine base"
+git commit -a -s -m "tests: Update packages to the latest linuxkit/alpine"
 git push $LK_REMOTE rel_$LK_RELEASE
 
 make push
@@ -176,6 +176,15 @@ done
 git commit -a -s -m "Update use of test packages to latest"
 ```
 
+Some tests also use `linuxkit/alpine`. Update them as well:
+
+```sh
+cd $LK_ROOT/test/cases
+../../scripts/update-component-sha.sh --image linuxkit/alpine:$LK_ALPINE
+
+git commit -a -s -m "tests: Update tests cases to the latest linuxkit/alpine"
+```
+
 ### Update packages
 
 Next, we update the LinuxKit packages. This is really the core of the
@@ -187,7 +196,7 @@ across packages.
 cd $LK_ROOT/pkg
 ../scripts/update-component-sha.sh --image linuxkit/alpine:$LK_ALPINE
 
-git commit -a -s -m "pkgs: Update packages to latest alpine base"
+git commit -a -s -m "pkgs: Update packages to the latest linuxkit/alpine"
 git push $LK_REMOTE rel_$LK_RELEASE
 ```
 

--- a/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
@@ -6,7 +6,7 @@
 FROM linuxkit/kernel:4.4.139 AS ksrc
 
 # Extract headers and compile module
-FROM linuxkit/alpine:f3cd219615428b2bd943411723eb28875275fae7 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 RUN apk add build-base libelf-dev
 
 COPY --from=ksrc /kernel-dev.tar /

--- a/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
@@ -6,7 +6,7 @@
 FROM linuxkit/kernel:4.9.111 AS ksrc
 
 # Extract headers and compile module
-FROM linuxkit/alpine:f3cd219615428b2bd943411723eb28875275fae7 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 RUN apk add build-base libelf-dev
 
 COPY --from=ksrc /kernel-dev.tar /

--- a/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
+++ b/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
@@ -6,7 +6,7 @@
 FROM linuxkit/kernel:4.14.54 AS ksrc
 
 # Extract headers and compile module
-FROM linuxkit/alpine:f3cd219615428b2bd943411723eb28875275fae7 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 RUN apk add build-base libelf-dev
 
 COPY --from=ksrc /kernel-dev.tar /

--- a/test/cases/020_kernel/019_kmod_4.17.x/Dockerfile
+++ b/test/cases/020_kernel/019_kmod_4.17.x/Dockerfile
@@ -6,7 +6,7 @@
 FROM linuxkit/kernel:4.17.5 AS ksrc
 
 # Extract headers and compile module
-FROM linuxkit/alpine:f3cd219615428b2bd943411723eb28875275fae7 AS build
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
 RUN apk add build-base libelf-dev
 
 COPY --from=ksrc /kernel-dev.tar /


### PR DESCRIPTION
For the past releases I've missed that we also use `linuxkit/alpine` in some of the test cases. Update to the alpine base for test cases and also add the instructions to the release doc. While at it also improve some of the commit messages.

![image](https://user-images.githubusercontent.com/3338098/42625645-3331280c-85c0-11e8-872d-97e3bc48c2bf.png)

