### PR TITLE
Update crosvm

### DIFF
--- a/contrib/crosvm/Dockerfile
+++ b/contrib/crosvm/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.30.0-stretch
 
 ENV CROSVM_REPO=https://chromium.googlesource.com/chromiumos/platform/crosvm
-ENV CROSVM_COMMIT=7a7268faf0a43c79b6a4520f5c2f35c3e0233932
+ENV CROSVM_COMMIT=510c783c847b6d0c18516f31fbe3dbdc782f1252
 ENV MINIJAIL_REPO=https://android.googlesource.com/platform/external/minijail
 ENV MINIJAIL_COMMIT=d45fc420bb8fd9d1fc9297174f3c344db8c20bbd
 

--- a/contrib/crosvm/Dockerfile
+++ b/contrib/crosvm/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.25.0-stretch
+FROM rust:1.30.0-stretch
 
 ENV CROSVM_REPO=https://chromium.googlesource.com/chromiumos/platform/crosvm
 ENV CROSVM_COMMIT=7a7268faf0a43c79b6a4520f5c2f35c3e0233932

--- a/contrib/crosvm/README.md
+++ b/contrib/crosvm/README.md
@@ -25,34 +25,14 @@ You may also have to create an empty directory `/var/empty`.
 ## Use with LinuxKit images
 
 You can build a LinuxKit image suitable for `crosvm` with the
-`kernel+squashfs` build format. For example, using this LinuxKit
-YAML file (`minimal.yml`):
-
-```
-kernel:
-  image: linuxkit/kernel:4.9.135
-  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
-init:
-  - linuxkit/init:6eb0158059b056a1567236280880cb87f03ff008
-  - linuxkit/runc:6cf26a0403376de3b5396cb676b88eea4f37aff8
-  - linuxkit/containerd:d955db7cd28dbd7be8a17d7063cc6b7f1bf91f0a
-services:
-  - name: getty
-    image: linuxkit/getty:v0.6
-    env:
-      - INSECURE=true
-trust:
-  org:
-    - linuxkit
-```
-
-run:
+`kernel+squashfs` build format. For example, using `minimal.yml` from
+the `./examples` directory, run:
 
 ```sh
-linuxkit build -output kernel+squashfs minimal.yml
+linuxkit build -format kernel+squashfs minimal.yml
 ```
 
-The kernel this produces (`minimal-kernel`) needs to be converted as
+The generated kernel file (`minimal-kernel`) needs to be converted as
 `crosvm` does not grok `bzImage`s. You can convert the LinuxKit kernel
 image with
 [extract-vmlinux](https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-vmlinux):


### PR DESCRIPTION
- Fix crosvm documentation
- Update crosvm build to rust 1.30
- Update crosvm commit to latest

I've done some light testing and the non-jail/non-seccomp version seems to boot

![waterant](https://user-images.githubusercontent.com/3338098/47681180-badc3e80-dbc0-11e8-8b83-6ceef446ee08.jpg)
