### PR TITLE
Update kernel Dockerfile with openssl-dev dep

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add \
     mpc1-dev \
     mpfr-dev \
     ncurses-dev \
+    openssl-dev \
     patch \
     sed \
     squashfs-tools \


### PR DESCRIPTION
Kernel series 5.1.x requires openssl headers to compile scripts/extract-cert.c.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added openssl-dev headers to the kernel/Dockerfle

**- How I did it**

Edited the Dockerfile.

**- How to verify it**

cd kernel && make build_5.1.x

**- Description for the changelog**

Added openssl-dev dependency to kernel compilation Dockerfile.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1150684/59025174-e361a080-8853-11e9-9d71-d9038c7aa559.png)
