### PR TITLE
Add GUID Partition Table (GPT) support to the `format` package

### DIFF
--- a/docs/external-disk.md
+++ b/docs/external-disk.md
@@ -52,9 +52,17 @@ onboot:
     command: ["/usr/bin/format", "-force", "-type", "xfs", "-label", "DATA", "-verbose", "/dev/vda"]
 ```
 
+```
+onboot:
+  - name: format
+    image: linuxkit/format:<hash>
+    command: ["/usr/bin/format", "-type", "ext4", "-partition", "gpt", "/dev/vda"]
+```
+
 - `-force` can be used to force the partition to be cleared and recreated (if applicable), and the recreated partition formatted. This option would be used to re-init the partition on every boot, rather than persisting the partition between boots.
 - `-label` can be used to give the disk a label
 - `-type` can be used to specify the type. This is `ext4` by default but `btrfs` and `xfs` are also supported
+- `-partition` can be used to specify the partition table type. This is `dos` by default but `gpt` is also supported
 - `-verbose` enables verbose logging, which can be used to troubleshoot device auto-detection and (re-)partitioning
 - The final (optional) argument specifies the device name
 

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -15,7 +15,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:697f996868d6625a78bbbefb199d7b6b6ae3533a
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "/dev/sda"]
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "/dev/sda"]
   - name: dm-crypt
     image: linuxkit/dm-crypt:0ea63bfd97b719d185b69994b4856d97fbc8a2dd

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -20,7 +20,7 @@ onboot:
     image: linuxkit/binfmt:94d59bc179c7a9155d8593a974d499352b70bfd5
   # Format and mount the disk image in /var/lib/docker
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69
     command: ["/usr/bin/mountie", "/var/lib"]

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -12,7 +12,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:697f996868d6625a78bbbefb199d7b6b6ae3533a
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69
     command: ["/usr/bin/mountie", "/var/external"]

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -20,12 +20,13 @@ const (
 )
 
 var (
-	labelVar   string
-	fsTypeVar  string
-	forceVar   bool
-	verboseVar bool
-	drives     map[string]bool
-	driveKeys  []string
+	labelVar    string
+	fsTypeVar   string
+	partTypeVar string
+	forceVar    bool
+	verboseVar  bool
+	drives      map[string]bool
+	driveKeys   []string
 )
 
 func hasPartitions(d string) bool {
@@ -72,7 +73,7 @@ func isEmptyDevice(d string) (bool, error) {
 	return isEmpty, nil
 }
 
-func autoformat(label, fsType string) error {
+func autoformat(label, fsType string, partType string) error {
 	var first string
 	for _, d := range driveKeys {
 		if verboseVar {
@@ -93,7 +94,7 @@ func autoformat(label, fsType string) error {
 		return fmt.Errorf("No eligible disks found")
 	}
 
-	return format(first, label, fsType, false)
+	return format(first, label, fsType, partType, false)
 }
 
 func refreshDevicesAndWaitFor(awaitedDevice string) error {
@@ -128,7 +129,7 @@ func refreshDevicesAndWaitFor(awaitedDevice string) error {
 	return nil
 }
 
-func format(d, label, fsType string, forced bool) error {
+func format(d, label, fsType string, partType string, forced bool) error {
 	if forced {
 		// clear partitions on device if forced format and they exist
 		if hasPartitions(d) {
@@ -154,7 +155,14 @@ func format(d, label, fsType string, forced bool) error {
 	http://bugs.alpinelinux.org/issues/145
 	*/
 	fdiskCmd := exec.Command("fdisk", d)
-	fdiskCmd.Stdin = strings.NewReader("w")
+	switch partType {
+	case "dos":
+		fdiskCmd.Stdin = strings.NewReader("w")
+	case "gpt":
+		fdiskCmd.Stdin = strings.NewReader("g\nw")
+	default:
+		return fmt.Errorf("Unsupported partition table type: %s", partType)
+	}
 	if out, err := fdiskCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("Error running fdisk: %v\n%s", err, out)
 	}
@@ -258,6 +266,7 @@ func init() {
 	flag.BoolVar(&forceVar, "force", false, "Force format of specified single device (default false)")
 	flag.StringVar(&labelVar, "label", "", "Disk label to apply")
 	flag.StringVar(&fsTypeVar, "type", "ext4", "Type of filesystem to create")
+	flag.StringVar(&partTypeVar, "partition", "dos", "Type of partition table to create")
 	flag.BoolVar(&verboseVar, "verbose", false, "Enable verbose output (default false)")
 }
 
@@ -283,7 +292,7 @@ func main() {
 	if flag.NArg() == 0 {
 		// auto-detect drives if a device to format is not explicitly specified
 		findDrives()
-		if err := autoformat(labelVar, fsTypeVar); err != nil {
+		if err := autoformat(labelVar, fsTypeVar, partTypeVar); err != nil {
 			log.Fatalf("%v", err)
 		}
 	} else {
@@ -294,13 +303,13 @@ func main() {
 		}
 
 		if forceVar == true {
-			if err := format(candidateDevice, labelVar, fsTypeVar, forceVar); err != nil {
+			if err := format(candidateDevice, labelVar, fsTypeVar, partTypeVar, forceVar); err != nil {
 				log.Fatalf("%v", err)
 			}
 		} else {
 			// add the deviceVar to the array of devices to consider autoformatting
 			driveKeys = []string{candidateDevice}
-			if err := autoformat(labelVar, fsTypeVar); err != nil {
+			if err := autoformat(labelVar, fsTypeVar, partTypeVar); err != nil {
 				log.Fatalf("%v", err)
 			}
 		}

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -15,7 +15,7 @@ onboot:
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -15,7 +15,7 @@ onboot:
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -12,7 +12,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:697f996868d6625a78bbbefb199d7b6b6ae3533a
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -13,7 +13,7 @@ onboot:
   - name: sysctl
     image: linuxkit/sysctl:541f60fe3676611328e89e8bac251fc636b1a6aa
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69
     command: ["/usr/bin/mountie", "/var/lib"]

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
 onboot:
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
 onboot:
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "-type", "xfs"]
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
 onboot:
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format"]
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
 onboot:
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "-label", "docker"]
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
 onboot:
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "@DEVICE@"]
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/modprobe:944769462b9d10b1b1506498d3eb03dcc5416f7f
     command: ["modprobe", "btrfs"]
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "-type", "btrfs" ]
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
 onboot:
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "-type", "xfs" ]
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -6,19 +6,19 @@ init:
   - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
 onboot:
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "-verbose", "-type", "ext4", "/dev/sda"]
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "-verbose", "-type", "ext4", "/dev/sdb"]
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "-verbose", "-type", "xfs", "/dev/sda"]
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "-verbose", "-force", "-type", "xfs", "/dev/sdb"]
   - name: test
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     binds:
       - /check.sh:/check.sh
     command: ["sh", "./check.sh"]

--- a/test/cases/040_packages/006_format_mount/006_gpt/check.sh
+++ b/test/cases/040_packages/006_format_mount/006_gpt/check.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+function failed {
+	printf "format_mount test suite FAILED\n" >&1
+	exit 1
+}
+
+touch /var/lib/docker/foo || failed
+
+printf "format_mount test suite PASSED\n" >&1

--- a/test/cases/040_packages/006_format_mount/006_gpt/test.sh
+++ b/test/cases/040_packages/006_format_mount/006_gpt/test.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# SUMMARY: Check that a GPT partitioned disk can be mounted
+# LABELS:
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+NAME=test-format
+DISK=disk.img
+
+clean_up() {
+	rm -rf ${NAME}-* ${DISK}
+}
+trap clean_up EXIT
+
+linuxkit build -format kernel+initrd -name ${NAME} test.yml
+RESULT="$(linuxkit run -disk file=${DISK},size=512M ${NAME})"
+echo "${RESULT}"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/040_packages/006_format_mount/006_gpt/test.yml
+++ b/test/cases/040_packages/006_format_mount/006_gpt/test.yml
@@ -5,12 +5,9 @@ init:
   - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
   - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
 onboot:
-  - name: modprobe
-    image: linuxkit/modprobe:944769462b9d10b1b1506498d3eb03dcc5416f7f
-    command: ["modprobe", "btrfs"]
   - name: format
     image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
-    command: ["/usr/bin/format", "-type", "btrfs" ]
+    command: ["/usr/bin/format", "-partition", "gpt"]
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69
     command: ["/usr/bin/mountie", "/var/lib/docker"]
@@ -18,11 +15,15 @@ onboot:
     image: alpine:3.11
     binds:
       - /var/lib/docker:/var/lib/docker
-    command: ["touch", "/var/lib/docker/bar"]
+      - /check.sh:/check.sh
+    command: ["sh", "./check.sh"]
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3
     command: ["/bin/sh", "/poweroff.sh", "10"]
+files:
+  - path: check.sh
+    source: ./check.sh
 trust:
-  org: 
+  org:
     - linuxkit
     - library

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -6,10 +6,10 @@ init:
   - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
 onboot:
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "-label", "docker"]
   - name: format
-    image: linuxkit/format:80bd847a90842d3f19460a560d7d95d6fe13bd71
+    image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96
     command: ["/usr/bin/format", "-label", "foo"]
   - name: mount
     image: linuxkit/mount:8363f4f1744e1df2557ec260a4cc94227178fd69


### PR DESCRIPTION
**- What I did**
I've added GUID Partition Table (GPT) support to the `format` package in order to support partitions greater than 2 TiB.

**- How I did it**
I've added an *optional* `--partition` input parameter to the `format` command-line that can be used to select one of the supported partition table modes:
- `dos`: **(default)** master boot record (MBR), DOS partition table;
- `gpt`: GUID partition table (GPT).

Note: an error is triggered (w/t early termination) if an invalid partition table mode is supplied.
Note: it defaults to the "legacy" MBR/DOS behavior.

GUID Partition Table (GPT) support has been implemented by prepending `g\n` to the `fdisk` standard input string reader.

<img width="500" alt="Screenshot 2020-04-20 at 15 33 35" src="https://user-images.githubusercontent.com/12744504/79757437-62e94880-831c-11ea-87ac-515182a6a428.png">

**- How to verify it**

- use `format` as an on-boot package;
- attach an empty disk > 2 TiB (e.g. `/dev/xvdb`);
- set the partition flag to `gpt` in the command line parameter (e.g. `-partition gpt`);
```
    command: ["/usr/bin/format", "-partition", "gpt", "-verbose", "/dev/xvdb"]
```
- verify the partition table (e.g. `sfdisk -l /dev/xvdb`) to have `Disklabel type: gpt`;
- verify the partition size (e.g. to be greater than 2 TiB).

**- Description for the changelog**
Added GUID Partition Table (GPT) support to the `format` package.

Signed-off-by: Federico Pellegatta <12744504+federico-pellegatta@users.noreply.github.com>