### PR TITLE
Move microcode download earlier in Dockerfile

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -64,6 +64,26 @@ RUN KERNEL_MAJOR=$(echo ${KERNEL_VERSION} | cut -d . -f 1) && \
     gpg2 --verify linux-${KERNEL_VERSION}.tar.sign linux-${KERNEL_VERSION}.tar && \
     cat linux-${KERNEL_VERSION}.tar | tar --absolute-names -x && mv /linux-${KERNEL_VERSION} /linux
 
+
+RUN mkdir -p /out/src
+
+WORKDIR /tmp
+# Download Intel ucode, create a CPIO archive for it, and keep it in the build context
+# so the firmware can also be referenced with CONFIG_EXTRA_FIRMWARE
+ENV UCODE_REPO=https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files
+ENV UCODE_COMMIT=1dd14da6d1ea5cfbd95923653f31c04aac3aa655
+RUN set -e && \
+    if [ $(uname -m) == x86_64 ]; then \
+        git clone ${UCODE_REPO} ucode && \
+        cd ucode && \
+        git checkout ${UCODE_COMMIT} && \
+        iucode_tool --normal-earlyfw --write-earlyfw=/out/intel-ucode.cpio ./intel-ucode && \
+        cp license /out/intel-ucode-license.txt && \
+        mkdir -p /lib/firmware && \
+        cp -rav ./intel-ucode /lib/firmware; \
+    fi
+
+
 WORKDIR /linux
 # Apply local specific patches if present
 RUN set -e && \
@@ -84,7 +104,7 @@ RUN set -e && \
         done; \
     fi
 
-RUN mkdir -p /out/src
+
 
 # Save kernel source
 RUN tar cJf /out/src/linux.tar.xz /linux
@@ -179,17 +199,6 @@ RUN DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdept
 
 RUN printf "KERNEL_SOURCE=${KERNEL_SOURCE}\n" > /out/kernel-source-info
 
-# Download Intel ucode and create a CPIO archive for it
-ENV UCODE_REPO=https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files
-ENV UCODE_COMMIT=1dd14da6d1ea5cfbd95923653f31c04aac3aa655
-RUN set -e && \
-    if [ $(uname -m) == x86_64 ]; then \
-        git clone ${UCODE_REPO} ucode && \
-        cd ucode && \
-        git checkout ${UCODE_COMMIT} && \
-        iucode_tool --normal-earlyfw --write-earlyfw=/out/intel-ucode.cpio ./intel-ucode && \
-        cp license /out/intel-ucode-license.txt; \
-    fi
 
 FROM scratch
 ENTRYPOINT []


### PR DESCRIPTION
**- What I did**
Make Intel microcode available for static build in the kernel using `CONFIG_EXTRA_FIRMWARE`

**- How I did it**
Move the code downloading Intel microcode in `kernel/Dockerfile` earlier in the process, and copy it to `/lib/firmware` where Linux build system will look for it.
It is still copied in the `out/` directory and so that it is still available for addition in a 'ucode:' section in linuxkit.yml

**- How to verify it**

Build a kernel with, for instance: 
```
CONFIG_EXTRA_FIRMWARE="intel-ucode/06-03-02"
```
and verify that it doesn't complain.

**- Description for the changelog**
Move microcode download earlier in Dockerfile so it's available to `CONFIG_EXTRA_FIRMWARE`.

**- A picture of a cute animal (not mandatory but encouraged)**

![hedgehog-1215140_960_720](https://user-images.githubusercontent.com/636005/65419434-f0a09c00-ddfe-11e9-850c-f3cc14e7e042.jpg)
