### PR TITLE
Fix relative path under Windows

### DIFF
--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/version"
 	log "github.com/sirupsen/logrus"
@@ -235,7 +233,11 @@ func (c *buildCtx) Copy(w io.WriteCloser) error {
 			if err != nil {
 				return fmt.Errorf("ctx: Converting FileInfo for %s: %v", p, err)
 			}
-			h.Name = path.Join(s.dst, strings.TrimPrefix(p, s.src))
+			rel, err := filepath.Rel(s.src, p)
+			if err != nil {
+				return err
+			}
+			h.Name = filepath.ToSlash(filepath.Join(s.dst, rel))
 			if err := tw.WriteHeader(h); err != nil {
 				return fmt.Errorf("ctx: Writing header for %s: %v", p, err)
 			}


### PR DESCRIPTION
**- What I did**

Fixed `linuxkit pkg build …` on Windows.

**- How I did it**

Using `filepath` primitives instead of manipulating file paths manually takes care of platform specific formats.

**- How to verify it**

Before
```
$ linuxkit.exe pkg build -disable-cache -hash current -org docker desktop-host-tools
Building "docker/desktop-host-tools:current"
you are not authorized to perform this operation: server returned 401.
No image pulled, continuing with build
Sending build context to Docker daemon  50.56MB
Error response from daemon: Cannot locate specified Dockerfile: Dockerfile
exit status 1
```

After
```
$ linuxkit.exe pkg build -disable-cache -hash current -org docker desktop-host-tools
Building "docker/desktop-host-tools:current"
you are not authorized to perform this operation: server returned 401.
No image pulled, continuing with build
Sending build context to Docker daemon  50.55MB
Step 1/23 : FROM docker/transfused:40eaf9a55f944ebbc5eedcaae4b0838bf2e230ee as transfused
 ---> 9336ce7e8a22
Step 2/23 : FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build
 ---> 9e5cfc2c8a33
Step 3/23 : RUN apk add --no-cache go musl-dev git build-base
 ---> Running in f69183e2c77a
(1/27) Installing binutils (2.30-r5)
(2/27) Installing libmagic (5.32-r0)
(3/27) Installing file (5.32-r0)
(4/27) Installing gmp (6.1.2-r1)
(5/27) Installing isl (0.18-r0)
(6/27) Installing libgomp (6.4.0-r8)
(7/27) Installing libatomic (6.4.0-r8)
(8/27) Installing pkgconf (1.5.1-r0)
(9/27) Installing libgcc (6.4.0-r8)
(10/27) Installing mpfr3 (3.1.5-r1)
(11/27) Installing mpc1 (1.0.3-r1)
(12/27) Installing libstdc++ (6.4.0-r8)
(13/27) Installing gcc (6.4.0-r8)
(14/27) Installing musl-dev (1.1.19-r10)
(15/27) Installing libc-dev (0.7.1-r0)
(16/27) Installing g++ (6.4.0-r8)
(17/27) Installing make (4.2.1-r2)
(18/27) Installing fortify-headers (0.9-r0)
(19/27) Installing build-base (0.5-r1)
(20/27) Installing ca-certificates (20171114-r3)
(21/27) Installing nghttp2-libs (1.32.0-r0)
(22/27) Installing libssh2 (1.8.0-r3)
(23/27) Installing libcurl (7.61.0-r0)
(24/27) Installing expat (2.2.5-r0)
(25/27) Installing pcre2 (10.31-r0)
(26/27) Installing git (2.18.0-r0)
(27/27) Installing go (1.10.1-r0)
Executing busybox-1.28.4-r1.trigger
Executing ca-certificates-20171114-r3.trigger
OK: 469 MiB in 40 packages
Removing intermediate container f69183e2c77a
 ---> 96a90264d59b
Step 4/23 : ENV GOPATH=/go PATH=$PATH:/go/bin
 ---> Running in 37db3bbc6b84
Removing intermediate container 37db3bbc6b84
 ---> 004f59cc1add
Step 5/23 : WORKDIR /go/src/github.com/docker/pinata
 ---> Running in 8df60f377fb6
Removing intermediate container 8df60f377fb6
 ---> f2f43d2018c2
Step 6/23 : COPY common common
 ---> c2788b2c0a49
Step 7/23 : WORKDIR /go/src/github.com/docker/pinata/linuxkit/pkg/desktop-host-tools
 ---> Running in 245dd54b4694
Removing intermediate container 245dd54b4694
 ---> c4c501989415
Step 8/23 : COPY . .
 ---> d644d7233a24
Step 9/23 : WORKDIR /go/src/github.com/docker/pinata/linuxkit/pkg/desktop-host-tools/cmd/lifecycle-server
 ---> Running in db08206c404e
Removing intermediate container db08206c404e
 ---> cfca85fdac64
Step 10/23 : RUN go build
 ---> Running in c1d91ea94777
Removing intermediate container c1d91ea94777
 ---> fc7427d52b2e
Step 11/23 : WORKDIR /go/src/github.com/docker/pinata/linuxkit/pkg/desktop-host-tools/cmd/sendtohost
 ---> Running in f4387ab97dbc
Removing intermediate container f4387ab97dbc
 ---> 745e0b74544b
Step 12/23 : RUN go build
 ---> Running in f0d1682c58e8
Removing intermediate container f0d1682c58e8
 ---> 00f527685cc5
Step 13/23 : COPY scripts /scripts
 ---> 8b09edf425f7
Step 14/23 : RUN chmod +x /scripts/*
 ---> Running in 9087b5cfa597
Removing intermediate container 9087b5cfa597
 ---> 66a2a0b49f23
Step 15/23 : FROM scratch
 --->
Step 16/23 : COPY --from=transfused /transfused /usr/bin/transfused
 ---> 3fb058ac1d1d
Step 17/23 : COPY --from=build /go/src/github.com/docker/pinata/linuxkit/pkg/desktop-host-tools/cmd/lifecycle-server/lifecycle-server /usr/bin/lifecycle-server
 ---> 026395fcc411
Step 18/23 : COPY --from=build /go/src/github.com/docker/pinata/linuxkit/pkg/desktop-host-tools/cmd/sendtohost/sendtohost /
 ---> ec3a9ebc38ea
Step 19/23 : COPY --from=build /scripts/* /usr/bin
 ---> 0b50d0d2c86d
Step 20/23 : LABEL org.mobyproject.linuxkit.revision=dca3b8ae64be3551c23906989053b75b6108badd
 ---> Running in 8b2f5d28c85f
Removing intermediate container 8b2f5d28c85f
 ---> 8b88b43c687e
Step 21/23 : LABEL org.mobyproject.linuxkit.version=v0.6+
 ---> Running in 8747c69433ba
Removing intermediate container 8747c69433ba
 ---> 4fcad1814929
Step 22/23 : LABEL org.opencontainers.image.revision=4710c8abfb15efd33724b3cb3633d0fa19c181c0
 ---> Running in 80b3eccda9bb
Removing intermediate container 80b3eccda9bb
 ---> 09a52ceb83b8
Step 23/23 : LABEL org.opencontainers.image.source=https://github.com/linuxkit/linuxkit
 ---> Running in eee6f83e6238
Removing intermediate container eee6f83e6238
 ---> 78fe5714505c
Successfully built 78fe5714505c
Successfully tagged docker/desktop-host-tools:current-amd64
SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.
Tagging docker/desktop-host-tools:current-amd64 as docker/desktop-host-tools:current
Build complete, not pushing, all done.
```
