### PR TITLE
Update GCP metadata provider

### DIFF
--- a/pkg/metadata/provider_gcp.go
+++ b/pkg/metadata/provider_gcp.go
@@ -53,7 +53,7 @@ func (p *ProviderGCP) Extract() ([]byte, error) {
 	}
 
 	// Generic userdata
-	userData, err := gcpGet(instance + "attributes/userdata")
+	userData, err := gcpGet(instance + "attributes/user-data")
 	if err != nil {
 		log.Printf("GCP: Failed to get user-data: %s", err)
 		// This is not an error
@@ -102,8 +102,10 @@ func (p *ProviderGCP) handleSSH() error {
 		return fmt.Errorf("Failed to get sshKeys: %s", err)
 	}
 
-	if err := os.Mkdir(path.Join(ConfigPath, SSH), 0755); err != nil {
-		return fmt.Errorf("Failed to create %s: %s", SSH, err)
+	if _, err := os.Stat(path.Join(ConfigPath, SSH)); os.IsNotExist(err) {
+		if err := os.Mkdir(path.Join(ConfigPath, SSH), 0755); err != nil {
+			return fmt.Errorf("Failed to create %s: %s", SSH, err)
+		}
 	}
 
 	rootKeys := ""

--- a/src/cmd/linuxkit/gcp.go
+++ b/src/cmd/linuxkit/gcp.go
@@ -266,7 +266,7 @@ func (g GCPClient) CreateInstance(name, image, zone, machineType string, disks D
 					Value: sshKey,
 				},
 				{
-					Key:   "userdata",
+					Key:   "user-data",
 					Value: data,
 				},
 			},


### PR DESCRIPTION
Updates the userdata key to the more common and documented `user-data` instead of `userdata`.

https://cloud.google.com/container-optimized-os/docs/how-to/create-configure-instance#using_cloud-init

Checks to see if the /run/config/ssh directory exists; this allows new ssh keys to be fetched on reboot.

Signed-off-by: Preston Holmes <preston@ptone.com>