### PR TITLE
rngd exits after being stopped and resumed

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/metadata:v0.7
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: sshd
     image: linuxkit/sshd:v0.7
     binds:

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/sysctl:v0.7
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7
   - name: sshd

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -26,7 +26,7 @@ services:
     env:
       - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: ntpd
     image: linuxkit/openntpd:v0.7
 

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -38,7 +38,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
 files:
   - path: etc/dm-crypt/key
     # the below key is just to keep the example self-contained

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -32,7 +32,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
 files:
   - path: etc/dm-crypt/key
     # the below key is just to keep the example self-contained

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -22,7 +22,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7
   - name: ntpd

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -20,7 +20,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: sshd
     image: linuxkit/sshd:v0.7
     binds:

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -19,7 +19,7 @@ services:
     #env:
     # - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -30,7 +30,7 @@ services:
           destination: writeable-host-etc
           options: ["rw", "lowerdir=/etc", "upperdir=/run/hostetc/upper", "workdir=/run/hostetc/work"]
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -11,7 +11,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7
   - name: node_exporter

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -17,7 +17,7 @@ onboot:
     command: ["/usr/bin/metadata", "openstack"]
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: sshd
     image: linuxkit/sshd:v0.7
     binds:

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -10,7 +10,7 @@ init:
   - linuxkit/firmware:v0.7
 onboot:
   - name: rngd1
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
     command: ["/sbin/rngd", "-1"]
   - name: sysctl
     image: linuxkit/sysctl:v0.7
@@ -22,7 +22,7 @@ onboot:
     command: ["/usr/bin/metadata", "packet"]
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: getty
     image: linuxkit/getty:v0.7
     env:

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -15,7 +15,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7
   - name: open-vm-tools

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -10,7 +10,7 @@ onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.7
   - name: rngd1
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
     command: ["/sbin/rngd", "-1"]
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7
@@ -23,7 +23,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
 trust:
   org:
     - linuxkit

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -10,7 +10,7 @@ onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.7
   - name: rngd1
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
     command: ["/sbin/rngd", "-1"]
 services:
   - name: getty
@@ -18,7 +18,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7
   - name: sshd

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -28,7 +28,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
 trust:
   org:
     - linuxkit

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -20,7 +20,7 @@ services:
   - name: tss
     image: linuxkit/tss:v0.7
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -15,7 +15,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7
   - name: nginx

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -20,7 +20,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: sshd
     image: linuxkit/sshd:v0.7
     binds:

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -45,7 +45,7 @@ services:
      - INSECURE=true
     net: /run/netns/wg1
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: nginx
     image: nginx:1.13.8-alpine
     net: /run/netns/wg0

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -22,7 +22,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -25,7 +25,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: ntpd
     image: linuxkit/openntpd:v0.7
   - name: docker

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -25,7 +25,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: ntpd
     image: linuxkit/openntpd:v0.7
   - name: docker

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -15,7 +15,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -16,7 +16,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7
 files:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -18,7 +18,7 @@ services:
     env:
      - INSECURE=true
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: nginx
     image: nginx:1.13.8-alpine
     capabilities:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -18,7 +18,7 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: rngd
-    image: linuxkit/rngd:v0.7
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7
   - name: docker


### PR DESCRIPTION
Linux has documented but somewhat unusual behavior around
SIGSTOP/SIGCONT and certain syscalls, of which epoll_wait(2) is one.  In
this particular case, rngd exited unexpectedly after getting ptrace'd
mid-epoll_wait.  Fix this by handling EINTR from this syscall, and
continuing to add entropy and wait.

Signed-off-by: Krister Johansen <krister.johansen@oracle.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Changed rngd so that it will no longer exit 1 upon being ptrace'd.

**- How I did it**

This change requires that the error handling around the `epoll_wait(2)` in rngd be modified so that it can cope with receiving an EINTR (or any temporary error) and continue instead of exiting.

**- How to verify it**

I validated this by running `strace(1)` against `rngd`.  Prior to the fix it would exit moments after the tracer attached.  With this fix, it's possible to observe the behavior of `rngd` with strace, and to have it attach and detach without issue.

**- Description for the changelog**

Rngd should gracefully handle SIGSTOP/SIGCONT

**- A picture of a cute animal (not mandatory but encouraged)**
![920x920](https://user-images.githubusercontent.com/26471578/57337558-b8fab700-70de-11e9-9c82-bf70bfeb2b40.jpg)
