### PR TITLE
Fetch Qemu v4.0.0 from Fedora

### DIFF
--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,6 +1,6 @@
-# Use Debian stretch until https://bugs.alpinelinux.org/issues/8131 is resolved.
-FROM debian@sha256:de3eac83cd481c04c5d6c7344cd7327625a1d8b2540e82a8231b5675cef0ae5f AS qemu
-RUN apt-get update && apt-get install -y qemu-user-static && \
+FROM fedora:30 as qemu
+RUN curl -OL https://kojipkgs.fedoraproject.org/packages/qemu/4.0.0/1.fc31/x86_64/qemu-user-static-4.0.0-1.fc31.x86_64.rpm && \
+    rpm -ivh qemu-user-static-4.0.0-1.fc31.x86_64.rpm --nodeps && \
     mv /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64 && \
     mv /usr/bin/qemu-arm-static /usr/bin/qemu-arm && \
     mv /usr/bin/qemu-ppc64le-static /usr/bin/qemu-ppc64le && \

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,6 +1,5 @@
 FROM fedora:30 as qemu
-RUN curl -OL https://kojipkgs.fedoraproject.org/packages/qemu/4.0.0/1.fc31/x86_64/qemu-user-static-4.0.0-1.fc31.x86_64.rpm && \
-    rpm -ivh qemu-user-static-4.0.0-1.fc31.x86_64.rpm --nodeps && \
+RUN dnf install qemu-user-static -y && \
     mv /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64 && \
     mv /usr/bin/qemu-arm-static /usr/bin/qemu-arm && \
     mv /usr/bin/qemu-ppc64le-static /usr/bin/qemu-ppc64le && \


### PR DESCRIPTION
**- What I did**

Fixes Issue #3339 where older Qemu version generates problems with Java application

**- How I did it**

Use a Fedora base image and fetch package directly from their buildservers.

**- How to verify it**

Binfmt package is build correctly with:

```
linuxkit pkg build -org=carlosedp -disable-content-trust pkg/binfmt
```

The binary is the correct version:

```
➜ docker run --rm -it carlosedp/binfmt:1b9e0a3a0a6bd07e7875581f0e4498ea561dde10-dirty /usr/bin/qemu-aarch64 --version
qemu-aarch64 version 4.0.0 (qemu-4.0.0-1.fc31)
Copyright (c) 2003-2019 Fabrice Bellard and the QEMU Project developers
```