### PR TITLE
wireguard: upgrade to 0.0.20180904

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180809
-ENV WIREGUARD_SHA256="3e351c42d22de427713f1da06d21189c5896a694a66cf19233a7c33295676f19"
+ENV WIREGUARD_VERSION=0.0.20180904
+ENV WIREGUARD_SHA256="a38ead72994a7db7cda2d0085f410df1111b4728db050a519883eda8f3fe38f1"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * wg-quick: darwin: prefer system paths for tools
  
  The only things wg-quick(8) needs from Homebrew are bash(1) and wg(8).
  Other than that, it's explicitly coded against the native system
  utilities. Since wg-quick(8) and bash(1) are invoked in auto_su by their
  full absolute path (via $SELF and $BASH, respectively), we can simply
  set the $PATH to be prefixed by the default system binary paths. This
  way, if users install tools that conflict with system tools -- such as
  GNU coreutils -- we won't accidently call those.
  
  * wg-quick: check correct variable for route deduplication
  
  This should avoid adding duplicate routes when adding the allowed IPs as
  interface routes automatically.
  
  * Kconfig: use new-style help marker
  * global: run through clang-format
  * uapi: reformat
  * global: satisfy check_patch.pl errors
  * global: prefer sizeof(*pointer) when possible
  * global: always find OOM unlikely
  
  Tons of style cleanups.
  
  * crypto: use unaligned helpers
  
  We now avoid unaligned accesses for generic users of the crypto API.
  
  * crypto: import zinc
  
  More style cleanups and a rearrangement of the crypto routines to fit how this
  is going to work upstream. This required some fairly big changes to our build
  system, so there may be some build errors we'll have to address in subsequent
  snapshots.
  
  * compat: rng_is_initialized made it into 4.19
  
  We therefore don't need it in the compat layer anymore.
  
  * curve25519-hacl64: use formally verified C for comparisons
  
  The previous code had been proved in Z3, but this new code from upstream
  KreMLin is directly generated from the F*, which is preferable. The
  assembly generated is identical.
  
  * curve25519-x86_64: let the compiler decide when/how to load constants
  
  Small performance boost.
  
  * curve25519-arm: reformat
  * curve25519-arm: cleanups from lkml
  * curve25519-arm: add spaces after commas
  * curve25519-arm: use ordinary prolog and epilogue
  * curve25519-arm: do not waste 32 bytes of stack
  * curve25519-arm: prefix immediates with #
  
  This incorporates ASM nits from upstream review.
  
  * netlink: insert peer version placeholder
  * tools: ipc: do not warn on unrecognized netlink attributes
  
  Adds a placeholder so that we can always bump versions without worrying about
  API guarantees.
```