### PR TITLE
Create swap file only if absent

### DIFF
--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -26,7 +26,7 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib"]
   # make a swap file on the mounted disk
   - name: swap
-    image: linuxkit/swap:v0.7
+    image: linuxkit/swap:f8b0434963b4c9114db473aab3b9409bccd4f85b
     command: ["/swap.sh", "--path", "/var/lib/swap", "--size", "1024M"]
   # mount-vpnkit mounts the 9p share used by vpnkit to coordinate port forwarding
   - name: mount-vpnkit

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:v0.7
     command: ["/usr/bin/mountie", "/var/external"]
   - name: swap
-    image: linuxkit/swap:v0.7
+    image: linuxkit/swap:f8b0434963b4c9114db473aab3b9409bccd4f85b
     # to use unencrypted swap, use:
     # command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G"]
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]


### PR DESCRIPTION
**- What I did**

Speed up swap onboot container.

**- How I did it**

`swapon || (dd && mkswap)`  instead of `dd && mkswap && swapon`. 

**- How to verify it**

Without this PR, container log always show dd output. With the PR, it appears only once.

**- Description for the changelog**

pkg/swap: create swap file only if absent.

**- A picture of a cute animal (not mandatory but encouraged)**

![](http://www.val2c.fr/wp-content/uploads/2015/01/ae4380f164151adb0c33adc84c97e3a5_large-1024x576.jpeg)