### PR TITLE
Containerd v1.2.5

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.88
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.88
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:b5f279abaa0386efeb3c03f46771609ff7c25bc3 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   # support metadata for optional config in /run/config

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: dhcpcd

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
   - linuxkit/memlogd:3d74c1153f99948d92c0fa9c759f816ab48d9855
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:85738d3d2f152a7879e17a61444f7714b858c2ee

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
 services:
   - name: getty
     image: linuxkit/getty:01993189b8c583dc91cbbc7d4be131832c0fc205

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
   - linuxkit/firmware:0e37338a2c994f768fc4569fce47fcf8d9133506
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:85738d3d2f152a7879e17a61444f7714b858c2ee

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.25-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:85738d3d2f152a7879e17a61444f7714b858c2ee

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:85738d3d2f152a7879e17a61444f7714b858c2ee

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:518c2ed0f398c5508969ac5e033607201fb419ed as alpine
+FROM linuxkit/alpine:6ed32ba2b29a12b3d75f3d5b9be1b4ac00e7d479 as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:518c2ed0f398c5508969ac5e033607201fb419ed AS build
+FROM linuxkit/alpine:6ed32ba2b29a12b3d75f3d5b9be1b4ac00e7d479 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -16,7 +16,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:518c2ed0f398c5508969ac5e033607201fb419ed AS mirror
+FROM linuxkit/alpine:6ed32ba2b29a12b3d75f3d5b9be1b4ac00e7d479 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg-17e2eee03ab59f8df8a9c10ace003a84aec2f540"
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:85738d3d2f152a7879e17a61444f7714b858c2ee

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:713e535f2d4e4c74aba50cc7f73e3826b2dd3857

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/src/cmd/linuxkit/moby/linuxkit.go
+++ b/src/cmd/linuxkit/moby/linuxkit.go
@@ -17,7 +17,7 @@ kernel:
   image: linuxkit/kernel:4.9.39
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: mkimage

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: dhcpcd

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
 
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
 services:
   - name: acpid
     image: linuxkit/acpid:c4559f5fdce997de5dedc4c750c7a0d1044b3425

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.162
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/002_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/002_config_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.105
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/005_config_4.19.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.19.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/006_config_4.20.x/test.yml
+++ b/test/cases/020_kernel/006_config_4.20.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.20.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.162
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: check

--- a/test/cases/020_kernel/012_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/012_kmod_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.105
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: check

--- a/test/cases/020_kernel/015_kmod_4.19.x/test.yml
+++ b/test/cases/020_kernel/015_kmod_4.19.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: check

--- a/test/cases/020_kernel/016_kmod_4.20.x/test.yml
+++ b/test/cases/020_kernel/016_kmod_4.20.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.20.14
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:019bc551972cf2d136b443d70b4bf94c54d0d1fe
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:998fdcb9ee8116ba77b24ca7ce7c5d0ad7be2dbe
+    image: linuxkit/test-containerd:4f832512b1ea2b997bdfb031c80f309d837c6bb3
   - name: poweroff
     image: linuxkit/poweroff:9f4e04f09bbb4a028f0a1f57d430e1ad3095ace1
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.88
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.88
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/004_dm-crypt/002_key/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/002_key/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.88
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/012_losetup/test.yml
+++ b/test/cases/040_packages/012_losetup/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.88
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: losetup

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
   - linuxkit/memlogd:3d74c1153f99948d92c0fa9c759f816ab48d9855
 services:

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
   - linuxkit/ca-certificates:906c46a26fd2df271bf64c0259bf2267f7593213
   - linuxkit/memlogd:3d74c1153f99948d92c0fa9c759f816ab48d9855
 services:

--- a/test/cases/040_packages/032_bcc/test.yml
+++ b/test/cases/040_packages/032_bcc/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
   - linuxkit/kernel-bcc:4.19.27
 onboot:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/containerd:6e6841be5ad15c30752d81d121b247fa3ae08c97
+  - linuxkit/containerd:39ac21278cfcc10dbcc32ad7f5abbe820852c5bd
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:85738d3d2f152a7879e17a61444f7714b858c2ee

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:5ce235f4fb55772e7f78871a70bfe26f774fe2b0 AS mirror
+FROM linuxkit/alpine:6ed32ba2b29a12b3d75f3d5b9be1b4ac00e7d479 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.19.27
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0
+  - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
 onboot:
   - name: test-ns

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -56,7 +56,7 @@ RUN go get -u github.com/LK4D4/vndr
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.2.4
+ENV CONTAINERD_COMMIT=v1.2.5
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,6 +1,6 @@
-# linuxkit/alpine:e6dcfd363a0c17f550f515071b57c7008522ed61-arm64
+# linuxkit/alpine:f20fe82103e63ff4ad69d3936515e1eda414405f-arm64
 # automatically generated list of installed packages
-abuild-3.3.0-r1
+abuild-3.3.1-r0
 alpine-baselayout-3.1.0-r3
 alpine-keys-2.1-r1
 apk-tools-2.10.3-r1
@@ -233,9 +233,9 @@ open-isns-lib-0.97-r4
 openntpd-6.2_p3-r2
 openrc-0.39.2-r3
 openresolv-3.9.0-r0
-openssh-keygen-7.9_p1-r2
-openssh-server-7.9_p1-r2
-openssh-server-common-7.9_p1-r2
+openssh-keygen-7.9_p1-r4
+openssh-server-7.9_p1-r4
+openssh-server-common-7.9_p1-r4
 openssl-1.1.1a-r1
 openssl-dev-1.1.1a-r1
 opus-1.3-r0

--- a/tools/alpine/versions.s390x
+++ b/tools/alpine/versions.s390x
@@ -1,6 +1,6 @@
-# linuxkit/alpine:8fe0884e721d9810a79d0bf467d49efffce3c7c5-s390x
+# linuxkit/alpine:4703ded9a2e82b8963b5f5a982e4ba49efe88628-s390x
 # automatically generated list of installed packages
-abuild-3.3.0-r1
+abuild-3.3.1-r0
 alpine-baselayout-3.1.0-r3
 alpine-keys-2.1-r1
 apk-tools-2.10.3-r1
@@ -227,9 +227,9 @@ open-isns-lib-0.97-r4
 openntpd-6.2_p3-r2
 openrc-0.39.2-r3
 openresolv-3.9.0-r0
-openssh-keygen-7.9_p1-r2
-openssh-server-7.9_p1-r2
-openssh-server-common-7.9_p1-r2
+openssh-keygen-7.9_p1-r4
+openssh-server-7.9_p1-r4
+openssh-server-common-7.9_p1-r4
 openssl-1.1.1a-r1
 openssl-dev-1.1.1a-r1
 opus-1.3-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,6 +1,6 @@
-# linuxkit/alpine:518c2ed0f398c5508969ac5e033607201fb419ed-amd64
+# linuxkit/alpine:6ed32ba2b29a12b3d75f3d5b9be1b4ac00e7d479-amd64
 # automatically generated list of installed packages
-abuild-3.3.0-r1
+abuild-3.3.1-r0
 alpine-baselayout-3.1.0-r3
 alpine-keys-2.1-r1
 apk-tools-2.10.3-r1
@@ -244,9 +244,9 @@ open-vm-tools-openrc-10.3.5-r1
 openntpd-6.2_p3-r2
 openrc-0.39.2-r3
 openresolv-3.9.0-r0
-openssh-keygen-7.9_p1-r2
-openssh-server-7.9_p1-r2
-openssh-server-common-7.9_p1-r2
+openssh-keygen-7.9_p1-r4
+openssh-server-7.9_p1-r4
+openssh-server-common-7.9_p1-r4
 openssl-1.1.1a-r1
 openssl-dev-1.1.1a-r1
 opus-1.3-r0


### PR DESCRIPTION
Containerd release: https://github.com/containerd/containerd/releases/tag/v1.2.5

This omits the usual implied `runc` bump (https://github.com/opencontainers/runc/compare/6635b4f0c6af3810594d2770f662f34ddc15b40d...2b18fe1d885ee5083ef9f0838fee39b62d653e30 in this case) because recent changes have introduced the use of `secure_getenv` which is a glibc extension and so not available with `musl`:
```
#10 1.022 CGO_ENABLED=1 go build -buildmode pie -tags "seccomp netgo osusergo static_build" -installsuffix netgo -ldflags "-w -extldflags -static -X main.gitCommit="2b18fe1d885ee5083ef9f0838fee39b62d653e30" -X main.version=1.0.0-rc6+dev -extldflags \"-fno-PIC -static\"" -o runc .
#10 8.372 # github.com/opencontainers/runc/libcontainer/nsenter
#10 8.372 /usr/lib/gcc/x86_64-alpine-linux-musl/8.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: $WORK/b119/_x003.o: in function `try_bindfd':
#10 8.372 libcontainer/nsenter/cloned_binary.c:354: undefined reference to `secure_getenv'
#10 8.372 /usr/lib/gcc/x86_64-alpine-linux-musl/8.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: $WORK/b119/_x003.o: in function `make_execfd':
#10 8.372 libcontainer/nsenter/cloned_binary.c:252: undefined reference to `secure_getenv'
#10 8.372 collect2: error: ld returned 1 exit status
#10 8.372 # github.com/opencontainers/runc/libcontainer/nsenter
#10 8.372 cloned_binary.c: In function 'make_execfd':
#10 8.372 cloned_binary.c:252:17: warning: implicit declaration of function 'secure_getenv' [-Wimplicit-function-declaration]
#10 8.372   char *prefix = secure_getenv("_LIBCONTAINER_STATEDIR");
#10 8.372                  ^~~~~~~~~~~~~
#10 8.372 cloned_binary.c:252:17: warning: initialization of 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
#10 8.372 cloned_binary.c: In function 'try_bindfd':
#10 8.372 cloned_binary.c:354:17: warning: initialization of 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
#10 8.372   char *prefix = secure_getenv("_LIBCONTAINER_STATEDIR");
#10 8.372                  ^~~~~~~~~~~~~
#10 14.44 make: *** [Makefile:43: static] Error 2
------
executor failed running [/bin/sh -c make static BUILDTAGS="seccomp" EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS="-extldflags \\\"-fno-PIC -static\\\""]: exit code: 2
```

@justincormack already raised a PR on runc for that https://github.com/opencontainers/runc/pull/2015, in the meantime there appears to be nothing too critical in the bump and it seems safer to stick with the existing, known good, version than to pick a commit just before the change.