### PR TITLE
read cdrom userdata from spec location

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:12794dd50fd1563dee6c960710fd8b923dba6231
+    image: linuxkit/metadata:04ce7519c2ea2eaf99bbdc76bb01fc036eed7ab0
 services:
   - name: rngd
     image: linuxkit/rngd:7fab61cca793113280397dcee8159f35dc37adcb

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -11,7 +11,7 @@ init:
 onboot:
   # support metadata for optional config in /run/config
   - name: metadata
-    image: linuxkit/metadata:12794dd50fd1563dee6c960710fd8b923dba6231
+    image: linuxkit/metadata:04ce7519c2ea2eaf99bbdc76bb01fc036eed7ab0
   - name: sysctl
     image: linuxkit/sysctl:541f60fe3676611328e89e8bac251fc636b1a6aa
   - name: sysfs

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:12794dd50fd1563dee6c960710fd8b923dba6231
+    image: linuxkit/metadata:04ce7519c2ea2eaf99bbdc76bb01fc036eed7ab0
 services:
   - name: getty
     image: linuxkit/getty:48f66df198981e692084bf70ab72b9fe2be0f880

--- a/examples/hetzner.yml
+++ b/examples/hetzner.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:12794dd50fd1563dee6c960710fd8b923dba6231
+    image: linuxkit/metadata:04ce7519c2ea2eaf99bbdc76bb01fc036eed7ab0
     command: ["/usr/bin/metadata", "hetzner"]
 services:
   - name: rngd

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:12794dd50fd1563dee6c960710fd8b923dba6231
+    image: linuxkit/metadata:04ce7519c2ea2eaf99bbdc76bb01fc036eed7ab0
     command: ["/usr/bin/metadata", "openstack"]
 services:
   - name: rngd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:12794dd50fd1563dee6c960710fd8b923dba6231
+    image: linuxkit/metadata:04ce7519c2ea2eaf99bbdc76bb01fc036eed7ab0
     command: ["/usr/bin/metadata", "packet"]
 services:
   - name: rngd

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:12794dd50fd1563dee6c960710fd8b923dba6231
+    image: linuxkit/metadata:04ce7519c2ea2eaf99bbdc76bb01fc036eed7ab0
 services:
   - name: getty
     image: linuxkit/getty:48f66df198981e692084bf70ab72b9fe2be0f880

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:12794dd50fd1563dee6c960710fd8b923dba6231
+    image: linuxkit/metadata:04ce7519c2ea2eaf99bbdc76bb01fc036eed7ab0
     command: ["/usr/bin/metadata", "vultr"]
 services:
   - name: getty


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes #3501 

**- What I did**

Read metadata for cdrom provider from `/user-data` per the spec (see #3501), falling back to `/config`

**- How I did it**

Read `/user-data` first, then `/config`

**- How to verify it**

Run it, CI.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Support userdata from standard location


Note: I only added metadata support. It _reads_ the metadata from the standard location if it exists, but does not write it out to file. That will be in a future stage