### PR TITLE
fixes #3373: remove fixed image sizes from vhd and vmdk outputs

### DIFF
--- a/tools/mkimage-vhd/make-vhd
+++ b/tools/mkimage-vhd/make-vhd
@@ -39,7 +39,7 @@ cd ..
 tar cf files.tar -C files .
 
 # no direct vhd support
-virt-make-fs --size=1G --type=ext4 --partition files.tar disk.img
+virt-make-fs --type=ext4 --partition files.tar disk.img
 
 guestfish -a disk.img -m /dev/sda1 <<EOF
   upload /usr/lib/SYSLINUX/mbr.bin /mbr.bin

--- a/tools/mkimage-vmdk/make-vmdk
+++ b/tools/mkimage-vmdk/make-vmdk
@@ -39,7 +39,7 @@ cd ..
 tar cf files.tar -C files .
 
 # Disk is created in qcow format, testing needed to see if raw->vmdk conversion makes any efficency gains
-virt-make-fs --size=1G --type=ext4 --partition files.tar --format=qcow2 disk.qcow
+virt-make-fs --type=ext4 --partition files.tar --format=qcow2 disk.qcow
 
 guestfish -a disk.qcow -m /dev/sda1 <<EOF
   upload /usr/lib/SYSLINUX/mbr.bin /mbr.bin


### PR DESCRIPTION
**- What I did**
Fixed an issue where an image manifest that contained files larger than 1G caused `vmdk` and `vhd` formatted builds to fail.  

**- How I did it**
Removed the 1G `virt-make-fs` size specification from the `make-vmdk` and `make-vhd` build scripts. 

**- How to verify it**
- Build a new `mkimage-*` Docker images for vmdk or vid outputs. 
- Modify [output.go](https://github.com/linuxkit/linuxkit/blob/master/src/cmd/linuxkit/moby/output.go) to use the new Docker images. 
- Build the linuxkit binary.
- Use the newly built binary to run `linuxkit build` against an image manifest that contains files larger than 1G.
- Observe massive success.

**- Description for the changelog**
Fixes an issue that causes builds to fail for image manifests containing large files.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/21316963/59382202-fcfe5e80-8d11-11e9-9b75-811b14026922.png)
