### PR TITLE
Fix mkimage- builds

### DIFF
--- a/src/cmd/linuxkit/moby/output.go
+++ b/src/cmd/linuxkit/moby/output.go
@@ -16,13 +16,13 @@ import (
 
 var (
 	outputImages = map[string]string{
-		"iso-bios":    "linuxkit/mkimage-iso-bios:fd0092700bc19ea36cc8dccccc9799b7847b4909",
-		"iso-efi":     "linuxkit/mkimage-iso-efi:79148c60bbf2a9526d976d708840492d85b0c576",
-		"raw-bios":    "linuxkit/mkimage-raw-bios:0ff04de5d11a88b0712cdc85b2ee5f0b966ffccf",
-		"raw-efi":     "linuxkit/mkimage-raw-efi:084f159cb44dc6c22351a70f1c1a043857be4e12",
-		"squashfs":    "linuxkit/mkimage-squashfs:36f3fa106cfb7f8b818a828d7aebb27f946c9526",
+		"iso-bios":    "linuxkit/mkimage-iso-bios:65254243f003cf0ac74c64b0a23b543195ddad8a",
+		"iso-efi":     "linuxkit/mkimage-iso-efi:1f5556e56da8e82d52458667ad354b719f314eb2",
+		"raw-bios":    "linuxkit/mkimage-raw-bios:2795f6282bdb8582934d5a0c2f1f859d3073336c",
+		"raw-efi":     "linuxkit/mkimage-raw-efi:21fbe24aa2a9c6b2d5847da5b7337f727e31339c",
+		"squashfs":    "linuxkit/mkimage-squashfs:9e3c0c2788665a54b949e79ebaacf66297ebd4df",
 		"gcp":         "linuxkit/mkimage-gcp:e6cdcf859ab06134c0c37a64ed5f886ec8dae1a1",
-		"qcow2-efi":   "linuxkit/mkimage-qcow2-efi:0eb853459785fad0b518d8edad3b7434add6ad96",
+		"qcow2-efi":   "linuxkit/mkimage-qcow2-efi:6a886a3f82d6d166f4ae540203cb3dffbc4cc12d",
 		"vhd":         "linuxkit/mkimage-vhd:3820219e5c350fe8ab2ec6a217272ae82f4b9242",
 		"dynamic-vhd": "linuxkit/mkimage-dynamic-vhd:743ac9959fe6d3912ebd78b4fd490b117c53f1a6",
 		"vmdk":        "linuxkit/mkimage-vmdk:cee81a3ed9c44ae446ef7ebff8c42c1e77b3e1b5",

--- a/tools/mkimage-iso-bios/Dockerfile
+++ b/tools/mkimage-iso-bios/Dockerfile
@@ -1,13 +1,16 @@
-FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc as mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    busybox \
+    cdrkit \
+    libarchive-tools \
+    syslinux \
+    && true
+RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 
-RUN \
-  apk update && apk upgrade && \
-  apk add --no-cache \
-  libarchive-tools \
-  cdrkit \
-  syslinux \
-  && true
-
+FROM scratch
+WORKDIR /
+COPY --from=mirror /out/ /
 COPY . .
-
 ENTRYPOINT [ "/make-iso" ]

--- a/tools/mkimage-iso-efi/Dockerfile
+++ b/tools/mkimage-iso-efi/Dockerfile
@@ -1,5 +1,4 @@
 FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS grub-build
-
 RUN apk add \
   automake \
   make \
@@ -39,19 +38,22 @@ RUN mkdir /grub-lib && \
     ;; \
   esac
 
-FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS make-img
-
-RUN \
-  apk update && apk upgrade && \
-  apk add --no-cache \
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+  alpine-baselayout \
+  binutils \
+  busybox \
   dosfstools \
   libarchive-tools \
-  binutils \
   mtools \
   xorriso \
   && true
+RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 
-COPY . .
+FROM scratch
+WORKDIR /
+COPY --from=mirror /out/ /
 COPY --from=grub-build /grub-lib/BOOT*.EFI /usr/local/share/
-
+COPY . .
 ENTRYPOINT [ "/make-efi" ]

--- a/tools/mkimage-qcow2-efi/Dockerfile
+++ b/tools/mkimage-qcow2-efi/Dockerfile
@@ -1,19 +1,17 @@
 FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS grub-build
-
 RUN apk add \
+  autoconf \
   automake \
-  make \
   bison \
-  gettext \
-  flex \
   gcc \
+  gettext \
   git \
-  libtool \
+  flex \
   libc-dev \
+  libtool \
   linux-headers \
-  python3 \
-
-  autoconf
+  make \
+  python3
 
 # because python is not available
 RUN ln -s python3 /usr/bin/python
@@ -40,22 +38,25 @@ RUN mkdir /grub-lib && \
     ;; \
   esac
 
-FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS make-img
-
-RUN \
-  apk update && apk upgrade && \
-  apk add --no-cache \
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+  alpine-baselayout \
+  binutils \
+  busybox \
   dosfstools \
   libarchive-tools \
-  binutils \
   mtools \
+  qemu-img \
   sfdisk \
   sgdisk \
   xfsprogs \
-  qemu-img \
   && true
+RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 
-COPY . .
+FROM scratch
+WORKDIR /
+COPY --from=mirror /out/ /
 COPY --from=grub-build /grub-lib/BOOT*.EFI /usr/local/share/
-
+COPY . .
 ENTRYPOINT [ "/make-efi" ]

--- a/tools/mkimage-raw-bios/Dockerfile
+++ b/tools/mkimage-raw-bios/Dockerfile
@@ -1,14 +1,17 @@
-FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    busybox \
+    dosfstools \
+    libarchive-tools \
+    sfdisk \
+    syslinux \
+    && true
+RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 
-RUN \
-  apk update && apk upgrade && \
-  apk add --no-cache \
-  dosfstools \
-  libarchive-tools \
-  sfdisk \
-  syslinux \
-  && true
-
+FROM scratch
+WORKDIR /
+COPY --from=mirror /out/ /
 COPY . .
-
 ENTRYPOINT [ "/make-bios" ]

--- a/tools/mkimage-raw-efi/Dockerfile
+++ b/tools/mkimage-raw-efi/Dockerfile
@@ -1,20 +1,17 @@
 FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS grub-build
-
 RUN apk add \
+  autoconf \
   automake \
-  make \
   bison \
-  gettext \
-  flex \
   gcc \
+  gettext \
   git \
-  libtool \
+  flex \
   libc-dev \
+  libtool \
   linux-headers \
-  python3 \
-
-  autoconf
-
+  make \
+  python3  
 # because python is not available
 RUN ln -s python3 /usr/bin/python
 
@@ -40,21 +37,24 @@ RUN mkdir /grub-lib && \
     ;; \
   esac
 
-FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS make-img
-
-RUN \
-  apk update && apk upgrade && \
-  apk add --no-cache \
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+  alpine-baselayout \
+  binutils \
+  busybox \
   dosfstools \
   libarchive-tools \
-  binutils \
   mtools \
   sfdisk \
   sgdisk \
   xfsprogs \
   && true
+RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 
-COPY . .
+FROM scratch
+WORKDIR /
+COPY --from=mirror /out/ /
 COPY --from=grub-build /grub-lib/BOOT*.EFI /usr/local/share/
-
+COPY . .
 ENTRYPOINT [ "/make-efi" ]

--- a/tools/mkimage-squashfs/Dockerfile
+++ b/tools/mkimage-squashfs/Dockerfile
@@ -1,12 +1,15 @@
-FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc
-
-RUN \
-  apk update && apk upgrade && \
-  apk add --no-cache \
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+  alpine-baselayout \
+  busybox \
   libarchive-tools \
   squashfs-tools \
   && true
+RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 
+FROM scratch
+WORKDIR /
+COPY --from=mirror /out/ /
 COPY . .
-
 ENTRYPOINT [ "/make-squashfs" ]


### PR DESCRIPTION
Quite a few of the `mkimage-` images were not build from `scratch` and thus included the entire alpine base, making them rather large. Fix it.

![mini-sal](https://user-images.githubusercontent.com/3338098/43167435-8a41b7da-8f91-11e8-9993-b38d1d41446e.jpg)

