### PR TITLE
Update kernels to 4.9.11/4.14.89/4.9.146/4.4.168

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -1,6 +1,6 @@
 # This is an example for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.6 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -1,6 +1,6 @@
 # Simple example of using an external logging service
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/packet.arm64.yml
+++ b/examples/packet.arm64.yml
@@ -5,7 +5,7 @@
 # for arm64 then the 'ucode' line in the kernel section can be left
 # out.
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyAMA0"
   ucode: ""
 onboot:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -262,21 +262,21 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,4.19.9,4.19.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.88,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.88,4.14.x,,-dbg))
+$(eval $(call kernel,4.19.11,4.19.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.89,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.89,4.14.x,,-dbg))
 $(eval $(call kernel,4.14.78,4.14.x,-rt,))
-$(eval $(call kernel,4.9.145,4.9.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.4.167,4.4.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.146,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.4.168,4.4.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,4.19.9,4.19.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.88,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.19.11,4.19.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.89,4.14.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.14.78,4.14.x,-rt,))
 
 else ifeq ($(ARCH),s390x)
-$(eval $(call kernel,4.19.9,4.19.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.14.88,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.19.11,4.19.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.89,4.14.x,$(EXTRA),$(DEBUG)))
 endif
 
 # Target for kernel config

--- a/kernel/config-4.14.x-aarch64
+++ b/kernel/config-4.14.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.88 Kernel Configuration
+# Linux/arm64 4.14.89 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/kernel/config-4.14.x-s390x
+++ b/kernel/config-4.14.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.14.88 Kernel Configuration
+# Linux/s390 4.14.89 Kernel Configuration
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.88 Kernel Configuration
+# Linux/x86 4.14.89 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.19.x-aarch64
+++ b/kernel/config-4.19.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.19.9 Kernel Configuration
+# Linux/arm64 4.19.11 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.19.x-s390x
+++ b/kernel/config-4.19.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.19.9 Kernel Configuration
+# Linux/s390 4.19.11 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.19.x-x86_64
+++ b/kernel/config-4.19.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.19.9 Kernel Configuration
+# Linux/x86 4.19.11 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.4.x-x86_64
+++ b/kernel/config-4.4.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.4.167 Kernel Configuration
+# Linux/x86 4.4.168 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.145 Kernel Configuration
+# Linux/x86 4.9.146 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From a033a484eabae063d9d57f083ed9fab1e1b14de5 Mon Sep 17 00:00:00 2001
+From 81bb859205b4a121c26b5aca4f54fcfae34ace3e Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 01/21] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,4 +1,4 @@
-From b62d0b3b7fc10c2f3acf62065e8032c22dcc91e0 Mon Sep 17 00:00:00 2001
+From 7f1255f3329714f856178c2711ebf334370d6a06 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
 Subject: [PATCH 02/21] hyper-v: trace vmbus_on_msg_dpc()

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,4 +1,4 @@
-From d3d8e28283141b6b059326e3da73150dccf1da43 Mon Sep 17 00:00:00 2001
+From 2c62a4b3bfca283c8cc187f038bed18550862824 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
 Subject: [PATCH 03/21] hyper-v: trace vmbus_on_message()

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,4 +1,4 @@
-From c3f03ae21b76a70e35c4c848cd737f1944f952b3 Mon Sep 17 00:00:00 2001
+From 7f6e1dd36d3ca990bac57f44977ae57a62301814 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
 Subject: [PATCH 04/21] hyper-v: trace vmbus_onoffer()

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,4 +1,4 @@
-From 601d341d8df2a3de762d80afa0c47728c15e94eb Mon Sep 17 00:00:00 2001
+From bb3a7f5e150258903ee262e8a91873bd68394b16 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
 Subject: [PATCH 05/21] hyper-v: trace vmbus_onoffer_rescind()

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,4 +1,4 @@
-From 8c48ae5442b62f8cb8a615c26db90d162b9d1409 Mon Sep 17 00:00:00 2001
+From 1432ccf34722756e3381215ecdfe00baa5f8c16b Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
 Subject: [PATCH 06/21] hyper-v: trace vmbus_onopen_result()

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,4 +1,4 @@
-From e9e272b7d0384b54372eacef98e45008073c5616 Mon Sep 17 00:00:00 2001
+From 5b3975821abfc74abdebc84c7e1cc4c9df7c81df Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
 Subject: [PATCH 07/21] hyper-v: trace vmbus_ongpadl_created()

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,4 +1,4 @@
-From 6f1dd61dcdfe1428826a9bdea42190836dcbb223 Mon Sep 17 00:00:00 2001
+From fd149af11bee82efa6af6dbdd4cacbe4b38eaf03 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
 Subject: [PATCH 08/21] hyper-v: trace vmbus_ongpadl_torndown()

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,4 +1,4 @@
-From 8c3ab59b60e32c6fa27bcab78f4247eba62c66f2 Mon Sep 17 00:00:00 2001
+From ea8d71492ca7880f1f681c9a14441844d69726d3 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
 Subject: [PATCH 09/21] hyper-v: trace vmbus_onversion_response()

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,4 +1,4 @@
-From 5ec4ab33943e6c154e3f80ae3587e14666b79c96 Mon Sep 17 00:00:00 2001
+From 75c15dd8dc12ab095ed84d0ece4f21ff1bde8af7 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
 Subject: [PATCH 10/21] hyper-v: trace vmbus_request_offers()

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 3fde22b0435cfc87f50547a2bf01063087bb569e Mon Sep 17 00:00:00 2001
+From fbb35d8ba6d1ac57bd75d72e86ae1de445351d30 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
 Subject: [PATCH 11/21] hyper-v: trace vmbus_open()

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,4 +1,4 @@
-From e74aac28ca9e728585c1dafd407ba0983f5a4140 Mon Sep 17 00:00:00 2001
+From a63d48c041f5ef48e715aa83a13fa243725061a4 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
 Subject: [PATCH 12/21] hyper-v: trace vmbus_close_internal()

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,4 +1,4 @@
-From ac75c9c08fba19f2e254b6f6fb86ae9bbcbc11f8 Mon Sep 17 00:00:00 2001
+From f135f8aeac416a7303580cc2d93afbb9a7b19a14 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
 Subject: [PATCH 13/21] hyper-v: trace vmbus_establish_gpadl()

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,4 +1,4 @@
-From 50c2740f477b81e1a3f8c15ee991017a345a7bca Mon Sep 17 00:00:00 2001
+From a7526016823857b554f83f5ce12e50a1c841104e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
 Subject: [PATCH 14/21] hyper-v: trace vmbus_teardown_gpadl()

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,4 +1,4 @@
-From 3300f45223944b320270b677c5b1884ca94dc659 Mon Sep 17 00:00:00 2001
+From 8d23310770c577d8b1172f2da7ddf240d08eaac4 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
 Subject: [PATCH 15/21] hyper-v: trace vmbus_negotiate_version()

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,4 +1,4 @@
-From cc9f244107ea5b3f0245c0fc4e1a726cbfb496f2 Mon Sep 17 00:00:00 2001
+From 014e9ff7bfc501914ca54d5f2963a92cd4e9f692 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
 Subject: [PATCH 16/21] hyper-v: trace vmbus_release_relid()

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,4 +1,4 @@
-From f6322b98e4281d6c1fdc6226aa12e067f1c25bab Mon Sep 17 00:00:00 2001
+From 3f836dd9b1f6fa32d89679d033938924e7a88cdb Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
 Subject: [PATCH 17/21] hyper-v: trace vmbus_send_tl_connect_request()

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,4 +1,4 @@
-From 07301f0c95f77a6af090f843277f797945a224d0 Mon Sep 17 00:00:00 2001
+From 531302f49e145244aba495bc18fadc2fe08a1fc9 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
 Subject: [PATCH 18/21] hyper-v: trace channel events

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From 563cdda487e16cd17973d166a3c03075dc5d4247 Mon Sep 17 00:00:00 2001
+From 98f1f0570b4231f007e3ade2fc2c2e7e66128b29 Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH 19/21] serial: forbid 8250 on s390

--- a/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
+++ b/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
@@ -1,4 +1,4 @@
-From e5fa06f029aa7eb7af0e77d9534872b94c8efd78 Mon Sep 17 00:00:00 2001
+From e0fcabcc4795b5f67b59a693991b179262342a0a Mon Sep 17 00:00:00 2001
 From: Cathy Avery <cavery@redhat.com>
 Date: Tue, 31 Oct 2017 08:52:06 -0400
 Subject: [PATCH 20/21] scsi: storvsc: Allow only one remove lun work item to

--- a/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
+++ b/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
@@ -1,4 +1,4 @@
-From 6394c1e25caf289cae3bfe8d69d12810c345cabe Mon Sep 17 00:00:00 2001
+From ffecd9d4d3aa48b7b6d64dcd96200a1ddb2b348e Mon Sep 17 00:00:00 2001
 From: Long Li <longli@microsoft.com>
 Date: Tue, 31 Oct 2017 14:58:08 -0700
 Subject: [PATCH 21/21] scsi: storvsc: Avoid excessive host scan on controller

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 447d8c4653d81e7358ce4ebb7df6e9a11e11d26b Mon Sep 17 00:00:00 2001
+From e301c97e074c394b8161ae11470aa90374ac447c Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/14] tools build: Add test for sched_getcpu()

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From d101fdc766a813e8406ce7002c169de296c6f4b4 Mon Sep 17 00:00:00 2001
+From 4e953359322bca1cd65ced6e6ba7e397e9de8406 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/14] perf jit: Avoid returning garbage for a ret variable

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From d102c7ef7f736c35cf82e2732d2253d1148e23df Mon Sep 17 00:00:00 2001
+From ca65c9afd72ff56df9e284494e794290902c54ca Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/14] hv_sock: introduce Hyper-V Sockets

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 4035d888ca2b8d2a013cd9a8a94407026aed0284 Mon Sep 17 00:00:00 2001
+From c42616b43608ea2412763655b9125bfa357b38e2 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/14] vmbus: Don't spam the logs with unknown GUIDs

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From 4f4cccf74d4ac0c6b39ac576c2bf80d9d611999f Mon Sep 17 00:00:00 2001
+From 89c83844eebd9f7d38d741ba1b6e448c328c7692 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/14] Drivers: hv: utils: Fix the mapping between host

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From 83d0c0a0721e0cca423e44b943b3c57e36b517fb Mon Sep 17 00:00:00 2001
+From 2c5a03300be9be203366b4d8e9e1ddb186f65a90 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/14] Drivers: hv: vss: Improve log messages.

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From b8a12a77a016845a4ad4b25d16aff27ee0bdd72b Mon Sep 17 00:00:00 2001
+From 6ecfe50934feea89d304acd19844e0af3520a5e6 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/14] Drivers: hv: vss: Operation timeouts should match host

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From f9921db72337e88d49fb8a2e33cd3f744c164d1b Mon Sep 17 00:00:00 2001
+From a12a079b53f99a0abacb76f56b4e796eae2f6b8c Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/14] Drivers: hv: vmbus: Use all supported IC versions to

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From cf64bf8842001b437bc2805075d4a2d50db97377 Mon Sep 17 00:00:00 2001
+From ea7f046463c5b52fab336d7e9b05be0fbad7aede Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/14] Drivers: hv: Log the negotiated IC versions.

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From 6c2ca02c457076554dd5d87b91b90a7ebc234015 Mon Sep 17 00:00:00 2001
+From 3d8c1857504847d2ed07b462924192b6086ee897 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/14] vmbus: fix missed ring events on boot

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From b8f2a0fe6c497c899764e5948de3ca4f0db1001e Mon Sep 17 00:00:00 2001
+From 68b41956e2e9b037140c48515ec16547c1793f2d Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/14] vmbus: remove "goto error_clean_msglist" in

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 4053ad7c7163caafa204efb33fa4b08cf8479f20 Mon Sep 17 00:00:00 2001
+From 8093bde24f0bce6c5ebd856f5000e796434c7c6e Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/14] vmbus: dynamically enqueue/dequeue the channel on

--- a/kernel/patches-4.9.x/0013-bridge-implement-missing-ndo_uninit.patch
+++ b/kernel/patches-4.9.x/0013-bridge-implement-missing-ndo_uninit.patch
@@ -1,4 +1,4 @@
-From 325b1550275d085cb05312f07d5af6c8ce7c7645 Mon Sep 17 00:00:00 2001
+From 036397c172d8d3a0b2909e77b4b507c6d1c4630c Mon Sep 17 00:00:00 2001
 From: Ido Schimmel <idosch@mellanox.com>
 Date: Mon, 10 Apr 2017 14:59:27 +0300
 Subject: [PATCH 13/14] bridge: implement missing ndo_uninit()

--- a/kernel/patches-4.9.x/0014-bridge-move-bridge-multicast-cleanup-to-ndo_uninit.patch
+++ b/kernel/patches-4.9.x/0014-bridge-move-bridge-multicast-cleanup-to-ndo_uninit.patch
@@ -1,4 +1,4 @@
-From 28ee2849c620d15522a3b5eb4ee7164713614557 Mon Sep 17 00:00:00 2001
+From 5a37c0a2e8e35228076a8550fde8abbbb7517c1e Mon Sep 17 00:00:00 2001
 From: Xin Long <lucien.xin@gmail.com>
 Date: Tue, 25 Apr 2017 22:58:37 +0800
 Subject: [PATCH 14/14] bridge: move bridge multicast cleanup to ndo_uninit

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/020_kernel/000_config_4.4.x/test.yml
+++ b/test/cases/020_kernel/000_config_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.167
+  image: linuxkit/kernel:4.4.168
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.145
+  image: linuxkit/kernel:4.9.146
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/020_kernel/002_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/002_config_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/020_kernel/005_config_4.19.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.19.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.9
+  image: linuxkit/kernel:4.19.11
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
+++ b/test/cases/020_kernel/010_kmod_4.4.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.4.167 AS ksrc
+FROM linuxkit/kernel:4.4.168 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.sh
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.4.167
+docker pull linuxkit/kernel:4.4.168
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/010_kmod_4.4.x/test.yml
+++ b/test/cases/020_kernel/010_kmod_4.4.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.4.167
+  image: linuxkit/kernel:4.4.168
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.145 AS ksrc
+FROM linuxkit/kernel:4.9.146 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.145
+docker pull linuxkit/kernel:4.9.146
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.145
+  image: linuxkit/kernel:4.9.146
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/020_kernel/012_kmod_4.14.x/Dockerfile
+++ b/test/cases/020_kernel/012_kmod_4.14.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.14.88 AS ksrc
+FROM linuxkit/kernel:4.14.89 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/012_kmod_4.14.x/test.sh
+++ b/test/cases/020_kernel/012_kmod_4.14.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.14.88
+docker pull linuxkit/kernel:4.14.89
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/012_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/012_kmod_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/020_kernel/015_kmod_4.19.x/Dockerfile
+++ b/test/cases/020_kernel/015_kmod_4.19.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.19.9 AS ksrc
+FROM linuxkit/kernel:4.19.11 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS build

--- a/test/cases/020_kernel/015_kmod_4.19.x/test.sh
+++ b/test/cases/020_kernel/015_kmod_4.19.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.19.9
+docker pull linuxkit/kernel:4.19.11
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/015_kmod_4.19.x/test.yml
+++ b/test/cases/020_kernel/015_kmod_4.19.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.9
+  image: linuxkit/kernel:4.19.11
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/002_bpftrace/test.yml
+++ b/test/cases/040_packages/002_bpftrace/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.5

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/cases/040_packages/032_bcc/test.yml
+++ b/test/cases/040_packages/032_bcc/test.yml
@@ -1,10 +1,10 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.5
   - linuxkit/runc:v0.5
-  - linuxkit/kernel-bcc:4.14.88
+  - linuxkit/kernel-bcc:4.14.89
 onboot:
   - name: check-bcc
     image: alpine:3.8

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -1,6 +1,6 @@
 # Sample YAML file for manual testing
 kernel:
-  image: linuxkit/kernel:4.14.88
+  image: linuxkit/kernel:4.14.89
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:c563953a2277eb73a89d89f70e4b6dcdcfebc2d1


### PR DESCRIPTION
Note this skips 4.9.10. The diff is quite small so not worth the hassle of adding a separate commit and compile cycle

![gannets](https://user-images.githubusercontent.com/3338098/50257293-99dedf80-03f2-11e9-834f-9921fc895c67.jpg)
