### PR TITLE
contrib: extend list of tolerations for open-vm-tools

### DIFF
--- a/contrib/open-vm-tools/open-vm-tools-ds.yaml
+++ b/contrib/open-vm-tools/open-vm-tools-ds.yaml
@@ -22,6 +22,9 @@ spec:
         value: "true"
         effect: NoSchedule
       - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
       containers:
       - image: linuxkit/open-vm-tools:v0.8
         name: open-vm-tools


### PR DESCRIPTION
**- What I did**
Extended list of tolerations with `node-role.kubernetes.io/master=true:NoSchedule`; kept the previous tolerations

Fixes #3549

**- How I did it**
- Added new toleration into the list of tolerations

**- How to verify it**
1) Taint a node with `node-role.kubernetes.io/master=true:NoSchedule`
2) Execute `kubectl apply -f contrib/open-vm-tools/open-vm-tools-ds.yaml`
3) Check that the `open-vm-tools` Pod started on the tainted node  from Step 1

**- Description for the changelog**
Extend list of tolerations for open-vm-tools
