### PR TITLE
contrib: Add kubernetes manifest for open-vm-tools

### DIFF
--- a/contrib/open-vm-tools/README.md
+++ b/contrib/open-vm-tools/README.md
@@ -1,0 +1,10 @@
+# open-vm-tools
+This should allow end-users to gracefully reboot or shutdown Kubernetes nodes (incuding control planes) running on vSphere Hypervisor.
+
+Furthermore, it is also mandatory to have `open-vm-tools` installed on your Kubernetes nodes to use vSphere Cloud Provider (i.e. determinte virtual machine's FQDN).
+
+## Remarks:
+- `spec.template.spec.hostNetwork: true`: correctly report node IP address; required
+- `spec.template.spec.hostPID: true`: send the right signal to node, instead of killing the container itself; required
+- `spec.template.spec.priorityClassName: system-cluster-critical`: critical to a fully functional cluster
+- `spec.template.spec.securityContext.privileged: true`: gain more privileges than its parent process; required

--- a/contrib/open-vm-tools/open-vm-tools-ds.yaml
+++ b/contrib/open-vm-tools/open-vm-tools-ds.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: open-vm-tools
+  name: open-vm-tools
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: open-vm-tools
+  template:
+    metadata:
+      labels:
+        app: open-vm-tools
+    spec:
+      hostNetwork: true
+      hostPID: true
+      priorityClassName: system-cluster-critical
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+      containers:
+      - image: linuxkit/open-vm-tools:v0.7
+        name: open-vm-tools
+        resources:
+          requests:
+            memory: "5Mi"
+            cpu: "100m"
+          limits:
+            memory: "25Mi"
+            cpu: "500m"
+        securityContext:
+          privileged: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always


### PR DESCRIPTION
**- What I did**
This should allow end-users to gracefully reboot or shutdown Kubernetes
nodes (incuding control planes) running on vSphere Hypervisor

There are several use cases when cluster administrators are not able to
install extra packages onto the host OS

Fixes #3462

**- How I did it**
Create DaemonSet which runs on all Kubernetes node.

**- How to verify it**
`kubectl apply -f contrib/open-vm-tools/open-vm-tools-ds.yaml`

**- Description for the changelog**
Add kubernetes manifest for open-vm-tools
