### PR TITLE
Post v0.8 cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Improved RPI3 build
 
 ### Removed
+- Containerized `qemu`
+- Windows binary from release
 
 ## [v0.7] - 2019-04-17
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION="v0.8"
+VERSION="v0.8+"
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
 GO_COMPILE=linuxkit/go-compile:b1446b2ba407225011f97ae1dba0f512ae7f9b84


### PR DESCRIPTION
- Bump version to v0.8+
- Update changelog (closes https://github.com/linuxkit/linuxkit/pull/3528)

![cats](https://user-images.githubusercontent.com/3338098/88476892-c85c5f00-cf33-11ea-928d-ad9273773075.jpeg)
