### PR TITLE
Update zfs to 0.8.1

### DIFF
--- a/kernel/Dockerfile.zfs
+++ b/kernel/Dockerfile.zfs
@@ -12,6 +12,7 @@ RUN apk add \
     libtool \
     mpc1-dev \
     mpfr-dev \
+    openssl-dev \
     util-linux-dev \
     zlib-dev
 
@@ -22,17 +23,8 @@ RUN tar xf kernel-dev.tar
 COPY --from=ksrc /kernel.tar /
 RUN tar xf kernel.tar
 
-# Note: ZFS and SPL commits must match. It's unclear how much the user
-# space tools must match the kernel module version.
-# package on Alpine is 0.6.5.9. We pick the version that compiles with
-# latest kernel we support.
-ENV VERSION=0.7.12
-
-ENV SPL_REPO=https://github.com/zfsonlinux/spl.git
-ENV SPL_COMMIT=spl-${VERSION}
-RUN git clone ${SPL_REPO} && \
-    cd spl && \
-    git checkout ${SPL_COMMIT}
+# SPL is part of the ZFS repo since 0.8.0 (https://github.com/zfsonlinux/zfs/releases/tag/zfs-0.8.0)
+ENV VERSION=0.8.1
 
 ENV ZFS_REPO=https://github.com/zfsonlinux/zfs.git
 ENV ZFS_COMMIT=zfs-${VERSION}
@@ -40,16 +32,10 @@ RUN git clone ${ZFS_REPO} && \
     cd zfs && \
     git checkout ${ZFS_COMMIT}
 
-WORKDIR /spl
-RUN ./autogen.sh && \
-    ./configure && \
-    cd module && \
-    make && \
-    make install
-
 WORKDIR /zfs
 RUN ./autogen.sh && \
-    ./configure --with-spl=/spl && \
+    ./configure && \
+    ./scripts/make_gitrev.sh && \
     cd module && \
     make -j "$(getconf _NPROCESSORS_ONLN)" && \
     make install


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated ZFS to 0.8.1 to be able to use its native encryption (added in 0.8.0)

**- How I did it**
Updated kernel/Dockerfile.zfs and tested with kernel 4.19.49

**- How to verify it**
Tested on docker-for-mac with this zfs.yml
```
kernel:
  image: test/kernel:<tag-from-make-command>
  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
init:
  - test/zfs-kmod:<tag-from-make-command>
  - linuxkit/init:v0.7
  - linuxkit/runc:v0.7
  - linuxkit/containerd:v0.7
  - linuxkit/ca-certificates:v0.7
onboot:
  - name: sysctl
    image: linuxkit/sysctl:v0.7
  - name: modprobe
    image: linuxkit/modprobe:v0.7
    command: ["modprobe", "-a", "zfs"]
services:
  - name: getty
    image: linuxkit/getty:v0.7
    env:
    - INSECURE=true
  - name: rngd
    image: linuxkit/rngd:v0.7
  - name: dhcpcd
    image: linuxkit/dhcpcd:v0.7
trust:
  org:
    - linuxkit
    - library
```
```
cd kernel
make ORG=test build_zfs_4.19.x
linuxkit build -format kernel+initrd zfs.yml
linuxkit run hyperkit -kernel zfs
apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main zfs
fallocate -l 70M /tmp/disk
zpool create rpool /tmp/disk
zfs create -o encryption=on -o keyformat=passphrase rpool/encrypted
zfs get encryption rpool/encrypted
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update zfs to be able to use native encryption

**- A picture of a cute animal (not mandatory but encouraged)**
