### PR TITLE
Allow external directories for 'linuxkit pkg build'

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -37,6 +37,7 @@ A package source consists of a directory containing at least two files:
 - `image` _(string)_: *(mandatory)* The name of the image to build
 - `org` _(string)_: The hub/registry organisation to which this package belongs
 - `arches` _(list of string)_: The architectures which this package should be built for (valid entries are `GOARCH` names)
+- `extra-sources` _(list of strings)_: Additional sources for the package outside the package directory. The format is `src:dst`, where `src` can be relative to the package directory and `dst` is the destination in the build context. This is useful for sharing files, such as vendored go code, between packages.
 - `gitrepo` _(string)_: The git repository where the package source is kept.
 - `network` _(bool)_: Allow network access during the package build (default: no)
 - `disable-content-trust` _(bool)_: Disable Docker content trust for this package (default: no)

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -17,6 +17,7 @@ type pkgInfo struct {
 	Image               string            `yaml:"image"`
 	Org                 string            `yaml:"org"`
 	Arches              []string          `yaml:"arches"`
+	ExtraSources        []string          `yaml:"extra-sources"`
 	GitRepo             string            `yaml:"gitrepo"` // ??
 	Network             bool              `yaml:"network"`
 	DisableContentTrust bool              `yaml:"disable-content-trust"`
@@ -32,12 +33,19 @@ type pkgInfo struct {
 	} `yaml:"depends"`
 }
 
+// Specifies the source directory for a package and their destination in the build context.
+type pkgSource struct {
+	src string
+	dst string
+}
+
 // Pkg encapsulates information about a package's source
 type Pkg struct {
 	// These correspond to pkgInfo fields
 	image         string
 	org           string
 	arches        []string
+	sources       []pkgSource
 	gitRepo       string
 	network       bool
 	trust         bool
@@ -199,6 +207,7 @@ func NewFromCLI(fs *flag.FlagSet, args ...string) (Pkg, error) {
 		hash:          hash,
 		commitHash:    hashCommit,
 		arches:        pi.Arches,
+		sources:       pi.Sources,
 		gitRepo:       pi.GitRepo,
 		network:       pi.Network,
 		trust:         !pi.DisableContentTrust,


### PR DESCRIPTION
This adds adds a new `sources` field to the `build.yml` where one can specify additional source directories for the package build outside the package directory. This is useful for sharing files, such as vendored go code, between packages.

If `sources` are specified, the package hash is calculated as the `sha1` of the strings of the git tree hashes of all the externals sources and the package directory. Therefore, `sources` need to be under git revision control.

`sources` are specified as a `src:dst` pair, where `src` can be a relative path the package directory and `dst` is the destination with the docker build context.

The `sources` features is implemented by `tar`ing up (and rewriting the paths) of the sources and pipe them to `stdin` of the `docker` process used to build the package.

There should be no changes for packages not using the `sources` features.

resolves #3108

![whales](https://user-images.githubusercontent.com/3338098/43212788-dba7ebbc-902c-11e8-9be4-902a33fb9bab.jpg)
