### PR TITLE
Metadata: add support for loading from a file

### DIFF
--- a/pkg/metadata/provider_file.go
+++ b/pkg/metadata/provider_file.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+type fileProvider string
+
+func (p fileProvider) String() string {
+	return string(p)
+}
+
+func (p fileProvider) Probe() bool {
+	_, err := os.Stat(string(p))
+	return err == nil
+}
+
+func (p fileProvider) Extract() ([]byte, error) {
+	return ioutil.ReadFile(string(p))
+}


### PR DESCRIPTION
**- What I did**
This adds a new configuration provider that just reads a file.
This is needed for Docker Desktop, where we will run a LinuxKit distro in an isolated namespace within WSL 2.
In this scenario, the config will be accessible trough the WSL2 built-in 9p mount of the Windows filesystem.

**- How I did it**
If no provider match the first command line argument, and there is an actual file at this location, it directly read the json payload from it

**- How to verify it**
- Create a LinuxKit image with a static config file in it
- Add an onboot metadata service passing the path to this file as an argument
- Check that /run/config is correctly populated

**- Description for the changelog**

Machine configuration can now be read directly from a file

**- A picture of a cute animal (not mandatory but encouraged)**

![animal](https://www.ancient-code.com/wp-content/uploads/2016/06/Octo-1024x767.jpg)
