### PR TITLE
wireguard: upgrade to 0.0.20181115

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20181018
-ENV WIREGUARD_SHA256="af05824211b27cbeeea2b8d6b76be29552c0d80bfe716471215e4e43d259e327"
+ENV WIREGUARD_VERSION=0.0.20181115
+ENV WIREGUARD_SHA256="11292c7e86fce6fb0d9fd170389d2afc609bda963a7faf1fd713e11c2af53085"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * Zinc no longer ships generated assembly code. Rather, we now
    bundle in the original perlasm generator for it. The primary purpose
    of this snapshot is to get testing of this.
  * Clarify the peer removal logic and make lifetimes more precise.
  * Use READ_ONCE for is_valid and is_dead.
  * No need to use atomic when the recounter is mutex protected.
  * Fix up macros and annotations in allowedips.
  * Increment drop counter when staged packets are dropped.
  * Use static constants instead of enums for 64-bit values in selftest.
  * Mark large constants as ULL in poly1305-donna64.
  * Fix sparse warnings in allowedips debugging code.
  * Do not use wg_peer_get_maybe_zero in timer callbacks, since we now can
    carefully control the lifetime of these functions and ensure they never
    execute after dropping the last reference.
  * Cleanup hashing in ratelimiter.
  * Do not guard timer removals, since del_timer is always okay.
  * We now check for PM_AUTOSLEEP, which makes the clear*on-suspend decision a
    bit more general.
  * Set csum_level to ~0, since the poly1305 authenticator certainly means
    that no data was modified in transit.
  * Use CHECKSUM_PARTIAL check for skb_checksum_help instead of
    skb_checksum_setup check.
  * wg.8: specify that wg(8) shows runtime info too
  * wg.8: AllowedIPs isn't actually required
  * keygen-html: add missing glue macro
  * wg-quick: android: do not choke on empty allowed-ips
```