### PR TITLE
Update InfluxDB example to 1.7

### DIFF
--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -16,32 +16,32 @@ services:
     env:
      - INSECURE=true
   - name: influxdb
-    image: influxdb:1.4
+    image: influxdb:1.7
     net: host
     capabilities:
       - CAP_NET_BIND_SERVICE
       - CAP_DAC_OVERRIDE
   - name: kapacitor
-    image: kapacitor:1.4
+    image: kapacitor:1.5
     net: host
     capabilities:
       - all
     env:
       - KAPACITOR_INFLUXDB_0_URLS_0=http://influxdb:8086
   - name: telegraf
-    image: telegraf:1.4
+    image: telegraf:1.9
     net: host
     capabilities:
       - all
   - name: chronograf
-    image: chronograf:1.4
+    image: chronograf:1.7
     net: host
     capabilities:
       - CAP_NET_BIND_SERVICE
       - CAP_DAC_OVERRIDE
     env:
-      - INFLUXDB_URL=http://localhost:8086
-      - KAPACITOR_URL=http://localhost:9092
+      - INFLUXDB_URL=http://127.0.0.1:8086
+      - KAPACITOR_URL=http://127.0.0.1:9092
 trust:
   org:
     - linuxkit


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>

**- What I did**

Updated the components of the InnfluxDB example to t he latest versions and changed localhost to 127.0.0.1.

**- How I did it**
By changing image names

**- How to verify it**

Build it
```
linuxkit build -format iso-bios examples/influxdb-os.yml
```

Run it
```
linuxkit run qemu --publish 8888:8888 -iso influxdb-os.iso
```


On your local machine

```
influx
```

```
Connected to http://localhost:8086 version 1.7.2
InfluxDB shell version: 1.7.2
Enter an InfluxQL query
```

**- Description for the changelog**
InfluxDB example updated to InfluxDB 1.7, Chronograf 1.7, Kapacitor 1.5 and Telegraf 1.9


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/3083633/50060275-3787a400-0192-11e9-8ba3-f0262774db17.png)

Image Credit [Andreas Butz](https://500px.com/photo/1166764/gentoo-penguins-by-andreas-butz)

