### PR TITLE
Containerd v1.2.4

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.6 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   # support metadata for optional config in /run/config

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: dhcpcd

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
   - linuxkit/memlogd:v0.6
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.6

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
 services:
   - name: getty
     image: linuxkit/getty:2eb742cd7a68e14cf50577c02f30147bc406e478

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
   - linuxkit/firmware:v0.6
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.6

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.87-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.6

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.6

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:19576072dd2b2f17fa73828e4bbd442e954992a3 as alpine
+FROM linuxkit/alpine:9f00542b8b74b7815936affb11dedb86945fe4ac as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:19576072dd2b2f17fa73828e4bbd442e954992a3 AS build
+FROM linuxkit/alpine:9f00542b8b74b7815936affb11dedb86945fe4ac AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -16,7 +16,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:19576072dd2b2f17fa73828e4bbd442e954992a3 AS mirror
+FROM linuxkit/alpine:9f00542b8b74b7815936affb11dedb86945fe4ac AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -11,7 +11,7 @@ RUN \
   make \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin
-ENV RUNC_COMMIT=12f6a991201fdb8f82579582d5e00e28fba06d0a
+ENV RUNC_COMMIT=6635b4f0c6af3810594d2770f662f34ddc15b40d
 RUN mkdir -p $GOPATH/src/github.com/opencontainers && \
   cd $GOPATH/src/github.com/opencontainers && \
   git clone https://github.com/opencontainers/runc.git

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:19576072dd2b2f17fa73828e4bbd442e954992a3 as alpine
+FROM linuxkit/alpine:9f00542b8b74b7815936affb11dedb86945fe4ac as alpine
 RUN \
   apk add \
   bash \

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.6

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.6

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/src/cmd/linuxkit/moby/linuxkit.go
+++ b/src/cmd/linuxkit/moby/linuxkit.go
@@ -17,8 +17,8 @@ kernel:
   image: linuxkit/kernel:4.9.39
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:v0.6

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.6

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
 
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:afe8f7dd0d47a7991c54519b0f09124cb8c4e300

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:afe8f7dd0d47a7991c54519b0f09124cb8c4e300

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:afe8f7dd0d47a7991c54519b0f09124cb8c4e300

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:afe8f7dd0d47a7991c54519b0f09124cb8c4e300

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:afe8f7dd0d47a7991c54519b0f09124cb8c4e300

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:afe8f7dd0d47a7991c54519b0f09124cb8c4e300

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:afe8f7dd0d47a7991c54519b0f09124cb8c4e300

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:afe8f7dd0d47a7991c54519b0f09124cb8c4e300

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:afe8f7dd0d47a7991c54519b0f09124cb8c4e300

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:afe8f7dd0d47a7991c54519b0f09124cb8c4e300

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
 services:
   - name: acpid
     image: linuxkit/acpid:v0.6

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.155
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:1aaef970b5f70791d74d6f980ad38af4035948f8

--- a/test/cases/020_kernel/002_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/002_config_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.98
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:1aaef970b5f70791d74d6f980ad38af4035948f8

--- a/test/cases/020_kernel/005_config_4.19.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.19.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:1aaef970b5f70791d74d6f980ad38af4035948f8

--- a/test/cases/020_kernel/006_config_4.20.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.20.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.20.7
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:1aaef970b5f70791d74d6f980ad38af4035948f8

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.155
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/012_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/012_kmod_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.98
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/015_kmod_4.19.x/test.yml
+++ b/test/cases/020_kernel/015_kmod_4.19.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/016_kmod_4.20.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.20.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.20.7
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 trust:
   org:
     - linuxkit

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: test
     image: alpine:3.8

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:e2d222038867ebd13b0b723c8351be559267050b

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:v0.6
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:8c7abc5cfdce5677d477f4a3d384a019aea339c9
+    image: linuxkit/test-containerd:c519056cae689157ab6805a309ff1ca0f1de11dc
   - name: poweroff
     image: linuxkit/poweroff:afe8f7dd0d47a7991c54519b0f09124cb8c4e300
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.6

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: format
     image: linuxkit/format:v0.6

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: extend
     image: linuxkit/extend:v0.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:v0.6

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:v0.6

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: format
     image: linuxkit/format:v0.6

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: extend
     image: linuxkit/extend:v0.6

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: format
     image: linuxkit/format:v0.6

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: format
     image: linuxkit/format:v0.6

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: format
     image: linuxkit/format:v0.6

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:v0.6

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: format
     image: linuxkit/format:v0.6

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: format
     image: linuxkit/format:v0.6

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: format
     image: linuxkit/format:v0.6

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:v0.6

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:afe8f7dd0d47a7991c54519b0f09124cb8c4e300

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.6

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
   - linuxkit/memlogd:v0.6
 services:

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
   - linuxkit/ca-certificates:v0.6
   - linuxkit/memlogd:v0.6
 services:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
-  - linuxkit/containerd:56e03cfa92d75d6eb5a7fc44742e50f427ba29a3
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
+  - linuxkit/containerd:2aff4d486220667364b2971b5fc6225bf165a069
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.6

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -29,4 +29,3 @@ WORKDIR $GOPATH/src/github.com/containerd/containerd
 ADD run.sh ./run.sh
 
 ENTRYPOINT ["/bin/sh", "run.sh"]
-LABEL org.mobyproject.config='{"capabilities": ["all"], "tmpfs": ["/tmp"], "binds": ["/dev:/dev", "/var/lib:/var/lib", "/etc/resolv.conf:/etc/resolv.conf", "/usr/bin/runc:/usr/bin/runc", "/usr/bin/containerd:/usr/bin/containerd", "/usr/bin/containerd-shim:/usr/bin/containerd-shim"], "mounts": [{"type": "cgroup", "options": ["rw","nosuid","noexec","nodev","relatime"]}],}'

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:19576072dd2b2f17fa73828e4bbd442e954992a3 AS mirror
+FROM linuxkit/alpine:9f00542b8b74b7815936affb11dedb86945fe4ac AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/containerd/build.yml
+++ b/test/pkg/containerd/build.yml
@@ -1,1 +1,16 @@
 image: test-containerd
+config:
+  capabilities:
+    - all
+  tmpfs:
+    - /tmp
+  binds:
+    - /dev:/dev
+    - /var/lib:/var/lib
+    - /etc/resolv.conf:/etc/resolv.conf
+    - /usr/bin/runc:/usr/bin/runc
+    - /usr/bin/containerd:/usr/bin/containerd
+    - /usr/bin/containerd-shim:/usr/bin/containerd-shim
+  mounts:
+    - type: cgroup
+      options: ["rw","nosuid","noexec","nodev","relatime"]

--- a/test/pkg/containerd/run.sh
+++ b/test/pkg/containerd/run.sh
@@ -9,6 +9,10 @@ function failed {
 git describe HEAD
 git rev-parse HEAD
 
+# The unit tests need user_xattr support, which /tmp (a tmpfs) does not support.
+mkdir -p /var/lib/tmp
+export TMPDIR=/var/lib/tmp
+
 # unset -race (does not work on alpine; see golang/go#14481)
 export TESTFLAGS=
 make root-test || failed

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:4.19.20
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:4448c4b6d4308244160b71c423bc9df32bc180db
-  - linuxkit/runc:a81d48a1568f41b1c2e048fe017dbd88c6a4bdcc
+  - linuxkit/init:a2166a6048ce041eebe005ab99454cfdeaa5c848
+  - linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -54,7 +54,7 @@ RUN go get -u github.com/LK4D4/vndr
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.2.3
+ENV CONTAINERD_COMMIT=v1.2.4
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:65ce4957b08baf27c6cce9dd3af2e869472f32d8-arm64
+# linuxkit/alpine:915a4c2f6bef52a89ec1e573d05431bbef4a546d-arm64
 # automatically generated list of installed packages
 abuild-3.2.0-r0
 alpine-baselayout-3.1.0-r0

--- a/tools/alpine/versions.s390x
+++ b/tools/alpine/versions.s390x
@@ -1,4 +1,4 @@
-# linuxkit/alpine:6b8f260bcaa4d7037049fab41cb1cca84a061568-s390x
+# linuxkit/alpine:61cdbbff3e159a0c082036f0c4bda4b5c03b7802-s390x
 # automatically generated list of installed packages
 abuild-3.2.0-r0
 alpine-baselayout-3.1.0-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:19576072dd2b2f17fa73828e4bbd442e954992a3-amd64
+# linuxkit/alpine:9f00542b8b74b7815936affb11dedb86945fe4ac-amd64
 # automatically generated list of installed packages
 abuild-3.2.0-r0
 alpine-baselayout-3.1.0-r0


### PR DESCRIPTION
Containerd release: https://github.com/containerd/containerd/releases/tag/v1.2.4

Updates runc for CVE-2019-5736.

This also fixes the issue investigated in #3287 (introduced via #3286) by running the containerd tests with a `$TMPDIR` which supports `user_xattrs` (which `/tmp`, a `tmpfs`, does not). While I was there I also updated `test/pkg/containerd` to use the `build.yml` method for specifying the config instead of the old label method (I thought I was going to need to tweak the config, in the end I didn't, but the cleanup is useful anyway).