### PR TITLE
Added prefix functionality

### DIFF
--- a/src/cmd/linuxkit/build.go
+++ b/src/cmd/linuxkit/build.go
@@ -48,6 +48,7 @@ func build(args []string) {
 	buildOutputFile := buildCmd.String("o", "", "File to use for a single output, or '-' for stdout")
 	buildSize := buildCmd.String("size", "1024M", "Size for output image, if supported and fixed size")
 	buildPull := buildCmd.Bool("pull", false, "Always pull images")
+	buildPrefix := buildCmd.String("prefix", "", "Add a prefix to the root filesystem of the image")
 	buildDisableTrust := buildCmd.Bool("disable-content-trust", false, "Skip image trust verification specified in trust section of config (default false)")
 	buildDecompressKernel := buildCmd.Bool("decompress-kernel", false, "Decompress the Linux kernel (default false)")
 	buildCmd.Var(&buildFormats, "format", "Formats to create [ "+strings.Join(outputTypes, " ")+" ]")
@@ -204,7 +205,7 @@ func build(args []string) {
 	if moby.Streamable(buildFormats[0]) {
 		tp = buildFormats[0]
 	}
-	err = moby.Build(m, w, *buildPull, tp, *buildDecompressKernel)
+	err = moby.Build(m, w, *buildPull, *buildPrefix, tp, *buildDecompressKernel)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}

--- a/src/cmd/linuxkit/moby/build.go
+++ b/src/cmd/linuxkit/moby/build.go
@@ -145,7 +145,7 @@ func outputImage(image *Image, section string, prefix string, m Moby, idMap map[
 }
 
 // Build performs the actual build process
-func Build(m Moby, w io.Writer, pull bool, tp string, decompressKernel bool) error {
+func Build(m Moby, w io.Writer, pull bool, prefix string, tp string, decompressKernel bool) error {
 	if MobyDir == "" {
 		MobyDir = defaultMobyConfigDir()
 	}
@@ -183,7 +183,7 @@ func Build(m Moby, w io.Writer, pull bool, tp string, decompressKernel bool) err
 		// get kernel and initrd tarball and ucode cpio archive from container
 		log.Infof("Extract kernel image: %s", m.Kernel.ref)
 		kf := newKernelFilter(iw, m.Kernel.Cmdline, m.Kernel.Binary, m.Kernel.Tar, m.Kernel.UCode, decompressKernel)
-		err := ImageTar(m.Kernel.ref, "", kf, enforceContentTrust(m.Kernel.ref.String(), &m.Trust), pull, "")
+		err := ImageTar(m.Kernel.ref, prefix, kf, enforceContentTrust(m.Kernel.ref.String(), &m.Trust), pull, "")
 		if err != nil {
 			return fmt.Errorf("Failed to extract kernel image and tarball: %v", err)
 		}
@@ -199,7 +199,7 @@ func Build(m Moby, w io.Writer, pull bool, tp string, decompressKernel bool) err
 	}
 	for _, ii := range m.initRefs {
 		log.Infof("Process init image: %s", ii)
-		err := ImageTar(ii, "", iw, enforceContentTrust(ii.String(), &m.Trust), pull, resolvconfSymlink)
+		err := ImageTar(ii, prefix, iw, enforceContentTrust(ii.String(), &m.Trust), pull, resolvconfSymlink)
 		if err != nil {
 			return fmt.Errorf("Failed to build init tarball from %s: %v", ii, err)
 		}

--- a/src/cmd/linuxkit/moby/linuxkit.go
+++ b/src/cmd/linuxkit/moby/linuxkit.go
@@ -62,7 +62,7 @@ func ensureLinuxkitImage(name string) error {
 		return err
 	}
 	defer os.Remove(tf.Name())
-	Build(m, tf, false, "", false)
+	Build(m, tf, false, "", "", false)
 	if err := tf.Close(); err != nil {
 		return err
 	}


### PR DESCRIPTION
The initrd image can now be generated with a prefix path to the root
filesystem of the Docker image, using the '-prefix' option.

This is a useful feature when trying to create a custom ramfs build, as
it removes the constraint of placing the Docker filesystem at the root
of the resulting image.

The code necessary for this is mostly already present, it only needs to
link with a CLI option.

Signed-off-by: Bogdan Neacsu <bnneacsu@amazon.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
