### PR TITLE
Update RPi firmware

### DIFF
--- a/src/cmd/linuxkit/moby/output.go
+++ b/src/cmd/linuxkit/moby/output.go
@@ -27,7 +27,7 @@ var (
 		"vhd":         "linuxkit/mkimage-vhd:3820219e5c350fe8ab2ec6a217272ae82f4b9242",
 		"dynamic-vhd": "linuxkit/mkimage-dynamic-vhd:743ac9959fe6d3912ebd78b4fd490b117c53f1a6",
 		"vmdk":        "linuxkit/mkimage-vmdk:cee81a3ed9c44ae446ef7ebff8c42c1e77b3e1b5",
-		"rpi3":        "linuxkit/mkimage-rpi3:97a9387ff0ff5db867dd8af931b825e55108bea4",
+		"rpi3":        "linuxkit/mkimage-rpi3:cb8427df175b61dd6b635e76f0e88bf261e30d8b",
 	}
 )
 

--- a/tools/mkimage-rpi3/Dockerfile
+++ b/tools/mkimage-rpi3/Dockerfile
@@ -37,7 +37,7 @@ RUN patch -p 1 < /u-boot.patch && \
 ENV RPI_COMMIT=478d637c476e838ffcfa8535232ff0b86daf5918
 RUN mkdir -p /out/boot && \
     cd /out/boot && \
-    curl -fsSLO https://github.com/raspberrypi/firmware/raw/$RPI_COMMIT/boot/bootcode.bin && \
+    curl -fsSLO https://github.com/raspberrypi/firmware/raw/$RPI_COMMIT/boot/LICENCE.broadcom && \
     curl -fsSLO https://github.com/raspberrypi/firmware/raw/$RPI_COMMIT/boot/bootcode.bin && \
     curl -fsSLO https://github.com/raspberrypi/firmware/raw/$RPI_COMMIT/boot/fixup_cd.dat && \
     curl -fsSLO https://github.com/raspberrypi/firmware/raw/$RPI_COMMIT/boot/fixup.dat && \

--- a/tools/mkimage-rpi3/Dockerfile
+++ b/tools/mkimage-rpi3/Dockerfile
@@ -34,7 +34,7 @@ RUN patch -p 1 < /u-boot.patch && \
     cp tools/mkimage /out/bin
 
 # fetch the Raspberry Pi 3 firmware (latest master)
-ENV RPI_COMMIT=478d637c476e838ffcfa8535232ff0b86daf5918
+ENV RPI_COMMIT=f8939644f7bd3065068787f1f92b3f3c79cf3de9
 RUN mkdir -p /out/boot && \
     cd /out/boot && \
     curl -fsSLO https://github.com/raspberrypi/firmware/raw/$RPI_COMMIT/boot/LICENCE.broadcom && \


### PR DESCRIPTION
**- What I did**
Update commit hash to include updated RPi firmware

**- How to verify it**
Attempt to boot a RPi and expect the power LED to remain on, and ACT to not flash with a debug code.  If successful, expect uboot to log to both serial consol and HDMI.

**- Description for the changelog**
Vendor RPi firmware blob license
Update RPi3 firmware to fix startup on newer kit

---

This is a potential fix for #3324, however the fix will be when the new image is updated in `src/cmd/linuxkit/moby/output.go`.  I assume this must merge before an image is produced that can provide an updated hash for `src/cmd/linuxkit/moby/output.go`?