### PR TITLE
Update the vendoring of virtsock

### DIFF
--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -61,7 +61,7 @@ services:
   # VSOCK to unix domain socket forwarding. Forwards guest /var/run/docker.sock
   # to a socket on the host.
   - name: vsudd
-    image: linuxkit/vsudd:v0.6
+    image: linuxkit/vsudd:98e554e4f3024c318e42c1f6876b541b654acd9f
     binds:
         - /var/run:/var/run
     command: ["/vsudd", "-inport", "2376:unix:/var/run/docker.sock"]
@@ -78,7 +78,7 @@ services:
     image: linuxkit/trim-after-delete:v0.6
   # When the host resumes from sleep, force a clock resync
   - name: host-timesync-daemon
-    image: linuxkit/host-timesync-daemon:v0.6
+    image: linuxkit/host-timesync-daemon:613dc55e67470ec375335a1958650c3711dc4aa6
   # Run dockerd with the vpnkit userland proxy from the vpnkit-forwarder container.
   # Bind mounts /var/run to allow vsudd to connect to docker.sock, /var/vpnkit
   # for vpnkit coordination and /run/config/docker for the configuration file.

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -11,7 +11,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: vsudd
-    image: linuxkit/vsudd:v0.6
+    image: linuxkit/vsudd:98e554e4f3024c318e42c1f6876b541b654acd9f
     binds:
         - /run/containerd/containerd.sock:/run/containerd/containerd.sock
     command: ["/vsudd",

--- a/pkg/host-timesync-daemon/Dockerfile
+++ b/pkg/host-timesync-daemon/Dockerfile
@@ -3,7 +3,7 @@ FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS mirror
 RUN apk add --no-cache go musl-dev git
 ENV GOPATH=/go PATH=$PATH:/go/bin
 
-ENV VIRTSOCK_COMMIT=a381dcc5bcddf1d7f449495c373dbf70f8e501c0
+ENV VIRTSOCK_COMMIT=f1e32d3189e0dbb81c0e752a4e214617487eb41f
 RUN mkdir -p $GOPATH/src/github.com/linuxkit && \
   cd $GOPATH/src/github.com/linuxkit && \
   git clone https://github.com/linuxkit/virtsock.git && \

--- a/pkg/vsudd/Dockerfile
+++ b/pkg/vsudd/Dockerfile
@@ -2,7 +2,7 @@ FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS mirror
 
 RUN apk add --no-cache go musl-dev git build-base
 ENV GOPATH=/go PATH=$PATH:/go/bin 
-ENV VIRTSOCK_COMMIT=a381dcc5bcddf1d7f449495c373dbf70f8e501c0
+ENV VIRTSOCK_COMMIT=f1e32d3189e0dbb81c0e752a4e214617487eb41f
 
 RUN git clone https://github.com/linuxkit/virtsock.git /go/src/github.com/linuxkit/virtsock && \
     cd /go/src/github.com/linuxkit/virtsock && \
@@ -10,5 +10,5 @@ RUN git clone https://github.com/linuxkit/virtsock.git /go/src/github.com/linuxk
     make vsudd
 
 FROM scratch
-COPY --from=mirror /go/src/github.com/linuxkit/virtsock/build/vsudd.linux /vsudd
+COPY --from=mirror /go/src/github.com/linuxkit/virtsock/bin/vsudd.linux /vsudd
 ENTRYPOINT ["/vsudd"]

--- a/test/cases/020_kernel/110_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/010_echo-short-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/010_echo-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/011_echo-short-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/011_echo-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/012_echo-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/012_echo-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/015_echo-long-1con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/015_echo-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/016_echo-long-10con-single/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/016_echo-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/050_unix-domain/017_echo-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/110_namespace/050_unix-domain/017_echo-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/100_mix/010_veth-unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/010_veth-unix-domain-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "mix"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/100_mix/011_veth-unix-domain-echo-reverse/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/011_veth-unix-domain-echo-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-reverse"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/100_mix/012_veth-ipv4-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/012_veth-ipv4-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv4"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/100_mix/013_veth-ipv6-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/013_veth-ipv6-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv6"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/100_mix/014_veth-tcp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/014_veth-tcp-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-tcp"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/100_mix/015_veth-udp-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/015_veth-udp-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-udp"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/110_namespace/100_mix/020_unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/110_namespace/100_mix/020_unix-domain-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:4dfa650d8f9c51fa68efbf75f8f12031f366e783
+    image: linuxkit/test-ns:a21f996641f391d467a7842e85088a304d24fae5
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-unix"]
     mounts: # for runc
     - type: cgroup

--- a/test/pkg/ns/Dockerfile
+++ b/test/pkg/ns/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache \
     go \
     musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin
-ENV VIRTSOCK_COMMIT=0416e3d85541e7a067fd000c69f50997b5d47c93
+ENV VIRTSOCK_COMMIT=f1e32d3189e0dbb81c0e752a4e214617487eb41f
 RUN git clone https://github.com/linuxkit/virtsock.git /go/src/github.com/linuxkit/virtsock && \
     cd /go/src/github.com/linuxkit/virtsock && \
     git checkout $VIRTSOCK_COMMIT && \

--- a/test/pkg/virtsock/Dockerfile
+++ b/test/pkg/virtsock/Dockerfile
@@ -9,17 +9,17 @@ FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build
 RUN apk add --no-cache go musl-dev git make
 ENV GOPATH=/go PATH=$PATH:/go/bin
 
-ENV VIRTSOCK_COMMIT=3bfdf22e3b63a7d130ae5db41c2d76eaffa444d4
-RUN mkdir -p $GOPATH/src/github.com/rneugeba && \
-  cd $GOPATH/src/github.com/rneugeba && \
-  git clone https://github.com/rneugeba/virtsock.git
-WORKDIR $GOPATH/src/github.com/rneugeba/virtsock
+ENV VIRTSOCK_COMMIT=f1e32d3189e0dbb81c0e752a4e214617487eb41f
+RUN mkdir -p $GOPATH/src/github.com/linuxkit && \
+  cd $GOPATH/src/github.com/linuxkit && \
+  git clone https://github.com/linuxkit/virtsock.git
+WORKDIR $GOPATH/src/github.com/linuxkit/virtsock
 RUN git checkout $VIRTSOCK_COMMIT
 # Don't use go-compile.sh quite yet as the virtsock package is not yet lint free
-RUN make build/virtsock_stress.linux && \
-    cp -a build/virtsock_stress.linux /virtsock_stress
+RUN make bin/sock_stress.linux && \
+    cp -a bin/sock_stress.linux /sock_stress
 
 FROM scratch
 COPY --from=mirror /out/ /
-COPY --from=build virtsock_stress usr/bin/virtsock_stress
-CMD ["/sbin/tini", "/usr/bin/virtsock_stress", "-s", "-v", "1"]
+COPY --from=build sock_stress usr/bin/sock_stress
+CMD ["/sbin/tini", "/usr/bin/sock_stress", "-s", "-v", "1"]


### PR DESCRIPTION
In addition to bug fixes, this removes the special protocol used for `shutdown` needed by old Windows builds < 14393-- this is of particular interest to `vsudd` which is used to proxy arbitrary socket connections.

**- Description for the changelog**
Update the version of `virtsock` used by `vsudd` to the latest version, removing the old workaround for lack of `shutdown` on Windows builds < 14393.


**- A picture of a cute animal (not mandatory but encouraged)**

![Sunbathing pig](http://humorhub.net/wp-content/uploads/2013/05/Animals-sunbathing4.jpg)
