### PR TITLE
Extract method that launch runc service

### DIFF
--- a/pkg/init/cmd/service/runc.go
+++ b/pkg/init/cmd/service/runc.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -67,94 +68,11 @@ func runcInit(rootPath, serviceType string) int {
 	for _, file := range files {
 		name := file.Name()
 		path := filepath.Join(rootPath, name)
-
-		runtimeConfig := getRuntimeConfig(path)
-
-		if err := prepareFilesystem(path, runtimeConfig); err != nil {
-			log.Printf("Error preparing %s: %v", name, err)
-			status = 1
-			continue
-		}
 		pidfile := filepath.Join(tmpdir, name)
-		cmd := exec.Command(runcBinary, "create", "--bundle", path, "--pid-file", pidfile, name)
-
-		stdoutLog := serviceType + "." + name + ".out"
-		stdout, err := logger.Open(stdoutLog)
-		if err != nil {
-			log.Printf("Error opening stdout log connection: %v", err)
+		if err := runcInitService(logger, serviceType, name, pidfile, path); err != nil {
+			log.Printf(err.Error())
 			status = 1
-			continue
 		}
-		defer stdout.Close()
-
-		stderrLog := serviceType + "." + name
-		stderr, err := logger.Open(stderrLog)
-		if err != nil {
-			log.Printf("Error opening stderr log connection: %v", err)
-			status = 1
-			continue
-		}
-		defer stderr.Close()
-
-		cmd.Stdout = stdout
-		cmd.Stderr = stderr
-
-		if err := cmd.Run(); err != nil {
-			log.Printf("Error creating %s: %v", name, err)
-			status = 1
-			// skip cleanup on error for debug
-			continue
-		}
-		pf, err := ioutil.ReadFile(pidfile)
-		if err != nil {
-			log.Printf("Cannot read pidfile: %v", err)
-			status = 1
-			continue
-		}
-		pid, err := strconv.Atoi(string(pf))
-		if err != nil {
-			log.Printf("Cannot parse pid from pidfile: %v", err)
-			status = 1
-			continue
-		}
-
-		if err := prepareProcess(pid, runtimeConfig); err != nil {
-			log.Printf("Cannot prepare process: %v", err)
-			status = 1
-			continue
-		}
-
-		waitFor := make(chan *os.ProcessState)
-		go func() {
-			// never errors in Unix
-			p, _ := os.FindProcess(pid)
-			state, err := p.Wait()
-			if err != nil {
-				log.Printf("Process wait error: %v", err)
-			}
-			waitFor <- state
-		}()
-
-		cmd = exec.Command(runcBinary, "start", name)
-		cmd.Stdout = stdout
-		cmd.Stderr = stderr
-
-		if err := cmd.Run(); err != nil {
-			log.Printf("Error starting %s: %v", name, err)
-			status = 1
-			continue
-		}
-
-		_ = <-waitFor
-
-		cleanup(path)
-		_ = os.Remove(pidfile)
-
-		// ideally we want to use io.MultiWriter here, sending one stream to stdout/stderr, another to the log
-		// however, this hangs if we do, due to a runc bug, see https://github.com/opencontainers/runc/issues/1721#issuecomment-366315563
-		// once that is fixed, this can be cleaned up
-		logger.Dump(stdoutLog)
-		logger.Dump(stderrLog)
 	}
 
 	_ = os.RemoveAll(tmpdir)
@@ -163,4 +81,78 @@ func runcInit(rootPath, serviceType string) int {
 	logger.Symlink(varLogLink)
 
 	return status
+}
+
+func runcInitService(logger Log, serviceType, name, pidfile, path string) error {
+	runtimeConfig := getRuntimeConfig(path)
+
+	if err := prepareFilesystem(path, runtimeConfig); err != nil {
+		return fmt.Errorf("Error preparing %s: %v", name, err)
+	}
+	cmd := exec.Command(runcBinary, "create", "--bundle", path, "--pid-file", pidfile, name)
+
+	stdoutLog := serviceType + "." + name + ".out"
+	stdout, err := logger.Open(stdoutLog)
+	if err != nil {
+		return fmt.Errorf("Error opening stdout log connection: %v", err)
+	}
+	defer stdout.Close()
+
+	stderrLog := serviceType + "." + name
+	stderr, err := logger.Open(stderrLog)
+	if err != nil {
+		return fmt.Errorf("Error opening stderr log connection: %v", err)
+	}
+	defer stderr.Close()
+
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("Error creating %s: %v", name, err)
+	}
+	pf, err := ioutil.ReadFile(pidfile)
+	if err != nil {
+		return fmt.Errorf("Cannot read pidfile: %v", err)
+	}
+	pid, err := strconv.Atoi(string(pf))
+	if err != nil {
+		return fmt.Errorf("Cannot parse pid from pidfile: %v", err)
+	}
+
+	if err := prepareProcess(pid, runtimeConfig); err != nil {
+		return fmt.Errorf("Cannot prepare process: %v", err)
+	}
+
+	waitFor := make(chan *os.ProcessState)
+	go func() {
+		// never errors in Unix
+		p, _ := os.FindProcess(pid)
+		state, err := p.Wait()
+		if err != nil {
+			log.Printf("Process wait error: %v", err)
+		}
+		waitFor <- state
+	}()
+
+	cmd = exec.Command(runcBinary, "start", name)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("Error starting %s: %v", name, err)
+	}
+
+	_ = <-waitFor
+
+	cleanup(path)
+	_ = os.Remove(pidfile)
+
+	// ideally we want to use io.MultiWriter here, sending one stream to stdout/stderr, another to the log
+	// however, this hangs if we do, due to a runc bug, see https://github.com/opencontainers/runc/issues/1721#issuecomment-366315563
+	// once that is fixed, this can be cleaned up
+	logger.Dump(stdoutLog)
+	logger.Dump(stderrLog)
+
+	return nil
 }


### PR DESCRIPTION
**- What I did**

Simplify a long method by extracting code inside the for-loop.

My goal is to open a follow-up PR that will log the time required to execute onboot/shutdown services. It will be useful in Docker Desktop for getting a better knowledge on "Why the boot is slow?"

**- How I did it**

Extract the method, use `fmt.Errorf` to carry the information.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![aaaproduction_0_0](https://user-images.githubusercontent.com/172624/58564378-1b059280-822d-11e9-9825-dd85c530aa1b.jpg)
