### PR TITLE
Removed fixed size arg from mkimage-gcp script.

### DIFF
--- a/tools/mkimage-gcp/make-gcp
+++ b/tools/mkimage-gcp/make-gcp
@@ -42,7 +42,7 @@ cd ..
 
 tar cf files.tar -C files .
 
-virt-make-fs --size=1G --type=ext4 --partition files.tar disk.raw
+virt-make-fs --type=ext4 --partition files.tar disk.raw
 
 guestfish -a disk.raw -m /dev/sda1 <<EOF
   upload /usr/lib/SYSLINUX/mbr.bin /mbr.bin


### PR DESCRIPTION
**- What I did**
Removed size arg from the tools/mkimage-gcp/make-gcp.sh script virt-make-fs command as this fixed size was failing with larger images.

**- How I did it**
delete key

**- How to verify it**
We have a large file included in our 'files:' directive, so this is where we found this issue. When making a large (>1GB) image with the old make-gcp script you'd get a "failed: exit code 1". We no longer get this error with the included change.

**- Description for the changelog**
Removed size arg from mkimage-gcp script.

**- A picture of a cute animal (not mandatory but encouraged)**
![elephants](https://user-images.githubusercontent.com/46323623/53970389-80e0f300-40f2-11e9-8999-dd8ef50fc7d7.jpg)
