### PR TITLE
Enhance `run vbox` to support multiple disks and network adapters

### DIFF
--- a/docs/platform-vbox.md
+++ b/docs/platform-vbox.md
@@ -20,11 +20,20 @@ stdio, providing interactive access to the VM.
 ## Disks
 
 The Virtualbox backend support configuring a persistent disk using the
-standard `linuxkit` `-disk` syntax.  Multiple disks are
+standard `linuxkit` `-disk` syntax. Multiple disks are
 supported and can be created in `raw` format; other formats that VirtualBox
-supports can be attached
+supports can be attached. Note that additional drives are attached to the
+SATA Controller, unlike the VM disk which is on the IDE Controller.
 
 ## Networking
 
-You can select the networking mode, which defaults to the standard `nat`, but
-some networking modes may require additional configuration.
+You can select the networking mode, which defaults to the standard `nat`, by using the
+`-networking` command-line option. Some networking modes (`hostonly`, `bridge`) will require 
+the additional `adapter` parameter to the `-networking` option:
+
+~~~
+-networking hostonly,adapter=vboxnet0
+~~~
+
+You can specify more than one `-networking` option to setup multiple adapters. It is
+recommended to setup the first adapter as `nat`.

--- a/src/cmd/linuxkit/run_vbox.go
+++ b/src/cmd/linuxkit/run_vbox.go
@@ -17,6 +17,43 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// VBNetwork is the config for a Virtual Box network
+type VBNetwork struct {
+	Type    string
+	Adapter string
+}
+
+// VBNetworks is the type for a list of VBNetwork
+type VBNetworks []VBNetwork
+
+func (l *VBNetworks) String() string {
+	return fmt.Sprint(*l)
+}
+
+// Set is used by flag to configure value from CLI
+func (l *VBNetworks) Set(value string) error {
+	d := VBNetwork{}
+	s := strings.Split(value, ",")
+	for _, p := range s {
+		c := strings.SplitN(p, "=", 2)
+		switch len(c) {
+		case 1:
+			d.Type = c[0]
+		case 2:
+			switch c[0] {
+			case "type":
+				d.Type = c[1]
+			case "adapter", "bridgeadapter", "hostadapter":
+				d.Adapter = c[1]
+			default:
+				return fmt.Errorf("Unknown network config: %s", c[0])
+			}
+		}
+	}
+	*l = append(*l, d)
+	return nil
+}
+
 func runVbox(args []string) {
 	invoked := filepath.Base(os.Args[0])
 	flags := flag.NewFlagSet("vbox", flag.ExitOnError)
@@ -51,8 +88,8 @@ func runVbox(args []string) {
 	uefiBoot := flags.Bool("uefi", false, "Use UEFI boot")
 
 	// networking
-	networking := flags.String("networking", "nat", "Networking mode. null|nat|bridged|intnet|hostonly|generic|natnetwork[<devicename>]")
-	bridgeadapter := flags.String("bridgeadapter", "", "Bridge adapter interface to use if networking mode is bridged")
+	var networks VBNetworks
+	flags.Var(&networks, "networking", "Network config, may be repeated. [type=](null|nat|bridged|intnet|hostonly|generic|natnetwork[<devicename>])[,[bridge|host]adapter=<interface>]")
 
 	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
@@ -201,25 +238,33 @@ func runVbox(args []string) {
 		}
 	}
 
-	_, out, err = manage(vboxmanage, "modifyvm", name, "--nictype1", "virtio")
-	if err != nil {
-		log.Fatalf("modifyvm --nictype error: %v\n%s", err, out)
-	}
-
-	_, out, err = manage(vboxmanage, "modifyvm", name, "--nic1", *networking)
-	if err != nil {
-		log.Fatalf("modifyvm --nic error: %v\n%s", err, out)
-	}
-	if *networking == "bridged" {
-		_, out, err = manage(vboxmanage, "modifyvm", name, "--bridgeadapter1", *bridgeadapter)
+	for i, d := range networks {
+		nic := i + 1
+		_, out, err = manage(vboxmanage, "modifyvm", name, fmt.Sprintf("--nictype%d", nic), "virtio")
 		if err != nil {
-			log.Fatalf("modifyvm --bridgeadapter error: %v\n%s", err, out)
+			log.Fatalf("modifyvm --nictype error: %v\n%s", err, out)
 		}
-	}
 
-	_, out, err = manage(vboxmanage, "modifyvm", name, "--cableconnected1", "on")
-	if err != nil {
-		log.Fatalf("modifyvm --cableconnected error: %v\n%s", err, out)
+		_, out, err = manage(vboxmanage, "modifyvm", name, fmt.Sprintf("--nic%d", nic), d.Type)
+		if err != nil {
+			log.Fatalf("modifyvm --nic error: %v\n%s", err, out)
+		}
+		if d.Type == "hostonly" {
+			_, out, err = manage(vboxmanage, "modifyvm", name, fmt.Sprintf("--hostonlyadapter%d", nic), d.Adapter)
+			if err != nil {
+				log.Fatalf("modifyvm --hostonlyadapter error: %v\n%s", err, out)
+			}
+		} else if d.Type == "bridged" {
+			_, out, err = manage(vboxmanage, "modifyvm", name, fmt.Sprintf("--bridgeadapter%d", nic), d.Adapter)
+			if err != nil {
+				log.Fatalf("modifyvm --bridgeadapter error: %v\n%s", err, out)
+			}
+		}
+
+		_, out, err = manage(vboxmanage, "modifyvm", name, fmt.Sprintf("--cableconnected%d", nic), "on")
+		if err != nil {
+			log.Fatalf("modifyvm --cableconnected error: %v\n%s", err, out)
+		}
 	}
 
 	// create socket

--- a/src/cmd/linuxkit/run_vbox.go
+++ b/src/cmd/linuxkit/run_vbox.go
@@ -171,6 +171,13 @@ func runVbox(args []string) {
 		}
 	}
 
+	if len(disks) > 0 {
+		_, out, err = manage(vboxmanage, "storagectl", name, "--name", "SATA", "--add", "sata")
+		if err != nil {
+			log.Fatalf("storagectl error: %v\n%s", err, out)
+		}
+	}
+
 	for i, d := range disks {
 		id := strconv.Itoa(i)
 		if d.Size != 0 && d.Format == "" {
@@ -188,7 +195,7 @@ func runVbox(args []string) {
 				log.Fatalf("Cannot create disk: %v", err)
 			}
 		}
-		_, out, err = manage(vboxmanage, "storageattach", name, "--storagectl", "IDE Controller", "--port", "2", "--device", id, "--type", "hdd", "--medium", d.Path)
+		_, out, err = manage(vboxmanage, "storageattach", name, "--storagectl", "SATA", "--port", "0", "--device", id, "--type", "hdd", "--medium", d.Path)
 		if err != nil {
 			log.Fatalf("storageattach error: %v\n%s", err, out)
 		}


### PR DESCRIPTION
fixes #3140
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

For an internal project where I needed to produce a VirtualBox based vagrant box, I started running a linuxkit VM with the `run vbox` command.
This specific VM requires to have an additional disk and two network adapter.

Unfortunately, adding an additional disk produces a VirtualBox error because there's no port 2 on IDE Controller (only port 0 and 1). Also adding more than one additional disk couldn't work because all would have used port 2, and IDE controllers only allow for 4 devices (one 
And `run vbox` only supports one network adapter.

I modified the `run vbox` code to use a SATA controller for any additional disks instead of the IDE controller, because it can host much more drives.

I also changed the code to allow to specify more than one `-networking` parameter. Unfortunately this breaks the backward compatibility with the previous way of setting up the network.
Previously one had to do:
~~~
-networking bridge -bridgeadapter vboxnet0
~~~
and now:
~~~
-networking bridge,bridgeadapter=vboxnet0
# or
-networking type=bridge,adapter=vboxnet0
~~~

**- How I did it**

N/A

**- How to verify it**

One can use the following `build.yml`:
~~~yaml
kernel:
  image: linuxkit/kernel:4.9.87
  cmdline: "console=ttyS0"
init:
  - linuxkit/init:6061875ba11fd9c563fda6234b103ed9997ff782
  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
  - linuxkit/containerd:13f62c61f0465fb07766d88b317cabb960261cbb
onboot:
  - name: dhcpcd
    image: linuxkit/dhcpcd:v0.2
    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
  - name: static_ip
    image: linuxkit/ip:v0.6
    net: host
    binds:
      - /etc/network/setup.conf:/etc/network/setup.conf
    command: ["ip", "-b", "/etc/network/setup.conf"]
# Format and mount the disk image in /var/lib for persistency
  - name: format
    image: linuxkit/format:v0.4
  - name: mount
    image: linuxkit/mount:v0.4
    command: ["/usr/bin/mountie", "/var/lib"]
services:
  # Enable acpi to shutdown on power events
  - name: acpid
    image: linuxkit/acpid:v0.4
  # Enable getty for easier debugging
  - name: getty
    image: linuxkit/getty:44730fd0a7c59dbacf5b48b54ba33f551bcf7ef0
    env:
        - INSECURE=true
  # Run ntpd to keep time synchronised in the VM
  - name: ntpd
    image: linuxkit/openntpd:v0.4
files:
  - path: /etc/network/setup.conf
    source: "setup.conf"
    mode: "0644"
trust:
  org:
    - linuxkit
    - library

~~~
With `setup.conf` being:
~~~
addr add 192.168.2.200/24 dev eth1
link set eth1 up
~~~

Then build and run the :
~~~
VBoxManage createhd --filename data.vdi --variant Standard --size 10240
linuxkit run vbox -mem 2048 -iso -disk file=data.vdi,size=10240M,format=vdi -networking type=nat -networking type=hostonly,adapter=vboxnet0
~~~

On the console, check that the drive is present and mounted, and that the second hostonly adapter is present and working:
~~~
linuxkit-080027c74f8e:/# mount | grep /var/lib
/dev/sda1 on /var/lib type ext4 (rw,relatime,data=ordered)
linuxkit-080027c74f8e:/# ip addr | grep eth
4: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 08:00:27:c7:4f:8e brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 brd 10.0.2.255 scope global eth0
5: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 08:00:27:0f:10:56 brd ff:ff:ff:ff:ff:ff
    inet 192.168.2.200/24 scope global eth1
~~~

**- Description for the changelog**

Improve `run vbox` to support multiple disks and network adapters

**- A picture of a cute animal (not mandatory but encouraged)**

![wombat](https://user-images.githubusercontent.com/20242/43515253-5658a9f0-9582-11e8-9edf-d85b015a754a.jpeg)
