### PR TITLE
wireguard: upgrade to 0.0.20181006

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20180918
-ENV WIREGUARD_SHA256="c0d931bdfce139a3678592ada463042c24f12dd01ba75badd3eeb0aee2211302"
+ENV WIREGUARD_VERSION=0.0.20181006
+ENV WIREGUARD_SHA256="9fe7cd5767eda65647463ec29ed707f917f4a77babaaf247adc4be7acaab4665"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * poly1305: better module description
  * blake2s: simplify final function
  * poly1305: no need to trick gcc 8.1
  * chacha20: prefer crypto_xor_cpy to avoid memmove
  * poly1305: account for simd being toggled off midway
  * crypto: do not waste space on selftest items
  * poly1305-mips32r2: remove all reorder directives
  * chacha20-mips32r2: fix typo to allow reorder again
  * chacha20-mips32r2: remove reorder directives
  * chacha20-arm: go with Ard's version to optimize for Cortex-A7
  * chacha20-mips32r2: use simpler calling convention
  * chacha20-mips32r2: reduce jumptable entry size and stack usage
  * chacha20: add chunked selftest and test sliding alignments and hchacha20
  * crypto-arm: rework KERNEL_MODE_NEON handling
  * chacha20-arm: use new scalar implementation
  * curve25519-fiat32: work around m68k compiler stack frame bug
  * crypto: flatten out makefile
  * crypto-arm: rework KERNEL_MODE_NEON handling again
  * poly1305-mips64: remove useless preprocessor error
  * chacha20-arm: updated scalar code from Andy
  * chacha20-arm: remove unused preambles
  * hchacha20: keep in native endian in words
  * crypto: make constant naming scheme consistent
  * chacha20-mips32r2: reduce stack and branches in loop, refactor jumptable handling
  * chacha20: add bounds checking to selftests
  * curve25519-hacl64: reduce stack usage under KASAN
  
  Tons of improvements to our cryptography API, including some nice performance
  boosts on ARM Cortex-A7 and MIPS32r2.
  
  * allowedips: change from BUG_ON to WARN_ON
  * allowedips: work around kasan stack frame bug in selftest
  * global: put SPDX identifier on its own line
  * netlink: reverse my christmas trees
  * global: reduce stack frame size
  
  Style and correctness changes. We now use less stack space as well.

  * Account for big-endian 2^26 conversion in Poly1305.
  * Account for big-endian NEON in Curve25519.
  * Fix macros in big-endian AArch64 code so that this will actually run there
    at all.
  * Prefer if (IS_ENABLED(...)) over ifdef mazes when possible.
  * Call simd_relax() within any preempt-disabling glue code every once in a
    while so as not to increase latency if folks pass in super long buffers.
  * Prefer compiler-defined architecture macros in assembly code, which puts us
    in closer alignment with upstream CRYPTOGAMS code, and is cleaner.
  * Non-static symbols are prefixed with wg_ to avoid polluting the global
    namespace.
  * Return a bool from simd_relax() indicating whether or not we were
    rescheduled.
  * Reflect the proper simd conditions on arm.
  * Do not reorder lines in Kbuild files for the simd asm-generic addition,
    since we don't want to cause merge conflicts.
  * WARN() if the selftests fail in Zinc, since if this is an initcall, it won't
    block module loading, so we want to be loud.
  * Document some interdependencies beside include statements.
  * Add missing static statement to fpu init functions.
  * Use union in chacha to access state words as a flat matrix, instead of
    casting a struct to a u8 and hoping all goes well. Then, by passing around
    that array as a struct for as long as possible, we can update counter[0]
    instead of state[12] in the generic blocks, which makes it clearer what's
    happening.
  * Remove __aligned(32) for chacha20_ctx since we no longer use vmovdqa on x86,
    and the other implementations do not require that kind of alignment either.
  * Submit patch to ARM tree for adjusting RiscPC's cflags to be -march=armv3 so
    that we can build code that uses umull.
  * Allow CONFIG_ARM[64] to imply [!]CONFIG_64BIT, and use zinc arch config
    variables consistently throughout.
  * Document rationale for the 2^26->2^64/32 conversion in code comments.
  * Convert all of remaining BUG_ON to WARN_ON.
  * Replace `bxeq lr` with `reteq lr` in ARM assembler to be compatible with old
    ISAs via the macro in <asm/assembler.h>.
  * Do not allow WireGuard to be a built-in if IPv6 is a module.
  * Writeback the base register and reorder multiplications in the NEON x25519
    implementation.
  * Try all combinations of different implementations in selftests, so that
    potential bugs are more immediately unearthed.
  * Self tests and SIMD glue code work with #include, which lets the compiler
    optimize these. Previously these files were .h, because they were included,
    but a simple grep of the kernel tree shows 259 other files that carry out
    this same pattern. Only they prefer to instead name the files with a .c
    instead of a .h, so we now follow the convention.
  * Support many more platforms in QEMU, especially big endian ones.
  * Kernels < 3.17 don't have read_cpuid_part, so fix building there.
```