### PR TITLE
Fix path in firmware image (and update while at it)

### DIFF
--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
   - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
   - linuxkit/ca-certificates:v0.7
-  - linuxkit/firmware:v0.7
+  - linuxkit/firmware:e246ab4c77bc4e70b53db091371a699fced5e01d
 onboot:
   - name: rngd1
     image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81

--- a/pkg/firmware-all/Dockerfile
+++ b/pkg/firmware-all/Dockerfile
@@ -3,7 +3,7 @@ RUN apk add --no-cache git
 
 # Make sure you also update the FW_COMMIT in ../firmware/Dockerfile
 ENV FW_URL=git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
-ENV FW_COMMIT=9ee52be785cf91fc6a3c6aa27d484873f8270b72
+ENV FW_COMMIT=dff98c6c57383fe343407bcb7b6e775e0b87274f
 
 RUN mkdir -p /out/lib && \
     cd /out/lib && \

--- a/pkg/firmware/Dockerfile
+++ b/pkg/firmware/Dockerfile
@@ -33,7 +33,7 @@ RUN tar xf /kernel.tar
 # Copy files required by the modules
 RUN set -e && \
     for fw in $(find /lib/modules -name \*.ko -exec modinfo --field=firmware {} \;); do \
-        mkdir -p "/out/lib/firmware/$fw" && \
+        mkdir -p "/out/lib/firmware/$(dirname $fw)" && \
         cp "/linux-firmware/$fw" "/out/lib/firmware/$fw"; \
     done
 

--- a/pkg/firmware/Dockerfile
+++ b/pkg/firmware/Dockerfile
@@ -1,5 +1,5 @@
 # Make modules from a recentish kernel available
-FROM linuxkit/kernel:4.14.28 AS kernel
+FROM linuxkit/kernel:4.14.126 AS kernel
 
 FROM linuxkit/alpine:86cd4f51b49fb9a078b50201d892a3c7973d48ec AS build
 RUN apk add --no-cache git kmod

--- a/pkg/firmware/Dockerfile
+++ b/pkg/firmware/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache git kmod
 # Clone the firmware repository
 # Make sure you also update the FW_COMMIT in ../firmware-all/Dockerfile
 ENV FW_URL=git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
-ENV FW_COMMIT=9ee52be785cf91fc6a3c6aa27d484873f8270b72
+ENV FW_COMMIT=dff98c6c57383fe343407bcb7b6e775e0b87274f
 WORKDIR /
 RUN git clone ${FW_URL} && \
     cd /linux-firmware && \


### PR DESCRIPTION
The `linuxkit/firmware` package stored firmware in `/lib/firmware/<driver>/<fw-image>/<fw-image>` when it should have stored it in `/lib/firmware/<driver>/<fw-image>`.

This fixes https://github.com/linuxkit/linuxkit/issues/3392

While at it, also use a newer kernel to figure out which modules to install and update to the latest firmware images.

![image](https://user-images.githubusercontent.com/3338098/62334528-ec6f9680-b4bf-11e9-80df-a9f92da63490.png)
