### PR TITLE
Update containerd to v1.3.4

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:3fd88b7025065843792484b1ad83ddd5c4b28684 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   # support metadata for optional config in /run/config

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/hetzner.yml
+++ b/examples/hetzner.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
   - linuxkit/firmware:2b5688289ec6708e41a20a10aa4b5a05d4b331f6
 onboot:

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: dhcpcd

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
   - linuxkit/memlogd:ddfd99754f0cfc63a675f49aa32a8f2c92785551
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
 services:
   - name: getty
     image: linuxkit/getty:48f66df198981e692084bf70ab72b9fe2be0f880

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
   - linuxkit/firmware:2b5688289ec6708e41a20a10aa4b5a05d4b331f6
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.28-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/static-ip.yml
+++ b/examples/static-ip.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
 onboot:
   - name: ip
     image: linuxkit/ip:22f0b3be72f25adb8a38aa67c075d59da49d20f2

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:bc528cf9d4065d2e09aa44ff76909b94cfe8d867 as alpine
+FROM linuxkit/alpine:e2391e0b164c57db9f6c4ae110ee84f766edc430 as alpine
 RUN apk add tzdata
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:bc528cf9d4065d2e09aa44ff76909b94cfe8d867 AS build
+FROM linuxkit/alpine:e2391e0b164c57db9f6c4ae110ee84f766edc430 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 
 ADD usermode-helper.c ./
@@ -18,7 +18,7 @@ RUN mkdir /tmp/bin && cd /tmp/bin/ && cp /go/bin/rc.init . && ln -s rc.init rc.s
 RUN cd /go/src/cmd/service && ./skanky-vendor.sh $GOPATH/src/github.com/containerd/containerd
 RUN go-compile.sh /go/src/cmd/service
 
-FROM linuxkit/alpine:bc528cf9d4065d2e09aa44ff76909b94cfe8d867 AS mirror
+FROM linuxkit/alpine:e2391e0b164c57db9f6c4ae110ee84f766edc430 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 

--- a/pkg/init/cmd/service/cmd.go
+++ b/pkg/init/cmd/service/cmd.go
@@ -6,10 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	pathutil "path"
 	"path/filepath"
-
-	syscall "golang.org/x/sys/unix"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
@@ -203,31 +200,12 @@ func start(ctx context.Context, service, sock, basePath, dumpSpec string) (strin
 
 	logger := GetLog(varLogDir)
 
-	// This is silly but necessary due to containerd bug
-	// https://github.com/containerd/containerd/issues/4019
-	// essentially, when you create a container and then remove it,
-	// containerd blows away everything in the parent dir of the first one it finds,
-	// in this case, "/dev/null", so it blows away everything in "/dev".
-	// This most certainly is a "bad thing".
-	//
-	// To fix it temporarily, we are creating a tmpdir and creating a null
-	// device there, so that it can blow away the tempdir
-	stdinDir := pathutil.Join("/run", "containers-stdin", service)
-	if err := os.MkdirAll(stdinDir, 0700); err != nil {
-		return "", 0, "failed to create stdin directory", err
-	}
-	stdinFile := pathutil.Join(stdinDir, "null")
-	// make a dev null in stdinDir
-	if err := syscall.Mknod(stdinFile, uint32(os.FileMode(0660)|syscall.S_IFCHR), int(syscall.Mkdev(1, 3))); err != nil {
-		return "", 0, "failed to create stdin null file", err
-	}
-
 	io := func(id string) (cio.IO, error) {
 		stdoutFile := logger.Path(service + ".out")
 		stderrFile := logger.Path(service)
 		return &logio{
 			cio.Config{
-				Stdin:    stdinFile,
+				Stdin:    "/dev/null",
 				Stdout:   stdoutFile,
 				Stderr:   stderrFile,
 				Terminal: false,

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -11,7 +11,7 @@ RUN \
   make \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin
-ENV RUNC_COMMIT=d736ef14f0288d6993a1845745d6756cfc9ddd5a
+ENV RUNC_COMMIT=v1.0.0-rc10
 RUN mkdir -p $GOPATH/src/github.com/opencontainers && \
   cd $GOPATH/src/github.com/opencontainers && \
   git clone https://github.com/opencontainers/runc.git

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:541f60fe3676611328e89e8bac251fc636b1a6aa

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/src/cmd/linuxkit/moby/linuxkit.go
+++ b/src/cmd/linuxkit/moby/linuxkit.go
@@ -17,8 +17,8 @@ kernel:
   image: linuxkit/kernel:4.9.39
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:cad5659e03d5e6d81c26bb0a9724cc626dee57b4

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
 
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
 services:
   - name: acpid
     image: linuxkit/acpid:d5692a8c9d7cfceb7922acb8e356928c920bc280

--- a/test/cases/010_platforms/110_gcp/000_run/test.yml
+++ b/test/cases/010_platforms/110_gcp/000_run/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3

--- a/test/cases/020_kernel/002_config_4.14.x/test.yml
+++ b/test/cases/020_kernel/002_config_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.175
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:fabda492c6efc9e34b9f994b09d03ffc0facd8d8

--- a/test/cases/020_kernel/005_config_4.19.x/test.yml
+++ b/test/cases/020_kernel/005_config_4.19.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.114
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:fabda492c6efc9e34b9f994b09d03ffc0facd8d8

--- a/test/cases/020_kernel/011_config_5.4.x/test.yml
+++ b/test/cases/020_kernel/011_config_5.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:fabda492c6efc9e34b9f994b09d03ffc0facd8d8

--- a/test/cases/020_kernel/012_config_5.6.x/test.yml
+++ b/test/cases/020_kernel/012_config_5.6.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.6.2
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:fabda492c6efc9e34b9f994b09d03ffc0facd8d8

--- a/test/cases/020_kernel/102_kmod_4.14.x/test.yml
+++ b/test/cases/020_kernel/102_kmod_4.14.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.14.175
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/105_kmod_4.19.x/test.yml
+++ b/test/cases/020_kernel/105_kmod_4.19.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.19.114
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/111_kmod_5.4.x/test.yml
+++ b/test/cases/020_kernel/111_kmod_5.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/112_kmod_5.6.x/test.yml
+++ b/test/cases/020_kernel/112_kmod_5.6.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.6.2
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/200_namespace/common.yml
+++ b/test/cases/020_kernel/200_namespace/common.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 trust:
   org:
     - linuxkit

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: test
     image: alpine:3.11

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:94d59bc179c7a9155d8593a974d499352b70bfd5

--- a/test/cases/040_packages/002_bpftrace/test.yml
+++ b/test/cases/040_packages/002_bpftrace/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
   - linuxkit/bpftrace:65c4dc9f6dcb3bbb52f7f13acf067d01f7e6e538
 onboot:
   - name: bpftrace-test

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: dhcpcd
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:19fa297189166206ac97261679c3e31fb140d48f
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:fa781a2ec490a63140a2e90f9c8d13c735dd4c5f
+    image: linuxkit/test-containerd:8e144d8bfc3bb10c1ed91ef65a82ac1997265e75
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3
 trust:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee

--- a/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: dm-crypt
     image: linuxkit/dm-crypt:0ea63bfd97b719d185b69994b4856d97fbc8a2dd

--- a/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: dm-crypt
     image: linuxkit/dm-crypt:0ea63bfd97b719d185b69994b4856d97fbc8a2dd

--- a/test/cases/040_packages/004_dm-crypt/002_key/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/002_key/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: dm-crypt
     image: linuxkit/dm-crypt:0ea63bfd97b719d185b69994b4856d97fbc8a2dd

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: format
     image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: extend
     image: linuxkit/extend:10bc501a6890be931c6f6602c8caca31337eafeb

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:944769462b9d10b1b1506498d3eb03dcc5416f7f

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:944769462b9d10b1b1506498d3eb03dcc5416f7f

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: format
     image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: extend
     image: linuxkit/extend:10bc501a6890be931c6f6602c8caca31337eafeb

--- a/test/cases/040_packages/005_extend/003_gpt/test-create.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: format
     image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96

--- a/test/cases/040_packages/005_extend/003_gpt/test.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: extend
     image: linuxkit/extend:10bc501a6890be931c6f6602c8caca31337eafeb

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: format
     image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: format
     image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: format
     image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:944769462b9d10b1b1506498d3eb03dcc5416f7f

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: format
     image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: format
     image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96

--- a/test/cases/040_packages/006_format_mount/006_gpt/test.yml
+++ b/test/cases/040_packages/006_format_mount/006_gpt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: format
     image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: format
     image: linuxkit/format:0b75e494eea0312f3015e6c6f7c5927620d56c96

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/012_losetup/test.yml
+++ b/test/cases/040_packages/012_losetup/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: losetup
     image: linuxkit/losetup:0730b61ac5c8803ba73318c2dd5121dc15cfbf34

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:cad5659e03d5e6d81c26bb0a9724cc626dee57b4

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:06dd4e46c62fbe79123a028835c921f80e4855d3

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:541f60fe3676611328e89e8bac251fc636b1a6aa

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
   - linuxkit/memlogd:ddfd99754f0cfc63a675f49aa32a8f2c92785551
 services:

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
   - linuxkit/memlogd:ddfd99754f0cfc63a675f49aa32a8f2c92785551
 services:

--- a/test/cases/040_packages/032_bcc/test.yml
+++ b/test/cases/040_packages/032_bcc/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
   - linuxkit/kernel-bcc:5.4.30
 onboot:
   - name: check-bcc

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
-  - linuxkit/containerd:8ee7a0d636fff9df7e13076f5492d06274e5f644
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
+  - linuxkit/containerd:6ef473a228db6f6ee163f9b9a051102a1552a4ef
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2f8a9b670aa6e96a09db56ec45c9f07ef2a811ee

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:bc528cf9d4065d2e09aa44ff76909b94cfe8d867 AS mirror
+FROM linuxkit/alpine:e2391e0b164c57db9f6c4ae110ee84f766edc430 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)
 # util-linux is required for btrfs test (losetup)

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:f670045ecb6ec31ea37dd10114366e9a1e915013
-  - linuxkit/runc:1eef77f5963e44e491abfe392206769037d47ae2
+  - linuxkit/init:7195dc244cd92af01fd0895fd204249a6114c5e2
+  - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:<hash>

--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -54,9 +54,8 @@ RUN go get -u github.com/LK4D4/vndr
 # checkout and compile containerd
 # Update `FROM` in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile` and
 # `test/pkg/containerd/Dockerfile` when changing this.
-# For v1.3.x cherry-pick a upstream commit to allow disabling some tests.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
-ENV CONTAINERD_COMMIT=v1.3.3
+ENV CONTAINERD_COMMIT=v1.3.4
 RUN mkdir -p $GOPATH/src/github.com/containerd && \
   cd $GOPATH/src/github.com/containerd && \
   git clone https://github.com/containerd/containerd.git && \

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -127,3 +127,4 @@ xz
 xz-dev
 zfs
 zlib-dev
+zlib-static

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:684208fa9e2d0b1cea695324e6b310768b095a79-arm64
+# linuxkit/alpine:e6635fd5f68e716e7c90ebab56543d291bef24eb-arm64
 # automatically generated list of installed packages
 abuild-3.5.0-r0
 alpine-baselayout-3.2.0-r3
@@ -93,8 +93,8 @@ gettext-0.20.1-r2
 gettext-asprintf-0.20.1-r2
 gettext-dev-0.20.1-r2
 gettext-libs-0.20.1-r2
-git-2.24.1-r0
-git-perl-2.24.1-r0
+git-2.24.3-r0
+git-perl-2.24.3-r0
 glib-2.62.6-r0
 gmp-6.1.2-r1
 gmp-dev-6.1.2-r1
@@ -147,7 +147,7 @@ libcap-2.27-r0
 libcap-ng-0.7.10-r0
 libcap-ng-dev-0.7.10-r0
 libcom_err-1.45.5-r0
-libcrypto1.1-1.1.1d-r3
+libcrypto1.1-1.1.1g-r0
 libcurl-7.67.0-r0
 libdrm-2.4.100-r0
 libedit-20191211.3.1-r0
@@ -189,7 +189,7 @@ libseccomp-2.4.2-r2
 libseccomp-dev-2.4.2-r2
 libsecret-0.19.1-r0
 libsmartcols-2.34-r1
-libssl1.1-1.1.1d-r3
+libssl1.1-1.1.1g-r0
 libstdc++-9.2.0-r4
 libtasn1-4.15.0-r0
 libtheora-1.1.1-r14
@@ -271,8 +271,8 @@ openresolv-3.9.2-r0
 openssh-keygen-8.1_p1-r0
 openssh-server-8.1_p1-r0
 openssh-server-common-8.1_p1-r0
-openssl-1.1.1d-r3
-openssl-dev-1.1.1d-r3
+openssl-1.1.1g-r0
+openssl-dev-1.1.1g-r0
 opus-1.3.1-r0
 orc-0.4.31-r0
 p11-kit-0.23.18.1-r0
@@ -284,7 +284,7 @@ pcre2-10.34-r1
 pcsc-lite-libs-1.8.25-r2
 perl-5.30.1-r0
 perl-error-0.17028-r0
-perl-git-2.24.1-r0
+perl-git-2.24.3-r0
 pigz-2.4-r0
 pinentry-1.1.0-r2
 pixman-0.38.4-r0
@@ -368,4 +368,5 @@ zfs-libs-0.8.3-r1
 zfs-openrc-0.8.3-r1
 zlib-1.2.11-r3
 zlib-dev-1.2.11-r3
+zlib-static-1.2.11-r3
 zstd-libs-1.4.4-r1

--- a/tools/alpine/versions.s390x
+++ b/tools/alpine/versions.s390x
@@ -1,4 +1,4 @@
-# linuxkit/alpine:10ac4242d642b9c9c0ada11990b63cf4183efcf6-s390x
+# linuxkit/alpine:890d3338f9cdf4419fb8aeb75863408329c9d1ce-s390x
 # automatically generated list of installed packages
 abuild-3.5.0-r0
 alpine-baselayout-3.2.0-r3
@@ -92,8 +92,8 @@ gettext-0.20.1-r2
 gettext-asprintf-0.20.1-r2
 gettext-dev-0.20.1-r2
 gettext-libs-0.20.1-r2
-git-2.24.1-r0
-git-perl-2.24.1-r0
+git-2.24.3-r0
+git-perl-2.24.3-r0
 glib-2.62.6-r0
 gmp-6.1.2-r1
 gmp-dev-6.1.2-r1
@@ -146,7 +146,7 @@ libcap-2.27-r0
 libcap-ng-0.7.10-r0
 libcap-ng-dev-0.7.10-r0
 libcom_err-1.45.5-r0
-libcrypto1.1-1.1.1d-r3
+libcrypto1.1-1.1.1g-r0
 libcurl-7.67.0-r0
 libdrm-2.4.100-r0
 libedit-20191211.3.1-r0
@@ -186,7 +186,7 @@ libseccomp-2.4.2-r2
 libseccomp-dev-2.4.2-r2
 libsecret-0.19.1-r0
 libsmartcols-2.34-r1
-libssl1.1-1.1.1d-r3
+libssl1.1-1.1.1g-r0
 libstdc++-9.2.0-r4
 libtasn1-4.15.0-r0
 libtheora-1.1.1-r14
@@ -264,8 +264,8 @@ openresolv-3.9.2-r0
 openssh-keygen-8.1_p1-r0
 openssh-server-8.1_p1-r0
 openssh-server-common-8.1_p1-r0
-openssl-1.1.1d-r3
-openssl-dev-1.1.1d-r3
+openssl-1.1.1g-r0
+openssl-dev-1.1.1g-r0
 opus-1.3.1-r0
 orc-0.4.31-r0
 p11-kit-0.23.18.1-r0
@@ -277,7 +277,7 @@ pcre2-10.34-r1
 pcsc-lite-libs-1.8.25-r2
 perl-5.30.1-r0
 perl-error-0.17028-r0
-perl-git-2.24.1-r0
+perl-git-2.24.3-r0
 pigz-2.4-r0
 pinentry-1.1.0-r2
 pixman-0.38.4-r0
@@ -360,4 +360,5 @@ zfs-libs-0.8.3-r1
 zfs-openrc-0.8.3-r1
 zlib-1.2.11-r3
 zlib-dev-1.2.11-r3
+zlib-static-1.2.11-r3
 zstd-libs-1.4.4-r1

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:bc528cf9d4065d2e09aa44ff76909b94cfe8d867-amd64
+# linuxkit/alpine:e2391e0b164c57db9f6c4ae110ee84f766edc430-amd64
 # automatically generated list of installed packages
 abuild-3.5.0-r0
 alpine-baselayout-3.2.0-r3
@@ -95,8 +95,8 @@ gettext-0.20.1-r2
 gettext-asprintf-0.20.1-r2
 gettext-dev-0.20.1-r2
 gettext-libs-0.20.1-r2
-git-2.24.1-r0
-git-perl-2.24.1-r0
+git-2.24.3-r0
+git-perl-2.24.3-r0
 glib-2.62.6-r0
 gmp-6.1.2-r1
 gmp-dev-6.1.2-r1
@@ -152,7 +152,7 @@ libcap-2.27-r0
 libcap-ng-0.7.10-r0
 libcap-ng-dev-0.7.10-r0
 libcom_err-1.45.5-r0
-libcrypto1.1-1.1.1d-r3
+libcrypto1.1-1.1.1g-r0
 libcurl-7.67.0-r0
 libdrm-2.4.100-r0
 libedit-20191211.3.1-r0
@@ -196,7 +196,7 @@ libseccomp-2.4.2-r2
 libseccomp-dev-2.4.2-r2
 libsecret-0.19.1-r0
 libsmartcols-2.34-r1
-libssl1.1-1.1.1d-r3
+libssl1.1-1.1.1g-r0
 libstdc++-9.2.0-r4
 libtasn1-4.15.0-r0
 libtheora-1.1.1-r14
@@ -281,8 +281,8 @@ openresolv-3.9.2-r0
 openssh-keygen-8.1_p1-r0
 openssh-server-8.1_p1-r0
 openssh-server-common-8.1_p1-r0
-openssl-1.1.1d-r3
-openssl-dev-1.1.1d-r3
+openssl-1.1.1g-r0
+openssl-dev-1.1.1g-r0
 opus-1.3.1-r0
 orc-0.4.31-r0
 ovmf-0.0.201908-r0
@@ -295,7 +295,7 @@ pcre2-10.34-r1
 pcsc-lite-libs-1.8.25-r2
 perl-5.30.1-r0
 perl-error-0.17028-r0
-perl-git-2.24.1-r0
+perl-git-2.24.3-r0
 pigz-2.4-r0
 pinentry-1.1.0-r2
 pixman-0.38.4-r0
@@ -379,4 +379,5 @@ zfs-libs-0.8.3-r1
 zfs-openrc-0.8.3-r1
 zlib-1.2.11-r3
 zlib-dev-1.2.11-r3
+zlib-static-1.2.11-r3
 zstd-libs-1.4.4-r1


### PR DESCRIPTION
While at it:
- bump runc
- remove workaround in init
- add zlib-static to alpine base (wip https://github.com/linuxkit/linuxkit/issues/3498)

![image](https://user-images.githubusercontent.com/3338098/80321956-59c71280-8819-11ea-9e38-00a57fbfe225.png)
