### PR TITLE
Update kernels to 5.0.6/4.19.33/4.14.110/4.9.167

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -1,6 +1,6 @@
 # This is an example for building the open source components of Docker for Mac
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:b5f279abaa0386efeb3c03f46771609ff7c25bc3 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -1,6 +1,6 @@
 # Simple example of using an external logging service
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/packet.arm64.yml
+++ b/examples/packet.arm64.yml
@@ -5,7 +5,7 @@
 # for arm64 then the 'ucode' line in the kernel section can be left
 # out.
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyAMA0"
   ucode: ""
 onboot:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -1,7 +1,7 @@
 # Minimal YAML to run a redis server (used at DockerCon'17)
 # connect: nc localhost 6379
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/static-ip.yml
+++ b/examples/static-ip.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add \
     gnupg \
     installkernel \
     kmod \
-    libelf-dev \
+    elfutils-dev \
     linux-headers \
     mpc1-dev \
     mpfr-dev \

--- a/kernel/Dockerfile.perf
+++ b/kernel/Dockerfile.perf
@@ -16,7 +16,7 @@ RUN apk add \
     gmp-dev \
     installkernel \
     kmod \
-    libelf-dev \
+    elfutils-dev \
     mpc1-dev \
     mpfr-dev \
     sed \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -251,21 +251,21 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,5.0.5,5.0.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.19.32,4.19.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.19.32,4.19.x,,-dbg))
+$(eval $(call kernel,5.0.6,5.0.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.19.33,4.19.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.19.33,4.19.x,,-dbg))
 $(eval $(call kernel,4.19.25,4.19.x,-rt,))
-$(eval $(call kernel,4.14.109,4.14.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.9.166,4.9.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.14.110,4.14.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.9.167,4.9.x,$(EXTRA),$(DEBUG)))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,5.0.5,5.0.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.19.32,4.19.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,5.0.6,5.0.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.19.33,4.19.x,$(EXTRA),$(DEBUG)))
 $(eval $(call kernel,4.19.25,4.19.x,-rt,))
 
 else ifeq ($(ARCH),s390x)
-$(eval $(call kernel,5.0.5,5.0.x,$(EXTRA),$(DEBUG)))
-$(eval $(call kernel,4.19.32,4.19.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,5.0.6,5.0.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,4.19.33,4.19.x,$(EXTRA),$(DEBUG)))
 endif
 
 # Target for kernel config

--- a/kernel/config-4.14.x-x86_64
+++ b/kernel/config-4.14.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.109 Kernel Configuration
+# Linux/x86 4.14.110 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-4.19.x-aarch64
+++ b/kernel/config-4.19.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.19.32 Kernel Configuration
+# Linux/arm64 4.19.33 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.19.x-s390x
+++ b/kernel/config-4.19.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 4.19.32 Kernel Configuration
+# Linux/s390 4.19.33 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.19.x-x86_64
+++ b/kernel/config-4.19.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.19.32 Kernel Configuration
+# Linux/x86 4.19.33 Kernel Configuration
 #
 
 #

--- a/kernel/config-4.9.x-x86_64
+++ b/kernel/config-4.9.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.166 Kernel Configuration
+# Linux/x86 4.9.167 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/kernel/config-5.0.x-aarch64
+++ b/kernel/config-5.0.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.0.5 Kernel Configuration
+# Linux/arm64 5.0.6 Kernel Configuration
 #
 
 #

--- a/kernel/config-5.0.x-s390x
+++ b/kernel/config-5.0.x-s390x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/s390 5.0.5 Kernel Configuration
+# Linux/s390 5.0.6 Kernel Configuration
 #
 
 #

--- a/kernel/config-5.0.x-x86_64
+++ b/kernel/config-5.0.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.0.5 Kernel Configuration
+# Linux/x86 5.0.6 Kernel Configuration
 #
 
 #

--- a/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
+++ b/kernel/patches-4.14.x/0001-NVDIMM-reducded-ND_MIN_NAMESPACE_SIZE-from-4MB-to-4K.patch
@@ -1,4 +1,4 @@
-From 0666cd56024cb4d55d98e2b544be6ab5538969a2 Mon Sep 17 00:00:00 2001
+From a6969a5f6e8b6b449381210b5f6a33fb05f8c24a Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 11 Jul 2017 16:58:26 -0700
 Subject: [PATCH 01/21] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB
@@ -24,5 +24,5 @@ index 145f242c7c90..e360610911f3 100644
  
  enum ars_masks {
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
+++ b/kernel/patches-4.14.x/0002-hyper-v-trace-vmbus_on_msg_dpc.patch
@@ -1,4 +1,4 @@
-From 6b6b1054f64c6ec0f089924f3039401948d2b083 Mon Sep 17 00:00:00 2001
+From 550064f09018aa9f038aac7b057ac13bb8ed6812 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:00 -0700
 Subject: [PATCH 02/21] hyper-v: trace vmbus_on_msg_dpc()
@@ -107,5 +107,5 @@ index 1fd812ed679b..70f857441399 100644
  		WARN_ONCE(1, "unknown msgtype=%d\n", hdr->msgtype);
  		goto msg_handled;
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
+++ b/kernel/patches-4.14.x/0003-hyper-v-trace-vmbus_on_message.patch
@@ -1,4 +1,4 @@
-From 5dd04dda1694042193026772acacf6bd1818e8b8 Mon Sep 17 00:00:00 2001
+From ac4ce9864d8830288022928165a86442db03e5d6 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:01 -0700
 Subject: [PATCH 03/21] hyper-v: trace vmbus_on_message()
@@ -45,5 +45,5 @@ index 9c2772922c76..d432aba5df8a 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
+++ b/kernel/patches-4.14.x/0004-hyper-v-trace-vmbus_onoffer.patch
@@ -1,4 +1,4 @@
-From 09a049c3558707452f4af1dc21d5e749966e6175 Mon Sep 17 00:00:00 2001
+From f7fb09289317710e666906f353937c5b0f8193fd Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:02 -0700
 Subject: [PATCH 04/21] hyper-v: trace vmbus_onoffer()
@@ -76,5 +76,5 @@ index d432aba5df8a..488b873b563e 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
+++ b/kernel/patches-4.14.x/0005-hyper-v-trace-vmbus_onoffer_rescind.patch
@@ -1,4 +1,4 @@
-From bb2f3f5dbc576eec101934135d974ff26b7af748 Mon Sep 17 00:00:00 2001
+From dca72b0e606677d7e0ae6acae093e593926cf35d Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:03 -0700
 Subject: [PATCH 05/21] hyper-v: trace vmbus_onoffer_rescind()
@@ -47,5 +47,5 @@ index 488b873b563e..dbbed1d1f327 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
+++ b/kernel/patches-4.14.x/0006-hyper-v-trace-vmbus_onopen_result.patch
@@ -1,4 +1,4 @@
-From a6d8a5e0084cd13b583935dd61f72d42914ca733 Mon Sep 17 00:00:00 2001
+From dfe968c81637b02a5dbe12b39be380de755ba2dd Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:04 -0700
 Subject: [PATCH 06/21] hyper-v: trace vmbus_onopen_result()
@@ -56,5 +56,5 @@ index dbbed1d1f327..9757c19d1c08 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
+++ b/kernel/patches-4.14.x/0007-hyper-v-trace-vmbus_ongpadl_created.patch
@@ -1,4 +1,4 @@
-From 166b99cce98e5458235f96ac66b595f54e051b26 Mon Sep 17 00:00:00 2001
+From c30d13d6c8a67b0d715c1b0248b49fc44f287b8f Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:05 -0700
 Subject: [PATCH 07/21] hyper-v: trace vmbus_ongpadl_created()
@@ -56,5 +56,5 @@ index 9757c19d1c08..20734b7b341b 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
+++ b/kernel/patches-4.14.x/0008-hyper-v-trace-vmbus_ongpadl_torndown.patch
@@ -1,4 +1,4 @@
-From 9072018143b16b3636040670235fb97102b056e2 Mon Sep 17 00:00:00 2001
+From b9fc14af1ba29669b0d259cee0578b1b2fc7bd20 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:06 -0700
 Subject: [PATCH 08/21] hyper-v: trace vmbus_ongpadl_torndown()
@@ -47,5 +47,5 @@ index 20734b7b341b..84c08cdf7235 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
+++ b/kernel/patches-4.14.x/0009-hyper-v-trace-vmbus_onversion_response.patch
@@ -1,4 +1,4 @@
-From 3593b3a45564649584fd0ba7eb326d154f9d40fc Mon Sep 17 00:00:00 2001
+From d4ca8c443cb86e89531942c7311bfd3a1bd14c85 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:07 -0700
 Subject: [PATCH 09/21] hyper-v: trace vmbus_onversion_response()
@@ -51,5 +51,5 @@ index 84c08cdf7235..2a046547107f 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
+++ b/kernel/patches-4.14.x/0010-hyper-v-trace-vmbus_request_offers.patch
@@ -1,4 +1,4 @@
-From 25f7870cffcd859607f43bf596b999d1f3bb2349 Mon Sep 17 00:00:00 2001
+From acc8d9c48a88eab57905032360c8af0c9b713e7e Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:08 -0700
 Subject: [PATCH 10/21] hyper-v: trace vmbus_request_offers()
@@ -51,5 +51,5 @@ index 2a046547107f..566ac0f2fe56 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
+++ b/kernel/patches-4.14.x/0011-hyper-v-trace-vmbus_open.patch
@@ -1,4 +1,4 @@
-From e651f0888c231da9a9c7f56105682b9f9f4f612f Mon Sep 17 00:00:00 2001
+From db88092c58aa4ebe598ffea65109e8f0150a2979 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:09 -0700
 Subject: [PATCH 11/21] hyper-v: trace vmbus_open()
@@ -66,5 +66,5 @@ index 566ac0f2fe56..38fedb803bd8 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
+++ b/kernel/patches-4.14.x/0012-hyper-v-trace-vmbus_close_internal.patch
@@ -1,4 +1,4 @@
-From ff41dd239443420109ac301eb06773d25cf747dc Mon Sep 17 00:00:00 2001
+From 6e0ae691d3190d583f16180d0ca9540e4cc1764c Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:10 -0700
 Subject: [PATCH 12/21] hyper-v: trace vmbus_close_internal()
@@ -54,5 +54,5 @@ index 38fedb803bd8..302bd4e964f0 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
+++ b/kernel/patches-4.14.x/0013-hyper-v-trace-vmbus_establish_gpadl.patch
@@ -1,4 +1,4 @@
-From 8002db5652059f918d33023109b06a631e8a1044 Mon Sep 17 00:00:00 2001
+From d5a98f1b4f3b7b3f1addd923c9c737cc0ea04f90 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:11 -0700
 Subject: [PATCH 13/21] hyper-v: trace vmbus_establish_gpadl()
@@ -92,5 +92,5 @@ index 302bd4e964f0..978e70bdc7c5 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
+++ b/kernel/patches-4.14.x/0014-hyper-v-trace-vmbus_teardown_gpadl.patch
@@ -1,4 +1,4 @@
-From e3deba79523116e6a42945b28b39e404142c90b3 Mon Sep 17 00:00:00 2001
+From d17892cd51186cebf0d53deaef09c99c208207a5 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:12 -0700
 Subject: [PATCH 14/21] hyper-v: trace vmbus_teardown_gpadl()
@@ -57,5 +57,5 @@ index 978e70bdc7c5..cd33a52ef27f 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
+++ b/kernel/patches-4.14.x/0015-hyper-v-trace-vmbus_negotiate_version.patch
@@ -1,4 +1,4 @@
-From 9be3956bf91e9a3d3ce16cfd08f75489979bb1dc Mon Sep 17 00:00:00 2001
+From 4a717b506633ec9708a3007cae20e29aa5739209 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:13 -0700
 Subject: [PATCH 15/21] hyper-v: trace vmbus_negotiate_version()
@@ -66,5 +66,5 @@ index cd33a52ef27f..f06284d64a8c 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
+++ b/kernel/patches-4.14.x/0016-hyper-v-trace-vmbus_release_relid.patch
@@ -1,4 +1,4 @@
-From 8499f56dd5323f2e1ae5d70bbdb1f913d3495aaa Mon Sep 17 00:00:00 2001
+From 9d0487fc37a680113b5ff8586e54afd59fa571d1 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:14 -0700
 Subject: [PATCH 16/21] hyper-v: trace vmbus_release_relid()
@@ -64,5 +64,5 @@ index f06284d64a8c..f0e437c3522f 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
+++ b/kernel/patches-4.14.x/0017-hyper-v-trace-vmbus_send_tl_connect_request.patch
@@ -1,4 +1,4 @@
-From 8eb14f269f981e83bdda0faa397cfba1534420d7 Mon Sep 17 00:00:00 2001
+From bac686d02e1f6cb849f4524cada2b8ba2d0ef2c2 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:15 -0700
 Subject: [PATCH 17/21] hyper-v: trace vmbus_send_tl_connect_request()
@@ -70,5 +70,5 @@ index f0e437c3522f..5382d9630306 100644
  #define TRACE_INCLUDE_PATH .
  #undef TRACE_INCLUDE_FILE
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
+++ b/kernel/patches-4.14.x/0018-hyper-v-trace-channel-events.patch
@@ -1,4 +1,4 @@
-From 01e1c16d3093a4ae0fb998addda2e21d063e9782 Mon Sep 17 00:00:00 2001
+From 60c3340171d09685c1a7e170142a1ecab70e6731 Mon Sep 17 00:00:00 2001
 From: Vitaly Kuznetsov <vkuznets@redhat.com>
 Date: Sun, 29 Oct 2017 12:21:16 -0700
 Subject: [PATCH 18/21] hyper-v: trace channel events
@@ -97,5 +97,5 @@ index 70f857441399..14288a2958d0 100644
  			case HV_CALL_ISR:
  				vmbus_channel_isr(channel);
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
+++ b/kernel/patches-4.14.x/0019-serial-forbid-8250-on-s390.patch
@@ -1,4 +1,4 @@
-From 2607da6add9497baa9345fef0d94b584e758126a Mon Sep 17 00:00:00 2001
+From 6519f8eef2017d93efab8e193eb1d87166ba8513 Mon Sep 17 00:00:00 2001
 From: Christian Borntraeger <borntraeger@de.ibm.com>
 Date: Tue, 12 Dec 2017 09:08:35 +0100
 Subject: [PATCH 19/21] serial: forbid 8250 on s390
@@ -31,5 +31,5 @@ index a5c0ef1e7695..16b1496e6105 100644
  	---help---
  	  This selects whether you want to include the driver for the standard
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
+++ b/kernel/patches-4.14.x/0020-scsi-storvsc-Allow-only-one-remove-lun-work-item-to-.patch
@@ -1,4 +1,4 @@
-From f2227120d3dd36a80a9fae854f68a5127a18cf29 Mon Sep 17 00:00:00 2001
+From cdda0d84f27668400ed0fdd652cac41cfbbec2e4 Mon Sep 17 00:00:00 2001
 From: Cathy Avery <cavery@redhat.com>
 Date: Tue, 31 Oct 2017 08:52:06 -0400
 Subject: [PATCH 20/21] scsi: storvsc: Allow only one remove lun work item to
@@ -128,5 +128,5 @@ index beb585ddc07d..e94f75e25cb1 100644
  	storvsc_dev_remove(dev);
  	scsi_host_put(host);
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
+++ b/kernel/patches-4.14.x/0021-scsi-storvsc-Avoid-excessive-host-scan-on-controller.patch
@@ -1,4 +1,4 @@
-From 1fd4679e401b6082bafd31e7ece7f52bc587f3df Mon Sep 17 00:00:00 2001
+From 508a06e083c80cb5927ae2ac87b3fbec0294c13b Mon Sep 17 00:00:00 2001
 From: Long Li <longli@microsoft.com>
 Date: Tue, 31 Oct 2017 14:58:08 -0700
 Subject: [PATCH 21/21] scsi: storvsc: Avoid excessive host scan on controller
@@ -106,5 +106,5 @@ index e94f75e25cb1..66b1b6ad0ae0 100644
  	ret = scsi_add_host(host, &device->device);
  	if (ret != 0)
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
+++ b/kernel/patches-4.9.x/0001-tools-build-Add-test-for-sched_getcpu.patch
@@ -1,4 +1,4 @@
-From 2c2ce7468c885efbd693d6e85763f26619da43cb Mon Sep 17 00:00:00 2001
+From 23428dbe56300d02a20adf4ed9b3ad1dbcfc265f Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 2 Mar 2017 12:55:49 -0300
 Subject: [PATCH 01/14] tools build: Add test for sched_getcpu()
@@ -146,5 +146,5 @@ index e72d370889f8..605c4812430f 100644
  
  int is_printable_array(char *p, unsigned int len);
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
+++ b/kernel/patches-4.9.x/0002-perf-jit-Avoid-returning-garbage-for-a-ret-variable.patch
@@ -1,4 +1,4 @@
-From 3f3f1926cd8995d68bd2d8a0bcdf09885060feaf Mon Sep 17 00:00:00 2001
+From 7f21960fd8c7032edddbdf7e118c6a7117aba227 Mon Sep 17 00:00:00 2001
 From: Arnaldo Carvalho de Melo <acme@redhat.com>
 Date: Thu, 13 Oct 2016 17:12:35 -0300
 Subject: [PATCH 02/14] perf jit: Avoid returning garbage for a ret variable
@@ -66,5 +66,5 @@ index 95f0884aae02..f3ed3c963c71 100644
  	while ((jr = jit_get_next_entry(jd))) {
  		switch(jr->prefix.id) {
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
+++ b/kernel/patches-4.9.x/0003-hv_sock-introduce-Hyper-V-Sockets.patch
@@ -1,4 +1,4 @@
-From 732a41fa4bc6dda62ff692eb39ffbe7ce274d7b5 Mon Sep 17 00:00:00 2001
+From 05fadd74f68ebd51b57bf8122ae655d83780f0f9 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sat, 23 Jul 2016 01:35:51 +0000
 Subject: [PATCH 03/14] hv_sock: introduce Hyper-V Sockets
@@ -1787,5 +1787,5 @@ index 000000000000..331d3759f5cb
 +MODULE_DESCRIPTION("Hyper-V Sockets");
 +MODULE_LICENSE("Dual BSD/GPL");
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
+++ b/kernel/patches-4.9.x/0004-vmbus-Don-t-spam-the-logs-with-unknown-GUIDs.patch
@@ -1,4 +1,4 @@
-From 19b8d9c04e70d0cdf61557e41313d23bd80962a1 Mon Sep 17 00:00:00 2001
+From 0367d3fa98e7b891de4d2184dad8e907c24d5738 Mon Sep 17 00:00:00 2001
 From: Rolf Neugebauer <rolf.neugebauer@gmail.com>
 Date: Mon, 23 May 2016 18:55:45 +0100
 Subject: [PATCH 04/14] vmbus: Don't spam the logs with unknown GUIDs
@@ -26,5 +26,5 @@ index 9360cdce740e..d838074e9add 100644
  }
  
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
+++ b/kernel/patches-4.9.x/0005-Drivers-hv-utils-Fix-the-mapping-between-host-versio.patch
@@ -1,4 +1,4 @@
-From f9520c3c8e3bfc0954693c97d117ae96c5b72d2e Mon Sep 17 00:00:00 2001
+From be3804c01ec67aff88f7f2d138b94d90f958f49c Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:07 -0800
 Subject: [PATCH 05/14] Drivers: hv: utils: Fix the mapping between host
@@ -44,5 +44,5 @@ index bcd06306f3e8..e7707747f56d 100644
  	}
  
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
+++ b/kernel/patches-4.9.x/0006-Drivers-hv-vss-Improve-log-messages.patch
@@ -1,4 +1,4 @@
-From ae050f8b4389fe54860a25ab5f1e3ebd1709e4a7 Mon Sep 17 00:00:00 2001
+From 0157443eee1248d1b1d7283f412fe9e1b7c9e7dd Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:10 -0800
 Subject: [PATCH 06/14] Drivers: hv: vss: Improve log messages.
@@ -101,5 +101,5 @@ index a6707133c297..5c95ba1e2ecf 100644
  	return 0;
  }
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
+++ b/kernel/patches-4.9.x/0007-Drivers-hv-vss-Operation-timeouts-should-match-host-.patch
@@ -1,4 +1,4 @@
-From 9b0c7f51f16a105ed5272531e8509822b874a337 Mon Sep 17 00:00:00 2001
+From 6039af86b5be56114451ce388b4a1974d0f3d75a Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sun, 6 Nov 2016 13:14:11 -0800
 Subject: [PATCH 07/14] Drivers: hv: vss: Operation timeouts should match host
@@ -44,5 +44,5 @@ index 5c95ba1e2ecf..eee238cc60bd 100644
  	rc = hvutil_transport_send(hvt, vss_msg, sizeof(*vss_msg), NULL);
  	if (rc) {
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
+++ b/kernel/patches-4.9.x/0008-Drivers-hv-vmbus-Use-all-supported-IC-versions-to-ne.patch
@@ -1,4 +1,4 @@
-From eda519bd60121779436c3d4085e6672b94227c67 Mon Sep 17 00:00:00 2001
+From 0e952a320f834e9e9b504b093df09b512d36e5a7 Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:17 -0700
 Subject: [PATCH 08/14] Drivers: hv: vmbus: Use all supported IC versions to
@@ -488,5 +488,5 @@ index c9af8369b4f7..7df9eb8f0cf7 100644
  void hv_event_tasklet_disable(struct vmbus_channel *channel);
  void hv_event_tasklet_enable(struct vmbus_channel *channel);
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
+++ b/kernel/patches-4.9.x/0009-Drivers-hv-Log-the-negotiated-IC-versions.patch
@@ -1,4 +1,4 @@
-From 1d96e6889a4943d7d6dbdc190cddbfc5fb004984 Mon Sep 17 00:00:00 2001
+From 0571b33751a28b2b98a587edbcc50c79977dacba Mon Sep 17 00:00:00 2001
 From: Alex Ng <alexng@messages.microsoft.com>
 Date: Sat, 28 Jan 2017 12:37:18 -0700
 Subject: [PATCH 09/14] Drivers: hv: Log the negotiated IC versions.
@@ -114,5 +114,5 @@ index f3797c07be10..89440c2eb346 100644
  					hb_srv_version & 0xFFFF);
  			}
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
+++ b/kernel/patches-4.9.x/0010-vmbus-fix-missed-ring-events-on-boot.patch
@@ -1,4 +1,4 @@
-From 2a59f903dcd1b2907c9408bfea03ab945a092cbe Mon Sep 17 00:00:00 2001
+From d6f8382799600f95447f0505254be4deff4d3e41 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Sun, 26 Mar 2017 16:42:20 +0800
 Subject: [PATCH 10/14] vmbus: fix missed ring events on boot
@@ -52,5 +52,5 @@ index 095dd37367de..effac8042dc6 100644
  
  void hv_process_channel_removal(struct vmbus_channel *channel, u32 relid)
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
+++ b/kernel/patches-4.9.x/0011-vmbus-remove-goto-error_clean_msglist-in-vmbus_open.patch
@@ -1,4 +1,4 @@
-From 1663c94704c52c45197c2b548ec0a1ebd8f8925a Mon Sep 17 00:00:00 2001
+From cf39079c4a8a602a85949a03bc79f61e7c234420 Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Wed, 29 Mar 2017 18:37:10 +0800
 Subject: [PATCH 11/14] vmbus: remove "goto error_clean_msglist" in
@@ -56,5 +56,5 @@ index 784c45484825..fb94b96e8469 100644
  	vmbus_teardown_gpadl(newchannel, newchannel->ringbuffer_gpadlhandle);
  	kfree(open_info);
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
+++ b/kernel/patches-4.9.x/0012-vmbus-dynamically-enqueue-dequeue-the-channel-on-vmb.patch
@@ -1,4 +1,4 @@
-From 75b9de7c4d306101595384dc30f825d6be481a24 Mon Sep 17 00:00:00 2001
+From 3362a0f1c8dc2b7a70e2d886dff33578ac2085cf Mon Sep 17 00:00:00 2001
 From: Dexuan Cui <decui@microsoft.com>
 Date: Fri, 24 Mar 2017 20:53:18 +0800
 Subject: [PATCH 12/14] vmbus: dynamically enqueue/dequeue the channel on
@@ -173,5 +173,5 @@ index 7df9eb8f0cf7..a87757cf277b 100644
  
  void vmbus_setevent(struct vmbus_channel *channel);
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0013-bridge-implement-missing-ndo_uninit.patch
+++ b/kernel/patches-4.9.x/0013-bridge-implement-missing-ndo_uninit.patch
@@ -1,4 +1,4 @@
-From 9c30c16c52c4a75714ad99af377df057331cdc33 Mon Sep 17 00:00:00 2001
+From 4f5d93d73850c0a171183669e6b9f2373c7c1e42 Mon Sep 17 00:00:00 2001
 From: Ido Schimmel <idosch@mellanox.com>
 Date: Mon, 10 Apr 2017 14:59:27 +0300
 Subject: [PATCH 13/14] bridge: implement missing ndo_uninit()
@@ -138,5 +138,5 @@ index 1b63177e0ccd..417edbe7b8b2 100644
  {
  	return 0;
 -- 
-2.19.2
+2.21.0
 

--- a/kernel/patches-4.9.x/0014-bridge-move-bridge-multicast-cleanup-to-ndo_uninit.patch
+++ b/kernel/patches-4.9.x/0014-bridge-move-bridge-multicast-cleanup-to-ndo_uninit.patch
@@ -1,4 +1,4 @@
-From 4de155bbfd0ea90985bbe295c7f8c0d4200c4342 Mon Sep 17 00:00:00 2001
+From fc251a2831095a6038f112d2fded1610c982c66e Mon Sep 17 00:00:00 2001
 From: Xin Long <lucien.xin@gmail.com>
 Date: Tue, 25 Apr 2017 22:58:37 +0800
 Subject: [PATCH 14/14] bridge: move bridge multicast cleanup to ndo_uninit
@@ -105,5 +105,5 @@ index 1764de88483c..e25b75654256 100644
  
  	br_sysfs_delbr(br->dev);
 -- 
-2.19.2
+2.21.0
 

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -1,6 +1,6 @@
 # NOTE: Images build from this file likely do not run
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.166
+  image: linuxkit/kernel:4.9.167
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/020_kernel/002_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/002_config_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.109
+  image: linuxkit/kernel:4.14.110
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/020_kernel/005_config_4.19.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.19.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/020_kernel/007_config_5.0.x/test.yml
+++ b/test/cases/020_kernel/007_config_5.0.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:5.0.5
+  image: linuxkit/kernel:5.0.6
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0

--- a/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
@@ -7,7 +7,7 @@ FROM linuxkit/kernel:4.9.167 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:5ce235f4fb55772e7f78871a70bfe26f774fe2b0 AS build
-RUN apk add build-base libelf-dev
+RUN apk add build-base elfutils-dev
 
 COPY --from=ksrc /kernel-dev.tar /
 RUN tar xf kernel-dev.tar

--- a/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
+++ b/test/cases/020_kernel/011_kmod_4.9.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.9.166 AS ksrc
+FROM linuxkit/kernel:4.9.167 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:5ce235f4fb55772e7f78871a70bfe26f774fe2b0 AS build

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.sh
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.9.166
+docker pull linuxkit/kernel:4.9.167
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.9.166
+  image: linuxkit/kernel:4.9.167
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/020_kernel/012_kmod_4.14.x/Dockerfile
+++ b/test/cases/020_kernel/012_kmod_4.14.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.14.109 AS ksrc
+FROM linuxkit/kernel:4.14.110 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:5ce235f4fb55772e7f78871a70bfe26f774fe2b0 AS build

--- a/test/cases/020_kernel/012_kmod_4.14.x/Dockerfile
+++ b/test/cases/020_kernel/012_kmod_4.14.x/Dockerfile
@@ -7,7 +7,7 @@ FROM linuxkit/kernel:4.14.110 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:5ce235f4fb55772e7f78871a70bfe26f774fe2b0 AS build
-RUN apk add build-base libelf-dev
+RUN apk add build-base elfutils-dev
 
 COPY --from=ksrc /kernel-dev.tar /
 RUN tar xf kernel-dev.tar

--- a/test/cases/020_kernel/012_kmod_4.14.x/test.sh
+++ b/test/cases/020_kernel/012_kmod_4.14.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.14.109
+docker pull linuxkit/kernel:4.14.110
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/012_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/012_kmod_4.14.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.109
+  image: linuxkit/kernel:4.14.110
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/020_kernel/015_kmod_4.19.x/Dockerfile
+++ b/test/cases/020_kernel/015_kmod_4.19.x/Dockerfile
@@ -7,7 +7,7 @@ FROM linuxkit/kernel:4.19.33 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:5ce235f4fb55772e7f78871a70bfe26f774fe2b0 AS build
-RUN apk add build-base libelf-dev
+RUN apk add build-base elfutils-dev
 
 COPY --from=ksrc /kernel-dev.tar /
 RUN tar xf kernel-dev.tar

--- a/test/cases/020_kernel/015_kmod_4.19.x/Dockerfile
+++ b/test/cases/020_kernel/015_kmod_4.19.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:4.19.32 AS ksrc
+FROM linuxkit/kernel:4.19.33 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:5ce235f4fb55772e7f78871a70bfe26f774fe2b0 AS build

--- a/test/cases/020_kernel/015_kmod_4.19.x/test.sh
+++ b/test/cases/020_kernel/015_kmod_4.19.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:4.19.32
+docker pull linuxkit/kernel:4.19.33
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/015_kmod_4.19.x/test.yml
+++ b/test/cases/020_kernel/015_kmod_4.19.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/020_kernel/017_kmod_5.0.x/Dockerfile
+++ b/test/cases/020_kernel/017_kmod_5.0.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:5.0.5 AS ksrc
+FROM linuxkit/kernel:5.0.6 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:5ce235f4fb55772e7f78871a70bfe26f774fe2b0 AS build

--- a/test/cases/020_kernel/017_kmod_5.0.x/Dockerfile
+++ b/test/cases/020_kernel/017_kmod_5.0.x/Dockerfile
@@ -7,7 +7,7 @@ FROM linuxkit/kernel:5.0.6 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:5ce235f4fb55772e7f78871a70bfe26f774fe2b0 AS build
-RUN apk add build-base libelf-dev
+RUN apk add build-base elfutils-dev
 
 COPY --from=ksrc /kernel-dev.tar /
 RUN tar xf kernel-dev.tar

--- a/test/cases/020_kernel/017_kmod_5.0.x/test.sh
+++ b/test/cases/020_kernel/017_kmod_5.0.x/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 # Make sure we have the latest kernel image
-docker pull linuxkit/kernel:5.0.5
+docker pull linuxkit/kernel:5.0.6
 # Build a package
 docker build -t ${IMAGE_NAME} .
 

--- a/test/cases/020_kernel/017_kmod_5.0.x/test.yml
+++ b/test/cases/020_kernel/017_kmod_5.0.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:5.0.5
+  image: linuxkit/kernel:5.0.6
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:005807f5c6a74e23f485a6d1657818bdccb70cd0

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/002_bpftrace/test.yml
+++ b/test/cases/040_packages/002_bpftrace/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.5

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/cases/040_packages/032_bcc/test.yml
+++ b/test/cases/040_packages/032_bcc/test.yml
@@ -1,10 +1,10 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff
   - linuxkit/runc:606971451ea29b4238029804ca638f9f85caf5af
-  - linuxkit/kernel-bcc:4.19.32
+  - linuxkit/kernel-bcc:4.19.33
 onboot:
   - name: check-bcc
     image: alpine:3.9

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -1,7 +1,7 @@
 # FIXME: This should use the minimal example
 # We continue to use the kernel-config-test as CI is currently expecting to see a success message
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -1,6 +1,6 @@
 # Sample YAML file for manual testing
 kernel:
-  image: linuxkit/kernel:4.19.32
+  image: linuxkit/kernel:4.19.33
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:629fdad56e62ae72bf8becf0c8a668241480d3ff


### PR DESCRIPTION
Note the somewhat gross hack in the second commit. The kernel compile for 5.06 started failing with the error mentioned in the commit message. I couldn't find a conclusive culprit, but fixing up the libelf header files seemed like the best way forward.

![seabright-chicken](https://user-images.githubusercontent.com/3338098/55612563-6137fb80-5780-11e9-8a78-b34826b74780.jpg)
