### PR TITLE
Do not use a log driver while running containers

### DIFF
--- a/src/cmd/linuxkit/moby/docker.go
+++ b/src/cmd/linuxkit/moby/docker.go
@@ -55,7 +55,7 @@ func dockerRun(input io.Reader, output io.Writer, trust bool, img string, args .
 		return err
 	}
 
-	args = append([]string{"run", "--network=none", "--rm", "-i", img}, args...)
+	args = append([]string{"run", "--network=none", "--log-driver=none", "--rm", "-i", img}, args...)
 	cmd := exec.Command(docker, args...)
 	cmd.Stdin = input
 	cmd.Stdout = output


### PR DESCRIPTION
This stops the output from also being copied to logs if the user
has a log driver configured.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
