### PR TITLE
Build linuxkit/grub off of master

### DIFF
--- a/tools/grub/Dockerfile
+++ b/tools/grub/Dockerfile
@@ -1,0 +1,64 @@
+FROM linuxkit/alpine:6ed32ba2b29a12b3d75f3d5b9be1b4ac00e7d479 AS grub-build
+RUN apk add \
+  automake \
+  make \
+  bison \
+  coreutils \
+  gettext \
+  gettext-dev \
+  flex \
+  gcc \
+  git \
+  libtool \
+  libc-dev \
+  linux-headers \
+  patch \
+  pkgconfig \
+  python3 \
+  autoconf
+
+# because python is not available
+RUN ln -s python3 /usr/bin/python
+
+ENV GRUB_MODULES="ext2 iso9660 gzio linux acpi normal cpio crypto disk boot crc64 part_gpt tftp xzio xfs video"
+ENV GRUB_COMMIT=5bc41db756c5b342aa22fc95508bde105e05a095
+ENV SRCDIR=/src
+
+# separate steps for better caching
+RUN mkdir /grub-lib ${SRCDIR} && \
+  set -e && \
+  cd ${SRCDIR} && \
+  git clone git://git.savannah.gnu.org/grub.git && \
+  cd grub && \
+  git checkout -b grub-build ${GRUB_COMMIT}
+
+WORKDIR ${SRCDIR}/grub
+
+# this is long and slow, so keep separate step
+RUN ./bootstrap
+
+# run these in separate steps for caching. 
+RUN ./configure --libdir=/grub-lib --with-platform=efi CFLAGS="-Os -Wno-unused-value" 
+
+RUN make -j "$(getconf _NPROCESSORS_ONLN)" && \
+  make install
+
+RUN \
+  arch=$(uname -m); \
+  outarch="${arch}" ;\
+  case "$arch" in \
+  x86_64) \
+    outarch=x86_64; \
+    outfile=BOOTX64.EFI; \
+    ;; \
+  aarch64|arm64) \
+    outarch=arm64; \
+    outfile=BOOTAA64.EFI; \
+    ;; \
+  esac ; \
+  grub-mkimage -O ${outarch}-efi -d /grub-lib/grub/${outarch}-efi -o /grub-lib/${outfile} -p /EFI/BOOT ${GRUB_MODULES} 
+
+FROM scratch
+ENTRYPOINT []
+WORKDIR /
+COPY --from=grub-build /grub-lib/*.EFI /

--- a/tools/grub/build.yml
+++ b/tools/grub/build.yml
@@ -1,0 +1,5 @@
+image: grub
+network: true
+arches:
+  - arm64
+  - amd64

--- a/tools/mkimage-iso-efi/Dockerfile
+++ b/tools/mkimage-iso-efi/Dockerfile
@@ -1,42 +1,4 @@
-FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS grub-build
-RUN apk add \
-  automake \
-  make \
-  bison \
-  gettext \
-  flex \
-  gcc \
-  git \
-  libtool \
-  libc-dev \
-  linux-headers \
-  python3 \
-  autoconf
-
-# because python is not available
-RUN ln -s python3 /usr/bin/python
-
-ENV GRUB_MODULES="part_gpt fat ext2 iso9660 gzio linux acpi normal cpio crypto disk boot crc64 gpt \
-search_disk_uuid tftp verify xzio xfs video"
-ENV GRUB_COMMIT=d3fd939f18446b05d1d5456f23823498a1eb3fb4
-
-RUN mkdir /grub-lib && \
-  set -e && \
-  git clone https://github.com/coreos/grub.git && \
-  cd grub && \
-  git checkout -b grub-build ${GRUB_COMMIT} && \
-  ./autogen.sh && \
-  ./configure --libdir=/grub-lib --with-platform=efi CFLAGS="-Os -Wno-unused-value" && \
-  make -j "$(getconf _NPROCESSORS_ONLN)" && \
-  make install && \
-  case $(uname -m) in \
-  x86_64) \
-    ./grub-mkimage -O x86_64-efi -d /grub-lib/grub/x86_64-efi -o /grub-lib/BOOTX64.EFI -p /EFI/BOOT ${GRUB_MODULES} linuxefi; \
-    ;; \
-  aarch64) \
-    ./grub-mkimage -O arm64-efi -d /grub-lib/grub/arm64-efi -o /grub-lib/BOOTAA64.EFI -p /EFI/BOOT ${GRUB_MODULES}; \
-    ;; \
-  esac
+FROM linuxkit/grub:4c3db0fd74e9526caca2e7c13d21d214c8dd2307 AS grub
 
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
@@ -54,6 +16,6 @@ RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 FROM scratch
 WORKDIR /
 COPY --from=mirror /out/ /
-COPY --from=grub-build /grub-lib/BOOT*.EFI /usr/local/share/
+COPY --from=grub /BOOT*.EFI /usr/local/share/
 COPY . .
 ENTRYPOINT [ "/make-efi" ]

--- a/tools/mkimage-iso-efi/make-efi
+++ b/tools/mkimage-iso-efi/make-efi
@@ -8,7 +8,7 @@ case $ARCH in
 x86_64)
   BOOTFILE=BOOTX64.EFI
   ROOTDEV=/dev/sr0
-  LINUX_ENTRY=linuxefi
+  LINUX_ENTRY=linux
   ;;
 aarch64)
   BOOTFILE=BOOTAA64.EFI

--- a/tools/mkimage-qcow2-efi/Dockerfile
+++ b/tools/mkimage-qcow2-efi/Dockerfile
@@ -1,42 +1,4 @@
-FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS grub-build
-RUN apk add \
-  autoconf \
-  automake \
-  bison \
-  gcc \
-  gettext \
-  git \
-  flex \
-  libc-dev \
-  libtool \
-  linux-headers \
-  make \
-  python3
-
-# because python is not available
-RUN ln -s python3 /usr/bin/python
-
-ENV GRUB_MODULES="part_gpt fat ext2 iso9660 gzio linux acpi normal cpio crypto disk boot crc64 gpt \
-search_disk_uuid tftp verify xzio xfs video"
-ENV GRUB_COMMIT=d3fd939f18446b05d1d5456f23823498a1eb3fb4
-
-RUN mkdir /grub-lib && \
-  set -e && \
-  git clone https://github.com/coreos/grub.git && \
-  cd grub && \
-  git checkout -b grub-build ${GRUB_COMMIT} && \
-  ./autogen.sh && \
-  ./configure --libdir=/grub-lib --with-platform=efi CFLAGS="-Os -Wno-unused-value" && \
-  make -j "$(getconf _NPROCESSORS_ONLN)" && \
-  make install && \
-  case $(uname -m) in \
-  x86_64) \
-    ./grub-mkimage -O x86_64-efi -d /grub-lib/grub/x86_64-efi -o /grub-lib/BOOTX64.EFI -p /EFI/BOOT ${GRUB_MODULES} linuxefi; \
-    ;; \
-  aarch64) \
-    ./grub-mkimage -O arm64-efi -d /grub-lib/grub/arm64-efi -o /grub-lib/BOOTAA64.EFI -p /EFI/BOOT ${GRUB_MODULES}; \
-    ;; \
-  esac
+FROM linuxkit/grub:4c3db0fd74e9526caca2e7c13d21d214c8dd2307 AS grub
 
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
@@ -57,6 +19,6 @@ RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 FROM scratch
 WORKDIR /
 COPY --from=mirror /out/ /
-COPY --from=grub-build /grub-lib/BOOT*.EFI /usr/local/share/
+COPY --from=grub /BOOT*.EFI /usr/local/share/
 COPY . .
 ENTRYPOINT [ "/make-efi" ]

--- a/tools/mkimage-qcow2-efi/make-efi
+++ b/tools/mkimage-qcow2-efi/make-efi
@@ -19,8 +19,8 @@ ARCH=`uname -m`
 case $ARCH in
 x86_64)
   BOOTFILE=BOOTX64.EFI
-  LINUX_ENTRY=linuxefi
-  INITRD_ENTRY=initrdefi
+  LINUX_ENTRY=linux
+  INITRD_ENTRY=initrd
   ;;
 aarch64)
   BOOTFILE=BOOTAA64.EFI

--- a/tools/mkimage-raw-efi/Dockerfile
+++ b/tools/mkimage-raw-efi/Dockerfile
@@ -1,41 +1,4 @@
-FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS grub-build
-RUN apk add \
-  autoconf \
-  automake \
-  bison \
-  gcc \
-  gettext \
-  git \
-  flex \
-  libc-dev \
-  libtool \
-  linux-headers \
-  make \
-  python3  
-# because python is not available
-RUN ln -s python3 /usr/bin/python
-
-ENV GRUB_MODULES="part_gpt fat ext2 iso9660 gzio linux acpi normal cpio crypto disk boot crc64 gpt \
-search_disk_uuid tftp verify xzio xfs video"
-ENV GRUB_COMMIT=d3fd939f18446b05d1d5456f23823498a1eb3fb4
-
-RUN mkdir /grub-lib && \
-  set -e && \
-  git clone https://github.com/coreos/grub.git && \
-  cd grub && \
-  git checkout -b grub-build ${GRUB_COMMIT} && \
-  ./autogen.sh && \
-  ./configure --libdir=/grub-lib --with-platform=efi CFLAGS="-Os -Wno-unused-value" && \
-  make -j "$(getconf _NPROCESSORS_ONLN)" && \
-  make install && \
-  case $(uname -m) in \
-  x86_64) \
-    ./grub-mkimage -O x86_64-efi -d /grub-lib/grub/x86_64-efi -o /grub-lib/BOOTX64.EFI -p /EFI/BOOT ${GRUB_MODULES} linuxefi; \
-    ;; \
-  aarch64) \
-    ./grub-mkimage -O arm64-efi -d /grub-lib/grub/arm64-efi -o /grub-lib/BOOTAA64.EFI -p /EFI/BOOT ${GRUB_MODULES}; \
-    ;; \
-  esac
+FROM linuxkit/grub:4c3db0fd74e9526caca2e7c13d21d214c8dd2307 AS grub
 
 FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
@@ -55,6 +18,6 @@ RUN mv /out/etc/apk/repositories.upstream /out/etc/apk/repositories
 FROM scratch
 WORKDIR /
 COPY --from=mirror /out/ /
-COPY --from=grub-build /grub-lib/BOOT*.EFI /usr/local/share/
+COPY --from=grub /BOOT*.EFI /usr/local/share/
 COPY . .
 ENTRYPOINT [ "/make-efi" ]

--- a/tools/mkimage-raw-efi/make-efi
+++ b/tools/mkimage-raw-efi/make-efi
@@ -19,8 +19,8 @@ ARCH=`uname -m`
 case $ARCH in
 x86_64)
   BOOTFILE=BOOTX64.EFI
-  LINUX_ENTRY=linuxefi
-  INITRD_ENTRY=initrdefi
+  LINUX_ENTRY=linux
+  INITRD_ENTRY=initrd
   ;;
 aarch64)
   BOOTFILE=BOOTAA64.EFI


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

* Separate the building of grub into its own modular element, as opposed to in each of the 3 tools that require it - `mkimage-iso-efi`, `mkimage-raw-efi`, `mkimage-qcow2-efi` . We do _not_ use grub for bios.
* Replace dependency on the largely abandoned coreos/grub fork with the maintained upstream grub. In the last several months to year, the same team that did much of the work on coreos/grub has upstreamed the important parts.

Note that this is compiling directly from master (a specific commit). We are not using the official release - which is available in `apk` - since that is based on the most recent release, 2.02, which is almost 2 years old.

As discussed with @rn and @justincormack .

Question: would like some additional testing, even if only smoke-testing style, "can we build it and get the image we want" (final OCI image has a single file in it). Any thoughts on it?

**- How I did it**

Build `tools/linuxkit/grub`

**- How to verify it**

```
cd tools/grub
docker build -t linuxkit/grub .
```

Or more properly:

```
lkt pkg build .
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Extract grub build to its own module.


**- A picture of a cute animal (not mandatory but encouraged)**

![sulphur-crested cockatoo](https://www.parrots.org/images/encyclopedia/1438/1024px-cacatua_galerita_2_-_austins_ferry__large.jpg) 
