### PR TITLE
Kernel update to 4.17.10/4.14.58/4.9.115/4.4.144

### DIFF
--- a/contrib/crosvm/README.md
+++ b/contrib/crosvm/README.md
@@ -30,7 +30,7 @@ YAML file (`minimal.yml`):
 
 ```
 kernel:
-  image: linuxkit/kernel:4.9.114
+  image: linuxkit/kernel:4.9.115
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -1,6 +1,6 @@
 # This is an example for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.5 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -1,6 +1,6 @@
 # Simple example of using an external logging service
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/packet.arm64.yml
+++ b/examples/packet.arm64.yml
@@ -5,7 +5,7 @@
 # for arm64 then the 'ucode' line in the kernel section can be left
 # out.
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyAMA0"
   ucode: ""
 onboot:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57-rt
+  image: linuxkit/kernel:4.14.58-rt
   cmdline: "console=tty0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -218,21 +218,21 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,4.17.9,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.57,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.57,4.14.x,,-dbg))
+$(eval $(call kernel,4.17.10,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.58,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.58,4.14.x,,-dbg))
 $(eval $(call kernel,4.14.53,4.14.x,-rt,))
-$(eval $(call kernel,4.9.114,4.9.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.4.143,4.4.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.115,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.4.144,4.4.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,4.17.9,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.57,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.10,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.58,4.14.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.53,4.14.x,-rt,))
 
 else ifeq ($(ARCH),s390x)
-$(eval $(call kernel,4.17.9,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.57,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.10,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.58,4.14.x,$(EXTRA),$(DEBUG)))
 endif
 
 # Target for kernel config

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.57 Kernel Configuration
+# Linux/arm64 4.14.58 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-s390x
+++ b/kernel/config-4.14.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.14.57 Kernel Configuration
+# Linux/s390 4.14.58 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.57 Kernel Configuration
+# Linux/x86 4.14.58 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.17.x-aarch64
+++ b/kernel/config-4.17.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.17.9 Kernel Configuration
+# Linux/arm64 4.17.10 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.17.x-s390x
+++ b/kernel/config-4.17.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.17.9 Kernel Configuration
+# Linux/s390 4.17.10 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.17.x-x86_64
+++ b/kernel/config-4.17.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.17.9 Kernel Configuration
+# Linux/x86 4.17.10 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.143 Kernel Configuration
+# Linux/x86 4.4.144 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.114 Kernel Configuration
+# Linux/x86 4.9.115 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 791b12332b51f9497657110944da91a89bb77d4d Mon Sep 17 00:00:00 2001
+From 4fabc3ccbfcbf1b29f4a41dd5367b1fcd77fc65b Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 01/21] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB
@@ -24,5 +24,5 @@ index 3f03567631cb..e63c201ed1ef 100644
  
  enum ars_masks {
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,4 +1,4 @@
-From 9724b51bba1eea8f2000f40893e04e1551d85ab7 Mon Sep 17 00:00:00 2001
+From b68f3db3c6b28c2a8f415fde4af410a0ecae54c8 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
 Subject: [PATCH 02/21] hyper-v: trace vmbus_on_msg_dpc()
@@ -107,5 +107,5 @@ index 2cd134dd94d2..9687e462fd43 100644
  		WARN_ONCE(1, "unknown msgtype=%d\n", hdr->msgtype);
  		goto msg_handled;
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,4 +1,4 @@
-From 0b1525e5815701be9384397ffd0e595947b58c3b Mon Sep 17 00:00:00 2001
+From 2b634ed4e3b0ff1cc528f63867215524300f059e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
 Subject: [PATCH 03/21] hyper-v: trace vmbus_on_message()
@@ -45,5 +45,5 @@ index 9c2772922c76..d432aba5df8a 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,4 +1,4 @@
-From 6e9a48bf6010da78680095e3e91859c7acf2d47a Mon Sep 17 00:00:00 2001
+From 908f2f26800936bf619f3617a927f4988a2b9421 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
 Subject: [PATCH 04/21] hyper-v: trace vmbus_onoffer()
@@ -76,5 +76,5 @@ index d432aba5df8a..488b873b563e 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,4 +1,4 @@
-From 678bd1b56f06cd77f709c91c64921fa0bfb943a8 Mon Sep 17 00:00:00 2001
+From 10ab7a26269bb3ff2e145b5fc2b73c752f437cd8 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
 Subject: [PATCH 05/21] hyper-v: trace vmbus_onoffer_rescind()
@@ -47,5 +47,5 @@ index 488b873b563e..dbbed1d1f327 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,4 +1,4 @@
-From d13313eeb0fa4622b6711e89177ddd219d83a08d Mon Sep 17 00:00:00 2001
+From fe0e871a20db0994cda89d358da3ff281a05e378 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
 Subject: [PATCH 06/21] hyper-v: trace vmbus_onopen_result()
@@ -56,5 +56,5 @@ index dbbed1d1f327..9757c19d1c08 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,4 +1,4 @@
-From 07ad772f559fcb982dcb21d920a5511200b6c061 Mon Sep 17 00:00:00 2001
+From 5347396a1b2d7a2f98d55744e90d5c9f17b8dfb6 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
 Subject: [PATCH 07/21] hyper-v: trace vmbus_ongpadl_created()
@@ -56,5 +56,5 @@ index 9757c19d1c08..20734b7b341b 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,4 +1,4 @@
-From e5ea9f15460012e4da14b54084c434de3d1c0546 Mon Sep 17 00:00:00 2001
+From d378acbe4836fa5cf0690afca436f9f15ea6c59e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
 Subject: [PATCH 08/21] hyper-v: trace vmbus_ongpadl_torndown()
@@ -47,5 +47,5 @@ index 20734b7b341b..84c08cdf7235 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,4 +1,4 @@
-From f7b19d76c370933562491febd2d5136a419a276b Mon Sep 17 00:00:00 2001
+From 23c634c3f3fb2f5afd713b05b01c26da168113f5 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
 Subject: [PATCH 09/21] hyper-v: trace vmbus_onversion_response()
@@ -51,5 +51,5 @@ index 84c08cdf7235..2a046547107f 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,4 +1,4 @@
-From decde6f05eee83fb6327d82ae54217d02bb924c9 Mon Sep 17 00:00:00 2001
+From 999780655b2e1cccfaac2a168f9d2eed8732c76d Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
 Subject: [PATCH 10/21] hyper-v: trace vmbus_request_offers()
@@ -51,5 +51,5 @@ index 2a046547107f..566ac0f2fe56 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 9452083211b1303b5b7dea9637eb1fbb67974f6a Mon Sep 17 00:00:00 2001
+From bc01bbbfce0751627f28f5548c865d511193670a Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
 Subject: [PATCH 11/21] hyper-v: trace vmbus_open()
@@ -66,5 +66,5 @@ index 566ac0f2fe56..38fedb803bd8 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,4 +1,4 @@
-From 1e40d04fecdedb20a4e56964e67e60843f3cd3fb Mon Sep 17 00:00:00 2001
+From d39de3ec255911c6d43047f26b61c960cc0757ef Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
 Subject: [PATCH 12/21] hyper-v: trace vmbus_close_internal()
@@ -54,5 +54,5 @@ index 38fedb803bd8..302bd4e964f0 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,4 +1,4 @@
-From 5a029588284f0ec61f7a9ec20668ae943bedee9c Mon Sep 17 00:00:00 2001
+From b092331d80b698a9ad7d822e7b9c0ef49b6d32f5 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
 Subject: [PATCH 13/21] hyper-v: trace vmbus_establish_gpadl()
@@ -92,5 +92,5 @@ index 302bd4e964f0..978e70bdc7c5 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,4 +1,4 @@
-From da924fe741a5dddc9af87dd0ccd7f292ca28253f Mon Sep 17 00:00:00 2001
+From 548ae4b4d29414184d57806ff3c773ac025946d2 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
 Subject: [PATCH 14/21] hyper-v: trace vmbus_teardown_gpadl()
@@ -57,5 +57,5 @@ index 978e70bdc7c5..cd33a52ef27f 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,4 +1,4 @@
-From aa1a536cd395c0f186f305f0d963c2906ca1eef6 Mon Sep 17 00:00:00 2001
+From b03df401827cbee2964941a29fc4ac13ee9cbcb6 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
 Subject: [PATCH 15/21] hyper-v: trace vmbus_negotiate_version()
@@ -66,5 +66,5 @@ index cd33a52ef27f..f06284d64a8c 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,4 +1,4 @@
-From 3bf60b9323f783a1f5e799fef093740cc3782658 Mon Sep 17 00:00:00 2001
+From 210682a76fa6193fefc49e2bdbb01974fe0bef76 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
 Subject: [PATCH 16/21] hyper-v: trace vmbus_release_relid()
@@ -64,5 +64,5 @@ index f06284d64a8c..f0e437c3522f 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,4 +1,4 @@
-From dea8f522c213fd73d7019c0040387054d49f7164 Mon Sep 17 00:00:00 2001
+From 89407d9dbcf558d08843ce0612f353eba3929837 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
 Subject: [PATCH 17/21] hyper-v: trace vmbus_send_tl_connect_request()
@@ -70,5 +70,5 @@ index f0e437c3522f..5382d9630306 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,4 +1,4 @@
-From 0dcb1eb72da9f0988ed79e651f1d26dfd5a1b119 Mon Sep 17 00:00:00 2001
+From cb551169323e21deaa6f30a2bda27b08efa4790c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
 Subject: [PATCH 18/21] hyper-v: trace channel events
@@ -97,5 +97,5 @@ index 9687e462fd43..27d5efd696ad 100644
  			case HV_CALL_ISR:
  				vmbus_channel_isr(channel);
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From c3dc144fe40a66aaca18850751ae527e40109bcf Mon Sep 17 00:00:00 2001
+From 9cce3eb78d66237935a7c73d7d62ec513eef0da3 Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH 19/21] serial: forbid 8250 on s390
@@ -31,5 +31,5 @@ index a5c0ef1e7695..16b1496e6105 100644
  	---help---
  	  This selects whether you want to include the driver for the standard
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
+++ b/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
@@ -1,4 +1,4 @@
-From ca020e4136e1abeea2d632414799c50fe11bbf58 Mon Sep 17 00:00:00 2001
+From 8ba5c4a3d02c3427ec0633a3348a47d41ae369ad Mon Sep 17 00:00:00 2001
 From: Cathy Avery <cavery@redhat.com>
 Date: Tue, 31 Oct 2017 08:52:06 -0400
 Subject: [PATCH 20/21] scsi: storvsc: Allow only one remove lun work item to
@@ -128,5 +128,5 @@ index beb585ddc07d..e94f75e25cb1 100644
  	storvsc_dev_remove(dev);
  	scsi_host_put(host);
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
+++ b/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
@@ -1,4 +1,4 @@
-From 1392a954e26d688d03373b5ad4f38752702aa9b0 Mon Sep 17 00:00:00 2001
+From 74fe018d0f5f6fb94553b7fc8a7f515fb98a9584 Mon Sep 17 00:00:00 2001
 From: Long Li <longli@microsoft.com>
 Date: Tue, 31 Oct 2017 14:58:08 -0700
 Subject: [PATCH 21/21] scsi: storvsc: Avoid excessive host scan on controller
@@ -106,5 +106,5 @@ index e94f75e25cb1..66b1b6ad0ae0 100644
  	ret = scsi_add_host(host, &device->device);
  	if (ret != 0)
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 5afebf11a53295f0ce152f08f4603fc4ee9d4f32 Mon Sep 17 00:00:00 2001
+From a005e66627723c7cb6bf888bf98df50d67c65c9f Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()
@@ -146,5 +146,5 @@ index e72d370889f8..605c4812430f 100644
  
  int is_printable_array(char *p, unsigned int len);
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 3cfeca80cf507c22fd7611c71dc6bd44437b66b2 Mon Sep 17 00:00:00 2001
+From d1cfa4ea52df5e98b3056cf24ef42a2251181a65 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable
@@ -66,5 +66,5 @@ index 95f0884aae02..f3ed3c963c71 100644
  	while ((jr = jit_get_next_entry(jd))) {
  		switch(jr->prefix.id) {
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 95547c5fb6bd9188568f08f5ec67d06fb1ec446e Mon Sep 17 00:00:00 2001
+From 72ddf854fc7145d80c3a63780c44caceae992e32 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets
@@ -28,13 +28,13 @@ Origin: https://patchwork.kernel.org/patch/9244467/
  MAINTAINERS                 |    2 +
  include/linux/hyperv.h      |   13 +
  include/linux/socket.h      |    4 +-
- include/net/af_hvsock.h     |   78 +++
+ include/net/af_hvsock.h     |   78 ++
  include/uapi/linux/hyperv.h |   23 +
  net/Kconfig                 |    1 +
  net/Makefile                |    1 +
  net/hv_sock/Kconfig         |   10 +
  net/hv_sock/Makefile        |    3 +
- net/hv_sock/af_hvsock.c     | 1507 +++++++++++++++++++++++++++++++++++++++++++
+ net/hv_sock/af_hvsock.c     | 1507 +++++++++++++++++++++++++++++++++++
  10 files changed, 1641 insertions(+), 1 deletion(-)
  create mode 100644 include/net/af_hvsock.h
  create mode 100644 net/hv_sock/Kconfig
@@ -1787,5 +1787,5 @@ index 000000000000..331d3759f5cb
 +MODULE_DESCRIPTION("Hyper-V Sockets");
 +MODULE_LICENSE("Dual BSD/GPL");
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From b1174ffda4cb052b0dd388c0ea160e39be1bd7b0 Mon Sep 17 00:00:00 2001
+From dec39efee06e309bf09f86740c91cedf9e5b166c Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs
@@ -26,5 +26,5 @@ index 9360cdce740e..d838074e9add 100644
  }
  
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 33566f656d0a3468ac53d0e71aea37f0d062b417 Mon Sep 17 00:00:00 2001
+From cd8b87a97135628a3909163a8aca40938a9a5ab6 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host
@@ -44,5 +44,5 @@ index bcd06306f3e8..e7707747f56d 100644
  	}
  
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From 0907b70f31dec84d859efc0cdfcd2f1801f201fa Mon Sep 17 00:00:00 2001
+From 4a0119831cd7ee385080a6320cde33b7993b590f Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.
@@ -101,5 +101,5 @@ index a6707133c297..5c95ba1e2ecf 100644
  	return 0;
  }
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From d040834c658b6c9a8cfb1b2033ad2f08fc7dfb5b Mon Sep 17 00:00:00 2001
+From fed70aa63d61707e537fcdb4c62ff70a0ddb3645 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host
@@ -44,5 +44,5 @@ index 5c95ba1e2ecf..eee238cc60bd 100644
  	rc = hvutil_transport_send(hvt, vss_msg, sizeof(*vss_msg), NULL);
  	if (rc) {
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From e154a405495251e1757dc8f25d8549eb005f1324 Mon Sep 17 00:00:00 2001
+From acba0dbe222b91f0e697960d22635f69d9392ef3 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to
@@ -25,12 +25,12 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
 Origin: git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 (cherry picked from commit a1656454131880980bc3a5313c8bf66ef5990c91)
 ---
- drivers/hv/channel_mgmt.c | 80 +++++++++++++++++++++++++++-------------
- drivers/hv/hv_fcopy.c     | 20 +++++++---
- drivers/hv/hv_kvp.c       | 41 +++++++++------------
- drivers/hv/hv_snapshot.c  | 18 +++++++--
- drivers/hv/hv_util.c      | 94 +++++++++++++++++++++++++----------------------
- include/linux/hyperv.h    |  7 ++--
+ drivers/hv/channel_mgmt.c | 80 ++++++++++++++++++++++-----------
+ drivers/hv/hv_fcopy.c     | 20 ++++++---
+ drivers/hv/hv_kvp.c       | 41 +++++++----------
+ drivers/hv/hv_snapshot.c  | 18 ++++++--
+ drivers/hv/hv_util.c      | 94 +++++++++++++++++++++------------------
+ include/linux/hyperv.h    |  7 +--
  6 files changed, 154 insertions(+), 106 deletions(-)
 
 diff --git a/drivers/hv/channel_mgmt.c b/drivers/hv/channel_mgmt.c
@@ -488,5 +488,5 @@ index c9af8369b4f7..7df9eb8f0cf7 100644
  void hv_event_tasklet_disable(struct vmbus_channel *channel);
  void hv_event_tasklet_enable(struct vmbus_channel *channel);
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 9baf046f0f268b08b049fbf1fc88cca91d016004 Mon Sep 17 00:00:00 2001
+From ee76170a5bed625fd873b96150668b15b9ed9c33 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.
@@ -114,5 +114,5 @@ index f3797c07be10..89440c2eb346 100644
  					hb_srv_version & 0xFFFF);
  			}
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From b4499d03d3c25d19c546713336b40ab3a628d770 Mon Sep 17 00:00:00 2001
+From eb6231df098695d8317880c2975c440a39c676d3 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot
@@ -52,5 +52,5 @@ index 095dd37367de..effac8042dc6 100644
  
  void hv_process_channel_removal(struct vmbus_channel *channel, u32 relid)
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From c19bfb30fbc884f7b3d1280d8bb2d288a510ed6f Mon Sep 17 00:00:00 2001
+From 25141f3ada36087ad07efc8a8143d29991186dda Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in
@@ -56,5 +56,5 @@ index 1606e7f08f4b..1caed01954f6 100644
  	vmbus_teardown_gpadl(newchannel, newchannel->ringbuffer_gpadlhandle);
  	kfree(open_info);
 -- 
-2.16.0
+2.18.0
 

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 309f1abcb4ed1c456372931c1e4c7df51c63a194 Mon Sep 17 00:00:00 2001
+From 9210fd3944ddab9ab658cb6fd3b8816cc749ae4e Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on
@@ -8,9 +8,9 @@ Signed-off-by: Dexuan Cui <decui@microsoft.com>
 Origin: git@github.com:dcui/linux.git
 (cherry picked from commit bee4910daa4aed57ce60d2e2350e3cc120c383ca)
 ---
- drivers/hv/channel.c      | 16 ++++++++++---
- drivers/hv/channel_mgmt.c | 58 ++++++++++++++++++++---------------------------
- include/linux/hyperv.h    |  3 +++
+ drivers/hv/channel.c      | 16 +++++++++--
+ drivers/hv/channel_mgmt.c | 58 ++++++++++++++++-----------------------
+ include/linux/hyperv.h    |  3 ++
  3 files changed, 40 insertions(+), 37 deletions(-)
 
 diff --git a/drivers/hv/channel.c b/drivers/hv/channel.c
@@ -173,5 +173,5 @@ index 7df9eb8f0cf7..a87757cf277b 100644
  
  void vmbus_setevent(struct vmbus_channel *channel);
 -- 
-2.16.0
+2.18.0
 

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.141
+  image: linuxkit/kernel:4.4.144
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.114
+  image: linuxkit/kernel:4.9.115
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/020_kernel/009_config_4.17.x/test.yml
+++ b/test/cases/020_kernel/009_config_4.17.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.17.9
+  image: linuxkit/kernel:4.17.10
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.4.141 AS ksrc
+FROM linuxkit/kernel:4.4.144 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.4.141
+docker pull linuxkit/kernel:4.4.144
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.141
+  image: linuxkit/kernel:4.4.144
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.114 AS ksrc
+FROM linuxkit/kernel:4.9.115 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.114
+docker pull linuxkit/kernel:4.9.115
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.114
+  image: linuxkit/kernel:4.9.115
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
+++ b/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.14.57 AS ksrc
+FROM linuxkit/kernel:4.14.58 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.sh
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.14.57
+docker pull linuxkit/kernel:4.14.58
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/020_kernel/019_kmod_4.17.x/Dockerfile
+++ b/test/cases/020_kernel/019_kmod_4.17.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.17.9 AS ksrc
+FROM linuxkit/kernel:4.17.10 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:daed76b8f1d28cdeeee215a95b9671c682a405dc AS build

--- a/test/cases/020_kernel/019_kmod_4.17.x/test.sh
+++ b/test/cases/020_kernel/019_kmod_4.17.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.17.9
+docker pull linuxkit/kernel:4.17.10
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/019_kmod_4.17.x/test.yml
+++ b/test/cases/020_kernel/019_kmod_4.17.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.17.9
+  image: linuxkit/kernel:4.17.10
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -1,6 +1,6 @@
 # Sample YAML file for manual testing
 kernel:
-  image: linuxkit/kernel:4.14.57
+  image: linuxkit/kernel:4.14.58
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:598439400c1e4bf8c25c63c98b2d3e83b1382be9


### PR DESCRIPTION
Regularly scheduled kernel updated

Looks like I missed updating the tests for 4.4.x for a few releases hence the bigger skip.

![screen shot 2018-07-04 at 11 25 47](https://user-images.githubusercontent.com/3338098/43230255-7bb67e16-905f-11e8-85bc-d0a46efe43fa.png)
