### PR TITLE
Make `pkg build` build the image

### DIFF
--- a/src/cmd/linuxkit/pkg_build.go
+++ b/src/cmd/linuxkit/pkg_build.go
@@ -29,7 +29,7 @@ func pkgBuild(args []string) {
 
 	fmt.Printf("Building %q\n", p.Tag())
 
-	var opts []pkglib.BuildOpt
+	opts := []pkglib.BuildOpt{pkglib.WithBuildImage()}
 	if *force {
 		opts = append(opts, pkglib.WithBuildForce())
 	}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed `pkg build` command not actually building anything. Think the problem originates from changes in https://github.com/linuxkit/linuxkit/commit/ea18be414eb85888f9990a7821608cdd505a2fe2.

**- How I did it**

Added `WithBuildImage` to opts in `pkg_build`.

**- How to verify it**

Running for example `linuxkit pkg build -org=example -disable-content-trust pkg/sshd` should result in a built image.

**- Description for the changelog**

Fixed `pkg build` command not building the image.

**- A picture of a cute animal (not mandatory but encouraged)**
