### PR TITLE
Enable CAN networking subsystem

### DIFF
--- a/projects/clear-containers/kernel/kernel_config
+++ b/projects/clear-containers/kernel/kernel_config
@@ -986,7 +986,7 @@ CONFIG_NET_FLOW_LIMIT=y
 #
 # CONFIG_NET_PKTGEN is not set
 # CONFIG_HAMRADIO is not set
-# CONFIG_CAN is not set
+CONFIG_CAN=y
 # CONFIG_IRDA is not set
 # CONFIG_BT is not set
 # CONFIG_AF_RXRPC is not set


### PR DESCRIPTION
**- What I did**

This PR should fix issue #3172 by enabling CAN network module for `clear-containers` within kernel flag config. This feature works for Linux Kernel 4.12 and above. 

**- How I did it**

By enabling kernel flag `CONFIG_CAN` to load this module. This namespace is introduced in [linux/linux-kernel@4.12](/torvalds/linux/tree/v4.12/drivers/net/can). After extension is loaded, we may bring up new `vcan` devices in container environment.

**- How to verify it**

Built against 4.12, or higher version supported within linuxkit kernel. Once built, we may either force or set bootable module. No patch for previous kernels, given the feature is proposed for upstream. Not implemented or tested in landlock since KSPP. Host machine using Kernel 4.12. **Not tested on MacOS nor equivalent image**.

See commit for details.

Manual (if avoiding mdev, or rebuilding):

```yml
onboot:
...
  - name: modprobe
    image: linuxkit/modprobe:<hash>
    command: ["modprobe", "vcan"]
```

Testing module:
```
$ modprobe vcan
$ sudo ip link add dev vcan0 type vcan
$ sudo ip link set up vcan0
```

Built passed for all [Linux] images, not tested is `docker-for-mac.yml` base.

**- Description for the changelog**

* Enable CAN module.