### PR TITLE
Write stderr to /var/log/<name>.log

### DIFF
--- a/contrib/crosvm/README.md
+++ b/contrib/crosvm/README.md
@@ -33,7 +33,7 @@ kernel:
   image: linuxkit/kernel:4.9.91
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
 services:

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.5 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -27,7 +27,7 @@ services:
   - name: write-and-rotate-logs
     image: linuxkit/logwrite:d9778c0d538094d398cf0cbfc89277aeca67f1be
   - name: kmsg
-    image: linuxkit/kmsg:v0.5
+    image: linuxkit/kmsg:cf3dc833591838596427aac032c829ea592599d0
 trust:
   org:
     - linuxkit

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
 services:

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
 onboot:

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
 onboot:

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
 onboot:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/pkg/init/cmd/service/cmd.go
+++ b/pkg/init/cmd/service/cmd.go
@@ -202,7 +202,7 @@ func start(ctx context.Context, service, sock, basePath, dumpSpec string) (strin
 
 	io := func(id string) (cio.IO, error) {
 		stdoutFile := logger.Path(service + ".out")
-		stderrFile := logger.Path(service + ".err")
+		stderrFile := logger.Path(service)
 		return &logio{
 			cio.Config{
 				Stdin:    "/dev/null",

--- a/pkg/init/cmd/service/runc.go
+++ b/pkg/init/cmd/service/runc.go
@@ -160,11 +160,7 @@ func runcInit(rootPath, serviceType string) int {
 	_ = os.RemoveAll(tmpdir)
 
 	// make sure the link exists from /var/log/onboot -> /run/log/onboot
-	if err := os.MkdirAll(varLogDir, 0755); err != nil {
-		log.Printf("Error creating secondary log directory %s: %v", varLogDir, err)
-	} else if err := os.Symlink(logDir, varLogLink); err != nil && !os.IsExist(err) {
-		log.Printf("Error creating symlink from %s to %s: %v", varLogLink, logDir, err)
-	}
+	logger.Symlink(varLogLink)
 
 	return status
 }

--- a/pkg/init/cmd/service/runc.go
+++ b/pkg/init/cmd/service/runc.go
@@ -87,7 +87,7 @@ func runcInit(rootPath, serviceType string) int {
 		}
 		defer stdout.Close()
 
-		stderrLog := serviceType + "." + name + ".err"
+		stderrLog := serviceType + "." + name
 		stderr, err := logger.Open(stderrLog)
 		if err != nil {
 			log.Printf("Error opening stderr log connection: %v", err)

--- a/pkg/kmsg/main.go
+++ b/pkg/kmsg/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/euank/go-kmsg-parser/kmsgparser"
@@ -20,6 +21,6 @@ func main() {
 	kmsg := parser.Parse()
 
 	for msg := range kmsg {
-		fmt.Printf("(%d) - %s: %s", msg.SequenceNumber, msg.Timestamp.Format(time.RFC3339Nano), msg.Message)
+		fmt.Fprintf(os.Stderr, "(%d) - %s: %s", msg.SequenceNumber, msg.Timestamp.Format(time.RFC3339Nano), msg.Message)
 	}
 }

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
 onboot:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
 services:

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.139
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.111
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/009_config_4.17.x/test.yml
+++ b/test/cases/020_kernel/009_config_4.17.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.17.5
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.139
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: check

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.111
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: check

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: check

--- a/test/cases/020_kernel/019_kmod_4.17.x/test.yml
+++ b/test/cases/020_kernel/019_kmod_4.17.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.17.5
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/ca-certificates:v0.5
 onboot:

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.x
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/test/cases/040_packages/031_kmsg/check.sh
+++ b/test/cases/040_packages/031_kmsg/check.sh
@@ -2,7 +2,7 @@
 
 for i in $(seq 1 20); do
 	# Look for a common kernel log message
-	if grep "SCSI subsystem initialized" /var/log/kmsg.out.log 2>/dev/null; then
+	if grep "SCSI subsystem initialized" /var/log/kmsg.log 2>/dev/null; then
 		printf "kmsg test suite PASSED\n" > /dev/console
 		/sbin/poweroff -f
 	fi
@@ -10,6 +10,6 @@ for i in $(seq 1 20); do
 done
 
 printf "kmsg test suite FAILED\n" > /dev/console
-echo "contents of /var/log/kmsg.out.log:" > /dev/console
-cat /var/log/kmsg.out.log > /dev/console
+echo "contents of /var/log/kmsg.log:" > /dev/console
+cat /var/log/kmsg.log > /dev/console
 /sbin/poweroff -f

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
   - linuxkit/ca-certificates:v0.5

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -9,7 +9,7 @@ init:
   - linuxkit/memlogd:v0.5
 services:
   - name: kmsg
-    image: linuxkit/kmsg:v0.5
+    image: linuxkit/kmsg:cf3dc833591838596427aac032c829ea592599d0
   - name: write-and-rotate-logs
     image: linuxkit/logwrite:d9778c0d538094d398cf0cbfc89277aeca67f1be
   - name: check-the-logs

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.14.54
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
   - linuxkit/containerd:v0.5
 onboot:

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:v0.5
+  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
   - linuxkit/runc:v0.5
 onboot:
   - name: test-ns


### PR DESCRIPTION
**- What I did**

- Ensured that `stderr` logs are written to `/var/log/<name>.log` (instead of `/var/log/<name>.err.log`). 
- Ensured that `pkg/kmsg` logs to `stderr`

See #3111

**- How I did it**

I renamed the `stderr` output to `<name>` (instead of `<name>.err`). The log file is therefore `<name>.log`.

**- How to verify it**

```
cd examples
linuxkit build -disable-content-trust logging.yml
linuxkit run logging
...
(ns: getty) linuxkit-025000000005:~# ls /var/log
getty.out.log              onboot.001-dhcpcd.log
kmsg.log                   write-to-the-logs.out.log
memlogd.log
```

With `memlogd` disabled (i.e. commented out)
```
(ns: getty) linuxkit-025000000005:~# ls /var/log
getty.log                      write-and-rotate-logs.log
getty.out.log                  write-and-rotate-logs.out.log
kmsg.log                       write-to-the-logs.log
kmsg.out.log                   write-to-the-logs.out.log
onboot
(ns: getty) linuxkit-025000000005:~# ls /var/log/onboot
onboot.000-sysctl.log      onboot.001-dhcpcd.log
onboot.000-sysctl.out.log  onboot.001-dhcpcd.out.log
```

**- Description for the changelog**

Write `stderr` logs to `/var/log/<name>.log` instead of `/var/log/<name>.err.log`

**- A picture of a cute animal (not mandatory but encouraged)**

![Cute picture](https://pbs.twimg.com/media/Dg28-zSUwAEhQg_.jpg)