### PR TITLE
4.9.x: backport multicast fixes

### DIFF
--- a/kernel/patches-4.9.x/0013-bridge-implement-missing-ndo_uninit.patch
+++ b/kernel/patches-4.9.x/0013-bridge-implement-missing-ndo_uninit.patch
@@ -1,0 +1,141 @@
+From e92af63720d7394588bf40b0044ef98c2d52da0d Mon Sep 17 00:00:00 2001
+From: Ido Schimmel <idosch@mellanox.com>
+Date: Mon, 10 Apr 2017 14:59:27 +0300
+Subject: [PATCH 1/2] bridge: implement missing ndo_uninit()
+
+While the bridge driver implements an ndo_init(), it was missing a
+symmetric ndo_uninit(), causing the different de-initialization
+operations to be scattered around its dellink() and destructor().
+
+Implement a symmetric ndo_uninit() and remove the overlapping operations
+from its dellink() and destructor().
+
+This is a prerequisite for the next patch, as it allows us to have a
+proper cleanup upon changelink() failure during the bridge's newlink().
+
+Fixes: b6677449dff6 ("bridge: netlink: call br_changelink() during br_dev_newlink()")
+Signed-off-by: Nikolay Aleksandrov <nikolay@cumulusnetworks.com>
+Signed-off-by: Ido Schimmel <idosch@mellanox.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+(cherry picked from commit b6fe0440c63716e09cfc0d1484e3898a0f29d1d1)
+---
+ net/bridge/br_device.c    | 20 +++++++++++---------
+ net/bridge/br_if.c        |  1 -
+ net/bridge/br_multicast.c |  7 +++++--
+ net/bridge/br_private.h   |  5 +++++
+ 4 files changed, 21 insertions(+), 12 deletions(-)
+
+diff --git a/net/bridge/br_device.c b/net/bridge/br_device.c
+index 5f5e28f210e0..15be72678bc8 100644
+--- a/net/bridge/br_device.c
++++ b/net/bridge/br_device.c
+@@ -122,6 +122,15 @@ static int br_dev_init(struct net_device *dev)
+ 	return err;
+ }
+
++static void br_dev_uninit(struct net_device *dev)
++{
++	struct net_bridge *br = netdev_priv(dev);
++
++	br_multicast_uninit_stats(br);
++	br_vlan_flush(br);
++	free_percpu(br->stats);
++}
++
+ static int br_dev_open(struct net_device *dev)
+ {
+ 	struct net_bridge *br = netdev_priv(dev);
+@@ -337,6 +346,7 @@ static const struct net_device_ops br_netdev_ops = {
+ 	.ndo_open		 = br_dev_open,
+ 	.ndo_stop		 = br_dev_stop,
+ 	.ndo_init		 = br_dev_init,
++	.ndo_uninit		 = br_dev_uninit,
+ 	.ndo_start_xmit		 = br_dev_xmit,
+ 	.ndo_get_stats64	 = br_get_stats64,
+ 	.ndo_set_mac_address	 = br_set_mac_address,
+@@ -363,14 +373,6 @@ static const struct net_device_ops br_netdev_ops = {
+ 	.ndo_features_check	 = passthru_features_check,
+ };
+
+-static void br_dev_free(struct net_device *dev)
+-{
+-	struct net_bridge *br = netdev_priv(dev);
+-
+-	free_percpu(br->stats);
+-	free_netdev(dev);
+-}
+-
+ static struct device_type br_type = {
+ 	.name	= "bridge",
+ };
+@@ -383,7 +385,7 @@ void br_dev_setup(struct net_device *dev)
+ 	ether_setup(dev);
+
+ 	dev->netdev_ops = &br_netdev_ops;
+-	dev->destructor = br_dev_free;
++	dev->destructor = free_netdev;
+ 	dev->ethtool_ops = &br_ethtool_ops;
+ 	SET_NETDEV_DEVTYPE(dev, &br_type);
+ 	dev->priv_flags = IFF_EBRIDGE | IFF_NO_QUEUE;
+diff --git a/net/bridge/br_if.c b/net/bridge/br_if.c
+index ed0dd3340084..8558371617e8 100644
+--- a/net/bridge/br_if.c
++++ b/net/bridge/br_if.c
+@@ -311,7 +311,6 @@ void br_dev_delete(struct net_device *dev, struct list_head *head)
+
+ 	br_fdb_delete_by_port(br, NULL, 0, 1);
+
+-	br_vlan_flush(br);
+ 	br_multicast_dev_del(br);
+ 	del_timer_sync(&br->gc_timer);
+
+diff --git a/net/bridge/br_multicast.c b/net/bridge/br_multicast.c
+index 2136e45f5277..4c16e01031d4 100644
+--- a/net/bridge/br_multicast.c
++++ b/net/bridge/br_multicast.c
+@@ -1898,8 +1898,6 @@ void br_multicast_dev_del(struct net_bridge *br)
+
+ out:
+ 	spin_unlock_bh(&br->multicast_lock);
+-
+-	free_percpu(br->mcast_stats);
+ }
+
+ int br_multicast_set_router(struct net_bridge *br, unsigned long val)
+@@ -2354,6 +2352,11 @@ int br_multicast_init_stats(struct net_bridge *br)
+ 	return 0;
+ }
+
++void br_multicast_uninit_stats(struct net_bridge *br)
++{
++	free_percpu(br->mcast_stats);
++}
++
+ static void mcast_stats_add_dir(u64 *dst, u64 *src)
+ {
+ 	dst[BR_MCAST_DIR_RX] += src[BR_MCAST_DIR_RX];
+diff --git a/net/bridge/br_private.h b/net/bridge/br_private.h
+index 1b63177e0ccd..417edbe7b8b2 100644
+--- a/net/bridge/br_private.h
++++ b/net/bridge/br_private.h
+@@ -601,6 +601,7 @@ void br_rtr_notify(struct net_device *dev, struct net_bridge_port *port,
+ void br_multicast_count(struct net_bridge *br, const struct net_bridge_port *p,
+ 			const struct sk_buff *skb, u8 type, u8 dir);
+ int br_multicast_init_stats(struct net_bridge *br);
++void br_multicast_uninit_stats(struct net_bridge *br);
+ void br_multicast_get_stats(const struct net_bridge *br,
+ 			    const struct net_bridge_port *p,
+ 			    struct br_mcast_stats *dest);
+@@ -741,6 +742,10 @@ static inline int br_multicast_init_stats(struct net_bridge *br)
+ 	return 0;
+ }
+
++static inline void br_multicast_uninit_stats(struct net_bridge *br)
++{
++}
++
+ static inline int br_multicast_igmp_type(const struct sk_buff *skb)
+ {
+ 	return 0;
+--
+2.17.1

--- a/kernel/patches-4.9.x/0014-bridge-move-bridge-multicast-cleanup-to-ndo_uninit.patch
+++ b/kernel/patches-4.9.x/0014-bridge-move-bridge-multicast-cleanup-to-ndo_uninit.patch
@@ -1,0 +1,104 @@
+From 35b28a27e8434a087421d4fa1c1158d84807ab61 Mon Sep 17 00:00:00 2001
+From: Xin Long <lucien.xin@gmail.com>
+Date: Tue, 25 Apr 2017 22:58:37 +0800
+Subject: [PATCH 2/2] bridge: move bridge multicast cleanup to ndo_uninit
+
+During removing a bridge device, if the bridge is still up, a new mdb entry
+still can be added in br_multicast_add_group() after all mdb entries are
+removed in br_multicast_dev_del(). Like the path:
+
+  mld_ifc_timer_expire ->
+    mld_sendpack -> ...
+      br_multicast_rcv ->
+        br_multicast_add_group
+
+The new mp's timer will be set up. If the timer expires after the bridge
+is freed, it may cause use-after-free panic in br_multicast_group_expired.
+
+BUG: unable to handle kernel NULL pointer dereference at 0000000000000048
+IP: [<ffffffffa07ed2c8>] br_multicast_group_expired+0x28/0xb0 [bridge]
+Call Trace:
+ <IRQ>
+ [<ffffffff81094536>] call_timer_fn+0x36/0x110
+ [<ffffffffa07ed2a0>] ? br_mdb_free+0x30/0x30 [bridge]
+ [<ffffffff81096967>] run_timer_softirq+0x237/0x340
+ [<ffffffff8108dcbf>] __do_softirq+0xef/0x280
+ [<ffffffff8169889c>] call_softirq+0x1c/0x30
+ [<ffffffff8102c275>] do_softirq+0x65/0xa0
+ [<ffffffff8108e055>] irq_exit+0x115/0x120
+ [<ffffffff81699515>] smp_apic_timer_interrupt+0x45/0x60
+ [<ffffffff81697a5d>] apic_timer_interrupt+0x6d/0x80
+
+Nikolay also found it would cause a memory leak - the mdb hash is
+reallocated and not freed due to the mdb rehash.
+
+unreferenced object 0xffff8800540ba800 (size 2048):
+  backtrace:
+    [<ffffffff816e2287>] kmemleak_alloc+0x67/0xc0
+    [<ffffffff81260bea>] __kmalloc+0x1ba/0x3e0
+    [<ffffffffa05c60ee>] br_mdb_rehash+0x5e/0x340 [bridge]
+    [<ffffffffa05c74af>] br_multicast_new_group+0x43f/0x6e0 [bridge]
+    [<ffffffffa05c7aa3>] br_multicast_add_group+0x203/0x260 [bridge]
+    [<ffffffffa05ca4b5>] br_multicast_rcv+0x945/0x11d0 [bridge]
+    [<ffffffffa05b6b10>] br_dev_xmit+0x180/0x470 [bridge]
+    [<ffffffff815c781b>] dev_hard_start_xmit+0xbb/0x3d0
+    [<ffffffff815c8743>] __dev_queue_xmit+0xb13/0xc10
+    [<ffffffff815c8850>] dev_queue_xmit+0x10/0x20
+    [<ffffffffa02f8d7a>] ip6_finish_output2+0x5ca/0xac0 [ipv6]
+    [<ffffffffa02fbfc6>] ip6_finish_output+0x126/0x2c0 [ipv6]
+    [<ffffffffa02fc245>] ip6_output+0xe5/0x390 [ipv6]
+    [<ffffffffa032b92c>] NF_HOOK.constprop.44+0x6c/0x240 [ipv6]
+    [<ffffffffa032bd16>] mld_sendpack+0x216/0x3e0 [ipv6]
+    [<ffffffffa032d5eb>] mld_ifc_timer_expire+0x18b/0x2b0 [ipv6]
+
+This could happen when ip link remove a bridge or destroy a netns with a
+bridge device inside.
+
+With Nikolay's suggestion, this patch is to clean up bridge multicast in
+ndo_uninit after bridge dev is shutdown, instead of br_dev_delete, so
+that netif_running check in br_multicast_add_group can avoid this issue.
+
+v1->v2:
+  - fix this issue by moving br_multicast_dev_del to ndo_uninit, instead
+    of calling dev_close in br_dev_delete.
+
+(NOTE: Depends upon b6fe0440c637 ("bridge: implement missing ndo_uninit()"))
+
+Fixes: e10177abf842 ("bridge: multicast: fix handling of temp and perm entries")
+Reported-by: Jianwen Ji <jiji@redhat.com>
+Signed-off-by: Xin Long <lucien.xin@gmail.com>
+Reviewed-by: Stephen Hemminger <stephen@networkplumber.org>
+Signed-off-by: Nikolay Aleksandrov <nikolay@cumulusnetworks.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+(cherry picked from commit b1b9d366028ff580e6dd80b48a69c473361456f1)
+---
+ net/bridge/br_device.c | 1 +
+ net/bridge/br_if.c     | 1 -
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/net/bridge/br_device.c b/net/bridge/br_device.c
+index 15be72678bc8..a0a7bb6a991f 100644
+--- a/net/bridge/br_device.c
++++ b/net/bridge/br_device.c
+@@ -126,6 +126,7 @@ static void br_dev_uninit(struct net_device *dev)
+ {
+ 	struct net_bridge *br = netdev_priv(dev);
+
++	br_multicast_dev_del(br);
+ 	br_multicast_uninit_stats(br);
+ 	br_vlan_flush(br);
+ 	free_percpu(br->stats);
+diff --git a/net/bridge/br_if.c b/net/bridge/br_if.c
+index 8558371617e8..c779a3ca9e96 100644
+--- a/net/bridge/br_if.c
++++ b/net/bridge/br_if.c
+@@ -311,7 +311,6 @@ void br_dev_delete(struct net_device *dev, struct list_head *head)
+
+ 	br_fdb_delete_by_port(br, NULL, 0, 1);
+
+-	br_multicast_dev_del(br);
+ 	del_timer_sync(&br->gc_timer);
+
+ 	br_sysfs_delbr(br->dev);
+--
+2.17.1


### PR DESCRIPTION

Under stress tests we would occasionally see logs like:

```
BUG: unable to handle kernel NULL pointer dereference at 0000000000000048
IP: [<ffffffff8f7e1e14>] br_multicast_group_expired+0x25/0x95
PGD 789f8067 PUD 789f1067
PMD 0
Oops: 0000 [#1] SMP
Modules linked in:
CPU: 0 PID: 0 Comm: swapper/0 Not tainted 4.9.21-moby #1
Hardware name:   BHYVE, BIOS 1.00 03/14/2014
task: ffffffff8fe10500 task.stack: ffffffff8fe00000
RIP: 0010:[<ffffffff8f7e1e14>]  [<ffffffff8f7e1e14>] br_multicast_group_expired+0x25/0x95
RSP: 0018:ffff8f67fc603e90  EFLAGS: 00010246
RAX: 0000000000000000 RBX: ffff8f67e5668840 RCX: ffff8f67fc603ef8
RDX: 0000000000000001 RSI: ffffffff8f7e1def RDI: ffff8f67e56fd2f0
RBP: ffff8f67e56fd2f0 R08: ffff8f67fc60f9a8 R09: ffff8f67fc603ef8
R10: 0000000000000020 R11: 0000000000000000 R12: ffff8f67e56fc880
R13: ffff8f67e5668880 R14: ffff8f67e5668840 R15: ffffffff8f7e1def
FS:  0000000000000000(0000) GS:ffff8f67fc600000(0000) knlGS:0000000000000000
CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
CR2: 0000000000000048 CR3: 0000000078983000 CR4: 00000000000406b0
Stack:
 ffff8f67fc60f940 0000000000000100 ffffffff8f7e1def ffffffff8f126ca9
 ffff8f67fc60f940 ffff8f67e5668880 0000000000000001 ffff8f67fc603ef0
 dead000000000200 ffffffff8f1271ba ffff8f67e5668840 ffff8f67ff660630
Call Trace:
 <IRQ>  [<ffffffff8f7e1def>] ? br_mdb_rehash+0x1d1/0x1d1
 [<ffffffff8f126ca9>] ? call_timer_fn+0x4f/0xf2
 [<ffffffff8f1271ba>] ? __run_timers.part.39+0x174/0x1ba
 [<ffffffff8f133e7c>] ? tick_sched_do_timer+0x29/0x29
 [<ffffffff8f12791a>] ? hrtimer_forward+0x8a/0x96
 [<ffffffff8f12722a>] ? run_timer_softirq+0x2a/0x54
 [<ffffffff8f84b1d8>] ? __do_softirq+0xf0/0x248
 [<ffffffff8f0e17bd>] ? irq_exit+0x52/0x91
 [<ffffffff8f84b026>] ? smp_apic_timer_interrupt+0x2f/0x39
 [<ffffffff8f84a6d2>] ? apic_timer_interrupt+0x82/0x90
 <EOI>  [<ffffffff8f8486a5>] ? native_safe_halt+0x2/0x3
 [<ffffffff8f848563>] ? default_idle+0x1b/0x2c
 [<ffffffff8f10e496>] ? cpu_startup_entry+0x12e/0x1e4
 [<ffffffff8ff7cf06>] ? start_kernel+0x42a/0x44a
 [<ffffffff8ff7c120>] ? early_idt_handler_array+0x120/0x120
 [<ffffffff8ff7c3fd>] ? x86_64_start_kernel+0x141/0x165
Code: 5d 41 5e 41 5f c3 0f 1f 44 00 00 41 54 55 53 4c 8b 67 20 48 89 fb 49 8d ac 24 70 0a 00 00 48 89 ef e8 83 6a 06 00 49 8b 44 24 18 <48> 8b 40 48 a8 01 74 5b 48 83 7b 48 00 75 54 48 83 7b 28 00 c6
RIP  [<ffffffff8f7e1e14>] br_multicast_group_expired+0x25/0x95
 RSP <ffff8f67fc603e90>
CR2: 0000000000000048
---[ end trace 743aa27f375113b7 ]---
Kernel panic - not syncing: Fatal exception in interrupt
Kernel Offset: 0xe000000 from 0xffffffff81000000 (relocation range: 0xffffffff80000000-0xffffffffbfffffff)
Rebooting in 120 seconds..ACPI MEMORY or I/O RESET_REG.
```

This packports the fix from https://patchwork.ozlabs.org/patch/754860/

The fix is already in 4.14.

This was originally identified by @ijc and @guillaumerose in Docker Desktop.

**- Description for the changelog**
> Backport fixes for multicast crash to kernel 4.9.x

**- A picture of a cute animal (not mandatory but encouraged)**

![An owl who likes reliable kernels](https://media-cdn.tripadvisor.com/media/photo-s/11/ff/07/4b/sweet-potato-spotted.jpg)
