### PR TITLE
wireguard: upgrade to 0.0.20181018

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20181006
-ENV WIREGUARD_SHA256="9fe7cd5767eda65647463ec29ed707f917f4a77babaaf247adc4be7acaab4665"
+ENV WIREGUARD_VERSION=0.0.20181018
+ENV WIREGUARD_SHA256="af05824211b27cbeeea2b8d6b76be29552c0d80bfe716471215e4e43d259e327"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * compat: don't output for grep errors
  * compat: look in Kbuild and Makefile since they differ based on arch
  * create-patch: blacklist instead of whitelist
  
  This should solve the last of the compat issues introduced with the revamped
  build system and upstream changes.
  
  * qemu: kill after 20 minutes
  
  Our test suite now accounts for hangs.
  
  * global: prefix functions used in callbacks with wg_
  * global: rename struct wireguard_ to struct wg_
  * global: more nits
  * timers: avoid using control statements in macro
  * allowedips: remove control statement from macro by rewriting
  * device: use textual error labels always
  * global: give if statements brackets and other cleanups
  * main: change module description
  * main: get rid of unloaded debug message
  
  Stylistic cleanups from upstream.
  
  * netlink: do not stuff index into nla type
  
  It's not used for anything, and LKML doesn't like the type being used as an
  index value. Technically this changes UAPI, but in practice nobody used this,
  and if they did use it for anything, that thing was probably broken anyway.
  
  * allowedips: swap endianness early on
  
  Otherwise if gcc's optimizer is able to look far in but not overly far
  in, we wind up with "warning: 'key' may be used uninitialized in this
  function [-Wmaybe-uninitialized]".
  
  * tools: use libc's endianness macro if no compiler macro
  * tools: compile on gnu99
  
  This lets us be compiled with ancient gcc.
  
  * tools: don't fail if a netlink interface dump is inconsistent
  
  Netlink returns NLM_F_DUMP_INTR if the set of all tunnels changed
  during the dump. That's unfortunate, but is pretty common on busy
  systems that are adding and removing tunnels all the time. Rather
  than retrying, potentially indefinitely, we just work with the
  partial results.
  
  
  * tools: wg-quick: wait for interface to disappear on freebsd
  
  This should improve init scripts that restart tunnels using wg-quick.
```