### PR TITLE
Use containerd restart manager to monitor services

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -208,6 +208,7 @@ which specifies some actions to take place when the container is being started.
 - `bindNS` specifies a namespace type and a path where the namespace from the container being created will be bound. This allows a namespace to be set up in an `onboot` container, and then
   using `net: path` for a `service` container to use that network namespace later.
 - `namespace` overrides the LinuxKit default containerd namespace to put the container in; only applicable to services.
+- `noRestart` By default, long running services in the `service` section are restarted upon exit. This boolean allows to disabling service restart.
 
 An example of using the `runtime` config to configure a network namespace with `wireguard` and then run `nginx` in that namespace is shown below:
 ```

--- a/pkg/init/cmd/service/prepare.go
+++ b/pkg/init/cmd/service/prepare.go
@@ -24,6 +24,7 @@ type Runtime struct {
 	Interfaces []Interface   `yaml:"interfaces" json:"interfaces,omitempty"`
 	BindNS     Namespaces    `yaml:"bindNS" json:"bindNS,omitempty"`
 	Namespace  string        `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	NoRestart  *bool         `yaml:"noRestart,omitempty" json:"noRestart,omitempty"`
 }
 
 // Namespaces is the type for configuring paths to bind namespaces

--- a/src/cmd/linuxkit/moby/config.go
+++ b/src/cmd/linuxkit/moby/config.go
@@ -116,6 +116,7 @@ type Runtime struct {
 	Interfaces *[]Interface   `yaml:"interfaces,omitempty,omitempty" json:"interfaces,omitempty"`
 	BindNS     Namespaces     `yaml:"bindNS,omitempty" json:"bindNS,omitempty"`
 	Namespace  *string        `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	NoRestart  *bool          `yaml:"noRestart,omitempty" json:"noRestart,omitempty"`
 }
 
 // Namespaces is the type for configuring paths to bind namespaces
@@ -590,6 +591,7 @@ func assignRuntime(v1, v2 *Runtime) Runtime {
 	runtimeMkdir := assignStrings(v1.Mkdir, v2.Mkdir)
 	runtimeInterfaces := assignRuntimeInterfaceArray(v1.Interfaces, v2.Interfaces)
 	runtimeNamespace := assignString(v1.Namespace, v2.Namespace)
+	runtimeNoRestart := assignBool(v1.NoRestart, v2.NoRestart)
 	runtime := Runtime{
 		Cgroups:    &runtimeCgroups,
 		Mounts:     &runtimeMounts,
@@ -605,6 +607,7 @@ func assignRuntime(v1, v2 *Runtime) Runtime {
 			Uts:    assignStringPtr(v1.BindNS.Uts, v2.BindNS.Uts),
 		},
 		Namespace: &runtimeNamespace,
+		NoRestart: &runtimeNoRestart,
 	}
 	return runtime
 }

--- a/src/cmd/linuxkit/moby/schema.go
+++ b/src/cmd/linuxkit/moby/schema.go
@@ -249,7 +249,8 @@ var schema = string(`
         "mkdir": {"$ref": "#/definitions/strings"},
         "interfaces": {"$ref": "#/definitions/interfaces"},
         "bindNS": {"$ref": "#/definitions/namespaces"},
-        "namespace": {"type": "string"}
+        "namespace": {"type": "string"},
+        "noRestart": {"type": "boolean"}
       }
     },
     "image": {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Adds system service uptime monitor that restarts stopped system services periodically (default is 10 seconds)

**- How I did it**
Integrate containerd https://github.com/containerd/containerd/pull/2318
Requires `CONTAINERD_COMMIT` v1.2.0

**- How to verify it**
```
(ns: sshd) linuxkit-08002771aa74:/var/log# ctr -n services.linuxkit c info sshd
{
    "ID": "sshd",
    "Labels": {
        "containerd.io/restart.logpath": "/var/log/sshd.restart.log",
        "containerd.io/restart.status": "running"
    },
...
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
