### PR TITLE
GCP: validate project name

### DIFF
--- a/src/cmd/linuxkit/gcp.go
+++ b/src/cmd/linuxkit/gcp.go
@@ -38,6 +38,9 @@ func NewGCPClient(keys, projectName string) (*GCPClient, error) {
 	log.Debugf("Connecting to GCP")
 	ctx := context.Background()
 	var client *GCPClient
+	if projectName == "" {
+		return nil, fmt.Errorf("the project name is not specified")
+	}
 	if keys != "" {
 		log.Debugf("Using Keys %s", keys)
 		f, err := os.Open(keys)
@@ -63,7 +66,7 @@ func NewGCPClient(keys, projectName string) (*GCPClient, error) {
 			projectName: projectName,
 		}
 	} else {
-		log.Debugf("Using Application Default crednetials")
+		log.Debugf("Using Application Default credentials")
 		gc, err := google.DefaultClient(
 			ctx,
 			storage.DevstorageReadWriteScope,

--- a/src/cmd/linuxkit/push_gcp.go
+++ b/src/cmd/linuxkit/push_gcp.go
@@ -52,13 +52,13 @@ func pushGcp(args []string) {
 		name = filepath.Base(name)
 	}
 
-	if bucket == "" {
-		log.Fatalf("Please specify the bucket to use")
-	}
-
 	client, err := NewGCPClient(keys, project)
 	if err != nil {
 		log.Fatalf("Unable to connect to GCP: %v", err)
+	}
+
+	if bucket == "" {
+		log.Fatalf("Please specify the bucket to use")
 	}
 
 	err = client.UploadFile(path, name+suffix, bucket, public)

--- a/src/cmd/linuxkit/run_gcp.go
+++ b/src/cmd/linuxkit/run_gcp.go
@@ -84,7 +84,7 @@ func runGcp(args []string) {
 
 	client, err := NewGCPClient(keys, project)
 	if err != nil {
-		log.Fatalf("Unable to connect to GCP")
+		log.Fatalf("Unable to connect to GCP: %v", err)
 	}
 
 	if err = client.CreateInstance(*name, image, zone, machine, disks, data, *nestedVirt, true); err != nil {


### PR DESCRIPTION
Signed-off-by: Eric Briand <eric.briand@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Validate that there is the project name given when using run and push in gcp.
**- How I did it**
Had the check of projetName in GCP client creation
**- How to verify it**
linuxkit run or linuxkit push without giving projectname should result to the output : 
```
FATA[0000] Unable to connect to GCP: the project name is not specified
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
GCP client - Notify when project is not set

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1011902/46872991-e24bb100-ce35-11e8-964a-5ecc16c2af62.png)
