### PR TITLE
memlogd/logwrite: use the same naming convention as init

### DIFF
--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/runc:v0.5
   - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
-  - linuxkit/memlogd:v0.5
+  - linuxkit/memlogd:ba4fcf55c35a3833546a1e39125bf0fa940327b0
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.5

--- a/pkg/memlogd/cmd/logwrite/main.go
+++ b/pkg/memlogd/cmd/logwrite/main.go
@@ -70,11 +70,11 @@ func main() {
 
 	raddr := net.UnixAddr{Name: serverSocket, Net: "unixgram"}
 
-	if err = sendFD(conn, &raddr, name+".stdout", remoteStdoutFd); err != nil {
+	if err = sendFD(conn, &raddr, name+".out", remoteStdoutFd); err != nil {
 		log.Fatal("fd stdout send failed: ", err)
 	}
 
-	if err = sendFD(conn, &raddr, name+".stderr", remoteStderrFd); err != nil {
+	if err = sendFD(conn, &raddr, name, remoteStderrFd); err != nil {
 		log.Fatal("fd stderr send failed: ", err)
 	}
 

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:v0.5
   - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
-  - linuxkit/memlogd:v0.5
+  - linuxkit/memlogd:ba4fcf55c35a3833546a1e39125bf0fa940327b0
 services:
 # A service which generates logs of log messages
   - name: fill-the-logs

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:v0.5
   - linuxkit/containerd:0784cc754edb296b996c3510abbdf69686ef0f24
   - linuxkit/ca-certificates:v0.5
-  - linuxkit/memlogd:v0.5
+  - linuxkit/memlogd:ba4fcf55c35a3833546a1e39125bf0fa940327b0
 services:
   - name: kmsg
     image: linuxkit/kmsg:cf3dc833591838596427aac032c829ea592599d0


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Note there is a confusing name clash between the `pkg/logwrite` package which writes logs to disk and the command-line wrapper program `cmd/logwrite` (part of the `memlogd` package) modified here.

In e8786d73bb5665b4d548781949e318af6967be03 the logwrite package will automatically append .log to every log filename.

In 5201049f2ccb92d3933ab39f1a1a498c09dda669 the init package will send stderr of a service `s` to a log named `s` and the stdout to `s.out`. Therefore the files we create on disk are `s.log` and `s.out.log`.

This patch modifies the memlogd `logwrite` command-line wrapper to use the same convention.


**- How to verify it**

```
/ # ./pkg/memlogd/cmd/logwrite/logwrite -n hello ls /fooo
/ # ls -1 /var/log
...
hello.log
...
/ # cat /var/log/hello.log
2018-07-20T14:46:45Z hello ls: cannot access '/fooo': No such file or directory
```

**- Description for the changelog**
The `logwrite` command-line wrapper now follows the same logging convention as the `init` package.

**- A picture of a cute animal (not mandatory but encouraged)**

![Kitten looking confused](http://boredomtherapy.com/wp-content/uploads/2015/03/19-confused-animals.jpg)
