### PR TITLE
Update AUTHORS

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -21,6 +21,7 @@ Dave Tucker <dt@docker.com> <dave@dtucker.co.uk>
 David Gageot <david.gageot@docker.com> <david@gageot.net>
 David Sheets <david.sheets@docker.com> <dsheets@docker.com>
 David Sheets <david.sheets@docker.com> <sheets@alum.mit.edu>
+Eric Briand <eric.briand@gmail.com>
 Ian Campbell <ian.campbell@docker.com> <ijc25@users.noreply.github.com>
 Ian Campbell <ian.campbell@docker.com> <ijc@docker.com>
 Ian Campbell <ian.campbell@docker.com> <ijc@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,9 @@
 Ajeet Singh Raina, Docker Captain, {Code} Catalysts, Dell EMC R&D <ajeetraina@gmail.com>
 Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
 Alan Raison <alanraison@users.noreply.github.com>
+Alex Ellis <alexellis2@gmail.com>
 Alex Johnson <hello@alex-johnson.net>
+Alexander Slesarev <alex.slesarev@nudatasecurity.com>
 Alice Frosi <alice@linux.vnet.ibm.com>
 Amir Chaudhry <amir.chaudhry@docker.com>
 Anil Madhavapeddy <anil.madhavapeddy@docker.com>
@@ -12,6 +14,7 @@ Avi Deitcher <avi@deitcher.net>
 Bill Kerr <bill@generalbill.com>
 Brice Figureau <brice-puppet@daysofwonder.com>
 Carlton-Semple <carlton.semple@ibm.com>
+Chanwit Kaewkasi <chanwit@gmail.com>
 Craig Ingram <cingram@heroku.com>
 Damiano Donati <damiano.donati@gmail.com>
 Dan Finneran <dan@thebsdbox.co.uk>
@@ -30,6 +33,7 @@ Dieter Reuter <dieter.reuter@me.com>
 Edward Vielmetti <edward.vielmetti@gmail.com>
 Emily Casey <ecasey@pivotal.io>
 Eric Briand <eric.briand@gmail.com>
+Evan Hazlett <ejhazlett@gmail.com>
 French Ben <frenchben@docker.com>
 functor <meehow@gmail.com>
 Garth Bushell <garth.bushell@oracle.com>
@@ -41,6 +45,7 @@ Ian Campbell <ian.campbell@docker.com>
 Ilya Dmitrichenko <errordeveloper@gmail.com>
 Isaac Rodman <isaac@eyz.us>
 Istvan Szukacs <l1x@users.noreply.github.com>
+Ivan Markin <sw@nogoegst.net>
 Jason A. Donenfeld <Jason@zx2c4.com>
 Jeff Wu <jeff.wu.junfei@gmail.com>
 Jeffrey Hogan <jeff.hogan1@gmail.com>
@@ -97,6 +102,7 @@ Scott Coulton <scott.coulton@puppet.com>
 Sebastiaan van Stijn <sebastiaan.vanstijn@docker.com>
 Simon Ferquel <simon.ferquel@docker.com>
 Sotiris Salloumis <sotiris.salloumis@gmail.com>
+Steeve Morin <steeve.morin@gmail.com>
 Stefan Bourlon <stefan.bourlon@ca.com>
 Stephen J Day <stephen.day@docker.com>
 Steve Hiehn <shiehn@pivotal.io>
@@ -109,7 +115,9 @@ Thomas Shaw <tomwillfixit@users.noreply.github.com>
 Tiago Pires <tandrepires@gmail.com>
 Tiejun Chen <tiejun.china@gmail.com>
 Tim Potter <tpot@hpe.com>
+Tobias Gesellchen <tobias@gesellix.de>
 Tobias Klauser <tklauser@distanz.ch>
+Tristan Slominski <tristan.slominski@gmail.com>
 Tycho Andersen <tycho@docker.com>
 Vincent Demeester <Vincent.Demeester@docker.com>
 Zachery Hostens <zacheryph@gmail.com>


### PR DESCRIPTION
We had a few contributors to `moby/tool`. Since this is merged here
update AUTHORS list.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

![owls](https://user-images.githubusercontent.com/3338098/42813170-02907dfa-89b8-11e8-8696-affad45bcb55.jpg)

