### PR TITLE
cmd/pkg: Fix symlink handling in pkg build context

### DIFF
--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -222,7 +222,16 @@ func (c *buildCtx) Copy(w io.WriteCloser) error {
 				return fmt.Errorf("ctx: Walk error on %s: %v", p, err)
 			}
 
-			h, err := tar.FileInfoHeader(i, "")
+			var link string
+			if i.Mode()&os.ModeSymlink != 0 {
+				var err error
+				link, err = os.Readlink(p)
+				if err != nil {
+					return fmt.Errorf("ctx: Failed to read symlink %s: %v", p, err)
+				}
+			}
+
+			h, err := tar.FileInfoHeader(i, link)
 			if err != nil {
 				return fmt.Errorf("ctx: Converting FileInfo for %s: %v", p, err)
 			}


### PR DESCRIPTION
When building the build context, symlink need special
treatment as the link name needs to be added when
building the tar.FileInfoHeader. This code does that.

We may also need to add a special case for hard links
as the moby/moby package 'archive' does, but this
should for now
fixes #3142

Signed-off-by: Rolf Neugebauer <rn@rneugeba.io>

![image](https://user-images.githubusercontent.com/3338098/43337957-0823034c-91cd-11e8-8970-4c7531c59338.png)


/cc @djs55 @ijc 