### PR TITLE
Containerd v1.1.2

### DIFF
--- a/contrib/crosvm/README.md
+++ b/contrib/crosvm/README.md
@@ -33,9 +33,9 @@ kernel:
   image: linuxkit/kernel:4.9.112
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
 services:
   - name: getty
     image: linuxkit/getty:v0.5

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.5 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   # support metadata for optional config in /run/config

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: dhcpcd

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
   - linuxkit/memlogd:v0.5
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.5

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
 services:
   - name: getty
     image: linuxkit/getty:v0.5

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
   - linuxkit/firmware:v0.5
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.5

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.5

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.5

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc as alpine
+FROM linuxkit/alpine:8a89682421abf0d886d777235a05f4a04a736df2 as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build
+FROM linuxkit/alpine:8a89682421abf0d886d777235a05f4a04a736df2 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -16,7 +16,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
+FROM linuxkit/alpine:8a89682421abf0d886d777235a05f4a04a736df2 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.5

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.5

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
 services:
   - name: acpid
     image: linuxkit/acpid:v0.5

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.140
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.112
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/009_config_4.17.x/test.yml
+++ b/test/cases/020_kernel/009_config_4.17.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.17.6
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.4.140
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: check

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.112
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: check

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: check

--- a/test/cases/020_kernel/019_kmod_4.17.x/test.yml
+++ b/test/cases/020_kernel/019_kmod_4.17.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.17.6
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
   - linuxkit/ca-certificates:v0.5
 onboot:

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:v0.5
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:1d1c9e9cb43617debe693b42608f014b118515e5
+    image: linuxkit/test-containerd:b3d96cddad849558e9c24ae54869e297aa5e33e3
   - name: poweroff
     image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
   - linuxkit/memlogd:v0.5
 services:

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
   - linuxkit/memlogd:v0.5
 services:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
-  - linuxkit/containerd:v0.5
+  - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.5

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
+FROM linuxkit/alpine:8a89682421abf0d886d777235a05f4a04a736df2 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.14.55
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:3f1e5c32d6ca9e83a7ea7ad9854da2032971a83f
+  - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9
   - linuxkit/runc:v0.5
 onboot:
   - name: test-ns

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -53,7 +53,7 @@ RUN go get -u github.com/LK4D4/vndr
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.1.1
+ENV CONTAINERD_COMMIT=v1.1.2
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:d94c0b0b11d1d669e72745739a078676b48a2fc6-arm64
+# linuxkit/alpine:7ce5554cf0ec50a19f9c13c7c4472b3f8a0777bc-arm64
 # automatically generated list of installed packages
 abuild-3.2.0-r0
 alpine-baselayout-3.1.0-r0
@@ -40,7 +40,7 @@ cmake-bash-completion-3.11.1-r2
 coreutils-8.29-r2
 cryptsetup-2.0.2-r3
 cryptsetup-libs-2.0.2-r3
-curl-7.60.0-r1
+curl-7.61.0-r0
 db-5.3.28-r0
 dbus-libs-1.10.24-r1
 device-mapper-libs-2.02.178-r0
@@ -128,7 +128,7 @@ libcap-ng-0.7.9-r0
 libcap-ng-dev-0.7.9-r0
 libcom_err-1.44.2-r0
 libcrypto1.0-1.0.2o-r1
-libcurl-7.60.0-r1
+libcurl-7.61.0-r0
 libdrm-2.4.92-r0
 libedit-20170329.3.1-r3
 libedit-dev-20170329.3.1-r3

--- a/tools/alpine/versions.s390x
+++ b/tools/alpine/versions.s390x
@@ -1,4 +1,4 @@
-# linuxkit/alpine:1be091fe902a92cea4573b2d64c2757e1fb8b282-s390x
+# linuxkit/alpine:24278490c0ae074fc401c1207de9e5e7b4294c67-s390x
 # automatically generated list of installed packages
 abuild-3.2.0-r0
 alpine-baselayout-3.1.0-r0
@@ -40,7 +40,7 @@ cmake-bash-completion-3.11.1-r2
 coreutils-8.29-r2
 cryptsetup-2.0.2-r3
 cryptsetup-libs-2.0.2-r3
-curl-7.60.0-r1
+curl-7.61.0-r0
 db-5.3.28-r0
 dbus-libs-1.10.24-r1
 device-mapper-libs-2.02.178-r0
@@ -127,7 +127,7 @@ libcap-ng-0.7.9-r0
 libcap-ng-dev-0.7.9-r0
 libcom_err-1.44.2-r0
 libcrypto1.0-1.0.2o-r1
-libcurl-7.60.0-r1
+libcurl-7.61.0-r0
 libdrm-2.4.92-r0
 libedit-20170329.3.1-r3
 libedit-dev-20170329.3.1-r3

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:cbf183a92cb4800c4129c2b9bb6e4d3eb3226330-amd64
+# linuxkit/alpine:8a89682421abf0d886d777235a05f4a04a736df2-amd64
 # automatically generated list of installed packages
 abuild-3.2.0-r0
 alpine-baselayout-3.1.0-r0
@@ -40,7 +40,7 @@ cmake-bash-completion-3.11.1-r2
 coreutils-8.29-r2
 cryptsetup-2.0.2-r3
 cryptsetup-libs-2.0.2-r3
-curl-7.60.0-r1
+curl-7.61.0-r0
 db-5.3.28-r0
 dbus-libs-1.10.24-r1
 device-mapper-libs-2.02.178-r0
@@ -132,7 +132,7 @@ libcap-ng-0.7.9-r0
 libcap-ng-dev-0.7.9-r0
 libcom_err-1.44.2-r0
 libcrypto1.0-1.0.2o-r1
-libcurl-7.60.0-r1
+libcurl-7.61.0-r0
 libdrm-2.4.92-r0
 libedit-20170329.3.1-r3
 libedit-dev-20170329.3.1-r3


### PR DESCRIPTION
Containerd release: https://github.com/containerd/containerd/releases/tag/v1.1.2
(just a fix for a CRI logging issue, but lets have it).