### PR TITLE
add support for build-args

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -204,6 +204,12 @@ linuxkit pkg build -org=wombat -disable-content-trust -hash=foo push
 and this will create `wombat/<image>:foo-<arch>` and
 `wombat/<image>:foo` for use in your YAML files.
 
+#### Build Args
+
+Like [docker build-time variables](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg), you can set build-time variables when running `linuxkit pkg build --build-arg=key=val`
+or simply `--build-arg ENVVAR`. See the documentation for
+[docker build-time variables](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) for more information.
+
 ### Proxies
 
 If you are building packages from behind a proxy, `linuxkit pkg build` respects

--- a/pkg/test/Dockerfile
+++ b/pkg/test/Dockerfile
@@ -1,0 +1,7 @@
+FROM library/alpine:3.11
+ARG MYARG=default
+
+RUN echo "My var is ${MYARG}"
+
+COPY test.sh /test.sh
+CMD /test.sh

--- a/pkg/test/build.yml
+++ b/pkg/test/build.yml
@@ -1,0 +1,4 @@
+image: test
+config:
+  capabilities:
+    - all

--- a/pkg/test/test.sh
+++ b/pkg/test/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "I am here"
+

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -21,6 +21,7 @@ type buildOpts struct {
 	manifest  bool
 	sign      bool
 	image     bool
+	args      []string
 }
 
 // BuildOpt allows callers to specify options to Build
@@ -78,6 +79,17 @@ func WithBuildSign() BuildOpt {
 func WithRelease(r string) BuildOpt {
 	return func(bo *buildOpts) error {
 		bo.release = r
+		return nil
+	}
+}
+
+// WithBuildArg add a build arg to the build, run as docker --build-arg=<passed value>
+func WithBuildArg(r string) BuildOpt {
+	return func(bo *buildOpts) error {
+		if bo.args == nil {
+			bo.args = []string{}
+		}
+		bo.args = append(bo.args, r)
 		return nil
 	}
 }
@@ -171,6 +183,10 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 
 		args = append(args, "--label=org.mobyproject.linuxkit.version="+version.Version)
 		args = append(args, "--label=org.mobyproject.linuxkit.revision="+version.GitCommit)
+
+		for _, arg := range bo.args {
+			args = append(args, fmt.Sprintf("--build-arg=%s", arg))
+		}
 
 		d.ctx = &buildCtx{sources: p.sources}
 


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added support for `--build-arg` to `lkt pkg build`, passing them on to `docker build --build-arg`

**- How I did it**

Added the command option to the `pkg build` flagSet, and then creating `WithBuildArg()` options

**- How to verify it**

Run it with and without the `--build-arg`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Support for `--build-arg`
