### PR TITLE
wireguard: upgrade to 0.0.20180910

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180904
-ENV WIREGUARD_SHA256="a38ead72994a7db7cda2d0085f410df1111b4728db050a519883eda8f3fe38f1"
+ENV WIREGUARD_VERSION=0.0.20180910
+ENV WIREGUARD_SHA256="43481ac82d4889491e1ae761d4ef10688410975cc861db5d2ac1845ac62eae39"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * curve25519: arm: do not modify sp directly
  * compat: support neon.h on old kernels
  * compat: arch-namespace certain includes
  * compat: move simd.h from crypto to compat since it's going upstream

  This fixes a decent amount of compat breakage and thumb2-mode breakage
  introduced by our move to Zinc.

  * crypto: use CRYPTOGAMS license

  Rather than using code from OpenSSL, use code directly from AndyP.

  * poly1305: rewrite self tests from scratch
  * poly1305: switch to donna

  This makes our C Poly1305 implementation a bit more intensely tested and also
  faster, especially on 64-bit systems. It also sets the stage for moving to a
  HACL* implementation when that's ready.
```