### PR TITLE
Switch the default kernel to 4.19.x

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -1,6 +1,6 @@
 # This is an example for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.6 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -1,6 +1,6 @@
 # Simple example of using an external logging service
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/packet.arm64.yml
+++ b/examples/packet.arm64.yml
@@ -5,7 +5,7 @@
 # for arm64 then the 'ucode' line in the kernel section can be left
 # out.
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyAMA0"
   ucode: ""
 onboot:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -1,6 +1,6 @@
 # NOTE: Images build from this file likely do not run
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/002_bpftrace/test.yml
+++ b/test/cases/040_packages/002_bpftrace/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.5

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/cases/040_packages/032_bcc/test.yml
+++ b/test/cases/040_packages/032_bcc/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.5

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -1,6 +1,6 @@
 # Sample YAML file for manual testing
 kernel:
-  image: linuxkit/kernel:4.14.92
+  image: linuxkit/kernel:4.19.14
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:e0dced91adbfba34c53cd673760e011f410638ff


### PR DESCRIPTION
4.19.x is the new LTS kernel and has been out for a while. Switch
all examples and tests to using it instead of the 4.14.x kernel.
resolves #3268 

![pink-dolphin](https://user-images.githubusercontent.com/3338098/51263768-d6c7d300-19ac-11e9-840d-8db238f93d94.jpg)
