### PR TITLE
Add docker-standard ftp_proxy + socks-standard all_proxy env vars

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -151,3 +151,27 @@ linuxkit pkg build -org=wombat -disable-content-trust -hash=foo push
 
 and this will create `wombat/<image>:foo-<arch>` and
 `wombat/<image>:foo` for use in your YAML files.
+
+### Proxies
+
+If you are building packages from behind a proxy, `linuxkit pkg build` respects
+the following environment variables, and will set them as `--build-arg` to
+`docker build` when building a package.
+
+* `http_proxy` / `HTTP_PROXY`
+* `https_proxy` / `HTTPS_PROXY`
+* `ftp_proxy` / `FTP_PROXY`
+* `no_proxy` / `NO_PROXY`
+* `all_proxy` / `ALL_PROXY`
+
+Note that the first four of these are the standard built-in `build-arg` options available
+for `docker build`; see the [docker build documentation](https://docs.docker.com/v17.09/engine/reference/builder/#arg).
+The last, `all_proxy`, is a standard var used for socks proxying. Since it is not built into `docker build`,
+if you want to use it, you will need to add the following line to the dockerfile:
+
+```dockerfile
+ARG all_proxy
+```
+
+Linuxkit does not judge between lower-cased or upper-cased variants of these options, e.g. `http_proxy` vs `HTTP_PROXY`,
+as `docker build` does not either. It just passes them through "as-is".


### PR DESCRIPTION
Also accepts upper-case `FTP_PROXY` or `ALL_PROXY`
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

We already support `http_proxy`/`HTTP_PROXY`, `https_proxy`/`HTTPS_PROXY`, `no_proxy`/`NO_PROXY` env vars to add build args. This does:

1. Adds support for `ftp_proxy` docker standard build-arg
2. Adds support for non-docker standard but socks standard `all_proxy`/`ALL_PROXY`
3. Adds documentation about using proxies when building
4. Fixes bug in building args wherein if build args are present, has them twice and overrides existing args.

**- How I did it**

Changed `src/cmd/linuxkit/pkglib/docker.go` and `docs/packages.md`

**- How to verify it**

Run `lkt pkg build` with the env vars set and `-v` to see the output

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixes bug in package building; adds support for more proxy variables.


