### PR TITLE
Support for dynamic selection of Raspberry Pi DTB

### DIFF
--- a/src/cmd/linuxkit/moby/output.go
+++ b/src/cmd/linuxkit/moby/output.go
@@ -27,7 +27,7 @@ var (
 		"vhd":         "linuxkit/mkimage-vhd:4cc60c4f46b07e11c64ba618e46b81fa0096c91f",
 		"dynamic-vhd": "linuxkit/mkimage-dynamic-vhd:99b9009ed54a793020d3ce8322a42e0cc06da71a",
 		"vmdk":        "linuxkit/mkimage-vmdk:b55ea46297a16d8a4448ce7f5a2df987a9602b27",
-		"rpi3":        "linuxkit/mkimage-rpi3:9f2d993daa83152c5d52af16ebb7fefa1e69f28e",
+		"rpi3":        "linuxkit/mkimage-rpi3:9dd4f7735e19e495c2b0a856a52af15141816534",
 	}
 )
 

--- a/tools/mkimage-rpi3/Dockerfile
+++ b/tools/mkimage-rpi3/Dockerfile
@@ -1,8 +1,10 @@
 FROM linuxkit/alpine:86cd4f51b49fb9a078b50201d892a3c7973d48ec as build
 RUN apk add \
     bc \
+    bison \
     dtc \
     curl \
+    flex \
     make \
     gcc \
     git \
@@ -20,11 +22,10 @@ RUN apk add --no-cache --initdb -p /out \
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
 # u-boot compile. The patch is needed to handle larger kernels
-ENV UBOOT_COMMIT=v2017.09
+ENV UBOOT_COMMIT=v2019.04
 COPY u-boot.patch .
-RUN git clone https://github.com/u-boot/u-boot.git && \
-    cd /u-boot && \
-    git checkout $UBOOT_COMMIT
+RUN git clone -b $UBOOT_COMMIT --depth 1 https://github.com/u-boot/u-boot.git && \
+    cd /u-boot
 WORKDIR /u-boot
 RUN patch -p 1 < /u-boot.patch && \
     make rpi_3_defconfig all && \

--- a/tools/mkimage-rpi3/Dockerfile
+++ b/tools/mkimage-rpi3/Dockerfile
@@ -24,8 +24,7 @@ RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 # u-boot compile. The patch is needed to handle larger kernels
 ENV UBOOT_COMMIT=v2019.04
 COPY u-boot.patch .
-RUN git clone -b $UBOOT_COMMIT --depth 1 https://github.com/u-boot/u-boot.git && \
-    cd /u-boot
+RUN git clone -b $UBOOT_COMMIT --depth 1 https://github.com/u-boot/u-boot.git
 WORKDIR /u-boot
 RUN patch -p 1 < /u-boot.patch && \
     make rpi_3_defconfig all && \

--- a/tools/mkimage-rpi3/boot.script
+++ b/tools/mkimage-rpi3/boot.script
@@ -1,9 +1,9 @@
 setenv bootargs "dwc_otg.lpm_enable=0 earlyprintk console=tty1 console=ttyS0,115200 root=/dev/ram0 rw"
-setenv dtbfile bcm2837-rpi-3-b.dtb
+setenv loadaddr 0x01000000
 setenv machid 0x00000c42
 saveenv
 
-fatload mmc 0:1 ${kernel_addr_r} kernel.uimg
-fatload mmc 0:1 ${fdt_addr_r} ${dtbfile}
+fatload mmc 0:1 ${loadaddr} kernel.uimg
+fatload mmc 0:1 ${fdt_addr_r} dtb/${fdtfile}
 fatload mmc 0:1 ${ramdisk_addr_r} initrd.uimg
-bootm ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr_r}
+bootm ${loadaddr} ${ramdisk_addr_r} ${fdt_addr_r}

--- a/tools/mkimage-rpi3/make-rpi3
+++ b/tools/mkimage-rpi3/make-rpi3
@@ -14,7 +14,8 @@ cd /files
 cd /
 
 # copy/convert files 
-cp /files/boot/dtb/broadcom/bcm2837-rpi-3-b.dtb /boot
+mkdir -p /boot/dtb/broadcom
+cp /files/boot/dtb/broadcom/bcm2837-rpi-3-b*.dtb /boot/dtb/broadcom
 /bin/mkimage -A arm64 -O linux -T kernel -C gzip -a 0x80000 -e 0x80000 \
              -d /files/boot/kernel /boot/kernel.uimg >> /boot/uboot.log
 /bin/mkimage -A arm64 -O linux -T script -C none -a 0x00000000 -e 0x00000000 -n RPi3 \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Support selecting devicetree for raspberry pi 3B vs 3B+ dynamically

**- How I did it**
Updated UBoot to a version which can detect the raspberry pi 3B+ correctly.
Install both device tree binaries.
Select the correct binary using the fdtfile variable populated by UBoot.

**- How to verify it**
Boot a raspberry pi 3B+ and run
`cat /proc/device-tree/model`
Should output correct model information.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Support selecting devicetree for raspberry pi 3B vs 3B+ dynamically

**- A picture of a cute animal (not mandatory but encouraged)**
![IMG_20160408_211321](https://user-images.githubusercontent.com/1963938/58380891-38c5c400-7faf-11e9-9632-693ce4b9b44c.jpg)

