### PR TITLE
Fix label argument mkfs.btrfs

### DIFF
--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -15,7 +15,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:v0.7
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
   - name: mount
     image: linuxkit/mount:v0.7
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "/dev/sda"]
   - name: mount
     image: linuxkit/mount:v0.7

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "/dev/sda"]
   - name: dm-crypt
     image: linuxkit/dm-crypt:v0.7

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -20,7 +20,7 @@ onboot:
     image: linuxkit/binfmt:v0.7
   # Format and mount the disk image in /var/lib/docker
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
   - name: mount
     image: linuxkit/mount:v0.7
     command: ["/usr/bin/mountie", "/var/lib"]

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -12,7 +12,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:v0.7
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
   - name: mount
     image: linuxkit/mount:v0.7
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
   - name: mount
     image: linuxkit/mount:v0.7
     command: ["/usr/bin/mountie", "/var/external"]

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -197,7 +197,7 @@ func format(d, label, fsType string, forced bool) error {
 	case "btrfs":
 		btrfsArgs := []string{"-f"}
 		if label != "" {
-			btrfsArgs = append(btrfsArgs, []string{"-l", label}...)
+			btrfsArgs = append(btrfsArgs, []string{"-L", label}...)
 		}
 		mkfsArgs = append(mkfsArgs, btrfsArgs...)
 	case "xfs":

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -15,7 +15,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
   - name: mount
     image: linuxkit/mount:v0.7
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -15,7 +15,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.7
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
   - name: mount
     image: linuxkit/mount:v0.7
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -12,7 +12,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:v0.7
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
   - name: mount
     image: linuxkit/mount:v0.7
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -13,7 +13,7 @@ onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.7
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
   - name: mount
     image: linuxkit/mount:v0.7
     command: ["/usr/bin/mountie", "/var/lib"]

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
   - name: mount
     image: linuxkit/mount:v0.7
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/modprobe:v0.7
     command: ["modprobe", "btrfs"]
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
     image: linuxkit/mount:v0.7

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "-type", "xfs"]
   - name: mount
     image: linuxkit/mount:v0.7

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format"]
   - name: mount
     image: linuxkit/mount:v0.7

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "-label", "docker"]
   - name: mount
     image: linuxkit/mount:v0.7

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "@DEVICE@"]
   - name: mount
     image: linuxkit/mount:v0.7

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/modprobe:v0.7
     command: ["modprobe", "btrfs"]
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
     image: linuxkit/mount:v0.7

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "-type", "xfs" ]
   - name: mount
     image: linuxkit/mount:v0.7

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -6,19 +6,19 @@ init:
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "-verbose", "-type", "ext4", "/dev/sda"]
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "-verbose", "-type", "ext4", "/dev/sdb"]
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "-verbose", "-type", "xfs", "/dev/sda"]
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "-verbose", "-force", "-type", "xfs", "/dev/sdb"]
   - name: test
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     binds:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -6,10 +6,10 @@ init:
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "-label", "docker"]
   - name: format
-    image: linuxkit/format:v0.7
+    image: linuxkit/format:65b9e0a76d0b9fb8ac5c5f3bc8d3131109290f56
     command: ["/usr/bin/format", "-label", "foo"]
   - name: mount
     image: linuxkit/mount:v0.7


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I changed the `-l` flag to `-L` because in the current version (`v.0.7`) of `LinuxKit/format` the `mkfs.btrfs` `-l` flag means 'leafsize'. The `-L` flag means label

**- How I did it**
n/a

**- How to verify it**
Verified the fix on a local build.

**- Description for the changelog**
Fix label argument mkfs.btrfs


**- A picture of a cute animal (not mandatory but encouraged)**
![Sloth](https://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-34.jpg)
