### PR TITLE
Allow building with custom containerd repo

### DIFF
--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -52,11 +52,11 @@ RUN go get -u github.com/LK4D4/vndr
 # checkout and compile containerd
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
-ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.1.2
+ARG CONTAINERD_REPO=https://github.com/containerd/containerd.git
+ARG CONTAINERD_COMMIT=v1.1.2
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
-  git clone https://github.com/containerd/containerd.git && \
+  git clone ${CONTAINERD_REPO} && \
   cd $GOPATH/src/github.com/containerd/containerd && \
   git checkout $CONTAINERD_COMMIT
 RUN apk add --no-cache btrfs-progs-dev gcc libc-dev linux-headers make libseccomp-dev

--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -30,7 +30,11 @@ show-tag:
 	@sed -n -e '1s/# \(.*\/.*:[0-9a-f]\{40\}\)/\1/p;q' versions.$(ARCH)
 
 iid: Dockerfile Makefile $(DEPS)
-	docker build --no-cache --iidfile iid .
+	docker build --no-cache \
+		--iidfile iid \
+		--build-arg CONTAINERD_REPO \
+		--build-arg CONTAINERD_COMMIT \
+		.
 
 hash: Makefile iid
 	docker run --rm $(shell cat iid) sh -c 'echo Dockerfile /lib/apk/db/installed $$(find /mirror -name '*.apk' -type f) $$(find /go/bin -type f) | xargs cat | sha1sum' | sed 's/ .*//' | sed 's/$$/$(SUFFIX)/'> $@


### PR DESCRIPTION
**- What I did**

Trying to hack on containerd with LinuxKit I found that I could _almost_ do `CONTAINERD_REPO=... CONTAINERD_COMMIT=... make iid` (in `tools/alpine`) to build from a custom containerd repo. But not quite, so I made this possible 😉.

Note: There are a few similar places where it might be useful to be able to override repo/commit - not sure if it makes sense to also add those?

**- How I did it**

- replaced `git clone`'s reference to the containerd repo with a reference to `$CONTAINERD_REPO` (which was unreferenced before)
- changed `ENV` to `ARG` so the 2 variables could be set as `--build-arg`s
- added the appropriate `--build-arg` flags to the `docker build` command

**- How to verify it**

```console
$ cd tools/alpine; CONTAINERD_REPO=https://github.com/hairyhenderson/containerd.git CONTAINERD_COMMIT=master make iid
...
Step 21/39 : RUN mkdir -p $GOPATH/src/github.com/containerd &&   cd $GOPATH/src/github.com/containerd &&   git clone ${CONTAINERD_REPO} &&   cd $GOPATH/src/github.com/containerd/containerd &&   git checkout $CONTAINERD_COMMIT
 ---> Running in e4adacf8228c
Cloning into 'containerd'...
Already on 'master'
Your branch is up to date with 'origin/master'.
...
```

**- Description for the changelog**

- Allow building with custom containerd repo

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://cdn.iwastesomuchtime.com/819201616500320017.jpg)


Signed-off-by: Dave Henderson <dhenderson@gmail.com>