### PR TITLE
Add trust parameter for docker pull in moby.Formats

### DIFF
--- a/src/cmd/linuxkit/build.go
+++ b/src/cmd/linuxkit/build.go
@@ -216,7 +216,7 @@ func build(args []string) {
 		}
 
 		log.Infof("Create outputs:")
-		err = moby.Formats(filepath.Join(*buildDir, name), image, buildFormats, size)
+		err = moby.Formats(filepath.Join(*buildDir, name), image, buildFormats, size, !*buildDisableTrust)
 		if err != nil {
 			log.Fatalf("Error writing outputs: %v", err)
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

`dockerRun` method was called with trust=true only. `linuxkit build` didn't respect the `-disable-content-trust` parameter in the output phase.

Hopefully it will fix this error (even if a previous docker pull succeeded, even with content trust disabled):
`time="2019-08-07T18:01:02Z" level=fatal msg="Error writing outputs: Error writing kernel+iso output: docker pull linuxkit/mkimage-iso:3d81e29b28ddf739becf10758eb6077b198d26d8 failed: exit status 1 output:\n"`

We have it once a day on the Docker Desktop CI.

**- How I did it**

Pass the trust parameter.

**- How to verify it**

`linuxkit -v build` with and without parameter `-disable-content-trust`. A log will appear when creating output.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/172624/62657852-af941b80-b967-11e9-8f96-d0d05757db75.png)

