### PR TITLE
match go version in CI to version in go-compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.11
-      uses: actions/setup-go@v1
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.11
+        go-version: 1.13.4
       id: go
 
     - name: Check out code

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ LOCAL_TARGET ?= $(LINUXKIT)
 .PHONY: local-check local-build local-test local-static-pie local-static local-dynamic local
 local-check: $(LINUXKIT_DEPS)
 	@echo gofmt... && o=$$(gofmt -s -l $(filter %.go,$(LINUXKIT_DEPS))) && if [ -n "$$o" ] ; then echo $$o ; exit 1 ; fi
-	@echo govet... && go tool vet -printf=false $(filter %.go,$(LINUXKIT_DEPS))
+	@echo govet... && go vet -printf=false ./src/cmd/linuxkit/...
 	@echo golint... && set -e ; for i in $(filter %.go,$(LINUXKIT_DEPS)); do golint $$i ; done
 	@echo ineffassign... && ineffassign  $(filter %.go,$(LINUXKIT_DEPS))
 

--- a/src/cmd/linuxkit/gcp.go
+++ b/src/cmd/linuxkit/gcp.go
@@ -477,7 +477,7 @@ func (g *GCPClient) pollOperationStatus(operationName string) error {
 			return fmt.Errorf("error fetching operation status: %v", err)
 		}
 		if operation.Error != nil {
-			return fmt.Errorf("error running operation: %s", operation.Error)
+			return fmt.Errorf("error running operation: %v", operation.Error)
 		}
 		if operation.Status == "DONE" {
 			return nil
@@ -494,7 +494,7 @@ func (g *GCPClient) pollZoneOperationStatus(operationName, zone string) error {
 			return fmt.Errorf("error fetching operation status: %v", err)
 		}
 		if operation.Error != nil {
-			return fmt.Errorf("error running operation: %s", operation.Error)
+			return fmt.Errorf("error running operation: %v", operation.Error)
 		}
 		if operation.Status == "DONE" {
 			return nil


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Since the move to alpine:3.11, our go-compile runs 1.13.4; this bumps our CI to use the same.

**- How I did it**

change ci.yml

**- How to verify it**

Let CI run

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use go1.13.4 in CI
