### PR TITLE
swap: speed up by preferring a 1MiB blocksize

### DIFF
--- a/pkg/swap/swap.sh
+++ b/pkg/swap/swap.sh
@@ -123,7 +123,12 @@ fi
 
 if [ ! -f $path ] || ! [ $(stat -c "%s" $path) == $(disksize_to_count 1 $size) ]; then
 	## Allocate the file
-	dd if=/dev/zero of=$path bs=1024 count=$(disksize_to_count 1024 $size)
+	## If possible use a large blocksize:
+	bs=1048576 # 1 MiB
+	if [ "$size" -lt "$bs" ]; then
+		bs=1024 # fall back to 1KiB
+	fi
+	dd if=/dev/zero of=$path bs=$bs count=$(disksize_to_count $bs $size)
 	chmod 0600 $path
 
 	## was it encrypted? use cryptsetup and get the mapped device


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Sped up the swapfile creation.

**- How I did it**

If the swap disk is larger than 1MiB, then use a 1MiB blocksize in `dd`

On my machine using a large block size speeds up swap file creation:

```
/ # time dd if=/dev/zero of=output bs=1024 count=1048576
1048576+0 records in
1048576+0 records out
real    0m 4.61s
user    0m 0.79s
sys     0m 3.77s
/ # time dd if=/dev/zero of=output bs=1048576 count=1024
1024+0 records in
1024+0 records out
real    0m 1.06s
user    0m 0.00s
sys     0m 1.04s
```

**- How to verify it**

I added a debug print to display the `dd` command-line

1. small sizes are created correctly, 2048 is written as 2 blocks of 1024:
```
$ docker run -it -v $(pwd):/foo -w /foo alpine sh
/foo # ls
Dockerfile  README.md   build.yml   swap.sh
/foo # ./swap.sh --path /var/foo --size 2048
2+0 records in
2+0 records out
dd if=/dev/zero of=/var/foo bs=1024 count=2
mkswap: image is too small
/foo # ls -l /var/foo
-rw-------    1 root     root          2048 Nov 22 20:42 /var/foo
```
2. larger sizes are created correctly, 10485760 is written as 10 blocks of 1048576:
```
/foo # ./swap.sh --path /var/foo --size 10485760
10+0 records in
10+0 records out
dd if=/dev/zero of=/var/foo bs=1048576 count=10
Setting up swapspace version 1, size = 10481664 bytes
UUID=3790b429-1550-4a6f-9b7f-0ba78e787787
swapon: /var/foo: Operation not permitted
/foo # ls -l /var/foo
-rw-------    1 root     root      10485760 Nov 22 20:43 /var/foo
```

**- Description for the changelog**
- Speed up swap file creation using a larger blocksize


**- A picture of a cute animal (not mandatory but encouraged)**

![snail](https://miro.medium.com/max/1440/1*pJ9OQUoYUgO0S2nS4_feaw.jpeg)
