### PR TITLE
Update alpine to 3.11

### DIFF
--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9 AS mirror
+FROM alpine:3.11 AS mirror
 
 # update base image
 RUN apk update && apk upgrade -a
@@ -6,6 +6,7 @@ RUN apk update && apk upgrade -a
 # Copy Dockerfile so we can include it in the hash
 COPY Dockerfile /Dockerfile
 COPY packages* /tmp/
+COPY libelf /libelf
 
 # mirror packages
 RUN cat /tmp/packages.$(uname -m) >> /tmp/packages && \
@@ -18,14 +19,20 @@ RUN cat /tmp/packages.$(uname -m) >> /tmp/packages && \
 RUN apk add alpine-sdk libmnl-dev curl && \
     adduser -D builder && \
     addgroup builder abuild && \
+    su -c "abuild-keygen -a -n" builder && \
     mkdir -p /wireguard && \
     chmod 0777 /wireguard && \
     cd /wireguard && \
     curl -fsSLo APKBUILD https://git.alpinelinux.org/cgit/aports/plain/community/wireguard-tools/APKBUILD && \
-    su -c "abuild-keygen -a -n && abuild -r" builder && \
-    cp /home/builder/packages/$(apk --print-arch)/wireguard-tools-[0-9]*.apk /mirror/$(apk --print-arch) && \
-    cp /home/builder/packages/$(apk --print-arch)/wireguard-tools-wg-[0-9]*.apk /mirror/$(apk --print-arch) && \
-    cp /home/builder/packages/$(apk --print-arch)/wireguard-tools-wg-quick-[0-9]*.apk /mirror/$(apk --print-arch)
+    su -c "abuild -r -P /wireguard/packages" builder && \
+    cp /wireguard/packages/$(apk --print-arch)/wireguard-tools-[0-9]*.apk /mirror/$(apk --print-arch) && \
+    cp /wireguard/packages/$(apk --print-arch)/wireguard-tools-wg-[0-9]*.apk /mirror/$(apk --print-arch) && \
+    cp /wireguard/packages/$(apk --print-arch)/wireguard-tools-wg-quick-[0-9]*.apk /mirror/$(apk --print-arch) && \
+    chmod 0777 /libelf && \
+    cd /libelf && \
+    su -c "abuild -r  -P /libelf/packages" builder && \
+    cp /libelf/packages/$(apk --print-arch)/libelf-[0-9]*.apk /mirror/$(apk --print-arch) && \
+    cp /libelf/packages/$(apk --print-arch)/libelf-dev-[0-9]*.apk /mirror/$(apk --print-arch)
 
 # install abuild for signing
 RUN apk add --no-cache abuild
@@ -47,7 +54,7 @@ RUN mv /etc/apk/repositories /etc/apk/repositories.upstream && echo "/mirror" > 
 COPY go-compile.sh /go/bin/
 RUN apk add --no-cache git go musl-dev
 ENV GOPATH=/go PATH=$PATH:/go/bin
-RUN go get -u github.com/golang/lint/golint
+RUN go get -u golang.org/x/lint/golint
 RUN go get -u github.com/gordonklaus/ineffassign
 RUN go get -u github.com/LK4D4/vndr
 
@@ -85,7 +92,7 @@ RUN set -e && \
         cp iucode_tool /iucode_tool; \
     fi
 
-FROM alpine:3.9
+FROM alpine:3.11
 
 COPY --from=mirror /etc/apk/repositories /etc/apk/repositories
 COPY --from=mirror /etc/apk/repositories.upstream /etc/apk/repositories.upstream

--- a/tools/alpine/libelf/APKBUILD
+++ b/tools/alpine/libelf/APKBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Natanael Copa <ncopa@alpinelinux.org>
+pkgname=libelf
+pkgver=0.8.13
+pkgrel=3
+pkgdesc="libelf is a free ELF object file access library"
+url="https://fossies.org/linux/misc/old"
+arch="all"
+license="GPL"
+depends=
+makedepends=
+subpackages="$pkgname-dev"
+source="https://fossies.org/linux/misc/old/$pkgname-$pkgver.tar.gz"
+
+builddir="$srcdir/$pkgname-$pkgver"
+
+prepare() {
+	cd "$builddir"
+	default_prepare
+	update_config_sub
+}
+
+build() {
+	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--enable-shared \
+		--enable-gnu-names \
+		--enable-compat \
+		--disable-nls
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+	make install prefix="$pkgdir"/usr
+}
+sha512sums="d2a4ea8ccc0bbfecac38fa20fbd96aefa8e86f8af38691fb6991cd9c5a03f587475ecc2365fc89a4954c11a679d93460ee9a5890693112f6133719af3e6582fe  libelf-0.8.13.tar.gz"

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -66,7 +66,6 @@ libc-utils
 libc6-compat
 libcap-ng-dev
 libedit-dev
-libelf-dev
 libressl-dev
 libseccomp-dev
 libtirpc-dev

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -135,7 +135,6 @@ libdrm-2.4.96-r0
 libedit-20181209.3.1-r0
 libedit-dev-20181209.3.1-r0
 libelf-0.8.13-r3
-libelf-dev-0.8.13-r3
 libepoxy-1.5.3-r0
 libevent-2.1.8-r6
 libexecinfo-1.1-r0

--- a/tools/alpine/versions.s390x
+++ b/tools/alpine/versions.s390x
@@ -135,7 +135,6 @@ libdrm-2.4.96-r0
 libedit-20181209.3.1-r0
 libedit-dev-20181209.3.1-r0
 libelf-0.8.13-r3
-libelf-dev-0.8.13-r3
 libepoxy-1.5.3-r0
 libevent-2.1.8-r6
 libfdisk-2.33-r0

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -141,7 +141,6 @@ libdrm-2.4.96-r0
 libedit-20181209.3.1-r0
 libedit-dev-20181209.3.1-r0
 libelf-0.8.13-r3
-libelf-dev-0.8.13-r3
 libepoxy-1.5.3-r0
 libevent-2.1.8-r6
 libexecinfo-1.1-r0


### PR DESCRIPTION
**- What I did**

I have updated the `tools/alpine` image to Alpine 3.11 and got it building.

**- How I did it**

Looks like `libelf-dev` has been missing from the Alpine APK indexes since 3.9.

Tracking down the original `APKBUILD` for this package (https://git.alpinelinux.org/aports/tree/main/libelf/APKBUILD?id=26fcb98d3493e2f881998bfdacd76efff0479003), it appears that the website it was being built from has been offline for some time (http://www.mr511.de/software/).

I have added a updated `APKBUILD` recipe that uses a different mirror. The checksum is the same as the original source archive, so the new package should be an exact replacement.

**- How to verify it**

`cd tools/alpine && make build`

**- Why I did it**

I was trying to improve my understanding of how LinuxKit fits together!

I honestly have no idea if this is actually useful. I guess other images would also have to receive updates to test and verify this? I hope that if someone who knows what they are doing bumps into the 'libelf-dev issue' they can at least crib from my solution. :)

If there are next steps I can take with this I am happy to put more work in!

For what it's worth, I've also tried updating containerd to 1.3.2 with this image and it appears to work. Well, the system boots.