### PR TITLE
Fix link to ADOPTERS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ There are monthly [development reports](reports/) summarising the work carried o
 
 ## Adopters
 
-We maintain an incomplete list of [adopters](adopters.md). Please open a PR if you are using LinuxKit in production or in your project, or both.
+We maintain an incomplete list of [adopters](ADOPTERS.md). Please open a PR if you are using LinuxKit in production or in your project, or both.
 
 ## FAQ
 


### PR DESCRIPTION
Signed-off-by: Ben Allen <bsallen@alcf.anl.gov>

**- What I did**
Quick change to fix broken link in README.md to ADOPTERS.md

**- Description for the changelog**
Fix broken link in README.md to ADOPTERS.md

**- A picture of a cute animal (not mandatory but encouraged)**
![65a0a349eef3999d345e17751cd69e3a--cute-goats-baby-goats](https://user-images.githubusercontent.com/1652762/51077008-ace97600-1665-11e9-978f-53f4f7af2216.jpg)
