### PR TITLE
Allowing modprobe modules to load firmware if needed

### DIFF
--- a/pkg/modprobe/build.yml
+++ b/pkg/modprobe/build.yml
@@ -2,6 +2,7 @@ image: modprobe
 config:
   binds:
     - /lib/modules:/lib/modules
+    - /lib/firmware:/lib/firmware
     - /sys:/sys
   capabilities:
-    - CAP_SYS_MODULE
+    - all


### PR DESCRIPTION
**- What I did**

Allowed for modprobe modules to load firmware files.

**- How I did it**

Made /lib/firmware available in the modprobe container and also added capabilities all. This last bit I'm really not sure of, but try as hard as I may the CAP_SYS capabilities don't seem to allow for kernel to load firmware files from the filesystem. I think it should be fine for this pkg, but would appreciate any guidance on how to make it more granular.

**- How to verify it**

Modprobe any WiFi driver that requires a firmware

**- Description for the changelog**

Allowed for modprobe modules to load firmware files.

**- A picture of a cute animal (not mandatory but encouraged)**

=!=!=
    - 
   \/