### PR TITLE
Update to containerd v1.2.8

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.88
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.14.88
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.7 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   # support metadata for optional config in /run/config

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: dhcpcd

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
   - linuxkit/memlogd:v0.7
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
 services:
   - name: getty
     image: linuxkit/getty:v0.7

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
   - linuxkit/firmware:e246ab4c77bc4e70b53db091371a699fced5e01d
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.50-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/static-ip.yml
+++ b/examples/static-ip.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
 onboot:
   - name: ip
     image: linuxkit/ip:v0.7

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.38
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:27df8a8be139cd19cd7348c21efca8843b424f2b as alpine
+FROM linuxkit/alpine:3fdc49366257e53276c6f363956a4353f95d9a81 as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:27df8a8be139cd19cd7348c21efca8843b424f2b AS build
+FROM linuxkit/alpine:3fdc49366257e53276c6f363956a4353f95d9a81 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -16,7 +16,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:27df8a8be139cd19cd7348c21efca8843b424f2b AS mirror
+FROM linuxkit/alpine:3fdc49366257e53276c6f363956a4353f95d9a81 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.7

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/src/cmd/linuxkit/moby/linuxkit.go
+++ b/src/cmd/linuxkit/moby/linuxkit.go
@@ -17,7 +17,7 @@ kernel:
   image: linuxkit/kernel:4.9.39
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: mkimage

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: dhcpcd

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
 
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
 services:
   - name: acpid
     image: linuxkit/acpid:v0.7

--- a/test/cases/020_kernel/001_config_4.9.x/test.yml
+++ b/test/cases/020_kernel/001_config_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.181
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/002_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/002_config_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.126
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/005_config_4.19.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.19.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/008_config_5.1.x/test.yml
+++ b/test/cases/020_kernel/008_config_5.1.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.1.10
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/011_kmod_4.9.x/test.yml
+++ b/test/cases/020_kernel/011_kmod_4.9.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.181
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: check

--- a/test/cases/020_kernel/012_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/012_kmod_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.126
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: check

--- a/test/cases/020_kernel/015_kmod_4.19.x/test.yml
+++ b/test/cases/020_kernel/015_kmod_4.19.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: check

--- a/test/cases/020_kernel/018_kmod_5.1.x/test.yml
+++ b/test/cases/020_kernel/018_kmod_5.1.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.1.10
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: check

--- a/test/cases/020_kernel/110_namespace/common.yml
+++ b/test/cases/020_kernel/110_namespace/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/002_bpftrace/test.yml
+++ b/test/cases/040_packages/002_bpftrace/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
   - linuxkit/bpftrace:v0.7
 onboot:

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
   - linuxkit/ca-certificates:v0.7
 onboot:

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:v0.7
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:3ccfd47993b159ab2ffc2a4cd8309b1cc67790df
+    image: linuxkit/test-containerd:ac28577db835db4a87b6ba390ad15f3369c1585a
   - name: poweroff
     image: linuxkit/poweroff:b498d30dd9660090565537fceb9e757618737a85
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.88
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.88
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/004_dm-crypt/002_key/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/002_key/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.88
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/012_losetup/test.yml
+++ b/test/cases/040_packages/012_losetup/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.88
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: losetup

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
   - linuxkit/memlogd:v0.7
 services:

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
   - linuxkit/ca-certificates:v0.7
   - linuxkit/memlogd:v0.7
 services:

--- a/test/cases/040_packages/032_bcc/test.yml
+++ b/test/cases/040_packages/032_bcc/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
   - linuxkit/kernel-bcc:4.19.51
 onboot:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
-  - linuxkit/containerd:2e7e59b8af98a1cec834dc9fe7aba271bf4b0a41
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.7

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:27df8a8be139cd19cd7348c21efca8843b424f2b AS mirror
+FROM linuxkit/alpine:3fdc49366257e53276c6f363956a4353f95d9a81 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.19.51
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1a0c6b624708b5a9e58b9a608a9ce3164e7b2908
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: test-ns

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -56,7 +56,7 @@ RUN go get -u github.com/LK4D4/vndr
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.2.7
+ENV CONTAINERD_COMMIT=v1.2.8
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:702c43e92506b4cd8db758153d26bd04a726f4af-arm64
+# linuxkit/alpine:8248d6dfb13af56f24ac1066c9d77173f9cacfa7-arm64
 # automatically generated list of installed packages
 abuild-3.3.1-r0
 alpine-baselayout-3.1.0-r3
@@ -27,7 +27,7 @@ btrfs-progs-libs-4.19.1-r0
 build-base-0.5-r1
 busybox-1.29.3-r10
 busybox-initscripts-3.1-r6
-bzip2-1.0.6-r6
+bzip2-1.0.6-r7
 ca-certificates-20190108-r0
 ca-certificates-cacert-20190108-r0
 cdrkit-1.1.11-r2
@@ -62,7 +62,7 @@ elfutils-libelf-0.168-r2
 ethtool-4.19-r0
 eudev-3.2.7-r0
 eudev-libs-3.2.7-r0
-expat-2.2.6-r0
+expat-2.2.7-r0
 expect-5.45.4-r0
 fakeroot-1.23-r0
 file-5.36-r0
@@ -113,18 +113,18 @@ krb5-libs-1.15.5-r0
 krb5-server-ldap-1.15.5-r0
 libacl-2.2.52-r5
 libaio-0.3.111-r0
-libarchive-3.3.2-r4
-libarchive-tools-3.3.2-r4
+libarchive-3.3.3-r0
+libarchive-tools-3.3.3-r0
 libassuan-2.5.1-r0
 libatomic-8.3.0-r0
 libattr-2.4.47-r7
 libblkid-2.33-r0
 libbsd-0.8.6-r2
 libburn-1.5.0-r0
-libbz2-1.0.6-r6
+libbz2-1.0.6-r7
 libc-dev-0.7.1-r0
 libc-utils-0.7.1-r0
-libc6-compat-1.1.20-r4
+libc6-compat-1.1.20-r5
 libcap-2.26-r0
 libcap-ng-0.7.9-r1
 libcap-ng-dev-0.7.9-r1
@@ -143,14 +143,14 @@ libexecinfo-dev-1.1-r0
 libfdisk-2.33-r0
 libffi-3.2.1-r6
 libgcc-8.3.0-r0
-libgcrypt-1.8.4-r0
+libgcrypt-1.8.4-r1
 libgmpxx-6.1.2-r1
 libgomp-8.3.0-r0
 libgpg-error-1.33-r0
 libintl-0.19.8.1-r4
 libisoburn-1.4.8-r0
 libisofs-1.4.8-r0
-libjpeg-turbo-1.5.3-r4
+libjpeg-turbo-1.5.3-r5
 libksba-1.3.5-r0
 libldap-2.4.47-r2
 libltdl-2.4.6-r5
@@ -175,7 +175,7 @@ libsmartcols-2.33-r0
 libssh2-1.8.2-r0
 libssl1.1-1.1.1b-r1
 libstdc++-8.3.0-r0
-libtasn1-4.13-r0
+libtasn1-4.14-r0
 libtirpc-1.0.3-r0
 libtirpc-dev-1.0.3-r0
 libtls-standalone-2.7.4-r6
@@ -215,9 +215,9 @@ mpfr-dev-3.1.5-r1
 mpfr3-3.1.5-r1
 mtools-4.0.23-r0
 multipath-tools-0.7.9-r0
-musl-1.1.20-r4
-musl-dev-1.1.20-r4
-musl-utils-1.1.20-r4
+musl-1.1.20-r5
+musl-dev-1.1.20-r5
+musl-utils-1.1.20-r5
 ncurses-dev-6.1_p20190105-r0
 ncurses-libs-6.1_p20190105-r0
 ncurses-terminfo-6.1_p20190105-r0
@@ -240,7 +240,7 @@ openssl-1.1.1b-r1
 openssl-dev-1.1.1b-r1
 opus-1.3-r0
 p11-kit-0.23.14-r0
-patch-2.7.6-r4
+patch-2.7.6-r6
 pax-utils-1.2.3-r0
 pcre-8.42-r1
 pcre2-10.32-r1
@@ -289,7 +289,7 @@ tar-1.32-r0
 tcl-8.6.9-r0
 tcpdump-4.9.2-r4
 tini-0.18.0-r0
-tzdata-2019a-r0
+tzdata-2019b-r0
 udev-init-scripts-32-r2
 udev-init-scripts-openrc-32-r2
 usbredir-0.7.1-r0
@@ -300,12 +300,12 @@ vde2-libs-2.3.2-r10
 vim-8.1.1365-r0
 virglrenderer-0.7.0-r1
 wayland-libs-server-1.16.0-r0
-wireguard-tools-0.0.20190601-r1
-wireguard-tools-wg-0.0.20190601-r1
-wireguard-tools-wg-quick-0.0.20190601-r1
+wireguard-tools-0.0.20190702-r0
+wireguard-tools-wg-0.0.20190702-r0
+wireguard-tools-wg-quick-0.0.20190702-r0
 wireless-tools-30_pre9-r0
-wpa_supplicant-2.7-r3
-wpa_supplicant-openrc-2.7-r3
+wpa_supplicant-2.7-r4
+wpa_supplicant-openrc-2.7-r4
 xfsprogs-4.19.0-r1
 xfsprogs-extra-4.19.0-r1
 xorriso-1.4.8-r0

--- a/tools/alpine/versions.s390x
+++ b/tools/alpine/versions.s390x
@@ -1,4 +1,4 @@
-# linuxkit/alpine:f1bf0f44c405ad95b4fd63ca6b1112169885bd9f-s390x
+# linuxkit/alpine:62e881bbdb89c56d7de3e1f697c745d6f8c7c48d-s390x
 # automatically generated list of installed packages
 abuild-3.3.1-r0
 alpine-baselayout-3.1.0-r3
@@ -27,7 +27,7 @@ btrfs-progs-libs-4.19.1-r0
 build-base-0.5-r1
 busybox-1.29.3-r10
 busybox-initscripts-3.1-r6
-bzip2-1.0.6-r6
+bzip2-1.0.6-r7
 ca-certificates-20190108-r0
 ca-certificates-cacert-20190108-r0
 cdrkit-1.1.11-r2
@@ -62,7 +62,7 @@ elfutils-libelf-0.168-r2
 ethtool-4.19-r0
 eudev-3.2.7-r0
 eudev-libs-3.2.7-r0
-expat-2.2.6-r0
+expat-2.2.7-r0
 expect-5.45.4-r0
 fakeroot-1.23-r0
 file-5.36-r0
@@ -113,18 +113,18 @@ krb5-libs-1.15.5-r0
 krb5-server-ldap-1.15.5-r0
 libacl-2.2.52-r5
 libaio-0.3.111-r0
-libarchive-3.3.2-r4
-libarchive-tools-3.3.2-r4
+libarchive-3.3.3-r0
+libarchive-tools-3.3.3-r0
 libassuan-2.5.1-r0
 libatomic-8.3.0-r0
 libattr-2.4.47-r7
 libblkid-2.33-r0
 libbsd-0.8.6-r2
 libburn-1.5.0-r0
-libbz2-1.0.6-r6
+libbz2-1.0.6-r7
 libc-dev-0.7.1-r0
 libc-utils-0.7.1-r0
-libc6-compat-1.1.20-r4
+libc6-compat-1.1.20-r5
 libcap-2.26-r0
 libcap-ng-0.7.9-r1
 libcap-ng-dev-0.7.9-r1
@@ -141,14 +141,14 @@ libevent-2.1.8-r6
 libfdisk-2.33-r0
 libffi-3.2.1-r6
 libgcc-8.3.0-r0
-libgcrypt-1.8.4-r0
+libgcrypt-1.8.4-r1
 libgmpxx-6.1.2-r1
 libgomp-8.3.0-r0
 libgpg-error-1.33-r0
 libintl-0.19.8.1-r4
 libisoburn-1.4.8-r0
 libisofs-1.4.8-r0
-libjpeg-turbo-1.5.3-r4
+libjpeg-turbo-1.5.3-r5
 libksba-1.3.5-r0
 libldap-2.4.47-r2
 libltdl-2.4.6-r5
@@ -173,7 +173,7 @@ libsmartcols-2.33-r0
 libssh2-1.8.2-r0
 libssl1.1-1.1.1b-r1
 libstdc++-8.3.0-r0
-libtasn1-4.13-r0
+libtasn1-4.14-r0
 libtirpc-1.0.3-r0
 libtirpc-dev-1.0.3-r0
 libtls-standalone-2.7.4-r6
@@ -209,9 +209,9 @@ mpfr-dev-3.1.5-r1
 mpfr3-3.1.5-r1
 mtools-4.0.23-r0
 multipath-tools-0.7.9-r0
-musl-1.1.20-r4
-musl-dev-1.1.20-r4
-musl-utils-1.1.20-r4
+musl-1.1.20-r5
+musl-dev-1.1.20-r5
+musl-utils-1.1.20-r5
 ncurses-dev-6.1_p20190105-r0
 ncurses-libs-6.1_p20190105-r0
 ncurses-terminfo-6.1_p20190105-r0
@@ -234,7 +234,7 @@ openssl-1.1.1b-r1
 openssl-dev-1.1.1b-r1
 opus-1.3-r0
 p11-kit-0.23.14-r0
-patch-2.7.6-r4
+patch-2.7.6-r6
 pax-utils-1.2.3-r0
 pcre-8.42-r1
 pcre2-10.32-r1
@@ -282,7 +282,7 @@ tar-1.32-r0
 tcl-8.6.9-r0
 tcpdump-4.9.2-r4
 tini-0.18.0-r0
-tzdata-2019a-r0
+tzdata-2019b-r0
 udev-init-scripts-32-r2
 udev-init-scripts-openrc-32-r2
 usbredir-0.7.1-r0
@@ -293,12 +293,12 @@ vde2-libs-2.3.2-r10
 vim-8.1.1365-r0
 virglrenderer-0.7.0-r1
 wayland-libs-server-1.16.0-r0
-wireguard-tools-0.0.20190601-r1
-wireguard-tools-wg-0.0.20190601-r1
-wireguard-tools-wg-quick-0.0.20190601-r1
+wireguard-tools-0.0.20190702-r0
+wireguard-tools-wg-0.0.20190702-r0
+wireguard-tools-wg-quick-0.0.20190702-r0
 wireless-tools-30_pre9-r0
-wpa_supplicant-2.7-r3
-wpa_supplicant-openrc-2.7-r3
+wpa_supplicant-2.7-r4
+wpa_supplicant-openrc-2.7-r4
 xfsprogs-4.19.0-r1
 xfsprogs-extra-4.19.0-r1
 xorriso-1.4.8-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:27df8a8be139cd19cd7348c21efca8843b424f2b-amd64
+# linuxkit/alpine:3fdc49366257e53276c6f363956a4353f95d9a81-amd64
 # automatically generated list of installed packages
 abuild-3.3.1-r0
 alpine-baselayout-3.1.0-r3
@@ -27,7 +27,7 @@ btrfs-progs-libs-4.19.1-r0
 build-base-0.5-r1
 busybox-1.29.3-r10
 busybox-initscripts-3.1-r6
-bzip2-1.0.6-r6
+bzip2-1.0.6-r7
 ca-certificates-20190108-r0
 ca-certificates-cacert-20190108-r0
 cdrkit-1.1.11-r2
@@ -62,7 +62,7 @@ elfutils-libelf-0.168-r2
 ethtool-4.19-r0
 eudev-3.2.7-r0
 eudev-libs-3.2.7-r0
-expat-2.2.6-r0
+expat-2.2.7-r0
 expect-5.45.4-r0
 fakeroot-1.23-r0
 file-5.36-r0
@@ -119,18 +119,18 @@ krb5-server-ldap-1.15.5-r0
 lddtree-1.26-r1
 libacl-2.2.52-r5
 libaio-0.3.111-r0
-libarchive-3.3.2-r4
-libarchive-tools-3.3.2-r4
+libarchive-3.3.3-r0
+libarchive-tools-3.3.3-r0
 libassuan-2.5.1-r0
 libatomic-8.3.0-r0
 libattr-2.4.47-r7
 libblkid-2.33-r0
 libbsd-0.8.6-r2
 libburn-1.5.0-r0
-libbz2-1.0.6-r6
+libbz2-1.0.6-r7
 libc-dev-0.7.1-r0
 libc-utils-0.7.1-r0
-libc6-compat-1.1.20-r4
+libc6-compat-1.1.20-r5
 libcap-2.26-r0
 libcap-ng-0.7.9-r1
 libcap-ng-dev-0.7.9-r1
@@ -149,14 +149,14 @@ libexecinfo-dev-1.1-r0
 libfdisk-2.33-r0
 libffi-3.2.1-r6
 libgcc-8.3.0-r0
-libgcrypt-1.8.4-r0
+libgcrypt-1.8.4-r1
 libgmpxx-6.1.2-r1
 libgomp-8.3.0-r0
 libgpg-error-1.33-r0
 libintl-0.19.8.1-r4
 libisoburn-1.4.8-r0
 libisofs-1.4.8-r0
-libjpeg-turbo-1.5.3-r4
+libjpeg-turbo-1.5.3-r5
 libksba-1.3.5-r0
 libldap-2.4.47-r2
 libltdl-2.4.6-r5
@@ -183,7 +183,7 @@ libsmartcols-2.33-r0
 libssh2-1.8.2-r0
 libssl1.1-1.1.1b-r1
 libstdc++-8.3.0-r0
-libtasn1-4.13-r0
+libtasn1-4.14-r0
 libtirpc-1.0.3-r0
 libtirpc-dev-1.0.3-r0
 libtls-standalone-2.7.4-r6
@@ -224,9 +224,9 @@ mpfr-dev-3.1.5-r1
 mpfr3-3.1.5-r1
 mtools-4.0.23-r0
 multipath-tools-0.7.9-r0
-musl-1.1.20-r4
-musl-dev-1.1.20-r4
-musl-utils-1.1.20-r4
+musl-1.1.20-r5
+musl-dev-1.1.20-r5
+musl-utils-1.1.20-r5
 ncurses-dev-6.1_p20190105-r0
 ncurses-libs-6.1_p20190105-r0
 ncurses-terminfo-6.1_p20190105-r0
@@ -252,7 +252,7 @@ openssl-dev-1.1.1b-r1
 opus-1.3-r0
 ovmf-0.0.20170624-r0
 p11-kit-0.23.14-r0
-patch-2.7.6-r4
+patch-2.7.6-r6
 pax-utils-1.2.3-r0
 pcre-8.42-r1
 pcre2-10.32-r1
@@ -301,7 +301,7 @@ tar-1.32-r0
 tcl-8.6.9-r0
 tcpdump-4.9.2-r4
 tini-0.18.0-r0
-tzdata-2019a-r0
+tzdata-2019b-r0
 udev-init-scripts-32-r2
 udev-init-scripts-openrc-32-r2
 usbredir-0.7.1-r0
@@ -312,12 +312,12 @@ vde2-libs-2.3.2-r10
 vim-8.1.1365-r0
 virglrenderer-0.7.0-r1
 wayland-libs-server-1.16.0-r0
-wireguard-tools-0.0.20190601-r1
-wireguard-tools-wg-0.0.20190601-r1
-wireguard-tools-wg-quick-0.0.20190601-r1
+wireguard-tools-0.0.20190702-r0
+wireguard-tools-wg-0.0.20190702-r0
+wireguard-tools-wg-quick-0.0.20190702-r0
 wireless-tools-30_pre9-r0
-wpa_supplicant-2.7-r3
-wpa_supplicant-openrc-2.7-r3
+wpa_supplicant-2.7-r4
+wpa_supplicant-openrc-2.7-r4
 xfsprogs-4.19.0-r1
 xfsprogs-extra-4.19.0-r1
 xorriso-1.4.8-r0


### PR DESCRIPTION
This should unlock the issue we have seen with newer Linux kernels, e.g., https://github.com/linuxkit/linuxkit/pull/3387.

![puffin](https://user-images.githubusercontent.com/3338098/63650597-2e4ccf00-c744-11e9-8fca-f7f38e8d9e44.jpeg)
