### PR TITLE
Change GCP metadata SSH keys URL

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.5
+    image: linuxkit/metadata:721562e6f3ba9b6c003f9e746ff7ee94796f5251
 services:
   - name: rngd
     image: linuxkit/rngd:v0.5

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -11,7 +11,7 @@ init:
 onboot:
   # support metadata for optional config in /run/config
   - name: metadata
-    image: linuxkit/metadata:v0.5
+    image: linuxkit/metadata:721562e6f3ba9b6c003f9e746ff7ee94796f5251
   - name: sysctl
     image: linuxkit/sysctl:v0.5
   - name: sysfs

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.5
+    image: linuxkit/metadata:721562e6f3ba9b6c003f9e746ff7ee94796f5251
 services:
   - name: getty
     image: linuxkit/getty:v0.5

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.5
+    image: linuxkit/metadata:721562e6f3ba9b6c003f9e746ff7ee94796f5251
     command: ["/usr/bin/metadata", "openstack"]
 services:
   - name: rngd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.5
+    image: linuxkit/metadata:721562e6f3ba9b6c003f9e746ff7ee94796f5251
     command: ["/usr/bin/metadata", "packet"]
 services:
   - name: rngd

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.5
+    image: linuxkit/metadata:721562e6f3ba9b6c003f9e746ff7ee94796f5251
 services:
   - name: getty
     image: linuxkit/getty:v0.5

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.5
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.5
+    image: linuxkit/metadata:721562e6f3ba9b6c003f9e746ff7ee94796f5251
 services:
   - name: getty
     image: linuxkit/getty:v0.5

--- a/pkg/metadata/provider_gcp.go
+++ b/pkg/metadata/provider_gcp.go
@@ -97,7 +97,7 @@ func gcpGet(url string) ([]byte, error) {
 // TODO split them into individual user files and make the ssh
 //      container construct those users
 func (p *ProviderGCP) handleSSH() error {
-	sshKeys, err := gcpGet(project + "attributes/sshKeys")
+	sshKeys, err := gcpGet(project + "attributes/ssh-keys")
 	if err != nil {
 		return fmt.Errorf("Failed to get sshKeys: %s", err)
 	}


### PR DESCRIPTION
**- What I did**

Tried to SSH on a linuxkit VM on GCP.
Got the following message on the serial console:
```
2018/07/14 23:19:48 GCP: Probe succeeded
2018/07/14 23:19:48 GCP: Failed to get ssh data: Failed to get sshKeys: GCP: Status not ok: 404
2018/07/14 23:19:48 GCP: Failed to get user-data: GCP: Status not ok: 404
```

**- How I did it**

```
$ gcloud compute ssh myinstance
```

**- Description for the changelog**

According to the [GCP doc](https://cloud.google.com/compute/docs/storing-retrieving-metadata) the URL is not `sshKeys` but `ssh-keys` now.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/137467/42729146-13d7351c-87cf-11e8-981e-b5c67d84791e.png)
