### PR TITLE
Fix #3091 enforce all outgoing tar files to use PAX

### DIFF
--- a/src/cmd/linuxkit/moby/image.go
+++ b/src/cmd/linuxkit/moby/image.go
@@ -140,6 +140,9 @@ func ImageTar(ref *reference.Spec, prefix string, tw tarWriter, trust bool, pull
 		if err != nil {
 			return err
 		}
+		// force PAX format, since it allows for unlimited Name/Linkname
+		// and we move all files below prefix.
+		hdr.Format = tar.FormatPAX
 		if exclude[hdr.Name] {
 			log.Debugf("image tar: %s %s exclude %s", ref, prefix, hdr.Name)
 			_, err = io.Copy(ioutil.Discard, tr)


### PR DESCRIPTION
fixes #3091 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

While processing the content of a tar image, linuxkit's moby tool was
blindly reusing the original tar format.

Moreover it locates the file under a new prefix, so if the original
file was stored as USTAR in the original archive, the filename length
and new prefix could be greater than the USTAR limit leading
to a fatal error.

**- How I did it**

The fix is to always enforce PAX format on all copied files from the
original image archive.

**- How to verify it**

Use the following minimal yaml:
~~~yaml
kernel:
  image: linuxkit/kernel:4.9.87
  cmdline: "console=ttyS0"
init:
  - linuxkit/init:6061875ba11fd9c563fda6234b103ed9997ff782
  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
  - linuxkit/containerd:13f62c61f0465fb07766d88b317cabb960261cbb
onboot:
  - name: dhcpcd
    image: linuxkit/dhcpcd:v0.2
    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
services:
  # Enable getty for easier debugging
  - name: getty
    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
    env:
        - INSECURE=true
  - name: elasticsearch
    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.10
    capabilities:
      - all
    net: host
    uid: 1000
    gid: 1000
    env:
      - ES_JAVA_OPTS=-Xms256m -Xmx256m
      - xpack.security.enabled=false
    binds:
      - /etc/resolv.conf:/etc/resolv.conf
    cwd: /usr/share/elasticsearch
trust:
  org:
    - linuxkit
    - library
~~~

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Prevent fatal error while processing incoming USTAR formatted tar container image 

**- A picture of a cute animal (not mandatory but encouraged)**

![wombat](https://user-images.githubusercontent.com/20242/43317066-b9166194-919b-11e8-99fb-4a39f884f088.jpg)
