### PR TITLE
wireguard: upgrade to 0.0.20180802

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180718
-ENV WIREGUARD_SHA256="083c093a6948c8d38f92e7ea5533f9ff926019f24dc2612ea974851ed3e24705"
+ENV WIREGUARD_VERSION=0.0.20180802
+ENV WIREGUARD_SHA256="cd1da34b377d58df760aadf69ced045081517570586fc2d4eed7f09f5d5a47c6"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * receive: check against proper return value type
  
  Ensure error counters are correct in the receive path.
  
  * embeddable-wg-library: do not left shift negative numbers
  
  Avoids implementation-defined C behavior and also improves performance.
  
  * wg-quick: android: allow package to be overridden
  * wg-quick: android: remove compat code
  
  Small android fixes.
  
  * qemu: show log if process crashes
  * qemu: update musl and kernel
  
  The usual QEMU suite bump.
  
  * curve25519-x86_64: tighten the x25519 assembly
  
  Small performance optimization from Samuel.
  The wide multiplication by 38 in mul_a24_eltfp25519_1w is redundant:
  (2^256-1) * 121666 / 2^256 is at most 121665, and therefore a 64-bit
  multiplication can never overflow.
  
  * curve25519-x86_64: tighten reductions modulo 2^256-38
  
  Small performance optimization from Samuel.
  At this stage the value if C[4] is at most ((2^256-1) + 38*(2^256-1)) / 2^256 = 38,
  so there is no need to use a wide multiplication.
  
  * curve25519-x86_64: simplify the final reduction by adding 19 beforehand
  
  Small performance optimization from Samuel.
  At this stage the value if C[4] is at most ((2^256-1) + 38*(2^256-1)) / 2^256 = 38,
  Correctness can be quickly verified with the following z3py script:
  
  >>> from z3 import *
  >>> x = BitVec("x", 256) # any 256-bit value
  >>> ref = URem(x, 2**255 - 19) # correct value
  >>> t = Extract(255, 255, x); x &= 2**255 - 1; # btrq $63, %3
  >>> u = If(t != 0, BitVecVal(38, 256), BitVecVal(19, 256)) # cmovncl %k5, %k4
  >>> x += u # addq %4, %0; adcq $0, %1; adcq $0, %2; adcq $0, %3;
  >>> t = Extract(255, 255, x); x &= 2**255 - 1; # btrq $63, %3
  >>> u = If(t != 0, BitVecVal(0, 256), BitVecVal(19, 256)) # cmovncl %k5, %k4
  >>> x -= u # subq %4, %0; sbbq $0, %1; sbbq $0, %2; sbbq $0, %3;
  >>> prove(x == ref)
  proved
  
  * ratelimiter: prevent init/uninit race
  
  Fixes a classic ABA problem that isn't actually reachable because of
  rtnl_lock, but it's good to be correct anyway.
  
  * peer: simplify rcu reference counts
  
  Use RCU reference counts only when we must, and otherwise use a more
  reasonably named function.
  
  * main: add missing chacha20poly1305 header
  * send: address of variable is never null
  * noise: remove outdated comment
  * main: properly name label
  * noise: use hex constant for tai64n offset
  * device: adjust comment
  
  A series of last minute nits before submitting upstream.

  * chacha20poly1305: selftest: split up test vector constants
  
  The test vectors are encoded as long strings -- really long strings -- and
  apparently RFC821 doesn't like lines longer than 998.
  https://cr.yp.to/smtp/message.html
  
  * queueing: keep reference to peer after setting atomic state bit
  
  This fixes a regression introduced when preparing the LKML submission.
  
  * allowedips: prevent double read in kref
  * allowedips: avoid window of disappeared peer
  * hashtables: document immediate zeroing semantics
  * peer: ensure resources are freed when creation fails
  * queueing: document double-adding and reference conditions
  * queueing: ensure strictly ordered loads and stores
  * cookie: returned keypair might disappear if rcu lock not held
  * noise: free peer references on failure
  * peer: ensure destruction doesn't race
  
  Various fixes, as well as lots of code comment documentation, for a
  small variety of the less obvious aspects of object lifecycles,
  focused on correctness.
  
  * allowedips: free root inside of RCU callback
  * allowedips: use different macro names so as to avoid confusion
  
  These incorporate two suggestions from LKML.
```