### PR TITLE
Build with go 1.11.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/linuxkit/linuxkit
     docker:
-      - image: circleci/golang:1.11-stretch
+      - image: circleci/golang:1.11.12-stretch
     steps:
       - checkout
       - run: mkdir -p ./bin


### PR DESCRIPTION
**- What I did**

golang 1.11.13 introduced a check for invalid port in `URL.parse()`. See https://github.com/golang/go/issues?q=milestone%3AGo1.11.13

Force circleci to use go 1.11.12 until a proper fix is written.

Currently, `linuxkit build redis-os.yml` fails with error: `FATA[0000] Invalid config: extract service image reference: parse dummy://redis:4.0.5-alpine: invalid port ":4.0.5-alpine" after host`

@rn feel free to close, it was just to start a discussion. I don't exactly know where the fix should be.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/172624/65860038-bc326000-e369-11e9-942d-2b63ee75d81e.png)

