### PR TITLE
mDNS/DNS-SD support via Avahi daemon package

### DIFF
--- a/pkg/avahi/Dockerfile
+++ b/pkg/avahi/Dockerfile
@@ -1,0 +1,19 @@
+FROM linuxkit/alpine:e2391e0b164c57db9f6c4ae110ee84f766edc430 AS mirror
+
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    --update --repository http://dl-cdn.alpinelinux.org/alpine/v3.11/main/ \
+    alpine-baselayout \
+    busybox \
+    musl \
+    avahi
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+FROM scratch
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=mirror /out/ /
+COPY --from=mirror /out/var/run /var/run
+COPY /avahi-daemon.conf /etc/avahi/avahi-daemon.conf
+CMD ["/usr/sbin/avahi-daemon"]

--- a/pkg/avahi/avahi-daemon.conf
+++ b/pkg/avahi/avahi-daemon.conf
@@ -1,0 +1,68 @@
+# This file is part of avahi.
+#
+# avahi is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# avahi is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with avahi; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+# USA.
+
+# See avahi-daemon.conf(5) for more information on this configuration
+# file!
+
+[server]
+#host-name=foo
+#domain-name=local
+#browse-domains=0pointer.de, zeroconf.org
+use-ipv4=yes
+use-ipv6=yes
+#allow-interfaces=eth0
+#deny-interfaces=eth1
+#check-response-ttl=no
+#use-iff-running=no
+enable-dbus=no
+#disallow-other-stacks=no
+#allow-point-to-point=no
+#cache-entries-max=4096
+#clients-max=4096
+#objects-per-client-max=1024
+#entries-per-entry-group-max=32
+ratelimit-interval-usec=1000000
+ratelimit-burst=1000
+
+[wide-area]
+enable-wide-area=yes
+
+[publish]
+#disable-publishing=no
+#disable-user-service-publishing=no
+#add-service-cookie=no
+#publish-addresses=yes
+publish-hinfo=no
+publish-workstation=no
+#publish-domain=yes
+#publish-dns-servers=192.168.50.1, 192.168.50.2
+#publish-resolv-conf-dns-servers=yes
+#publish-aaaa-on-ipv4=yes
+#publish-a-on-ipv6=no
+
+[reflector]
+#enable-reflector=no
+#reflect-ipv=no
+
+[rlimits]
+#rlimit-as=
+#rlimit-core=0
+#rlimit-data=8388608
+#rlimit-fsize=0
+#rlimit-nofile=768
+#rlimit-stack=8388608
+#rlimit-nproc=3

--- a/pkg/avahi/build.yml
+++ b/pkg/avahi/build.yml
@@ -1,0 +1,6 @@
+image: avahi
+config:
+  capabilities:
+    - CAP_SYS_CHROOT
+    - CAP_SETUID
+    - CAP_SETGID

--- a/tools/alpine/packages
+++ b/tools/alpine/packages
@@ -7,6 +7,7 @@ attr-dev
 audit
 autoconf
 automake
+avahi
 bash
 bc
 binutils


### PR DESCRIPTION
**- What I did**
I've implemented  RFC 6762 multicast DNS (mDNS) and RFC 6763 DNS Service Discovery (DNS-SD) via the Avahi daemon as a package.

**- How I did it**
Add the Avahi daemon package in order to support mDNS/DNS-SD.

**- Description for the changelog**
mDNS/DNS-SD support via Avahi daemon package