### PR TITLE
pkg/bpftrace: Add bpftrace as a core pkg

### DIFF
--- a/pkg/bpftrace/Dockerfile
+++ b/pkg/bpftrace/Dockerfile
@@ -1,0 +1,37 @@
+FROM linuxkit/alpine:ace75d0ec6978762d445083d6c8c6336bdb658ed AS build
+RUN apk add --update \
+    bison \
+    build-base \
+    clang-dev \
+    clang-static \
+    cmake \
+    elfutils-dev \
+    flex-dev \
+    git \
+    linux-headers \
+    llvm5-dev \
+    llvm5-static \
+    zlib-dev
+
+# Put LLVM directories where CMake expects them to be
+RUN ln -s /usr/lib/cmake/llvm5 /usr/lib/cmake/llvm
+RUN ln -s /usr/include/llvm5/llvm /usr/include/llvm
+RUN ln -s /usr/include/llvm5/llvm-c /usr/include/llvm-c
+
+ENV GITREPO=https://github.com/iovisor/bpftrace.git
+ENV COMMIT=8f7f8214d7dd7bc25b7740a3c0e9a580a89e0244
+ENV STATIC_LINKING=on
+ENV RUN_TESTS=0
+
+RUN git clone ${GITREPO} /bpftrace \
+    && cd /bpftrace/ \ 
+    && mkdir -p /bpftrace/build \
+    && git checkout ${COMMIT} \
+    && chmod +x /bpftrace/docker/build.sh \
+    && /bpftrace/docker/build.sh /bpftrace/build Release -j$(nproc)
+
+FROM scratch
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=build /bpftrace/build/src/bpftrace /usr/bin/bpftrace

--- a/pkg/bpftrace/build.yml
+++ b/pkg/bpftrace/build.yml
@@ -1,0 +1,4 @@
+image: bpftrace
+network: true
+arches: 
+  - amd64

--- a/test/cases/040_packages/002_bpftrace/check.sh
+++ b/test/cases/040_packages/002_bpftrace/check.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+nsenter -t1 -m -- /usr/bin/bpftrace -l
+if [ "$?" -ne "0" ]; then
+	printf "bpftrace test suite FAILED\n" >&1
+	exit 1
+fi;
+
+printf "bpftrace test suite PASSED\n" >&1

--- a/test/cases/040_packages/002_bpftrace/test.sh
+++ b/test/cases/040_packages/002_bpftrace/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# SUMMARY: Check that the bpftrace package works
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+NAME=bpftrace
+
+clean_up() {
+	rm -rf ${NAME}-*
+}
+trap clean_up EXIT
+
+# Test code goes here
+linuxkit build -format kernel+initrd -name "${NAME}" test.yml
+RESULT="$(linuxkit run ${NAME})"
+echo "${RESULT}"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/040_packages/002_bpftrace/test.yml
+++ b/test/cases/040_packages/002_bpftrace/test.yml
@@ -1,0 +1,29 @@
+kernel:
+  image: linuxkit/kernel:4.14.86
+  cmdline: "console=ttyS0 console=ttyAMA0"
+init:
+  - linuxkit/init:v0.5
+  - linuxkit/runc:v0.5
+  - linuxkit/bpftrace:67b5c3b4f13a4acf22eab8f422091e1efc06852d
+onboot:
+  - name: bpftrace-test
+    image: alpine:3.8
+    binds:
+      - /check.sh:/check.sh
+    command: ["sh", "./check.sh"]
+    pid: host
+    net: host
+    ipc: host
+    capabilities:
+      - all
+  - name: poweroff
+    image: linuxkit/poweroff:2687ed712690766b8156a77ac600005b532d2c7d
+    command: ["/bin/sh", "/poweroff.sh", "10"]
+files:
+  - path: check.sh
+    source: ./check.sh
+trust:
+  org:
+    - linuxkit
+  image:
+    - alpine:3.8


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This PR adds [bpftrace](https://github.com/iovisor/bpftrace) as a package to linuxkit. It includes all the necessary components and directory structures in order to build a bpftrace inside of a docker container.

Addresses: https://github.com/linuxkit/linuxkit/issues/3201

**- How I did it**
I started off by looking at existing packages for a reference model of how to structure a package in linuxkit. I also read the https://github.com/linuxkit/linuxkit/blob/master/docs/packages.md doc.

**- How to verify it**
You can build it locally to test it out using the following command:
```linuxkit pkg build -org=<orgname> -disable-content-trust <path/to/bpftrace>```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This commit adds bpftrace to linuxkit packages and addresses the issue: https://github.com/linuxkit/linuxkit/issues/3201


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1254783/48658100-e77dbc00-e9f0-11e8-8557-60d2b1bb733c.png)


Signed-off-by: Simarpreet Singh <simar@linux.com>
