### PR TITLE
Fix typo in examples/docker-for-mac.md

### DIFF
--- a/examples/docker-for-mac.md
+++ b/examples/docker-for-mac.md
@@ -35,7 +35,7 @@ configuration, for example:
 ```
 
 In another terminal you should now be able to access docker via the
-socket `guest.00000947` in the state directory
+socket `guest.00000948` in the state directory
 (`docker-for-mac-state/` by default):
 
 ```


### PR DESCRIPTION
**- What I did**
Updated the socket name in the documentation file `examples/docker-for-mac.md`
