### PR TITLE
Update kernels up to 4.17.14/414/62/4.9.119/4.4.147

### DIFF
--- a/contrib/crosvm/README.md
+++ b/contrib/crosvm/README.md
@@ -30,7 +30,7 @@ YAML file (`minimal.yml`):
 
 ```
 kernel:
-  image: linuxkit/kernel:4.9.115
+  image: linuxkit/kernel:4.9.119
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -1,6 +1,6 @@
 # This is an example for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.6 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -1,6 +1,6 @@
 # Simple example of using an external logging service
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/packet.arm64.yml
+++ b/examples/packet.arm64.yml
@@ -5,7 +5,7 @@
 # for arm64 then the 'ucode' line in the kernel section can be left
 # out.
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyAMA0"
   ucode: ""
 onboot:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
   - linuxkit/init:v0.6

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0"
 init:
   - linuxkit/init:v0.6

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -218,21 +218,21 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,4.17.13,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.61,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.61,4.14.x,,-dbg))
+$(eval $(call kernel,4.17.14,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.62,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.62,4.14.x,,-dbg))
 $(eval $(call kernel,4.14.59,4.14.x,-rt,))
-$(eval $(call kernel,4.9.118,4.9.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.4.146,4.4.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.119,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.4.147,4.4.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,4.17.13,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.61,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.14,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.62,4.14.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.59,4.14.x,-rt,))
 
 else ifeq ($(ARCH),s390x)
-$(eval $(call kernel,4.17.13,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.61,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.14,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.62,4.14.x,$(EXTRA),$(DEBUG)))
 endif
 
 # Target for kernel config

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -218,21 +218,21 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,4.17.12,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.60,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.60,4.14.x,,-dbg))
+$(eval $(call kernel,4.17.13,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.61,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.61,4.14.x,,-dbg))
 $(eval $(call kernel,4.14.59,4.14.x,-rt,))
-$(eval $(call kernel,4.9.117,4.9.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.4.145,4.4.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.118,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.4.146,4.4.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,4.17.12,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.60,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.13,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.61,4.14.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.59,4.14.x,-rt,))
 
 else ifeq ($(ARCH),s390x)
-$(eval $(call kernel,4.17.12,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.60,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.13,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.61,4.14.x,$(EXTRA),$(DEBUG)))
 endif
 
 # Target for kernel config

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -218,21 +218,21 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,4.17.10,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.58,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.58,4.14.x,,-dbg))
+$(eval $(call kernel,4.17.11,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.59,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.59,4.14.x,,-dbg))
 $(eval $(call kernel,4.14.59,4.14.x,-rt,))
-$(eval $(call kernel,4.9.115,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.116,4.9.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.4.144,4.4.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,4.17.10,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.58,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.11,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.59,4.14.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.59,4.14.x,-rt,))
 
 else ifeq ($(ARCH),s390x)
-$(eval $(call kernel,4.17.10,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.58,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.11,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.59,4.14.x,$(EXTRA),$(DEBUG)))
 endif
 
 # Target for kernel config

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -218,21 +218,21 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,4.17.11,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.59,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.59,4.14.x,,-dbg))
+$(eval $(call kernel,4.17.12,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.60,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.60,4.14.x,,-dbg))
 $(eval $(call kernel,4.14.59,4.14.x,-rt,))
-$(eval $(call kernel,4.9.116,4.9.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.4.144,4.4.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.117,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.4.145,4.4.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,4.17.11,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.59,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.12,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.60,4.14.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.59,4.14.x,-rt,))
 
 else ifeq ($(ARCH),s390x)
-$(eval $(call kernel,4.17.11,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.59,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.12,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.60,4.14.x,$(EXTRA),$(DEBUG)))
 endif
 
 # Target for kernel config

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.59 Kernel Configuration
+# Linux/arm64 4.14.60 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.61 Kernel Configuration
+# Linux/arm64 4.14.62 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.58 Kernel Configuration
+# Linux/arm64 4.14.59 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.60 Kernel Configuration
+# Linux/arm64 4.14.61 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-s390x
+++ b/kernel/config-4.14.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.14.60 Kernel Configuration
+# Linux/s390 4.14.61 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.14.x-s390x
+++ b/kernel/config-4.14.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.14.58 Kernel Configuration
+# Linux/s390 4.14.59 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.14.x-s390x
+++ b/kernel/config-4.14.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.14.61 Kernel Configuration
+# Linux/s390 4.14.62 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.14.x-s390x
+++ b/kernel/config-4.14.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.14.59 Kernel Configuration
+# Linux/s390 4.14.60 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.60 Kernel Configuration
+# Linux/x86 4.14.61 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.59 Kernel Configuration
+# Linux/x86 4.14.60 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.58 Kernel Configuration
+# Linux/x86 4.14.59 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.61 Kernel Configuration
+# Linux/x86 4.14.62 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.17.x-aarch64
+++ b/kernel/config-4.17.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.17.12 Kernel Configuration
+# Linux/arm64 4.17.13 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.17.x-aarch64
+++ b/kernel/config-4.17.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.17.13 Kernel Configuration
+# Linux/arm64 4.17.14 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.17.x-aarch64
+++ b/kernel/config-4.17.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.17.11 Kernel Configuration
+# Linux/arm64 4.17.12 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.17.x-aarch64
+++ b/kernel/config-4.17.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.17.10 Kernel Configuration
+# Linux/arm64 4.17.11 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.17.x-s390x
+++ b/kernel/config-4.17.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.17.12 Kernel Configuration
+# Linux/s390 4.17.13 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.17.x-s390x
+++ b/kernel/config-4.17.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.17.10 Kernel Configuration
+# Linux/s390 4.17.11 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.17.x-s390x
+++ b/kernel/config-4.17.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.17.11 Kernel Configuration
+# Linux/s390 4.17.12 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.17.x-s390x
+++ b/kernel/config-4.17.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.17.13 Kernel Configuration
+# Linux/s390 4.17.14 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.17.x-x86_64
+++ b/kernel/config-4.17.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.17.10 Kernel Configuration
+# Linux/x86 4.17.11 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.17.x-x86_64
+++ b/kernel/config-4.17.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.17.12 Kernel Configuration
+# Linux/x86 4.17.13 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.17.x-x86_64
+++ b/kernel/config-4.17.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.17.11 Kernel Configuration
+# Linux/x86 4.17.12 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.17.x-x86_64
+++ b/kernel/config-4.17.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.17.13 Kernel Configuration
+# Linux/x86 4.17.14 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.145 Kernel Configuration
+# Linux/x86 4.4.146 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.144 Kernel Configuration
+# Linux/x86 4.4.145 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.146 Kernel Configuration
+# Linux/x86 4.4.147 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.115 Kernel Configuration
+# Linux/x86 4.9.116 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.116 Kernel Configuration
+# Linux/x86 4.9.117 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.118 Kernel Configuration
+# Linux/x86 4.9.119 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.117 Kernel Configuration
+# Linux/x86 4.9.118 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 221ac7248223818591874803225a021588bcb540 Mon Sep 17 00:00:00 2001
+From f684a9476c4d40443ca1fbe954e946dbf40e2d99 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 01/21] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 6ca78fefc023b9481d32f710e9ce4c6ed0ad1d92 Mon Sep 17 00:00:00 2001
+From 221ac7248223818591874803225a021588bcb540 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 01/21] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From f684a9476c4d40443ca1fbe954e946dbf40e2d99 Mon Sep 17 00:00:00 2001
+From 6bf940c4a1e4950afbdb9769e05ead23ad95f69a Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 01/21] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 4fabc3ccbfcbf1b29f4a41dd5367b1fcd77fc65b Mon Sep 17 00:00:00 2001
+From 6ca78fefc023b9481d32f710e9ce4c6ed0ad1d92 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 01/21] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,4 +1,4 @@
-From 1113b68175d914f9ac9fb8c289f091083991f496 Mon Sep 17 00:00:00 2001
+From 84b3a7eb6b0a0722623785ede49a197dc1f431ce Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
 Subject: [PATCH 02/21] hyper-v: trace vmbus_on_msg_dpc()

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,4 +1,4 @@
-From 84b3a7eb6b0a0722623785ede49a197dc1f431ce Mon Sep 17 00:00:00 2001
+From b518a6977beb07d350011654c2f3a795bec71bef Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
 Subject: [PATCH 02/21] hyper-v: trace vmbus_on_msg_dpc()

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,4 +1,4 @@
-From b518a6977beb07d350011654c2f3a795bec71bef Mon Sep 17 00:00:00 2001
+From 39eeba58d1ce2422b2f7bb87aa3608cb93f91c1b Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
 Subject: [PATCH 02/21] hyper-v: trace vmbus_on_msg_dpc()

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,4 +1,4 @@
-From b68f3db3c6b28c2a8f415fde4af410a0ecae54c8 Mon Sep 17 00:00:00 2001
+From 1113b68175d914f9ac9fb8c289f091083991f496 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
 Subject: [PATCH 02/21] hyper-v: trace vmbus_on_msg_dpc()

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,4 +1,4 @@
-From ac4e5f0d75d39e8900b6273875f224e219bf27b4 Mon Sep 17 00:00:00 2001
+From 2e8defad92a8901647aa510dfcb6eeed53801d0f Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
 Subject: [PATCH 03/21] hyper-v: trace vmbus_on_message()

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,4 +1,4 @@
-From b7a8183c99afd2018f2d44cd41f6b60d9902d56f Mon Sep 17 00:00:00 2001
+From 948a0b1aa1e4b0494c15ab7a594af4b0f5a69a13 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
 Subject: [PATCH 03/21] hyper-v: trace vmbus_on_message()

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,4 +1,4 @@
-From 948a0b1aa1e4b0494c15ab7a594af4b0f5a69a13 Mon Sep 17 00:00:00 2001
+From ac4e5f0d75d39e8900b6273875f224e219bf27b4 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
 Subject: [PATCH 03/21] hyper-v: trace vmbus_on_message()

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,4 +1,4 @@
-From 2b634ed4e3b0ff1cc528f63867215524300f059e Mon Sep 17 00:00:00 2001
+From b7a8183c99afd2018f2d44cd41f6b60d9902d56f Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
 Subject: [PATCH 03/21] hyper-v: trace vmbus_on_message()

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,4 +1,4 @@
-From 26e5c3b2df839af27a04421c5d15da2e9d7c6d0b Mon Sep 17 00:00:00 2001
+From 2a5bcdc3cc08858e9292304073297742dca32cd1 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
 Subject: [PATCH 04/21] hyper-v: trace vmbus_onoffer()

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,4 +1,4 @@
-From 908f2f26800936bf619f3617a927f4988a2b9421 Mon Sep 17 00:00:00 2001
+From 46c7d69b9c92c90b371e30d0583033714d393af5 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
 Subject: [PATCH 04/21] hyper-v: trace vmbus_onoffer()

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,4 +1,4 @@
-From 2a5bcdc3cc08858e9292304073297742dca32cd1 Mon Sep 17 00:00:00 2001
+From 6ce87087e9413ea72efc9c586087039f2532f82c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
 Subject: [PATCH 04/21] hyper-v: trace vmbus_onoffer()

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,4 +1,4 @@
-From 46c7d69b9c92c90b371e30d0583033714d393af5 Mon Sep 17 00:00:00 2001
+From 26e5c3b2df839af27a04421c5d15da2e9d7c6d0b Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
 Subject: [PATCH 04/21] hyper-v: trace vmbus_onoffer()

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,4 +1,4 @@
-From d4197d14bdb83cb23c5cffb91a54e04b96160c9d Mon Sep 17 00:00:00 2001
+From 8209e6484e5ad8090888add781d56af201898bc8 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
 Subject: [PATCH 05/21] hyper-v: trace vmbus_onoffer_rescind()

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,4 +1,4 @@
-From 0d6217b666d9398edfc765cf27f52017c0e2c1a2 Mon Sep 17 00:00:00 2001
+From d4197d14bdb83cb23c5cffb91a54e04b96160c9d Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
 Subject: [PATCH 05/21] hyper-v: trace vmbus_onoffer_rescind()

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,4 +1,4 @@
-From 9372ce8697313dc9911ec15cc0e7788d303caf8b Mon Sep 17 00:00:00 2001
+From 0d6217b666d9398edfc765cf27f52017c0e2c1a2 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
 Subject: [PATCH 05/21] hyper-v: trace vmbus_onoffer_rescind()

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,4 +1,4 @@
-From 10ab7a26269bb3ff2e145b5fc2b73c752f437cd8 Mon Sep 17 00:00:00 2001
+From 9372ce8697313dc9911ec15cc0e7788d303caf8b Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
 Subject: [PATCH 05/21] hyper-v: trace vmbus_onoffer_rescind()

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,4 +1,4 @@
-From b44989770074ed044f5a4f66790f4f05e7670872 Mon Sep 17 00:00:00 2001
+From 9c8fcd80d48281c5e021ed97db836dd397065ab0 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
 Subject: [PATCH 06/21] hyper-v: trace vmbus_onopen_result()

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,4 +1,4 @@
-From dbe5c106ba5de432682240f94cd48d0f90a755dc Mon Sep 17 00:00:00 2001
+From a79892650a6d739cca5e3cfdc80276fe43e0f4ab Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
 Subject: [PATCH 06/21] hyper-v: trace vmbus_onopen_result()

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,4 +1,4 @@
-From fe0e871a20db0994cda89d358da3ff281a05e378 Mon Sep 17 00:00:00 2001
+From b44989770074ed044f5a4f66790f4f05e7670872 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
 Subject: [PATCH 06/21] hyper-v: trace vmbus_onopen_result()

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,4 +1,4 @@
-From 9c8fcd80d48281c5e021ed97db836dd397065ab0 Mon Sep 17 00:00:00 2001
+From dbe5c106ba5de432682240f94cd48d0f90a755dc Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
 Subject: [PATCH 06/21] hyper-v: trace vmbus_onopen_result()

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,4 +1,4 @@
-From 87b6f1de8ac94717039aaf8fbd8383d705a671d1 Mon Sep 17 00:00:00 2001
+From 0d5bec78bec45edf0e3b3c57c0f320d8a019b7a0 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
 Subject: [PATCH 07/21] hyper-v: trace vmbus_ongpadl_created()

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,4 +1,4 @@
-From 0d5bec78bec45edf0e3b3c57c0f320d8a019b7a0 Mon Sep 17 00:00:00 2001
+From a44fdd5b7e46c1f0e34a8baa5ca01380deb5acbb Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
 Subject: [PATCH 07/21] hyper-v: trace vmbus_ongpadl_created()

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,4 +1,4 @@
-From d5fd01e71f687a5d2932a9d8f5f9c58dce7413ce Mon Sep 17 00:00:00 2001
+From 87b6f1de8ac94717039aaf8fbd8383d705a671d1 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
 Subject: [PATCH 07/21] hyper-v: trace vmbus_ongpadl_created()

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,4 +1,4 @@
-From 5347396a1b2d7a2f98d55744e90d5c9f17b8dfb6 Mon Sep 17 00:00:00 2001
+From d5fd01e71f687a5d2932a9d8f5f9c58dce7413ce Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
 Subject: [PATCH 07/21] hyper-v: trace vmbus_ongpadl_created()

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,4 +1,4 @@
-From d378acbe4836fa5cf0690afca436f9f15ea6c59e Mon Sep 17 00:00:00 2001
+From 649e2dfd2521b77d48a9dedfa5eefacd2088bcfd Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
 Subject: [PATCH 08/21] hyper-v: trace vmbus_ongpadl_torndown()

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,4 +1,4 @@
-From bd2353d253e838eeb9bff4dc8b237d4fd9350e75 Mon Sep 17 00:00:00 2001
+From 568bdf6d7dcfcc184982fe64dafedb1bfb5347c5 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
 Subject: [PATCH 08/21] hyper-v: trace vmbus_ongpadl_torndown()

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,4 +1,4 @@
-From 568bdf6d7dcfcc184982fe64dafedb1bfb5347c5 Mon Sep 17 00:00:00 2001
+From cb106cc0803b9a4e2e19e0942b1ac1b511914d9f Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
 Subject: [PATCH 08/21] hyper-v: trace vmbus_ongpadl_torndown()

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,4 +1,4 @@
-From 649e2dfd2521b77d48a9dedfa5eefacd2088bcfd Mon Sep 17 00:00:00 2001
+From bd2353d253e838eeb9bff4dc8b237d4fd9350e75 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
 Subject: [PATCH 08/21] hyper-v: trace vmbus_ongpadl_torndown()

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,4 +1,4 @@
-From 27d602f24e6043e8541e9c3c6199efe5795ff06f Mon Sep 17 00:00:00 2001
+From d6e468e983df1218999f830fd17b475c1ace2f20 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
 Subject: [PATCH 09/21] hyper-v: trace vmbus_onversion_response()

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,4 +1,4 @@
-From d6e468e983df1218999f830fd17b475c1ace2f20 Mon Sep 17 00:00:00 2001
+From d07a78fc089ea9025331aa0971790d04dc891596 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
 Subject: [PATCH 09/21] hyper-v: trace vmbus_onversion_response()

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,4 +1,4 @@
-From 23c634c3f3fb2f5afd713b05b01c26da168113f5 Mon Sep 17 00:00:00 2001
+From a75d50213c679df68dc3648b32f6cdc46f30a6f7 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
 Subject: [PATCH 09/21] hyper-v: trace vmbus_onversion_response()

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,4 +1,4 @@
-From a75d50213c679df68dc3648b32f6cdc46f30a6f7 Mon Sep 17 00:00:00 2001
+From 27d602f24e6043e8541e9c3c6199efe5795ff06f Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
 Subject: [PATCH 09/21] hyper-v: trace vmbus_onversion_response()

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,4 +1,4 @@
-From 999780655b2e1cccfaac2a168f9d2eed8732c76d Mon Sep 17 00:00:00 2001
+From b4306bb7db5992193ae1bd3468e35a7213c9ad64 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
 Subject: [PATCH 10/21] hyper-v: trace vmbus_request_offers()

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,4 +1,4 @@
-From cd448111c7e4e0b99ea1d47a2403f005afa3bfbe Mon Sep 17 00:00:00 2001
+From 27ba7b32c2cd27897576b5b2827cad6527d13ff3 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
 Subject: [PATCH 10/21] hyper-v: trace vmbus_request_offers()

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,4 +1,4 @@
-From 27ba7b32c2cd27897576b5b2827cad6527d13ff3 Mon Sep 17 00:00:00 2001
+From bcb71d3da501ab49e8de5a01469e3c4e3c79af7c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
 Subject: [PATCH 10/21] hyper-v: trace vmbus_request_offers()

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,4 +1,4 @@
-From b4306bb7db5992193ae1bd3468e35a7213c9ad64 Mon Sep 17 00:00:00 2001
+From cd448111c7e4e0b99ea1d47a2403f005afa3bfbe Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
 Subject: [PATCH 10/21] hyper-v: trace vmbus_request_offers()

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,4 +1,4 @@
-From bc01bbbfce0751627f28f5548c865d511193670a Mon Sep 17 00:00:00 2001
+From 3d950810a314e5a4714211f8128253445424c6ff Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
 Subject: [PATCH 11/21] hyper-v: trace vmbus_open()

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 99afc08e62d55b69e75de5ae49272aa25dd2275e Mon Sep 17 00:00:00 2001
+From c729bb25750d57541d60f09497ac36a9e8ff4982 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
 Subject: [PATCH 11/21] hyper-v: trace vmbus_open()

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 3d950810a314e5a4714211f8128253445424c6ff Mon Sep 17 00:00:00 2001
+From b87608ab687550026402f238acbf61d5fc41820b Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
 Subject: [PATCH 11/21] hyper-v: trace vmbus_open()

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,4 +1,4 @@
-From b87608ab687550026402f238acbf61d5fc41820b Mon Sep 17 00:00:00 2001
+From 99afc08e62d55b69e75de5ae49272aa25dd2275e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
 Subject: [PATCH 11/21] hyper-v: trace vmbus_open()

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,4 +1,4 @@
-From 8370048792fa9db331f2d1a5f4300df12a655818 Mon Sep 17 00:00:00 2001
+From 2589cc41027085975a749ddf238267f760105b30 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
 Subject: [PATCH 12/21] hyper-v: trace vmbus_close_internal()

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,4 +1,4 @@
-From 1bd0771b1740d9893e309acf1d3bf4a9e9ef01c0 Mon Sep 17 00:00:00 2001
+From 8370048792fa9db331f2d1a5f4300df12a655818 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
 Subject: [PATCH 12/21] hyper-v: trace vmbus_close_internal()

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,4 +1,4 @@
-From d39de3ec255911c6d43047f26b61c960cc0757ef Mon Sep 17 00:00:00 2001
+From d771614b69ecadc770bd965728816f62b6725548 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
 Subject: [PATCH 12/21] hyper-v: trace vmbus_close_internal()

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,4 +1,4 @@
-From d771614b69ecadc770bd965728816f62b6725548 Mon Sep 17 00:00:00 2001
+From 1bd0771b1740d9893e309acf1d3bf4a9e9ef01c0 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
 Subject: [PATCH 12/21] hyper-v: trace vmbus_close_internal()

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,4 +1,4 @@
-From e7f571e2f8af6144b006ff9a97653a0e851faed2 Mon Sep 17 00:00:00 2001
+From 5b8001466b1b2d861fcb366f810ffbb6370dc44e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
 Subject: [PATCH 13/21] hyper-v: trace vmbus_establish_gpadl()

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,4 +1,4 @@
-From 8a5f3a52b5936628fe1ba5d679214e9afc095cce Mon Sep 17 00:00:00 2001
+From e7f571e2f8af6144b006ff9a97653a0e851faed2 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
 Subject: [PATCH 13/21] hyper-v: trace vmbus_establish_gpadl()

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,4 +1,4 @@
-From b092331d80b698a9ad7d822e7b9c0ef49b6d32f5 Mon Sep 17 00:00:00 2001
+From 8a5f3a52b5936628fe1ba5d679214e9afc095cce Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
 Subject: [PATCH 13/21] hyper-v: trace vmbus_establish_gpadl()

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,4 +1,4 @@
-From 5b8001466b1b2d861fcb366f810ffbb6370dc44e Mon Sep 17 00:00:00 2001
+From 46cdaccb0a9de1b9ebf36161b652e43cbd1d6fd9 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
 Subject: [PATCH 13/21] hyper-v: trace vmbus_establish_gpadl()

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,4 +1,4 @@
-From 548ae4b4d29414184d57806ff3c773ac025946d2 Mon Sep 17 00:00:00 2001
+From 8e07f424093915687bfd9fd2e3ee8bba8f1632a2 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
 Subject: [PATCH 14/21] hyper-v: trace vmbus_teardown_gpadl()

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,4 +1,4 @@
-From edaf50d60132889f66612adfa2252b61c5c1f45c Mon Sep 17 00:00:00 2001
+From e64a1f7f820070d0edc04149aaec212514a4a9b2 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
 Subject: [PATCH 14/21] hyper-v: trace vmbus_teardown_gpadl()

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,4 +1,4 @@
-From 8e07f424093915687bfd9fd2e3ee8bba8f1632a2 Mon Sep 17 00:00:00 2001
+From edaf50d60132889f66612adfa2252b61c5c1f45c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
 Subject: [PATCH 14/21] hyper-v: trace vmbus_teardown_gpadl()

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,4 +1,4 @@
-From e64a1f7f820070d0edc04149aaec212514a4a9b2 Mon Sep 17 00:00:00 2001
+From 1f79bca0f43a1708cae1bfac8e3a766891bc5f74 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
 Subject: [PATCH 14/21] hyper-v: trace vmbus_teardown_gpadl()

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,4 +1,4 @@
-From b03df401827cbee2964941a29fc4ac13ee9cbcb6 Mon Sep 17 00:00:00 2001
+From bc6db5d7a0bcf9013657240b24df839af180544c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
 Subject: [PATCH 15/21] hyper-v: trace vmbus_negotiate_version()

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,4 +1,4 @@
-From bc6db5d7a0bcf9013657240b24df839af180544c Mon Sep 17 00:00:00 2001
+From ab2969908c20b312b63928e04b2c1d102e119a9d Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
 Subject: [PATCH 15/21] hyper-v: trace vmbus_negotiate_version()

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,4 +1,4 @@
-From dd4703d6bfad5f3b3b5e782a8acbf91f18f77300 Mon Sep 17 00:00:00 2001
+From ba4b0a8ad1464bad30d3e4bc3ec808a4af19c477 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
 Subject: [PATCH 15/21] hyper-v: trace vmbus_negotiate_version()

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,4 +1,4 @@
-From ab2969908c20b312b63928e04b2c1d102e119a9d Mon Sep 17 00:00:00 2001
+From dd4703d6bfad5f3b3b5e782a8acbf91f18f77300 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
 Subject: [PATCH 15/21] hyper-v: trace vmbus_negotiate_version()

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,4 +1,4 @@
-From 55997844064ae4b2298ef74969b93712317f7758 Mon Sep 17 00:00:00 2001
+From 1b23e8eca50d93b6e9a477d26bbd3a6b7d49d0ea Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
 Subject: [PATCH 16/21] hyper-v: trace vmbus_release_relid()

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,4 +1,4 @@
-From 1b23e8eca50d93b6e9a477d26bbd3a6b7d49d0ea Mon Sep 17 00:00:00 2001
+From e40c2cd76d1ee4cde0bc222dddb833ee3fb79ac2 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
 Subject: [PATCH 16/21] hyper-v: trace vmbus_release_relid()

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,4 +1,4 @@
-From e40c2cd76d1ee4cde0bc222dddb833ee3fb79ac2 Mon Sep 17 00:00:00 2001
+From 3ad32115332ce7874ff20459b658244c90ef8fe5 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
 Subject: [PATCH 16/21] hyper-v: trace vmbus_release_relid()

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,4 +1,4 @@
-From 210682a76fa6193fefc49e2bdbb01974fe0bef76 Mon Sep 17 00:00:00 2001
+From 55997844064ae4b2298ef74969b93712317f7758 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
 Subject: [PATCH 16/21] hyper-v: trace vmbus_release_relid()

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,4 +1,4 @@
-From 7cb51fbd062a15d921536a3eb949406c5c663bda Mon Sep 17 00:00:00 2001
+From e96e858d60f00b0ca359006ce7ae82e8547da2bc Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
 Subject: [PATCH 17/21] hyper-v: trace vmbus_send_tl_connect_request()

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,4 +1,4 @@
-From 89407d9dbcf558d08843ce0612f353eba3929837 Mon Sep 17 00:00:00 2001
+From 18289cb8d2523de3dff3a6434731083d353c53c2 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
 Subject: [PATCH 17/21] hyper-v: trace vmbus_send_tl_connect_request()

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,4 +1,4 @@
-From e2b0de9eabfb280684c6a983c5f3bdc973ceb780 Mon Sep 17 00:00:00 2001
+From 7cb51fbd062a15d921536a3eb949406c5c663bda Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
 Subject: [PATCH 17/21] hyper-v: trace vmbus_send_tl_connect_request()

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,4 +1,4 @@
-From 18289cb8d2523de3dff3a6434731083d353c53c2 Mon Sep 17 00:00:00 2001
+From e2b0de9eabfb280684c6a983c5f3bdc973ceb780 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
 Subject: [PATCH 17/21] hyper-v: trace vmbus_send_tl_connect_request()

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,4 +1,4 @@
-From 0511a3b43848373dd72c1085f576106695d4d026 Mon Sep 17 00:00:00 2001
+From 8930231ecf956d8f95f592fef18b31d3bdfa399a Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
 Subject: [PATCH 18/21] hyper-v: trace channel events

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,4 +1,4 @@
-From 8930231ecf956d8f95f592fef18b31d3bdfa399a Mon Sep 17 00:00:00 2001
+From 41b7b92d8df2160e84615d1badd5b06fdb2e4b7d Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
 Subject: [PATCH 18/21] hyper-v: trace channel events

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,4 +1,4 @@
-From 4e77ecb0b9f9393887048e2647e7bf77690118fe Mon Sep 17 00:00:00 2001
+From 0511a3b43848373dd72c1085f576106695d4d026 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
 Subject: [PATCH 18/21] hyper-v: trace channel events

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,4 +1,4 @@
-From cb551169323e21deaa6f30a2bda27b08efa4790c Mon Sep 17 00:00:00 2001
+From 4e77ecb0b9f9393887048e2647e7bf77690118fe Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
 Subject: [PATCH 18/21] hyper-v: trace channel events

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From 9cce3eb78d66237935a7c73d7d62ec513eef0da3 Mon Sep 17 00:00:00 2001
+From 9ee248b5803627a5fad6a08a569e2f2bdb445b01 Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH 19/21] serial: forbid 8250 on s390

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From 45e34fb74e8505da7752abcd901c9958a8697157 Mon Sep 17 00:00:00 2001
+From a16cb269ded032de9550000c54bc0c5dcc778621 Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH 19/21] serial: forbid 8250 on s390

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From 9ee248b5803627a5fad6a08a569e2f2bdb445b01 Mon Sep 17 00:00:00 2001
+From c41edd1517ca6f970c69e6370a782c3b6be43263 Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH 19/21] serial: forbid 8250 on s390

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From c41edd1517ca6f970c69e6370a782c3b6be43263 Mon Sep 17 00:00:00 2001
+From 45e34fb74e8505da7752abcd901c9958a8697157 Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH 19/21] serial: forbid 8250 on s390

--- a/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
+++ b/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
@@ -1,4 +1,4 @@
-From 8ba5c4a3d02c3427ec0633a3348a47d41ae369ad Mon Sep 17 00:00:00 2001
+From fd023529023cabb1d39a4a69d6f4da70bc9afa30 Mon Sep 17 00:00:00 2001
 From: Cathy Avery <cavery@redhat.com>
 Date: Tue, 31 Oct 2017 08:52:06 -0400
 Subject: [PATCH 20/21] scsi: storvsc: Allow only one remove lun work item to

--- a/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
+++ b/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
@@ -1,4 +1,4 @@
-From fd023529023cabb1d39a4a69d6f4da70bc9afa30 Mon Sep 17 00:00:00 2001
+From 27c43870d11a9349ec81aa2339461130ab731a4f Mon Sep 17 00:00:00 2001
 From: Cathy Avery <cavery@redhat.com>
 Date: Tue, 31 Oct 2017 08:52:06 -0400
 Subject: [PATCH 20/21] scsi: storvsc: Allow only one remove lun work item to

--- a/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
+++ b/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
@@ -1,4 +1,4 @@
-From 27c43870d11a9349ec81aa2339461130ab731a4f Mon Sep 17 00:00:00 2001
+From abdc475a887b7b24181401481a84fa499b8b1c12 Mon Sep 17 00:00:00 2001
 From: Cathy Avery <cavery@redhat.com>
 Date: Tue, 31 Oct 2017 08:52:06 -0400
 Subject: [PATCH 20/21] scsi: storvsc: Allow only one remove lun work item to

--- a/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
+++ b/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
@@ -1,4 +1,4 @@
-From abdc475a887b7b24181401481a84fa499b8b1c12 Mon Sep 17 00:00:00 2001
+From 3b2d8cb6a4f53249a8388134c06f86687be9a122 Mon Sep 17 00:00:00 2001
 From: Cathy Avery <cavery@redhat.com>
 Date: Tue, 31 Oct 2017 08:52:06 -0400
 Subject: [PATCH 20/21] scsi: storvsc: Allow only one remove lun work item to

--- a/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
+++ b/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
@@ -1,4 +1,4 @@
-From 2259c19b9733b1f0b6cd7080ba079fc67345032f Mon Sep 17 00:00:00 2001
+From 84260e214af54769eb9e4b0af5daf99950eaa5c9 Mon Sep 17 00:00:00 2001
 From: Long Li <longli@microsoft.com>
 Date: Tue, 31 Oct 2017 14:58:08 -0700
 Subject: [PATCH 21/21] scsi: storvsc: Avoid excessive host scan on controller

--- a/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
+++ b/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
@@ -1,4 +1,4 @@
-From 74fe018d0f5f6fb94553b7fc8a7f515fb98a9584 Mon Sep 17 00:00:00 2001
+From d45fc0c4e913b260925f7b28c27924f7c6a4150c Mon Sep 17 00:00:00 2001
 From: Long Li <longli@microsoft.com>
 Date: Tue, 31 Oct 2017 14:58:08 -0700
 Subject: [PATCH 21/21] scsi: storvsc: Avoid excessive host scan on controller

--- a/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
+++ b/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
@@ -1,4 +1,4 @@
-From d45fc0c4e913b260925f7b28c27924f7c6a4150c Mon Sep 17 00:00:00 2001
+From f34de6fe37cf518837ef6592cbcf3890161a017f Mon Sep 17 00:00:00 2001
 From: Long Li <longli@microsoft.com>
 Date: Tue, 31 Oct 2017 14:58:08 -0700
 Subject: [PATCH 21/21] scsi: storvsc: Avoid excessive host scan on controller

--- a/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
+++ b/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
@@ -1,4 +1,4 @@
-From f34de6fe37cf518837ef6592cbcf3890161a017f Mon Sep 17 00:00:00 2001
+From 2259c19b9733b1f0b6cd7080ba079fc67345032f Mon Sep 17 00:00:00 2001
 From: Long Li <longli@microsoft.com>
 Date: Tue, 31 Oct 2017 14:58:08 -0700
 Subject: [PATCH 21/21] scsi: storvsc: Avoid excessive host scan on controller

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 504c55ecb5d9a32020f07fbd6c3889a6681652dc Mon Sep 17 00:00:00 2001
+From ae4b758d0931f8094f2c0a8625e3cd1559a661f5 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 88349139e19388d58700886fe995812a0c187f1c Mon Sep 17 00:00:00 2001
+From c9f594aa0c45e3b2e555f37d01c8505f2849e148 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From ae4b758d0931f8094f2c0a8625e3cd1559a661f5 Mon Sep 17 00:00:00 2001
+From 88349139e19388d58700886fe995812a0c187f1c Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From a005e66627723c7cb6bf888bf98df50d67c65c9f Mon Sep 17 00:00:00 2001
+From 504c55ecb5d9a32020f07fbd6c3889a6681652dc Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From aef76d09bbe0c5c0a0e7a216c053cf57debf17f2 Mon Sep 17 00:00:00 2001
+From f4fa633d5cc21ba9c29926a4aa144e94fb1b8cbe Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From d1cfa4ea52df5e98b3056cf24ef42a2251181a65 Mon Sep 17 00:00:00 2001
+From 49315bbe95dfda604df8a886f7ab4c09d877bb91 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From d1128679b35d380182f8229c991ae0a42b9bfe83 Mon Sep 17 00:00:00 2001
+From aef76d09bbe0c5c0a0e7a216c053cf57debf17f2 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 49315bbe95dfda604df8a886f7ab4c09d877bb91 Mon Sep 17 00:00:00 2001
+From d1128679b35d380182f8229c991ae0a42b9bfe83 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 4424d213072c0bb5626d415273754d125e81a5cd Mon Sep 17 00:00:00 2001
+From 65ef54ef3d1c8d29ab2fb899736e8001897e1545 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 05d2e26b14aaa07efd4565c1e9e43cbb036412e3 Mon Sep 17 00:00:00 2001
+From 4424d213072c0bb5626d415273754d125e81a5cd Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 72ddf854fc7145d80c3a63780c44caceae992e32 Mon Sep 17 00:00:00 2001
+From 47f6c1ff22369c30e4e96f75a105accc52fbaa38 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 47f6c1ff22369c30e4e96f75a105accc52fbaa38 Mon Sep 17 00:00:00 2001
+From 05d2e26b14aaa07efd4565c1e9e43cbb036412e3 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 1b79c81f7b40756852dfdacb1a7fb0ed3c5ba5e5 Mon Sep 17 00:00:00 2001
+From 68ff415142ca9b4ea15874852233b953408b75fb Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From dec39efee06e309bf09f86740c91cedf9e5b166c Mon Sep 17 00:00:00 2001
+From 1b79c81f7b40756852dfdacb1a7fb0ed3c5ba5e5 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 4ed3b6844831f34c12653e1258261f30b4741a6e Mon Sep 17 00:00:00 2001
+From 7b532c9bd03dfb12193f4e853a417b70cac6c625 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 68ff415142ca9b4ea15874852233b953408b75fb Mon Sep 17 00:00:00 2001
+From 4ed3b6844831f34c12653e1258261f30b4741a6e Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 4ed0d2019da13f76137684446ab88f8dc7a74ec7 Mon Sep 17 00:00:00 2001
+From d491c009e23b650f8e3bd40684a650170fdc09fd Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From d491c009e23b650f8e3bd40684a650170fdc09fd Mon Sep 17 00:00:00 2001
+From 167b858e2c006bee44f165c4d94994e3305026ba Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From cd8b87a97135628a3909163a8aca40938a9a5ab6 Mon Sep 17 00:00:00 2001
+From 3bedde6b15165d04a40b7f9ef0f2fa9f5ceaa43a Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 3bedde6b15165d04a40b7f9ef0f2fa9f5ceaa43a Mon Sep 17 00:00:00 2001
+From 4ed0d2019da13f76137684446ab88f8dc7a74ec7 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From ee5053d39822b471bad463fd96a8e9558c3087fc Mon Sep 17 00:00:00 2001
+From 48e7ac3a2830b8360bb6d976d3fae1f9fb3fd712 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From cc482adb6b2012ac01d70f959af1eeae9829bdc4 Mon Sep 17 00:00:00 2001
+From d8d75a727ae6120603937f92b7c346e00ec9e370 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From 48e7ac3a2830b8360bb6d976d3fae1f9fb3fd712 Mon Sep 17 00:00:00 2001
+From cc482adb6b2012ac01d70f959af1eeae9829bdc4 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From 4a0119831cd7ee385080a6320cde33b7993b590f Mon Sep 17 00:00:00 2001
+From ee5053d39822b471bad463fd96a8e9558c3087fc Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From 08db822f45afe48be8993b91e8b1f384fe181091 Mon Sep 17 00:00:00 2001
+From 9e8896dd4c781bd2e67a985ba509cde1b9124d05 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From fed70aa63d61707e537fcdb4c62ff70a0ddb3645 Mon Sep 17 00:00:00 2001
+From 099049d6c1130ac70f8bba1b7d6826ef6cc11877 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From 344fc491c78fd28931f2c378fef5d87a3f45f0da Mon Sep 17 00:00:00 2001
+From 08db822f45afe48be8993b91e8b1f384fe181091 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From 099049d6c1130ac70f8bba1b7d6826ef6cc11877 Mon Sep 17 00:00:00 2001
+From 344fc491c78fd28931f2c378fef5d87a3f45f0da Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From acba0dbe222b91f0e697960d22635f69d9392ef3 Mon Sep 17 00:00:00 2001
+From 65d8157641227573df683f6e8c3b27f63cad2927 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From fcbd4dd224a57c26871a26db47e63be10e050177 Mon Sep 17 00:00:00 2001
+From 72fcaa81f55c42897c8b5012ae7b581e9d79fa1f Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From 9780629e1252cc4edfcaa8554afdddec70a9489e Mon Sep 17 00:00:00 2001
+From fcbd4dd224a57c26871a26db47e63be10e050177 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From 65d8157641227573df683f6e8c3b27f63cad2927 Mon Sep 17 00:00:00 2001
+From 9780629e1252cc4edfcaa8554afdddec70a9489e Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 38b89a1b9db8861208569511f31dddb737019ff8 Mon Sep 17 00:00:00 2001
+From b5173275c481fafe220690ad561026ace7a6cf06 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From b5173275c481fafe220690ad561026ace7a6cf06 Mon Sep 17 00:00:00 2001
+From 78605b21e74599fa3b44deb702222c449f383074 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From ee76170a5bed625fd873b96150668b15b9ed9c33 Mon Sep 17 00:00:00 2001
+From 32850de6182286178cc1c9236e680f344084c405 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 32850de6182286178cc1c9236e680f344084c405 Mon Sep 17 00:00:00 2001
+From 38b89a1b9db8861208569511f31dddb737019ff8 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From 939d01b1639d1835de5d71bb8a774e4562f0e12d Mon Sep 17 00:00:00 2001
+From 2a61e4ba803e6cb74a29b8f29cf783000796c118 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From 2a61e4ba803e6cb74a29b8f29cf783000796c118 Mon Sep 17 00:00:00 2001
+From 8f78fd2a693e2f29779a468b41ca274ceeda3aa6 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From e0cd40149a2656e838bb8d5ead70cf2d0a3a753f Mon Sep 17 00:00:00 2001
+From 939d01b1639d1835de5d71bb8a774e4562f0e12d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From eb6231df098695d8317880c2975c440a39c676d3 Mon Sep 17 00:00:00 2001
+From e0cd40149a2656e838bb8d5ead70cf2d0a3a753f Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 25141f3ada36087ad07efc8a8143d29991186dda Mon Sep 17 00:00:00 2001
+From de0ce0ad9400491553f96f71b4506d66c908cbbd Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 9d13ba1f7ea6206dd46c74a1bd7dc22a2efbd663 Mon Sep 17 00:00:00 2001
+From e108b69306a8843f423f9a4856c58cada401f2bd Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 8f0c2f3e85627d2aeade3bf6f0b27e7ae4618620 Mon Sep 17 00:00:00 2001
+From 9d13ba1f7ea6206dd46c74a1bd7dc22a2efbd663 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From de0ce0ad9400491553f96f71b4506d66c908cbbd Mon Sep 17 00:00:00 2001
+From 8f0c2f3e85627d2aeade3bf6f0b27e7ae4618620 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 2bc1909f09aa1d8f21c55f9089e74b10151df056 Mon Sep 17 00:00:00 2001
+From 629c6cf6215f8a56ff949985e2b8fdc4c15551b6 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 9210fd3944ddab9ab658cb6fd3b8816cc749ae4e Mon Sep 17 00:00:00 2001
+From 2bc1909f09aa1d8f21c55f9089e74b10151df056 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 629c6cf6215f8a56ff949985e2b8fdc4c15551b6 Mon Sep 17 00:00:00 2001
+From 28f03bfff2298fa756a03d8860a2f6846414875a Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 28f03bfff2298fa756a03d8860a2f6846414875a Mon Sep 17 00:00:00 2001
+From 4d7964338af907e591accbeb29cfe745f6f00af0 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:v0.6

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:v0.6

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.144
+  image: linuxkit/kernel:4.4.147
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.115
+  image: linuxkit/kernel:4.9.119
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/006_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/009_config_4.17.x/test.yml
+++ b/test/cases/020_kernel/009_config_4.17.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.17.10
+  image: linuxkit/kernel:4.17.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.4.144 AS ksrc
+FROM linuxkit/kernel:4.4.147 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.4.144
+docker pull linuxkit/kernel:4.4.147
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.144
+  image: linuxkit/kernel:4.4.147
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.115 AS ksrc
+FROM linuxkit/kernel:4.9.119 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.115
+docker pull linuxkit/kernel:4.9.119
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.115
+  image: linuxkit/kernel:4.9.119
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
+++ b/test/cases/020_kernel/016_kmod_4.14.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.14.58 AS ksrc
+FROM linuxkit/kernel:4.14.62 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.sh
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.14.58
+docker pull linuxkit/kernel:4.14.62
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/016_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/019_kmod_4.17.x/Dockerfile
+++ b/test/cases/020_kernel/019_kmod_4.17.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.17.10 AS ksrc
+FROM linuxkit/kernel:4.17.14 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/019_kmod_4.17.x/test.sh
+++ b/test/cases/020_kernel/019_kmod_4.17.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.17.10
+docker pull linuxkit/kernel:4.17.14
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/019_kmod_4.17.x/test.yml
+++ b/test/cases/020_kernel/019_kmod_4.17.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.17.10
+  image: linuxkit/kernel:4.17.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -1,6 +1,6 @@
 # Sample YAML file for manual testing
 kernel:
-  image: linuxkit/kernel:4.14.58
+  image: linuxkit/kernel:4.14.62
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6


### PR DESCRIPTION
This catches up with recent kernel updates:
- 4.17.11/4.17.12/4.17.13/4.17.14
- 4.14.59/4.14.60/4.14.61/4.14.62
- 4.9.116/4.9.117/4.9.118/4.9.119
- 4.4.145/4.4.146/4.4.147

It also picks up the recent update to WireGuard and the latest `-rt` kernel

![round-tailed-ground-squirrel](https://user-images.githubusercontent.com/3338098/43990783-332e69fa-9d58-11e8-93b6-07f85f60bbc6.jpg)
