### PR TITLE
Add support for named pipes to init

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.6 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
 services:

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
 onboot:

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.87-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
 onboot:

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
 onboot:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/pkg/init/cmd/init/init.go
+++ b/pkg/init/cmd/init/init.go
@@ -136,8 +136,9 @@ func copyFS(newRoot string) error {
 				return err
 			}
 		case (info.Mode() & os.ModeNamedPipe) == os.ModeNamedPipe:
-			// TODO support named pipes, although no real use case
-			return errors.New("Unsupported named pipe on rootfs")
+			if err := unix.Mkfifo(dest, uint32(info.Mode())); err != nil {
+				return err
+			}
 		case (info.Mode() & os.ModeSocket) == os.ModeSocket:
 			// TODO support sockets, although no real use case
 			return errors.New("Unsupported socket on rootfs")

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
 onboot:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/src/cmd/linuxkit/moby/linuxkit.go
+++ b/src/cmd/linuxkit/moby/linuxkit.go
@@ -17,7 +17,7 @@ kernel:
   image: linuxkit/kernel:4.9.39
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: mkimage

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: dhcpcd

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
 

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
 services:

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.154
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/002_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/002_config_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.97
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/005_config_4.19.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.19.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/006_config_4.20.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.20.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.20.6
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.154
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: check

--- a/test/cases/020_kernel/012_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/012_kmod_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.97
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: check

--- a/test/cases/020_kernel/015_kmod_4.19.x/test.yml
+++ b/test/cases/020_kernel/015_kmod_4.19.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: check

--- a/test/cases/020_kernel/016_kmod_4.20.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.20.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.20.6
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/ca-certificates:v0.6
 onboot:

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
   - linuxkit/ca-certificates:v0.6

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
   - linuxkit/containerd:cf158d5f56c5b4867f29f0fc3ec49ea505e99333
 onboot:

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.19.19
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff
+  - linuxkit/init:d4755947f0599c3e73b54777cf8c6f29fe089a1f
   - linuxkit/runc:b87c49e73eb14ba73d23eabf75423e987a043209
 onboot:
   - name: test-ns


### PR DESCRIPTION
Signed-off-by: Tomas Knappek <tomas.knappek@gmail.com>

**- What I did**
Added support for named pipes in based images.

**- How I did it**
`pkg/init/cmd/init/init.go` to allow ` os.ModeNamedPipe` on rootfs

**- How to verify it**
Use RHEL based image for a service, and run it.

**- Description for the changelog**
Allow based images that use named pipes, for example RHEL descendants that use named pipe in /dev for systemd.

