### PR TITLE
Missing s390x in the switch for qemu Dockerfile

### DIFF
--- a/tools/qemu/Dockerfile
+++ b/tools/qemu/Dockerfile
@@ -12,6 +12,9 @@ RUN apk add --no-cache --initdb -p /out \
     aarch64) \
         apk add --no-cache --initdb -p /out qemu-system-aarch64; \
         ;; \
+    s390x) \
+        apk add --no-cache --initdb -p /out qemu-system-s390x; \
+        ;; \
     esac
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 


### PR DESCRIPTION
Signed-off-by: Alice Frosi <afrosi@de.ibm.com>

