### PR TITLE
Update and fix compose project

### DIFF
--- a/projects/compose/Makefile
+++ b/projects/compose/Makefile
@@ -3,9 +3,7 @@
 ORG?=linuxkitprojects
 IMAGE=compose
 DEPS=image/Dockerfile docker-compose.yml image/waitfordocker.sh image/load-images-and-compose.sh
-COMMON_IMAGES := \
-	nginx:alpine \
-	traefik
+COMMON_IMAGES := $(shell awk '/image:/ {print $$2}' docker-compose.yml | sort | uniq)
 
 
 HASH?=$(shell git ls-tree HEAD -- ./image | awk '{print $$3}')
@@ -32,7 +30,7 @@ run-dynamic:
 	linuxkit run dist/compose-dynamic
 
 run-static:
-	linuxkit run dist/compose-static
+	linuxkit run -mem 2048 dist/compose-static
 
 clean:
 	rm -rf image-cache

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -20,14 +20,19 @@ onboot:
     image: linuxkit/mount:v0.6
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
+  - name: getty
+    image: linuxkit/getty:v0.6
+    env:
+     - INSECURE=true
   - name: rngd
     image: linuxkit/rngd:v0.6
   - name: ntpd
     image: linuxkit/openntpd:v0.6
   - name: docker
-    image: docker:17.07.0-ce-dind
+    image: docker:18.06.0-ce-dind
     capabilities:
      - all
+    net: host
     mounts:
      - type: cgroup
        options: ["rw","nosuid","noexec","nodev","relatime"]
@@ -39,11 +44,13 @@ services:
      - /etc/html:/var/html
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: compose
-    image: linuxkitprojects/compose:0535e78608f57702745dfd56fbe78d28d237e469
+    image: linuxkitprojects/compose:111f9f32a933c9e7acbf3ccfc13fedbdfce8224f
     binds:
      - /var/run:/var/run
      - /etc/compose:/compose
 files:
+  - path: var/lib/docker
+    directory: true
   - path: etc/html/a/index.html
     source: html-a.html
   - path: etc/html/b/index.html
@@ -53,3 +60,4 @@ files:
 trust:
   org:
     - linuxkit
+    - library

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -20,14 +20,19 @@ onboot:
     image: linuxkit/mount:v0.6
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
+  - name: getty
+    image: linuxkit/getty:v0.6
+    env:
+     - INSECURE=true
   - name: rngd
     image: linuxkit/rngd:v0.6
   - name: ntpd
     image: linuxkit/openntpd:v0.6
   - name: docker
-    image: docker:17.07.0-ce-dind
+    image: docker:18.06.0-ce-dind
     capabilities:
      - all
+    net: host
     mounts:
      - type: cgroup
        options: ["rw","nosuid","noexec","nodev","relatime"]
@@ -39,11 +44,13 @@ services:
      - /etc/html:/var/html
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: compose
-    image: linuxkitprojects/compose:0535e78608f57702745dfd56fbe78d28d237e469
+    image: linuxkitprojects/compose:111f9f32a933c9e7acbf3ccfc13fedbdfce8224f
     binds:
      - /var/run:/var/run
      - /etc/compose:/compose
 files:
+  - path: var/lib/docker
+    directory: true
   - path: etc/html/a/index.html
     source: html-a.html
   - path: etc/html/b/index.html
@@ -57,3 +64,4 @@ files:
 trust:
   org:
     - linuxkit
+    - library

--- a/projects/compose/image/load-images-and-compose.sh
+++ b/projects/compose/image/load-images-and-compose.sh
@@ -9,9 +9,11 @@ set -e
 
 [ -n "$DEBUG" ] && set -x
 
-for image in /compose/images/*.tar ; do
-	docker image load -i $image && rm -f $image
-done
+if [ -d /compose/images/ ]; then
+	for image in /compose/images/*.tar ; do
+		docker image load -i $image
+	done
+fi
 
 
 docker-compose -f /compose/docker-compose.yml up -d


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated the compose project as follows:

* remove `rm` of pre-loaded tar files in static as they are in a read-only filesystem
* Updated docker version to `18.06`
* Bumped memory for static in Makefile's `run-static` target to handle the larger file
* Added `getty` to the compose examples
* Removed static list of images from `Makefile` and just looked for them dynamically in the compose file


**- How I did it**

Changed the `linuxprojects/compose` image, updated and pushed, then changed the `Makefile` and the two linuxkit ymls

**- How to verify it**
For both static and dynamic, build the `lkt` images, run them, check the output:

1. build: `make static` or `make dynamic`
2. run: `make run-static` or `make run-dynamic`
3. Wait for the console to come up
4. Check the logs in `/var/log/compose.log` and `/var/log/compose.out.log` - it takes a few moments for docker to start up, and then (in dynamic case) for it to download the images
5. Exec into docker container: `ctr -n services.linuxkit t exec --tty --exec-id 999 docker sh`
6. List the containers running: `docker ps`. Expect output as follows (with different timestamps and IDs, of course):

```
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                NAMES
46bc1627bde0        traefik             "/traefik --web --do…"   19 seconds ago      Up 17 seconds       0.0.0.0:80->80/tcp   compose_proxy_1
9cc75e427ba7        nginx:alpine        "nginx -g 'daemon of…"   19 seconds ago      Up 17 seconds       80/tcp               compose_b_1
0af4179f1251        nginx:alpine        "nginx -g 'daemon of…"   19 seconds ago      Up 17 seconds       80/tcp               compose_a_1
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update compose example and fix startup errors


**- A picture of a cute animal (not mandatory but encouraged)**