### PR TITLE
metadata: add support for digitalocean

### DIFF
--- a/pkg/metadata/main.go
+++ b/pkg/metadata/main.go
@@ -78,7 +78,7 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	providers := []string{"aws", "gcp", "hetzner", "openstack", "scaleway", "vultr", "packet", "cdrom"}
+	providers := []string{"aws", "gcp", "hetzner", "openstack", "scaleway", "vultr", "digitalocean", "packet", "cdrom"}
 	args := flag.Args()
 	if len(args) > 0 {
 		providers = args
@@ -99,6 +99,8 @@ func main() {
 			netProviders = append(netProviders, NewScaleway())
 		case p == "vultr":
 			netProviders = append(netProviders, NewVultr())
+		case p == "digitalocean":
+			netProviders = append(netProviders, NewDigitalOcean())
 		case p == "cdrom":
 			cdromProviders = ListCDROMs()
 		case strings.HasPrefix(p, "file="):

--- a/pkg/metadata/provider_digitalocean.go
+++ b/pkg/metadata/provider_digitalocean.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"time"
+)
+
+const (
+	digitalOceanMetaDataURL = "http://169.254.169.254/metadata/v1/"
+)
+
+// ProviderDigitalOcean is the type implementing the Provider interface for DigitalOcean
+type ProviderDigitalOcean struct {
+}
+
+// NewDigitalOcean returns a new ProviderDigitalOcean
+func NewDigitalOcean() *ProviderDigitalOcean {
+	return &ProviderDigitalOcean{}
+}
+
+func (p *ProviderDigitalOcean) String() string {
+	return "DigitalOcean"
+}
+
+// Probe checks if we are running on DigitalOcean
+func (p *ProviderDigitalOcean) Probe() bool {
+	// Getting the index should always work...
+	_, err := digitalOceanGet(digitalOceanMetaDataURL)
+	return (err == nil)
+}
+
+// Extract gets both the DigitalOcean specific and generic userdata
+func (p *ProviderDigitalOcean) Extract() ([]byte, error) {
+	// Get host name. This must not fail
+	hostname, err := digitalOceanGet(digitalOceanMetaDataURL + "hostname")
+	if err != nil {
+		return nil, err
+	}
+	err = ioutil.WriteFile(path.Join(ConfigPath, Hostname), hostname, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("DigitalOcean: Failed to write hostname: %s", err)
+	}
+
+	// public ipv4
+	digitalOceanMetaGet("interfaces/public/0/ipv4/address", "public_ipv4", 0644)
+
+	// private ipv4
+	digitalOceanMetaGet("interfaces/private/0/ipv4/address", "private_ipv4", 0644)
+
+	// region
+	digitalOceanMetaGet("region", "region", 0644)
+
+	// droplet id
+	digitalOceanMetaGet("id", "id", 0644)
+
+	// ssh
+	if err := p.handleSSH(); err != nil {
+		log.Printf("DigitalOcean: Failed to get ssh data: %s", err)
+	}
+
+	// Generic userdata
+	userData, err := digitalOceanGet(digitalOceanMetaDataURL + "user-data")
+	if err != nil {
+		log.Printf("DigitalOcean: Failed to get user-data: %s", err)
+		// This is not an error
+		return nil, nil
+	}
+	return userData, nil
+}
+
+// lookup a value (lookupName) in DigitalOcean metaservice and store in given fileName
+func digitalOceanMetaGet(lookupName string, fileName string, fileMode os.FileMode) {
+	if lookupValue, err := digitalOceanGet(digitalOceanMetaDataURL + lookupName); err == nil {
+		// we got a value from the metadata server, now save to filesystem
+		err = ioutil.WriteFile(path.Join(ConfigPath, fileName), lookupValue, fileMode)
+		if err != nil {
+			// we couldn't save the file for some reason
+			log.Printf("DigitalOcean: Failed to write %s:%s %s", fileName, lookupValue, err)
+		}
+	} else {
+		// we did not get a value back from the metadata server
+		log.Printf("DigitalOcean: Failed to get %s: %s", lookupName, err)
+	}
+}
+
+// digitalOceanGet requests and extracts the requested URL
+func digitalOceanGet(url string) ([]byte, error) {
+	var client = &http.Client{
+		Timeout: time.Second * 2,
+	}
+
+	req, err := http.NewRequest("", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("DigitalOcean: http.NewRequest failed: %s", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("DigitalOcean: Could not contact metadata service: %s", err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("DigitalOcean: Status not ok: %d", resp.StatusCode)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("DigitalOcean: Failed to read http response: %s", err)
+	}
+	return body, nil
+}
+
+// SSH keys:
+func (p *ProviderDigitalOcean) handleSSH() error {
+	sshKeys, err := digitalOceanGet(digitalOceanMetaDataURL + "public-keys")
+	if err != nil {
+		return fmt.Errorf("Failed to get sshKeys: %s", err)
+	}
+
+	if err := os.Mkdir(path.Join(ConfigPath, SSH), 0755); err != nil {
+		return fmt.Errorf("Failed to create %s: %s", SSH, err)
+	}
+
+	err = ioutil.WriteFile(path.Join(ConfigPath, SSH, "authorized_keys"), sshKeys, 0600)
+	if err != nil {
+		return fmt.Errorf("Failed to write ssh keys: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
**- What I did**

Add support for fetching metadata and user data from the DigitalOcean metadata service.

**- How I did it**

Copied an existing metadata provider (Vultr) and changed the URLs and paths to match those in the DigitalOcean documentation: https://www.digitalocean.com/docs/droplets/resources/metadata/

**- How to verify it**

1. Create a DigitalOcean droplet with [custom image](https://www.digitalocean.com/docs/images/custom-images/) using this linuxkit.yaml and `-format raw-bios`:
```
kernel:
  image: linuxkit/kernel:5.4.30
  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
init:
  - linuxkit/init:v0.7
  - linuxkit/runc:v0.7
  - linuxkit/containerd:v0.7
  - linuxkit/ca-certificates:v0.7
onboot:
  - name: sysctl
    image: linuxkit/sysctl:v0.7
  - name: dhcpcd
    image: linuxkit/dhcpcd:v0.7
    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
  - name: metadata
    image: linuxkit/metadata:latest
services:
  - name: getty
    image: linuxkit/getty:v0.7
    env:
     - INSECURE=true
```

2. Inspect /run/config:

```
# ls -lh /run/config/
total 20
-rw-r--r--    1 root     root          13 Apr 26 16:53 hostname
-rw-r--r--    1 root     root           9 Apr 26 16:53 id
-rw-r--r--    1 root     root          12 Apr 26 16:53 provider
-rw-r--r--    1 root     root          13 Apr 26 16:53 public_ipv4
-rw-r--r--    1 root     root           4 Apr 26 16:53 region
drwxr-xr-x    2 root     root          60 Apr 26 16:52 ssh
-rw-r--r--    1 root     root           0 Apr 26 16:53 userdata
# cat /run/config/provider
DigitalOcean
# cat /run/config/region
nyc3
```

**- Description for the changelog**

metadata: add support for digitalocean
