### PR TITLE
trim-after-delete: handle containers and volumes as well as images

### DIFF
--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -75,7 +75,7 @@ services:
     command: ["/vpnkit-forwarder", "-vsockPort", "62373"]
   # Monitor for image deletes and invoke a TRIM on the container filesystem
   - name: trim-after-delete
-    image: linuxkit/trim-after-delete:v0.8
+    image: linuxkit/trim-after-delete:6258aec13d91259379289b577f8a79754819777e
   # When the host resumes from sleep, force a clock resync
   - name: host-timesync-daemon
     image: linuxkit/host-timesync-daemon:v0.8

--- a/pkg/trim-after-delete/main.go
+++ b/pkg/trim-after-delete/main.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-// Listen for Docker image delete events and run a command after a delay.
+// Listen for Docker image, container, and volume delete events and run a command after a delay.
 
 // Event represents the subset of the Docker event message that we're
 // interested in
@@ -136,7 +136,13 @@ RECONNECT:
 				continue RECONNECT
 			}
 			if event.Action == "delete" && event.Type == "image" {
-				log.Printf("The delayed action will happen at least once more")
+				log.Printf("An image has been removed: will run the action at least once more")
+				action.AtLeastOnceMore()
+			} else if event.Action == "destroy" && event.Type == "container" {
+				log.Printf("A container has been removed: will run the action at least once more")
+				action.AtLeastOnceMore()
+			} else if event.Action == "destroy" && event.Type == "volume" {
+				log.Printf("A volume has been removed: will run the action at least once more")
 				action.AtLeastOnceMore()
 			}
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Extended `trim-after-delete` to run the command after a container destroy and volume destroy.

**- How I did it**

We already watch for events, so it's a simple matter to handle the additional container and volume events.

**- How to verify it**

I run
```
trim-after-delete -- /sbin/fstrim /var/lib/docker
```
and then `docker rm` a container. I see the following output:
```
2020/07/24 13:08:10 A container has been deleted: will run the action at least once more
2020/07/24 13:08:20 Running /sbin/fstrim /var/lib/docker
```

If I `docker image rm` an image I see the following output:
```
2020/07/24 13:08:41 An image has been deleted: will run the action at least once more
2020/07/24 13:08:51 Running /sbin/fstrim /var/lib/docker
```

If I `docker volume rm` a volume I see the following output:
```
2020/07/24 13:25:25 A volume has been removed: will run the action at least once more
2020/07/24 13:25:35 Running /sbin/fstrim /var/lib/docker
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

- `trim-after-delete`: run the command also after container destroy and volume destroy.

**- A picture of a cute animal (not mandatory but encouraged)**

![iu](https://user-images.githubusercontent.com/198586/88394665-bd7cbf80-cdb7-11ea-9812-5fb1561fc43b.jpeg)
