### PR TITLE
update how to create an EC2 instance

### DIFF
--- a/docs/platform-aws.md
+++ b/docs/platform-aws.md
@@ -47,7 +47,7 @@ With the image created, we can now create an instance.
 You won't be able to see the serial console output until after it has terminated.
 
 ```
-linuxkit run aws aws
+linuxkit run aws -security-group "<security_group_id>" aws
 ```
 
 You can edit the AWS example to allow you to SSH to your instance in order to use it.


### PR DESCRIPTION
The security group seems to be required to run the command.

When I run:

```
linuxkit run aws aws
```

I have this error:
```
FATA[0000] Unable to run instance: MissingParameter: When specifying a security group you must specify one of group id or group name for each item
	status code: 400, request id: 3f317231-1b9e-423d-908f-7a27259e699a 
```

Adding the SG option solves the problem.