### PR TITLE
Use latest stable release of ZFS

### DIFF
--- a/kernel/Dockerfile.zfs
+++ b/kernel/Dockerfile.zfs
@@ -23,10 +23,10 @@ COPY --from=ksrc /kernel.tar /
 RUN tar xf kernel.tar
 
 # Note: ZFS and SPL commits must match. It's unclear how much the user
-# space tools must match the kernel module version. The current zfs
-# package on Alpine is 0.6.5.9. We pick 0.6.5.10 because it has
-# support for 4.12 based kernels.
-ENV VERSION=0.6.5.10
+# space tools must match the kernel module version.
+# package on Alpine is 0.6.5.9. We pick the version that compiles with
+# latest kernel we support.
+ENV VERSION=0.7.12
 
 ENV SPL_REPO=https://github.com/zfsonlinux/spl.git
 ENV SPL_COMMIT=spl-${VERSION}


### PR DESCRIPTION
This change makes `make -C kernel build_zfs_4.14.x` succeed.

Closes #2950.