### PR TITLE
Remove riyazdf from MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -162,7 +162,6 @@ on disputes for technical matters."
 			"deitch",
 			"ijc",
 			"justincormack",
-			"riyazdf",
 			"rn",
 		]
 
@@ -187,11 +186,6 @@ on disputes for technical matters."
 	Name = "Justin Cormack"
 	Email = "justin.cormack@docker.com"
 	GitHub = "justincormack"
-
-	[people.riyazdf]
-	Name = "Riyaz Faizullabhoy"
-	Email = "riyaz@docker.com"
-	GitHub = "riyazdf"
 
 	[people.rn]
 	Name = "Rolf Neugebauer"


### PR DESCRIPTION
I'd like to formally step down as a maintainer, as I haven't been as involved as of late -- exciting to see all of the progress :) 

Signed-off-by: Riyaz Faizullabhoy <riyazdf@berkeley.edu>

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1865981/69988236-19779880-14f6-11ea-8521-e7653f6fce21.png)
