### PR TITLE
Add Hetzner provider in the metadata package

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -101,6 +101,14 @@ hostname and populate the `/run/config/ssh/authorized_keys` from metadata.
 AWS userdata is extracted from `http://169.254.169.254/latest/user-data` and
 and made available in `/run/config/userdata`.
 
+## Hetzner
+
+Hetzner metadata is reached via the following URL
+(`http://169.254.169.254/latest/meta-data/`) and currently we extract the
+hostname and populate the `/run/config/ssh/authorized_keys` from metadata.
+
+Hetzner userdata is extracted from `http://169.254.169.254/latest/user-data` and
+and made available in `/run/config/userdata`.
 
 ## HyperKit
 

--- a/examples/hetzner.yml
+++ b/examples/hetzner.yml
@@ -1,0 +1,39 @@
+kernel:
+  image: linuxkit/kernel:4.19.71
+  cmdline: console=ttyS1
+  ucode: intel-ucode.cpio
+init:
+  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
+  - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
+  - linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc
+  - linuxkit/ca-certificates:v0.7
+  - linuxkit/firmware:e246ab4c77bc4e70b53db091371a699fced5e01d
+onboot:
+  - name: rngd1
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
+    command: ["/sbin/rngd", "-1"]
+  - name: sysctl
+    image: linuxkit/sysctl:v0.7
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:v0.7
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+  - name: metadata
+    image: linuxkit/metadata:fc88e2104ef06d0bf467181da7088fc06e60b6f7
+    command: ["/usr/bin/metadata", "hetzner"]
+services:
+  - name: rngd
+    image: linuxkit/rngd:02c555b50cd1887aa628836662d2eec54c0d7e81
+  - name: getty
+    image: linuxkit/getty:v0.7
+    env:
+     - INSECURE=true
+  - name: sshd
+    image: linuxkit/sshd:v0.7
+files:
+  - path: root/.ssh/authorized_keys
+    source: ~/.ssh/id_rsa.pub
+    mode: "0600"
+    optional: true
+trust:
+  org:
+    - linuxkit

--- a/pkg/metadata/main.go
+++ b/pkg/metadata/main.go
@@ -45,7 +45,7 @@ var netProviders []Provider
 var cdromProviders []Provider
 
 func main() {
-	providers := []string{"aws", "gcp", "openstack", "scaleway", "vultr", "packet", "cdrom"}
+	providers := []string{"aws", "gcp", "hetzner", "openstack", "scaleway", "vultr", "packet", "cdrom"}
 	if len(os.Args) > 1 {
 		providers = os.Args[1:]
 	}
@@ -55,6 +55,8 @@ func main() {
 			netProviders = append(netProviders, NewAWS())
 		case "gcp":
 			netProviders = append(netProviders, NewGCP())
+		case "hetzner":
+			netProviders = append(netProviders, NewHetzner())
 		case "openstack":
 			netProviders = append(netProviders, NewOpenstack())
 		case "packet":

--- a/pkg/metadata/provider_hetzner.go
+++ b/pkg/metadata/provider_hetzner.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"time"
+)
+
+// ProviderHetzner is the type implementing the Provider interface for Hetzner
+type ProviderHetzner struct {
+}
+
+// NewHetzner returns a new ProviderHetzner
+func NewHetzner() *ProviderHetzner {
+	return &ProviderHetzner{}
+}
+
+func (p *ProviderHetzner) String() string {
+	return "Hetzner"
+}
+
+// Probe checks if we are running on Hetzner
+func (p *ProviderHetzner) Probe() bool {
+	// Getting the hostname should always work...
+	_, err := hetznerGet(metaDataURL + "hostname")
+	return (err == nil)
+}
+
+// Extract gets both the Hetzner specific and generic userdata
+func (p *ProviderHetzner) Extract() ([]byte, error) {
+	// Get host name. This must not fail
+	hostname, err := hetznerGet(metaDataURL + "hostname")
+	if err != nil {
+		return nil, err
+	}
+	err = ioutil.WriteFile(path.Join(ConfigPath, Hostname), hostname, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("Hetzner: Failed to write hostname: %s", err)
+	}
+
+	// public ipv4
+	hetznerMetaGet("public-ipv4", "public_ipv4", 0644)
+
+	// private ipv4
+	hetznerMetaGet("local-ipv4", "local_ipv4", 0644)
+
+	// instance-id
+	hetznerMetaGet("instance-id", "instance_id", 0644)
+
+	// // local-hostname
+	// hetznerMetaGet("local-hostname", "local_hostname", 0644)
+
+	// ssh
+	if err := p.handleSSH(); err != nil {
+		log.Printf("Hetzner: Failed to get ssh data: %s", err)
+	}
+
+	// Generic userdata
+	userData, err := hetznerGet(userDataURL)
+	if err != nil {
+		log.Printf("Hetzner: Failed to get user-data: %s", err)
+		// This is not an error
+		return nil, nil
+	}
+	return userData, nil
+}
+
+// lookup a value (lookupName) in hetzner metaservice and store in given fileName
+func hetznerMetaGet(lookupName string, fileName string, fileMode os.FileMode) {
+	if lookupValue, err := hetznerGet(metaDataURL + lookupName); err == nil {
+		// we got a value from the metadata server, now save to filesystem
+		err = ioutil.WriteFile(path.Join(ConfigPath, fileName), lookupValue, fileMode)
+		if err != nil {
+			// we couldn't save the file for some reason
+			log.Printf("Hetzner: Failed to write %s:%s %s", fileName, lookupValue, err)
+		}
+	} else {
+		// we did not get a value back from the metadata server
+		log.Printf("Hetzner: Failed to get %s: %s", lookupName, err)
+	}
+}
+
+// hetznerGet requests and extracts the requested URL
+func hetznerGet(url string) ([]byte, error) {
+	var client = &http.Client{
+		Timeout: time.Second * 2,
+	}
+
+	req, err := http.NewRequest("", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Hetzner: http.NewRequest failed: %s", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Hetzner: Could not contact metadata service: %s", err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Hetzner: Status not ok: %d", resp.StatusCode)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Hetzner: Failed to read http response: %s", err)
+	}
+	return body, nil
+}
+
+// SSH keys:
+func (p *ProviderHetzner) handleSSH() error {
+	sshKeysJSON, err := hetznerGet(metaDataURL + "public-keys")
+	if err != nil {
+		return fmt.Errorf("Failed to get sshKeys: %s", err)
+	}
+
+	var sshKeys []string
+	err = json.Unmarshal(sshKeysJSON, &sshKeys)
+	if err != nil {
+		return fmt.Errorf("Failed to get sshKeys: %s", err)
+	}
+
+	if err := os.Mkdir(path.Join(ConfigPath, SSH), 0755); err != nil {
+		return fmt.Errorf("Failed to create %s: %s", SSH, err)
+	}
+
+	fileHandle, _ := os.OpenFile(path.Join(ConfigPath, SSH, "authorized_keys"), os.O_CREATE|os.O_APPEND, 0600)
+	writer := bufio.NewWriter(fileHandle)
+	defer fileHandle.Close()
+
+	for _, sshKey := range sshKeys {
+		_, err = fmt.Fprintln(writer, sshKey)
+		if err != nil {
+			return fmt.Errorf("Failed to write ssh keys: %s", err)
+		}
+	}
+
+	writer.Flush()
+	return nil
+}


### PR DESCRIPTION
The title of the PR is pretty self-explanatory 😜

I copied the AWS provider file and removed a few lines that get metadata that's not available on Hetzner and updated the function `handleSSH` to parse the JSON array of ssh keys Hetzner provides and for each key write it to the authorized_keys file on a new line.

I'm not a Go developer so I might have missed something obvious, etc. so please do a proper review before merging 😄