### PR TITLE
Add kernel+iso output

### DIFF
--- a/test/cases/000_build/000_formats/004_aws/test.sh
+++ b/test/cases/000_build/000_formats/004_aws/test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SUMMARY: Check that raw output format is generated
+# SUMMARY: Check that aws output format is generated
 # LABELS: amd64
 
 set -e

--- a/test/cases/000_build/000_formats/008_raw_bios/test.sh
+++ b/test/cases/000_build/000_formats/008_raw_bios/test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SUMMARY: Check that raw output format is generated
+# SUMMARY: Check that raw-bios output format is generated
 # LABELS: amd64
 
 set -e

--- a/test/cases/000_build/000_formats/009_raw_efi/test.sh
+++ b/test/cases/000_build/000_formats/009_raw_efi/test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SUMMARY: Check that raw output format is generated
+# SUMMARY: Check that raw-efi output format is generated
 # LABELS:
 
 set -e

--- a/test/cases/000_build/000_formats/011_kernel+squashfs/test.sh
+++ b/test/cases/000_build/000_formats/011_kernel+squashfs/test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SUMMARY: Check that kernel+initrd output format is generated
+# SUMMARY: Check that kernel+squashfs output format is generated
 # LABELS:
 
 set -e

--- a/test/cases/000_build/000_formats/012_kernel+iso/test.sh
+++ b/test/cases/000_build/000_formats/012_kernel+iso/test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# SUMMARY: Check that kernel+iso output format is generated
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+NAME=check
+
+clean_up() {
+	rm -f ${NAME}*
+}
+
+trap clean_up EXIT
+
+linuxkit build -format kernel+iso -name "${NAME}" ../test.yml
+[ -f "${NAME}-kernel" ] || exit 1
+[ -f "${NAME}.iso" ] || exit 1
+[ -f "${NAME}-cmdline" ] || exit 1
+
+exit 0

--- a/tools/mkimage-iso/Dockerfile
+++ b/tools/mkimage-iso/Dockerfile
@@ -1,0 +1,15 @@
+FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    busybox \
+    cdrkit \
+    libarchive-tools \
+    && true
+RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
+
+FROM scratch
+WORKDIR /
+COPY --from=mirror /out/ /
+COPY . .
+ENTRYPOINT [ "/make-iso" ]

--- a/tools/mkimage-iso/build.yml
+++ b/tools/mkimage-iso/build.yml
@@ -1,0 +1,3 @@
+image: mkimage-iso
+arches:
+  - amd64

--- a/tools/mkimage-iso/make-iso
+++ b/tools/mkimage-iso/make-iso
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+mkdir -p /tmp/iso
+cd /tmp/iso
+
+# input is a tarball of filesystem on stdin
+# output is an iso on stdout
+
+# extract. BSD tar auto recognises compression, unlike GNU tar
+# only if stdin is a tty, if so need files volume mounted...
+[ -t 0 ] || bsdtar xzf -
+
+genisoimage -o ../linuxkit.iso -l -J -R \
+		-joliet-long -input-charset utf8 \
+                -V LinuxKit .
+cat ../linuxkit.iso


### PR DESCRIPTION
We already have kernel+squashfs and kernel+initrd. Booting a kernel with a read-only ISO might also be useful.

resolves #3133 

![carpet-shark](https://user-images.githubusercontent.com/3338098/43196502-0677f68e-9000-11e8-8255-56eeafdb8a51.jpg)
