### PR TITLE
wireguard: upgrade to 0.0.20180918

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180910
-ENV WIREGUARD_SHA256="43481ac82d4889491e1ae761d4ef10688410975cc861db5d2ac1845ac62eae39"
+ENV WIREGUARD_VERSION=0.0.20180918
+ENV WIREGUARD_SHA256="c0d931bdfce139a3678592ada463042c24f12dd01ba75badd3eeb0aee2211302"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * blake2s-x86_64: fix whitespace errors
  * crypto: do not use compound literals in selftests
  * crypto: make sure UML is properly disabled
  * kconfig: make NEON depend on CPU_V7
  * poly1305: rename finish to final
  * chacha20: add constant for words in block
  * curve25519-x86_64: remove useless define
  * poly1305: precompute 5*r in init instead of blocks
  * chacha20-arm: swap scalar and neon functions
  * simd: add __must_check annotation
  * poly1305: do not require simd context for arch
  * chacha20-x86_64: cascade down implementations
  * crypto: pass simd by reference
  * chacha20-x86_64: don't activate simd for small blocks
  * poly1305-x86_64: don't activate simd for small blocks
  * crypto: do not use -include trick
  * crypto: turn Zinc into individual modules
  * chacha20poly1305: relax simd between sg chunks
  * chacha20-x86_64: more limited cascade
  * crypto: allow for disabling simd in zinc modules
  * poly1305-x86_64: show full struct for state
  * chacha20-x86_64: use correct cut off for avx512-vl
  * curve25519-arm: only compile if symbols will be used
  * chacha20poly1305: add __init to selftest helper functions
  * chacha20: add independent self test
  
  Tons of improvements all around the board to our cryptography library,
  including some performance boosts with how we handle SIMD for small packets.
  
  * send/receive: reduce number of sg entries
  
  This quells a powerpc stack usage warning.
  
  * global: remove non-essential inline annotations
  
  We now allow the compiler to determine whether or not to inline certain
  functions, while still manually choosing so for a few performance-critical
  sections.
```