### PR TITLE
wireguard: upgrade to 0.0.20180718

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180708
-ENV WIREGUARD_SHA256="5e38d554f7d1e3a64e3a5319ca1a3b790c84ed89c896586c490a93ac1f953a91"
+ENV WIREGUARD_VERSION=0.0.20180718
+ENV WIREGUARD_SHA256="083c093a6948c8d38f92e7ea5533f9ff926019f24dc2612ea974851ed3e24705"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * tools: only error on wg show if all interfaces fail
  
  wg(8) now has a more reasonable error code semantic.
  
  * receive: account for zero or negative budget
  
  A correctness fix that no other drivers implement but that we really should
  be doing anyway.
  
  * recieve: disable NAPI busy polling
  
  This avoids adding one reference per peer to the napi_hash hashtable, as
  normally done by netif_napi_add(). Since we potentially could have up to
  2^20 peers this would make busy polling very slow globally. This approach is
  preferable to having only a single napi struct because we get one gro_list
  per peer, which means packets can be combined nicely even if we have a large
  number of peers. This is also done by gro_cells_init() in net/core/gro_cells.c.
  
  * receive: use gro call instead of plain call
  
  This enables incredible performance improvements in some cases. Benchmark and
  see for yourself. It should affect large TCP flows.
  
  * wg-quick: allow link local default gateway
  
  IPv6 endpoints will now work better on BSD and Darwin.
  
  * device: destroy workqueue before freeing queue
  
  Another small correctness fix.
```