### PR TITLE
Fix the Scaleway provider in the metadata package

### DIFF
--- a/pkg/metadata/provider_scaleway.go
+++ b/pkg/metadata/provider_scaleway.go
@@ -210,11 +210,11 @@ func scalewayGetUserdata() ([]byte, error) {
 		return nil, errors.New("not able to found a free port below 1024")
 	}
 	defer conn.Close()
-	fmt.Fprintf(conn, "GET /user_data HTTP/1.0\r\n\r\n")
+	fmt.Fprintf(conn, "GET /user_data/cloud-init HTTP/1.0\r\n\r\n")
 
 	reader := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(reader, nil)
-	if err != nil {
+	if err != nil || resp.StatusCode == 404 {
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -245,10 +245,7 @@ func (p *ProviderScaleway) handleSSH(metadata []byte) error {
 		}
 
 		line := string(bytes.Trim(sshKey, "'"))
-		parts := strings.SplitN(line, " ", 2)
-		if len(parts) == 2 {
-			rootKeys = rootKeys + parts[1] + "\n"
-		}
+		rootKeys = rootKeys + line + "\n"
 	}
 
 	if err := os.Mkdir(path.Join(ConfigPath, SSH), 0755); err != nil {


### PR DESCRIPTION
Currently the Scaleway provider in the `metadata` package isn't working as expected, at least for me in k3os, which is using that package.

This will update the provider to use the endpoint `.../user_data/cloud-init` where the cloud-init data is served if it was provided. This is also the endpoint the python cloud-init scaleway provider is using from what I could tell. If no cloud-init data was provided this request will return a 404 and check for that in this fix so that we don't get an error if there is no cloud-init data.

This will also remove some code that stripped away the `ssh-rsa`/`ssh-dsa` part in the SSH keys, as no other provider code does that and a complete ssh key should include that part, as least to my knowledge.