### PR TITLE
Fix path separator on Windows

### DIFF
--- a/src/cmd/linuxkit/moby/build.go
+++ b/src/cmd/linuxkit/moby/build.go
@@ -454,7 +454,7 @@ func filesystem(m Moby, tw *tar.Writer, idMap map[string]uint32) error {
 			return errors.New("Did not specify path for file")
 		}
 		// tar archives should not have absolute paths
-		if f.Path[0] == os.PathSeparator {
+		if f.Path[0] == '/' {
 			f.Path = f.Path[1:]
 		}
 		mode := int64(0600)

--- a/src/cmd/linuxkit/moby/image.go
+++ b/src/cmd/linuxkit/moby/image.go
@@ -58,11 +58,11 @@ func tarPrefix(path string, tw tarWriter) error {
 	if path == "" {
 		return nil
 	}
-	if path[len(path)-1] != byte('/') {
+	if path[len(path)-1] != '/' {
 		return fmt.Errorf("path does not end with /: %s", path)
 	}
 	path = path[:len(path)-1]
-	if path[0] == byte('/') {
+	if path[0] == '/' {
 		return fmt.Errorf("path should be relative: %s", path)
 	}
 	mkdir := ""
@@ -85,7 +85,7 @@ func tarPrefix(path string, tw tarWriter) error {
 // ImageTar takes a Docker image and outputs it to a tar stream
 func ImageTar(ref *reference.Spec, prefix string, tw tarWriter, trust bool, pull bool, resolv string) (e error) {
 	log.Debugf("image tar: %s %s", ref, prefix)
-	if prefix != "" && prefix[len(prefix)-1] != byte('/') {
+	if prefix != "" && prefix[len(prefix)-1] != '/' {
 		return fmt.Errorf("prefix does not end with /: %s", prefix)
 	}
 


### PR DESCRIPTION
Sorry for opening a PR per fix, It's just I'm so glad I'm making progress every time. 😋 

**- What I did**

Fixed more file path handling on Windows.

**- How I did it**

On Windows `os.PathSeparator` is `\` but here it's all unix file paths being manipulated.

And not really related but `byte('/')` is really just `'/'`.

**- How to verify it**

Before
```
../bin/linuxkit build  -format iso-efi -name docker-for-mac -dir build image.yml image-mac.yml
…
Create outputs:
  build\docker-for-mac-efi.iso
[31mFATA[0m[0096] Error writing outputs: Error writing iso-efi output: docker run linuxkit/mkimage-iso-efi:248673cd3784eb3664d0f80b5bd31829465ca784 failed: exit status 1 output:

```
(errors right away with no output, no logs, no clue …)

Now
```
../bin/linuxkit build  -format iso-efi -name docker-for-mac -dir build image.yml image-mac.yml
…
Create outputs:
  build\docker-for-mac-efi.iso
mv -fv build/docker-for-mac-efi.iso build/docker-for-mac.iso
…
```
