### PR TITLE
workaround bad containerd bug

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.171
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.171
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:v0.7 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/hetzner.yml
+++ b/examples/hetzner.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
 services:

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
 onboot:

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.59-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/static-ip.yml
+++ b/examples/static-ip.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
 onboot:

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
 onboot:

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
 onboot:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
 onboot:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/src/cmd/linuxkit/moby/linuxkit.go
+++ b/src/cmd/linuxkit/moby/linuxkit.go
@@ -17,7 +17,7 @@ kernel:
   image: linuxkit/kernel:4.9.39
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: mkimage

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: dhcpcd

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
 

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
 services:

--- a/test/cases/010_platforms/110_gcp/000_run/test.yml
+++ b/test/cases/010_platforms/110_gcp/000_run/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:1d8e0532ca588c5ad0d9ca6038349a70bb7ac626
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:c1f0db27e71d948f3134b31ce76276f843849b0a
 onboot:
   - name: poweroff

--- a/test/cases/020_kernel/002_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/002_config_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.171
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/005_config_4.19.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.19.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/011_config_5.4.x/test.yml
+++ b/test/cases/020_kernel/011_config_5.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.4.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/102_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/102_kmod_4.14.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.171
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: check

--- a/test/cases/020_kernel/105_kmod_4.19.x/test.yml
+++ b/test/cases/020_kernel/105_kmod_4.19.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: check

--- a/test/cases/020_kernel/111_kmod_5.4.x/test.yml
+++ b/test/cases/020_kernel/111_kmod_5.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.4.19
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: check

--- a/test/cases/020_kernel/200_namespace/common.yml
+++ b/test/cases/020_kernel/200_namespace/common.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 trust:
   org:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: test

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/002_bpftrace/test.yml
+++ b/test/cases/040_packages/002_bpftrace/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/bpftrace:v0.7
 onboot:

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/ca-certificates:v0.7
 onboot:

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.171
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.171
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/004_dm-crypt/002_key/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/002_key/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.171
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/test/cases/040_packages/012_losetup/test.yml
+++ b/test/cases/040_packages/012_losetup/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.14.171
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: losetup

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
   - linuxkit/ca-certificates:v0.7

--- a/test/cases/040_packages/032_bcc/test.yml
+++ b/test/cases/040_packages/032_bcc/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/kernel-bcc:4.19.104
 onboot:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
   - linuxkit/containerd:09553963ed9da626c25cf8acdf6d62ec37645412
 onboot:

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:4.19.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:a4fcf333298f644dfac6adf680b83140927aa85e
+  - linuxkit/init:a0246dd478a24abbee0a4cede99662ffc4931691
   - linuxkit/runc:69b4a35eaa22eba4990ee52cccc8f48f6c08ed03
 onboot:
   - name: test-ns


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Replaced `/dev/null` for stdin in `cmd` with a temporary null file as `/run/containers-stdin/<servicename>/null`.

This is because of https://github.com/containerd/containerd/issues/4019, where containerd, on task delete, likes to delete everything in the parent directory of stdin. When using `/dev/null`, that means wiping out `/dev`. Oops.

**- How I did it**

Created a directory for all stdins in `/run`, then a directory per named service, then a null file with `mknod`

**- How to verify it**

CI. Run it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Temporary workaround for bad containerd bug that can wipe out `/dev`


**- A picture of a cute animal (not mandatory but encouraged)**
