### PR TITLE
Update kernels up to 4.18.5/4,17.19/4.14.67/4.9.124/4.4.152

### DIFF
--- a/contrib/crosvm/README.md
+++ b/contrib/crosvm/README.md
@@ -30,7 +30,7 @@ YAML file (`minimal.yml`):
 
 ```
 kernel:
-  image: linuxkit/kernel:4.9.120
+  image: linuxkit/kernel:4.9.124
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -1,6 +1,6 @@
 # This is an example for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.6 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -1,6 +1,6 @@
 # Simple example of using an external logging service
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/packet.arm64.yml
+++ b/examples/packet.arm64.yml
@@ -5,7 +5,7 @@
 # for arm64 then the 'ucode' line in the kernel section can be left
 # out.
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyAMA0"
   ucode: ""
 onboot:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63-rt
+  image: linuxkit/kernel:4.14.67-rt
   cmdline: "console=tty0"
 init:
   - linuxkit/init:v0.6

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
   - linuxkit/init:v0.6

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.6

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0"
 init:
   - linuxkit/init:v0.6

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -259,22 +259,22 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,4.18.3,4.18.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.17.17,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.65,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.65,4.14.x,,-dbg))
+$(eval $(call kernel,4.18.4,4.18.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.18,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.66,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.66,4.14.x,,-dbg))
 $(eval $(call kernel,4.14.63,4.14.x,-rt,))
-$(eval $(call kernel,4.9.122,4.9.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.4.150,4.4.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.123,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.4.151,4.4.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,4.18.3,4.18.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.65,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.18.4,4.18.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.66,4.14.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.63,4.14.x,-rt,))
 
 else ifeq ($(ARCH),s390x)
-$(eval $(call kernel,4.18.3,4.18.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.65,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.18.4,4.18.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.66,4.14.x,$(EXTRA),$(DEBUG)))
 endif
 
 # Target for kernel config

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -259,22 +259,22 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,4.18.1,4.18.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.17.15,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.63,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.63,4.14.x,,-dbg))
+$(eval $(call kernel,4.18.3,4.18.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.17,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.65,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.65,4.14.x,,-dbg))
 $(eval $(call kernel,4.14.63,4.14.x,-rt,))
-$(eval $(call kernel,4.9.120,4.9.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.4.148,4.4.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.122,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.4.150,4.4.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,4.18.1,4.18.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.63,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.18.3,4.18.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.65,4.14.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.63,4.14.x,-rt,))
 
 else ifeq ($(ARCH),s390x)
-$(eval $(call kernel,4.18.1,4.18.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.63,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.18.3,4.18.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.65,4.14.x,$(EXTRA),$(DEBUG)))
 endif
 
 # Target for kernel config

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -259,22 +259,22 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,4.18.4,4.18.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.17.18,4.17.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.66,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.66,4.14.x,,-dbg))
+$(eval $(call kernel,4.18.5,4.18.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.17.19,4.17.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.67,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.67,4.14.x,,-dbg))
 $(eval $(call kernel,4.14.63,4.14.x,-rt,))
-$(eval $(call kernel,4.9.123,4.9.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.4.151,4.4.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.124,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.4.152,4.4.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,4.18.4,4.18.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.66,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.18.5,4.18.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.67,4.14.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.63,4.14.x,-rt,))
 
 else ifeq ($(ARCH),s390x)
-$(eval $(call kernel,4.18.4,4.18.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.66,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.18.5,4.18.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.67,4.14.x,$(EXTRA),$(DEBUG)))
 endif
 
 # Target for kernel config

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.66 Kernel Configuration
+# Linux/arm64 4.14.67 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.63 Kernel Configuration
+# Linux/arm64 4.14.65 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.65 Kernel Configuration
+# Linux/arm64 4.14.66 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-s390x
+++ b/kernel/config-4.14.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.14.65 Kernel Configuration
+# Linux/s390 4.14.66 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.14.x-s390x
+++ b/kernel/config-4.14.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.14.66 Kernel Configuration
+# Linux/s390 4.14.67 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.14.x-s390x
+++ b/kernel/config-4.14.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.14.63 Kernel Configuration
+# Linux/s390 4.14.65 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.66 Kernel Configuration
+# Linux/x86 4.14.67 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.65 Kernel Configuration
+# Linux/x86 4.14.66 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.63 Kernel Configuration
+# Linux/x86 4.14.65 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.17.x-x86_64
+++ b/kernel/config-4.17.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.17.17 Kernel Configuration
+# Linux/x86 4.17.18 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.17.x-x86_64
+++ b/kernel/config-4.17.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.17.18 Kernel Configuration
+# Linux/x86 4.17.19 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.17.x-x86_64
+++ b/kernel/config-4.17.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.17.15 Kernel Configuration
+# Linux/x86 4.17.17 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.18.x-aarch64
+++ b/kernel/config-4.18.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.18.3 Kernel Configuration
+# Linux/arm64 4.18.4 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.18.x-aarch64
+++ b/kernel/config-4.18.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.18.4 Kernel Configuration
+# Linux/arm64 4.18.5 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.18.x-aarch64
+++ b/kernel/config-4.18.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.18.1 Kernel Configuration
+# Linux/arm64 4.18.3 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.18.x-s390x
+++ b/kernel/config-4.18.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.18.3 Kernel Configuration
+# Linux/s390 4.18.4 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.18.x-s390x
+++ b/kernel/config-4.18.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.18.1 Kernel Configuration
+# Linux/s390 4.18.3 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.18.x-s390x
+++ b/kernel/config-4.18.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.18.4 Kernel Configuration
+# Linux/s390 4.18.5 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.18.x-x86_64
+++ b/kernel/config-4.18.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.18.4 Kernel Configuration
+# Linux/x86 4.18.5 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.18.x-x86_64
+++ b/kernel/config-4.18.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.18.3 Kernel Configuration
+# Linux/x86 4.18.4 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.18.x-x86_64
+++ b/kernel/config-4.18.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.18.1 Kernel Configuration
+# Linux/x86 4.18.3 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.150 Kernel Configuration
+# Linux/x86 4.4.151 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.151 Kernel Configuration
+# Linux/x86 4.4.152 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.148 Kernel Configuration
+# Linux/x86 4.4.150 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.122 Kernel Configuration
+# Linux/x86 4.9.123 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.123 Kernel Configuration
+# Linux/x86 4.9.124 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.120 Kernel Configuration
+# Linux/x86 4.9.122 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 256d3c1ae0fa384475525e771d87aab098098a29 Mon Sep 17 00:00:00 2001
+From e0dd2607dd8daf96c5a6a674a2fcadfed7cdd35f Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 01/21] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 8741a79650111f533032aa6ab21036302c5c6629 Mon Sep 17 00:00:00 2001
+From 256d3c1ae0fa384475525e771d87aab098098a29 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 01/21] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 1eac439963ea0387a71e2f227a18a3e3de24cfdc Mon Sep 17 00:00:00 2001
+From 8741a79650111f533032aa6ab21036302c5c6629 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 01/21] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,4 +1,4 @@
-From 93631e752fdee35bb3e7a67add9e78b82f904803 Mon Sep 17 00:00:00 2001
+From 4eaa5d7dc4b2e2171d84716cb581207a1bce7297 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
 Subject: [PATCH 02/21] hyper-v: trace vmbus_on_msg_dpc()

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,4 +1,4 @@
-From c897ba945377b8dfd80c82b289d3418c1a71f87c Mon Sep 17 00:00:00 2001
+From 681b49afa9fa910d85efb31d38e15db76eb94568 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
 Subject: [PATCH 02/21] hyper-v: trace vmbus_on_msg_dpc()

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,4 +1,4 @@
-From 681b49afa9fa910d85efb31d38e15db76eb94568 Mon Sep 17 00:00:00 2001
+From 93631e752fdee35bb3e7a67add9e78b82f904803 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
 Subject: [PATCH 02/21] hyper-v: trace vmbus_on_msg_dpc()

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,4 +1,4 @@
-From ee566ca6999c47da7cb15cd895eebf8377010502 Mon Sep 17 00:00:00 2001
+From e1a0c25dac66a05b72ba0e32975dd2a4575ca7fc Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
 Subject: [PATCH 03/21] hyper-v: trace vmbus_on_message()

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,4 +1,4 @@
-From a8dbf919efefd4b2c2eaa558b873b574a5bad9af Mon Sep 17 00:00:00 2001
+From ee566ca6999c47da7cb15cd895eebf8377010502 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
 Subject: [PATCH 03/21] hyper-v: trace vmbus_on_message()

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,4 +1,4 @@
-From e1a0c25dac66a05b72ba0e32975dd2a4575ca7fc Mon Sep 17 00:00:00 2001
+From c2e582d597a5772d646fcedaf401baa3f5250edd Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
 Subject: [PATCH 03/21] hyper-v: trace vmbus_on_message()

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,4 +1,4 @@
-From 608cb03ea23f091c1b030150f42cba6424476503 Mon Sep 17 00:00:00 2001
+From 74182c910da233914b73de615581b175d58167e6 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
 Subject: [PATCH 04/21] hyper-v: trace vmbus_onoffer()

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,4 +1,4 @@
-From d02493565c577a03417c8e3d907e46a8413b8cbb Mon Sep 17 00:00:00 2001
+From c8057caa44e4d51a5312889a76034af932053191 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
 Subject: [PATCH 04/21] hyper-v: trace vmbus_onoffer()

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,4 +1,4 @@
-From c8057caa44e4d51a5312889a76034af932053191 Mon Sep 17 00:00:00 2001
+From 608cb03ea23f091c1b030150f42cba6424476503 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
 Subject: [PATCH 04/21] hyper-v: trace vmbus_onoffer()

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,4 +1,4 @@
-From 8c46f35401f85d8990f119c83c0941e8802b1b10 Mon Sep 17 00:00:00 2001
+From 876acb9a829445bdbf3f00d68d3217758727e1c9 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
 Subject: [PATCH 05/21] hyper-v: trace vmbus_onoffer_rescind()

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,4 +1,4 @@
-From 876acb9a829445bdbf3f00d68d3217758727e1c9 Mon Sep 17 00:00:00 2001
+From 1060b978d675a04fe8cb34ea4eccfd33e83b72dd Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
 Subject: [PATCH 05/21] hyper-v: trace vmbus_onoffer_rescind()

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,4 +1,4 @@
-From 4f9df76c876c4ad6c9ab30ea3bb4c72657fc7ec5 Mon Sep 17 00:00:00 2001
+From 8c46f35401f85d8990f119c83c0941e8802b1b10 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
 Subject: [PATCH 05/21] hyper-v: trace vmbus_onoffer_rescind()

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,4 +1,4 @@
-From 0cc00e28b1b6009652791c5b9fd4c1caeafe8c71 Mon Sep 17 00:00:00 2001
+From 79e77dca67908a7651c4bbc7d976411b45194679 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
 Subject: [PATCH 06/21] hyper-v: trace vmbus_onopen_result()

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,4 +1,4 @@
-From 79e77dca67908a7651c4bbc7d976411b45194679 Mon Sep 17 00:00:00 2001
+From 8e243d4e7e206a051d65d4ac240e7cfefc95cecb Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
 Subject: [PATCH 06/21] hyper-v: trace vmbus_onopen_result()

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,4 +1,4 @@
-From f2c44a942ccf5fdd1e882524d15be039c44b26d9 Mon Sep 17 00:00:00 2001
+From 0cc00e28b1b6009652791c5b9fd4c1caeafe8c71 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
 Subject: [PATCH 06/21] hyper-v: trace vmbus_onopen_result()

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,4 +1,4 @@
-From 130a92cb8b73ccd667fce11bd7fc43116972c89c Mon Sep 17 00:00:00 2001
+From ab2bac357b15059b57aa2e69c59d0a24321bd1d6 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
 Subject: [PATCH 07/21] hyper-v: trace vmbus_ongpadl_created()

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,4 +1,4 @@
-From 4946a011c8556d0cbca8892686d89d4c6db458f2 Mon Sep 17 00:00:00 2001
+From 130a92cb8b73ccd667fce11bd7fc43116972c89c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
 Subject: [PATCH 07/21] hyper-v: trace vmbus_ongpadl_created()

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,4 +1,4 @@
-From 224758bbc0d11f7c343a6fe02a68abed62bd99c8 Mon Sep 17 00:00:00 2001
+From 4946a011c8556d0cbca8892686d89d4c6db458f2 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
 Subject: [PATCH 07/21] hyper-v: trace vmbus_ongpadl_created()

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,4 +1,4 @@
-From c0d6493fdf8c1563b70c1779d0bfe6b69aefb15e Mon Sep 17 00:00:00 2001
+From 0257e806db6c0c21fe7dc84fd8e993158dc8ace0 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
 Subject: [PATCH 08/21] hyper-v: trace vmbus_ongpadl_torndown()

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,4 +1,4 @@
-From e6d1f2e876f2aff1d61f7f6fc54dc067910e31dd Mon Sep 17 00:00:00 2001
+From c0d6493fdf8c1563b70c1779d0bfe6b69aefb15e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
 Subject: [PATCH 08/21] hyper-v: trace vmbus_ongpadl_torndown()

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,4 +1,4 @@
-From 87674d325b1b1bd344a708ea1e2130a430842418 Mon Sep 17 00:00:00 2001
+From e6d1f2e876f2aff1d61f7f6fc54dc067910e31dd Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
 Subject: [PATCH 08/21] hyper-v: trace vmbus_ongpadl_torndown()

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,4 +1,4 @@
-From 15037ab1438508bd7482731b99256b4fb657057f Mon Sep 17 00:00:00 2001
+From 6bc6de5c69ccd97f239bd989a4cf9267f07c8309 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
 Subject: [PATCH 09/21] hyper-v: trace vmbus_onversion_response()

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,4 +1,4 @@
-From 8cf948deb27918556ff93e81c3116c8ae84b93d3 Mon Sep 17 00:00:00 2001
+From e5e94131734b54ea6cfe35b80cdd3d4c04a26a81 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
 Subject: [PATCH 09/21] hyper-v: trace vmbus_onversion_response()

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,4 +1,4 @@
-From 6bc6de5c69ccd97f239bd989a4cf9267f07c8309 Mon Sep 17 00:00:00 2001
+From 8cf948deb27918556ff93e81c3116c8ae84b93d3 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
 Subject: [PATCH 09/21] hyper-v: trace vmbus_onversion_response()

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,4 +1,4 @@
-From e9220f5ec43a315e84b31f649435e33b3953578e Mon Sep 17 00:00:00 2001
+From 67ccbd72be7ca95474d8454906c9259089ee0ae5 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
 Subject: [PATCH 10/21] hyper-v: trace vmbus_request_offers()

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,4 +1,4 @@
-From 3c315e0d6ac666fb4b5201048e245120f594ac9e Mon Sep 17 00:00:00 2001
+From e9220f5ec43a315e84b31f649435e33b3953578e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
 Subject: [PATCH 10/21] hyper-v: trace vmbus_request_offers()

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,4 +1,4 @@
-From 67ccbd72be7ca95474d8454906c9259089ee0ae5 Mon Sep 17 00:00:00 2001
+From 5d267aafb1fe43ed504a62cf8e3526e81fbe1659 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
 Subject: [PATCH 10/21] hyper-v: trace vmbus_request_offers()

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 2ce7c7a606f783cf2a7bdf30e947e5ef2309b878 Mon Sep 17 00:00:00 2001
+From 55a246828603adc472e65a371934acc78ac3c693 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
 Subject: [PATCH 11/21] hyper-v: trace vmbus_open()

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,4 +1,4 @@
-From c5a59908e0bf098bd957a089995a4ab99fdd4fac Mon Sep 17 00:00:00 2001
+From aaaa0d504cc3d6d418449d4d5c6a7aad863da2cd Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
 Subject: [PATCH 11/21] hyper-v: trace vmbus_open()

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 55a246828603adc472e65a371934acc78ac3c693 Mon Sep 17 00:00:00 2001
+From c5a59908e0bf098bd957a089995a4ab99fdd4fac Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
 Subject: [PATCH 11/21] hyper-v: trace vmbus_open()

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,4 +1,4 @@
-From 54513048eb67ed5b4fb826e402cbf3858071e5d3 Mon Sep 17 00:00:00 2001
+From af8964ef39aa2a3f26f4da82a7e1bd77a39a6c87 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
 Subject: [PATCH 12/21] hyper-v: trace vmbus_close_internal()

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,4 +1,4 @@
-From f462358f6edae8db08241026e05ec2bd92db6eb7 Mon Sep 17 00:00:00 2001
+From ddc7ea0a56f14d4550b8068898ba499aa53a1bb9 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
 Subject: [PATCH 12/21] hyper-v: trace vmbus_close_internal()

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,4 +1,4 @@
-From ddc7ea0a56f14d4550b8068898ba499aa53a1bb9 Mon Sep 17 00:00:00 2001
+From 54513048eb67ed5b4fb826e402cbf3858071e5d3 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
 Subject: [PATCH 12/21] hyper-v: trace vmbus_close_internal()

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,4 +1,4 @@
-From 2cd2b920517f035dfb6791130f7312dc99d398cf Mon Sep 17 00:00:00 2001
+From ef1ed507e52f0a4720c86a63f37d6f4c9eb22c3e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
 Subject: [PATCH 13/21] hyper-v: trace vmbus_establish_gpadl()

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,4 +1,4 @@
-From ef1ed507e52f0a4720c86a63f37d6f4c9eb22c3e Mon Sep 17 00:00:00 2001
+From 10a82ba6e5e28e16b55cbd4f5273832b6fde693c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
 Subject: [PATCH 13/21] hyper-v: trace vmbus_establish_gpadl()

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,4 +1,4 @@
-From 10a82ba6e5e28e16b55cbd4f5273832b6fde693c Mon Sep 17 00:00:00 2001
+From 50c203eedbb245bf3cb5cadfb833bbecc6034a8a Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
 Subject: [PATCH 13/21] hyper-v: trace vmbus_establish_gpadl()

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,4 +1,4 @@
-From d317b85aef2e58c8172e2d09875cb16d9aa5e464 Mon Sep 17 00:00:00 2001
+From e85cf5df9163dc60c2173f6cee5bc66436ef577f Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
 Subject: [PATCH 14/21] hyper-v: trace vmbus_teardown_gpadl()

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,4 +1,4 @@
-From e85cf5df9163dc60c2173f6cee5bc66436ef577f Mon Sep 17 00:00:00 2001
+From 6ea9d36f9d9f068d0aca1b6215b50b0321ae53ea Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
 Subject: [PATCH 14/21] hyper-v: trace vmbus_teardown_gpadl()

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,4 +1,4 @@
-From 6ea9d36f9d9f068d0aca1b6215b50b0321ae53ea Mon Sep 17 00:00:00 2001
+From 3bd38de884f2dc0c55c2d39a17046f4c01325ef4 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
 Subject: [PATCH 14/21] hyper-v: trace vmbus_teardown_gpadl()

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,4 +1,4 @@
-From 9d5727cf6684860059042c661bda40e4cea6d75b Mon Sep 17 00:00:00 2001
+From ea9c32e7a143e8fed6edb1a56cf94925db3eed81 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
 Subject: [PATCH 15/21] hyper-v: trace vmbus_negotiate_version()

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,4 +1,4 @@
-From 5e8fa021f74dbdc97e4e8520f909ff7b103ae6cc Mon Sep 17 00:00:00 2001
+From 9d5727cf6684860059042c661bda40e4cea6d75b Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
 Subject: [PATCH 15/21] hyper-v: trace vmbus_negotiate_version()

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,4 +1,4 @@
-From 82194d074370efd2b2a6c550cbe7050dd932b136 Mon Sep 17 00:00:00 2001
+From 5e8fa021f74dbdc97e4e8520f909ff7b103ae6cc Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
 Subject: [PATCH 15/21] hyper-v: trace vmbus_negotiate_version()

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,4 +1,4 @@
-From 1e482a1d72f7e49376ea6204b74728b9bd748a21 Mon Sep 17 00:00:00 2001
+From a54c8bcf47d2e8c704c2bdafdc2512b60a6e314a Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
 Subject: [PATCH 16/21] hyper-v: trace vmbus_release_relid()

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,4 +1,4 @@
-From a54c8bcf47d2e8c704c2bdafdc2512b60a6e314a Mon Sep 17 00:00:00 2001
+From 308e1dd17c0193d88d29ef23661d8c567228bebd Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
 Subject: [PATCH 16/21] hyper-v: trace vmbus_release_relid()

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,4 +1,4 @@
-From 308e1dd17c0193d88d29ef23661d8c567228bebd Mon Sep 17 00:00:00 2001
+From f5b62e4ac7f7c62fcc519da492b48aa76d98f8c3 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
 Subject: [PATCH 16/21] hyper-v: trace vmbus_release_relid()

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,4 +1,4 @@
-From 2419f4c888f25e843f3a67fa15e9cef6586c354c Mon Sep 17 00:00:00 2001
+From 0df35164fcac46e7e338593c3d3de854783fdb47 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
 Subject: [PATCH 17/21] hyper-v: trace vmbus_send_tl_connect_request()

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,4 +1,4 @@
-From 0df35164fcac46e7e338593c3d3de854783fdb47 Mon Sep 17 00:00:00 2001
+From 32412e51472569946a67990abacd727478855fbc Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
 Subject: [PATCH 17/21] hyper-v: trace vmbus_send_tl_connect_request()

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,4 +1,4 @@
-From 32412e51472569946a67990abacd727478855fbc Mon Sep 17 00:00:00 2001
+From 0bb069f7d5902f4c4860966cc5f18acd23bcf3e2 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
 Subject: [PATCH 17/21] hyper-v: trace vmbus_send_tl_connect_request()

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,4 +1,4 @@
-From edd110798168926f32e02ef447e2425c0cebb55c Mon Sep 17 00:00:00 2001
+From d8a45361285f651751ed441c0ceccd0ff8b3d949 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
 Subject: [PATCH 18/21] hyper-v: trace channel events

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,4 +1,4 @@
-From 889530d689cd56435d7201ed2e82c80c3cc40715 Mon Sep 17 00:00:00 2001
+From f2dbe3db5cac5b99294e651f310a4db1e2d0ade9 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
 Subject: [PATCH 18/21] hyper-v: trace channel events

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,4 +1,4 @@
-From f2dbe3db5cac5b99294e651f310a4db1e2d0ade9 Mon Sep 17 00:00:00 2001
+From edd110798168926f32e02ef447e2425c0cebb55c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
 Subject: [PATCH 18/21] hyper-v: trace channel events

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From 9b1d4609ec50bf1f8ec93e725dbe6391683f5489 Mon Sep 17 00:00:00 2001
+From a5c117b97f5a92d3af360e2e31e482fe1d42f0a3 Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH 19/21] serial: forbid 8250 on s390

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From fd47a72ca77043a324da9e1cd3d5f4cad46fd35b Mon Sep 17 00:00:00 2001
+From 9b1d4609ec50bf1f8ec93e725dbe6391683f5489 Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH 19/21] serial: forbid 8250 on s390

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From a5c117b97f5a92d3af360e2e31e482fe1d42f0a3 Mon Sep 17 00:00:00 2001
+From 462aadc2b36b650eab7ea59a21c77dc089483cbd Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH 19/21] serial: forbid 8250 on s390

--- a/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
+++ b/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
@@ -1,4 +1,4 @@
-From 72aad803a3cf64392a984503ceb173c7519b7d14 Mon Sep 17 00:00:00 2001
+From 4ecb8e47fbace7d087bfa61cd4ef4e00284e1a47 Mon Sep 17 00:00:00 2001
 From: Cathy Avery <cavery@redhat.com>
 Date: Tue, 31 Oct 2017 08:52:06 -0400
 Subject: [PATCH 20/21] scsi: storvsc: Allow only one remove lun work item to

--- a/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
+++ b/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
@@ -1,4 +1,4 @@
-From 4ecb8e47fbace7d087bfa61cd4ef4e00284e1a47 Mon Sep 17 00:00:00 2001
+From de2414d315f49bf878de1a8359e8548cf892f112 Mon Sep 17 00:00:00 2001
 From: Cathy Avery <cavery@redhat.com>
 Date: Tue, 31 Oct 2017 08:52:06 -0400
 Subject: [PATCH 20/21] scsi: storvsc: Allow only one remove lun work item to

--- a/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
+++ b/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
@@ -1,4 +1,4 @@
-From de2414d315f49bf878de1a8359e8548cf892f112 Mon Sep 17 00:00:00 2001
+From a1c7c4c497cf968bdaf98058a0eb74627883b890 Mon Sep 17 00:00:00 2001
 From: Cathy Avery <cavery@redhat.com>
 Date: Tue, 31 Oct 2017 08:52:06 -0400
 Subject: [PATCH 20/21] scsi: storvsc: Allow only one remove lun work item to

--- a/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
+++ b/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
@@ -1,4 +1,4 @@
-From 147f959fea03655b96a0f95eeea958c38760fe49 Mon Sep 17 00:00:00 2001
+From b4bba78a0982e081eaaa7abfdb4416222e2a8f88 Mon Sep 17 00:00:00 2001
 From: Long Li <longli@microsoft.com>
 Date: Tue, 31 Oct 2017 14:58:08 -0700
 Subject: [PATCH 21/21] scsi: storvsc: Avoid excessive host scan on controller

--- a/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
+++ b/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
@@ -1,4 +1,4 @@
-From 3ec810b6bc55a4f727e1c8a75836e3fe1ed1dc5b Mon Sep 17 00:00:00 2001
+From 0b12cc4933326e1e7c80c14ca3a2bc8253da4705 Mon Sep 17 00:00:00 2001
 From: Long Li <longli@microsoft.com>
 Date: Tue, 31 Oct 2017 14:58:08 -0700
 Subject: [PATCH 21/21] scsi: storvsc: Avoid excessive host scan on controller

--- a/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
+++ b/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
@@ -1,4 +1,4 @@
-From b4bba78a0982e081eaaa7abfdb4416222e2a8f88 Mon Sep 17 00:00:00 2001
+From 3ec810b6bc55a4f727e1c8a75836e3fe1ed1dc5b Mon Sep 17 00:00:00 2001
 From: Long Li <longli@microsoft.com>
 Date: Tue, 31 Oct 2017 14:58:08 -0700
 Subject: [PATCH 21/21] scsi: storvsc: Avoid excessive host scan on controller

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 4d85ad29b81cde20c5c31139ee9ce4141336f74c Mon Sep 17 00:00:00 2001
+From 0f5769b0a9cc45e468527a2b720223b2b6eca9eb Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 0f5769b0a9cc45e468527a2b720223b2b6eca9eb Mon Sep 17 00:00:00 2001
+From a75b02e1c30f7bac427162194a320e046e45a588 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From a75b02e1c30f7bac427162194a320e046e45a588 Mon Sep 17 00:00:00 2001
+From 7a429323e05141854e794d6a4478f6289048f34c Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/12] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 9114b0b0adf04367b56b3f3a8811946c39ace96c Mon Sep 17 00:00:00 2001
+From 1799e9d0fc0b5599ccb1661b4a3cb5b7f28d761e Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 1799e9d0fc0b5599ccb1661b4a3cb5b7f28d761e Mon Sep 17 00:00:00 2001
+From 2a494a3a862514d364070bcdd24f3061b827d167 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 2a494a3a862514d364070bcdd24f3061b827d167 Mon Sep 17 00:00:00 2001
+From cc3952199183a1927dce1586c0c91b586468bb52 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/12] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From deca1f6de688172202829fecd364950c6772b36e Mon Sep 17 00:00:00 2001
+From 02ce270c4a3f84f16b9011c6fd71d60390365f33 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 9cdd02e892680d18bd826693c930e7e70f1af695 Mon Sep 17 00:00:00 2001
+From 753983044662e9e738dcd1d236759a39756de790 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 753983044662e9e738dcd1d236759a39756de790 Mon Sep 17 00:00:00 2001
+From deca1f6de688172202829fecd364950c6772b36e Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/12] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 0e72a057c78c91ccd2e3a419fda97634d2af14c2 Mon Sep 17 00:00:00 2001
+From 96ccd6856ecd76d693a20fdbc4267658762d36ad Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 96ccd6856ecd76d693a20fdbc4267658762d36ad Mon Sep 17 00:00:00 2001
+From cee61725e622f8fbf9ea5b408067283126d89b23 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From cee61725e622f8fbf9ea5b408067283126d89b23 Mon Sep 17 00:00:00 2001
+From b252e6752377c5ec830689fb66d77cba7ce312cd Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/12] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 959db81f9c942ee0f13cda3714490a2ef35d40c5 Mon Sep 17 00:00:00 2001
+From 1e89dbb7f2d88efc3d871b36dd32fe0d46db94c6 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 1e89dbb7f2d88efc3d871b36dd32fe0d46db94c6 Mon Sep 17 00:00:00 2001
+From 909eea0674e15aa4f49764650cea01f174877374 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 909eea0674e15aa4f49764650cea01f174877374 Mon Sep 17 00:00:00 2001
+From 5e339eb93d6247a4d8920f8714b9ff9f1eb3f438 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/12] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From 21cda1e67f421a4549367c4f8b121af4c8d0d224 Mon Sep 17 00:00:00 2001
+From 68b79d1f5539dbedcff3656373e233aa5ff9b170 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From aa13bdeceed3a83384ef6107ac6a41acd57f8019 Mon Sep 17 00:00:00 2001
+From 21cda1e67f421a4549367c4f8b121af4c8d0d224 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From 68b79d1f5539dbedcff3656373e233aa5ff9b170 Mon Sep 17 00:00:00 2001
+From 0af7b0cd420d98fd087842afe5d888ebe5b62cef Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/12] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From 2faed3d29a3e2db77d625bfc61f3056351405862 Mon Sep 17 00:00:00 2001
+From e43b4ce513ef244cf4ea358ded74d8b6299e9cb3 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From e43b4ce513ef244cf4ea358ded74d8b6299e9cb3 Mon Sep 17 00:00:00 2001
+From 8c7edfb82a666024343ec84982252cfccdaecf17 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From 7b2f8601322859f5d5ce19362d812097803131ec Mon Sep 17 00:00:00 2001
+From 2faed3d29a3e2db77d625bfc61f3056351405862 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/12] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From c96e02baa7c112c6604db82e3247539186736de5 Mon Sep 17 00:00:00 2001
+From 5faf0f118ed32392d3ce15100af4f1c87465535b Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From c133c5a3f1a71170786034d99f6c2bf42645c35b Mon Sep 17 00:00:00 2001
+From 15e6ed856d7a92f98438df79da93814db6597354 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From 15e6ed856d7a92f98438df79da93814db6597354 Mon Sep 17 00:00:00 2001
+From c96e02baa7c112c6604db82e3247539186736de5 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/12] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From ebc9fa695a9dba16066086323f481fee8fc1fafd Mon Sep 17 00:00:00 2001
+From 6e52418e06c174c6106fa0bc5111ebe373fea4b7 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 8b45a15a2cb4d319142471affbe52b695b4a28a1 Mon Sep 17 00:00:00 2001
+From ebc9fa695a9dba16066086323f481fee8fc1fafd Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 6e52418e06c174c6106fa0bc5111ebe373fea4b7 Mon Sep 17 00:00:00 2001
+From 364445920dd65201b71c3be4d31f9405ef613c3a Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/12] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From c826d06c6b5e2a39bbca2fb4e6a68bbb44c38899 Mon Sep 17 00:00:00 2001
+From a4e0ad829e66f7c93276bb360271dae8685c3a4e Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From a4e0ad829e66f7c93276bb360271dae8685c3a4e Mon Sep 17 00:00:00 2001
+From c37bfce7c3ca0b101b35051b706d5ab61cd21e23 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From 74eac7cdda571ca69299eba69d3f7f8a712f1355 Mon Sep 17 00:00:00 2001
+From c826d06c6b5e2a39bbca2fb4e6a68bbb44c38899 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/12] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 0e2fe03145afeea9f5a5a671b674576f23c58a14 Mon Sep 17 00:00:00 2001
+From caa664561ddc4e49ea6b71d19b1f6c5dd6cd6e19 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 24c7ec4eef2035e8ca59c9708c712c68c07c7958 Mon Sep 17 00:00:00 2001
+From b8f1dd8637e1d504ae4f9f410888394ebe800cad Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From b8f1dd8637e1d504ae4f9f410888394ebe800cad Mon Sep 17 00:00:00 2001
+From 0e2fe03145afeea9f5a5a671b674576f23c58a14 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/12] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From f00b8ddad77c5701e0711a4cab01ee12efd2a14c Mon Sep 17 00:00:00 2001
+From 46b3cf96489fb2cebcc731b57d08f647d11f1f05 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From fa3da21eead5c57498c61f4f578cca262cdba744 Mon Sep 17 00:00:00 2001
+From 9c4cb5bf5058485c494f86fbc4fd205ad0e5f2ab Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 9c4cb5bf5058485c494f86fbc4fd205ad0e5f2ab Mon Sep 17 00:00:00 2001
+From f00b8ddad77c5701e0711a4cab01ee12efd2a14c Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/12] vmbus: dynamically enqueue/dequeue the channel on

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:v0.6

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:v0.6

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.148
+  image: linuxkit/kernel:4.4.152
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.120
+  image: linuxkit/kernel:4.9.124
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/002_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/002_config_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/003_config_4.17.x/test.yml
+++ b/test/cases/020_kernel/003_config_4.17.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.17.15
+  image: linuxkit/kernel:4.17.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/004_config_4.18.x/test.yml
+++ b/test/cases/020_kernel/004_config_4.18.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.18.1
+  image: linuxkit/kernel:4.18.5
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.4.148 AS ksrc
+FROM linuxkit/kernel:4.4.152 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.4.148
+docker pull linuxkit/kernel:4.4.152
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.148
+  image: linuxkit/kernel:4.4.152
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.120 AS ksrc
+FROM linuxkit/kernel:4.9.124 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.120
+docker pull linuxkit/kernel:4.9.124
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.120
+  image: linuxkit/kernel:4.9.124
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/012_kmod_4.14.x/Dockerfile
+++ b/test/cases/020_kernel/012_kmod_4.14.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.14.63 AS ksrc
+FROM linuxkit/kernel:4.14.67 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/012_kmod_4.14.x/test.sh
+++ b/test/cases/020_kernel/012_kmod_4.14.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.14.63
+docker pull linuxkit/kernel:4.14.67
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/012_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/012_kmod_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/013_kmod_4.17.x/Dockerfile
+++ b/test/cases/020_kernel/013_kmod_4.17.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.17.15 AS ksrc
+FROM linuxkit/kernel:4.17.19 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/013_kmod_4.17.x/test.sh
+++ b/test/cases/020_kernel/013_kmod_4.17.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.17.15
+docker pull linuxkit/kernel:4.17.19
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/013_kmod_4.17.x/test.yml
+++ b/test/cases/020_kernel/013_kmod_4.17.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.17.15
+  image: linuxkit/kernel:4.17.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/014_kmod_4.18.x/Dockerfile
+++ b/test/cases/020_kernel/014_kmod_4.18.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.18.1 AS ksrc
+FROM linuxkit/kernel:4.18.5 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/014_kmod_4.18.x/test.sh
+++ b/test/cases/020_kernel/014_kmod_4.18.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.18.1
+docker pull linuxkit/kernel:4.18.5
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/014_kmod_4.18.x/test.yml
+++ b/test/cases/020_kernel/014_kmod_4.18.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.18.1
+  image: linuxkit/kernel:4.18.5
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.6

--- a/test/cases/040_packages/032_bcc/test.yml
+++ b/test/cases/040_packages/032_bcc/test.yml
@@ -1,10 +1,10 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.5
   - linuxkit/runc:v0.5
-  - linuxkit/kernel-bcc:4.14.63
+  - linuxkit/kernel-bcc:4.14.67
 onboot:
   - name: check-bcc
     image: alpine:3.8

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -1,6 +1,6 @@
 # Sample YAML file for manual testing
 kernel:
-  image: linuxkit/kernel:4.14.63
+  image: linuxkit/kernel:4.14.67
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:v0.6


### PR DESCRIPTION
- Update to 4.18.3/4.17.17/4.14.65/4.9.122/4.4.150
- Skip kernels 4.18.2/4.17.16/4.14.64/4.9.121/4.4.149 as they only have one commit diff to the next kernel
- Update to 4.18.4/4.17.18/4.14.66/4.9.123/4.4.151
- Update to 4.18.5/4.17.19/4.14.67/4.9.124/4.4.152

This also build the latest `-rt` kernels from https://github.com/linuxkit/linuxkit/pull/3169 and picks up the kernel config changes from https://github.com/linuxkit/linuxkit/pull/3160

![egrets-herons](https://user-images.githubusercontent.com/3338098/44752596-61e62080-ab13-11e8-88de-77d192dfe075.jpg)

