### PR TITLE
Expand all image references before passing to containerd reference.Parse

### DIFF
--- a/src/cmd/linuxkit/moby/config.go
+++ b/src/cmd/linuxkit/moby/config.go
@@ -168,37 +168,50 @@ func uniqueServices(m Moby) error {
 	return nil
 }
 
+// referenceExpand expands "redis" to "docker.io/library/redis" so all images have a full domain
+func referenceExpand(ref string) string {
+	parts := strings.Split(ref, "/")
+	switch len(parts) {
+	case 1:
+		return "docker.io/library/" + ref
+	case 2:
+		return "docker.io/" + ref
+	default:
+		return ref
+	}
+}
+
 func extractReferences(m *Moby) error {
 	if m.Kernel.Image != "" {
-		r, err := reference.Parse(m.Kernel.Image)
+		r, err := reference.Parse(referenceExpand(m.Kernel.Image))
 		if err != nil {
 			return fmt.Errorf("extract kernel image reference: %v", err)
 		}
 		m.Kernel.ref = &r
 	}
 	for _, ii := range m.Init {
-		r, err := reference.Parse(ii)
+		r, err := reference.Parse(referenceExpand(ii))
 		if err != nil {
 			return fmt.Errorf("extract on boot image reference: %v", err)
 		}
 		m.initRefs = append(m.initRefs, &r)
 	}
 	for _, image := range m.Onboot {
-		r, err := reference.Parse(image.Image)
+		r, err := reference.Parse(referenceExpand(image.Image))
 		if err != nil {
 			return fmt.Errorf("extract on boot image reference: %v", err)
 		}
 		image.ref = &r
 	}
 	for _, image := range m.Onshutdown {
-		r, err := reference.Parse(image.Image)
+		r, err := reference.Parse(referenceExpand(image.Image))
 		if err != nil {
 			return fmt.Errorf("extract on shutdown image reference: %v", err)
 		}
 		image.ref = &r
 	}
 	for _, image := range m.Services {
-		r, err := reference.Parse(image.Image)
+		r, err := reference.Parse(referenceExpand(image.Image))
 		if err != nil {
 			return fmt.Errorf("extract service image reference: %v", err)
 		}


### PR DESCRIPTION
Short references without domains will now fail parsing on recent versions
of Go as net/url parser is more strict.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

replace #3419 as this is a proper fix.

![Domestic_Goose](https://user-images.githubusercontent.com/482364/65873877-34a21c80-e37c-11e9-90ed-9e66c633b5f5.jpg)
