### PR TITLE
options to split image steps and manifest steps

### DIFF
--- a/src/cmd/linuxkit/pkg_push.go
+++ b/src/cmd/linuxkit/pkg_push.go
@@ -22,6 +22,9 @@ func pkgPush(args []string) {
 	force := flags.Bool("force", false, "Force rebuild")
 	release := flags.String("release", "", "Release the given version")
 	nobuild := flags.Bool("nobuild", false, "Skip the build")
+	manifest := flags.Bool("manifest", true, "Create and push multi-arch manifest")
+	image := flags.Bool("image", true, "Build and push image for the current platform")
+	sign := flags.Bool("sign", true, "sign the manifest, if a manifest is created; ignored if --manifest=false")
 
 	p, err := pkglib.NewFromCLI(flags, args...)
 	if err != nil {
@@ -43,6 +46,16 @@ func pkgPush(args []string) {
 	}
 	if *release != "" {
 		opts = append(opts, pkglib.WithRelease(*release))
+	}
+	if *manifest {
+		opts = append(opts, pkglib.WithBuildManifest())
+	}
+	if *image {
+		opts = append(opts, pkglib.WithBuildImage())
+	}
+	// only sign manifests; ignore for image only
+	if *sign && *manifest {
+		opts = append(opts, pkglib.WithBuildSign())
 	}
 
 	if *nobuild {


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Split `pkg push` into 2 distinct stages, but can be executed as one:

1. Push the image from your local arch (e.g. amd64, arm64, etc.)
1. Create and push the manifest and sign it

The `docs/packages.md` has been updated to reflect how to do it. Short form:

1. Go to each arch and do 

```
lkt pkg push --manifest=false path/to/pkg
```

1. Go to wherever you have your signing keys and do

```
DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=<whatever> lkt pkg push --image=false path/to/pkg
```

You can disable signing as well by doing `--sign=false`

The default remains the current behaviour 

**- How I did it**

Split up the code in `src/cmd/linuxkit/pkg_push.go`

**- How to verify it**

Create a package, test it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Push packages and push manifest and sign manifest optionally distinct stages

