### PR TITLE
wireguard: upgrade to 0.0.20181119

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20181115
-ENV WIREGUARD_SHA256="11292c7e86fce6fb0d9fd170389d2afc609bda963a7faf1fd713e11c2af53085"
+ENV WIREGUARD_VERSION=0.0.20181119
+ENV WIREGUARD_SHA256="7d47f7996dd291069de4efb3097c42f769f60dc3ac6f850a4d5705f321e4406b"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * chacha20,poly1305: fix up for win64
  * poly1305: only export neon symbols when in use
  * poly1305: cleanup leftover debugging changes
  * crypto: resolve target prefix on buggy kernels
  * chacha20,poly1305: don't do compiler testing in generator and remove xor helper
  * crypto: better path resolution and more specific generated .S
  * poly1305: make frame pointers for auxiliary calls
  * chacha20,poly1305: do not use xlate
  
  This should fix up the various build errors, warnings, and insertion errors
  introduced by the previous snapshot, where we added some significant
  refactoring. In short, we're trying to port to using Andy Polyakov's original
  perlasm files, and this means quite a lot of work to re-do that had stableized
  in our old .S.
```