### PR TITLE
wireguard: upgrade to 0.0.20181218

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -42,8 +42,8 @@ ENV KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VE
 ENV KERNEL_SHA256_SUMS=https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 ENV KERNEL_PGP2_SIGN=https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.sign
 
-ENV WIREGUARD_VERSION=0.0.20181119
-ENV WIREGUARD_SHA256="7d47f7996dd291069de4efb3097c42f769f60dc3ac6f850a4d5705f321e4406b"
+ENV WIREGUARD_VERSION=0.0.20181218
+ENV WIREGUARD_SHA256="2e9f86acefa49dbfb7fa6f5e10d543f1885a2d5460cd5e102696901107675735"
 ENV WIREGUARD_URL=https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WIREGUARD_VERSION}.tar.xz
 
 # We copy the entire directory. This copies some unneeded files, but


### PR DESCRIPTION
```
  * jerry-rig: replace S_shipped with pl
  
  This fixes our jerry rig script, so that people can patch WireGuard into
  arbitrary kernel trees, instead of building as a standalone module.
  
  * chacha20,poly1305: simplify perlasm fanciness
  
  Numerous cleanups and correctness fixes in the assembly generators.
  
  * compat: don't undef BUILD_BUG_ON for Clang >=8
  
  The clang bug was finally fixed upstream, so we remove the workaround, while
  retaining the hack in our compat layer.
  
  * embeddable-wg-library: do not warn on unrecognized netlink attributes
  
  This brings behavior into parity with wg(8), and also allows more graceful
  addition of netlink attributes.
  
  * chacha20: do not define unused asm function
  
  This not only decreases code size, but also makes PaX's RAP happier.
  
  * compat: account for Clang CFI
  
  It turns out that RAP is no longer the only game in town, when it comes to CFI
  on kernels before Kees' epic timer_list refactoring. The Pixel 3/3XL kernels
  are based on 4.9 and come with Clang CFI on by default, so we account for this
  in our compat layer, so that we don't get CFI violation's and thus crashes.
  
  * wg-quick: bring interface up while setting MTU
  
  A small optimization to save a fork/exec.
  
  * makefile: use immediate expansion and use correct template patterns
  
  Coming up with the right combination of makefile template params that work on
  many kernels hasn't been easy, but hopefully this should solve building in a
  number of strange circumstances. If you're still having issues and you're
  using ccache, be sure to flush your cache first, as the cache might be serving
  stale copies of gcc's dependency info.
```