### PR TITLE
GCP PUSH: Fix typo and add error message when project is missing

### DIFF
--- a/src/cmd/linuxkit/gcp.go
+++ b/src/cmd/linuxkit/gcp.go
@@ -63,7 +63,7 @@ func NewGCPClient(keys, projectName string) (*GCPClient, error) {
 			projectName: projectName,
 		}
 	} else {
-		log.Debugf("Using Application Default crednetials")
+		log.Debugf("Using Application Default credentials")
 		gc, err := google.DefaultClient(
 			ctx,
 			storage.DevstorageReadWriteScope,

--- a/src/cmd/linuxkit/push_gcp.go
+++ b/src/cmd/linuxkit/push_gcp.go
@@ -52,6 +52,10 @@ func pushGcp(args []string) {
 		name = filepath.Base(name)
 	}
 
+	if project == "" {
+		log.Fatalf("Please specify the project to use")
+	}
+
 	if bucket == "" {
 		log.Fatalf("Please specify the bucket to use")
 	}


### PR DESCRIPTION
Signed-off-by: Pierre-Yves Aillet <pyaillet@gmail.com>

**- What I did**
Fix error message for gcp push when project is not specified
Before:
FATA[0004] Error creating Google Compute Image: googleapi: got HTTP response code 404 with body: Not Found

**- How I did it**
Check for project var being empty and exiting with an error message

**- How to verify it**
Launching linuxkit push gcp without project being set should output an error:
```shell
$ linuxkit push gcp nginx-os.img.tar.gz
FATA[0000] Please specify the project to use
```

**- Description for the changelog**
GCP push - Notify when project is not set

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/11957179/46633426-e3d35b80-cb4d-11e8-944b-cbab4d4ec662.png)

