### PR TITLE
Revert "Removed fixed size arg from mkimage-gcp script."

### DIFF
--- a/tools/mkimage-gcp/make-gcp
+++ b/tools/mkimage-gcp/make-gcp
@@ -43,7 +43,7 @@ cd ..
 
 tar cf files.tar -C files .
 
-virt-make-fs --type=ext4 --partition files.tar disk.raw
+virt-make-fs --size=1G --type=ext4 --partition files.tar disk.raw
 
 guestfish -a disk.raw -m /dev/sda1 <<EOF
   upload /usr/lib/SYSLINUX/mbr.bin /mbr.bin


### PR DESCRIPTION
Reverts linuxkit/linuxkit#3300

This does not work and the CI fails building the GCP image (see https://github.com/linuxkit/linuxkit/pull/3451). Enabling more logging in `mkimage-gcp` gives the following error:

```
supermin: build: visiting /usr/lib/x86_64-linux-gnu/guestfs/supermin.d/packages type uncompressed packages
supermin: build: visiting /usr/lib/x86_64-linux-gnu/guestfs/supermin.d/packages-hfsplus type uncompressed packages
supermin: build: visiting /usr/lib/x86_64-linux-gnu/guestfs/supermin.d/packages-reiserfs type uncompressed packages
supermin: build: visiting /usr/lib/x86_64-linux-gnu/guestfs/supermin.d/packages-xfs type uncompressed packages
supermin: build: visiting /usr/lib/x86_64-linux-gnu/guestfs/supermin.d/udev-rules.tar.gz type gzip base image (tar)
supermin: mapping package names to installed packages
supermin: resolving full list of package dependencies
supermin: build: 192 packages, including dependencies
supermin: build: 10676 files
supermin: build: 6472 files, after matching excludefiles
supermin: build: 6475 files, after adding hostfiles
supermin: build: 6475 files, after removing unreadable files
supermin: build: 6478 files, after munging
supermin: kernel: picked kernel vmlinuz-4.9.0-5-amd64
supermin: kernel: picked modules path /lib/modules/4.9.0-5-amd64
supermin: kernel: kernel_version 4.9.0-5-amd64
supermin: kernel: modules /lib/modules/4.9.0-5-amd64
supermin: ext2: creating empty ext2 filesystem '/var/tmp/.guestfs-0/appliance.d.fchyrekj/root'
supermin: ext2: populating from base image
supermin: error: statvfs: No space left on device: /var/tmp/.guestfs-0/appliance.d.fchyrekj/root
libguestfs: error: /usr/bin/supermin exited with error status 1, see debug messages above
libguestfs: trace: launch = -1 (error)
```

I've tried a number of different options for sizing and none seem to work.

I suggest to revert this PR for now.