### PR TITLE
Update referenced Raspberry Pi firmware

### DIFF
--- a/src/cmd/linuxkit/moby/output.go
+++ b/src/cmd/linuxkit/moby/output.go
@@ -27,7 +27,7 @@ var (
 		"vhd":         "linuxkit/mkimage-vhd:4cc60c4f46b07e11c64ba618e46b81fa0096c91f",
 		"dynamic-vhd": "linuxkit/mkimage-dynamic-vhd:99b9009ed54a793020d3ce8322a42e0cc06da71a",
 		"vmdk":        "linuxkit/mkimage-vmdk:b55ea46297a16d8a4448ce7f5a2df987a9602b27",
-		"rpi3":        "linuxkit/mkimage-rpi3:cb8427df175b61dd6b635e76f0e88bf261e30d8b",
+		"rpi3":        "linuxkit/mkimage-rpi3:9f2d993daa83152c5d52af16ebb7fefa1e69f28e",
 	}
 )
 

--- a/tools/mkimage-rpi3/Dockerfile
+++ b/tools/mkimage-rpi3/Dockerfile
@@ -34,7 +34,7 @@ RUN patch -p 1 < /u-boot.patch && \
     cp tools/mkimage /out/bin
 
 # fetch the Raspberry Pi 3 firmware (latest master)
-ENV RPI_COMMIT=f8939644f7bd3065068787f1f92b3f3c79cf3de9
+ENV RPI_COMMIT=e1900836948f6c6bdf4571da1b966a9085c95d37
 RUN mkdir -p /out/boot && \
     cd /out/boot && \
     curl -fsSLO https://github.com/raspberrypi/firmware/raw/$RPI_COMMIT/boot/LICENCE.broadcom && \


### PR DESCRIPTION
Update Raspberry Pi firmware used in mkimage-rpi3 to the latest stable
version to support newer hardware models such as the 3B+

Signed-off-by: Richard Connon <richard@connon.me.uk>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated the version of the raspberry pi firmware used by mkimage-rpi3

**- How I did it**
Modified the commit sha referenced in the Dockerfile

**- How to verify it**
Build an image using mkimage-rpi3 and test it on newer hardware such as a raspberry pi 3B+

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update referenced Raspberry Pi firmware to 1.20190517

**- A picture of a cute animal (not mandatory but encouraged)**
![IMG_20160427_090752](https://user-images.githubusercontent.com/1963938/57988459-a8572300-7a86-11e9-896e-f2cb92311923.jpg)
13.jpg)