### PR TITLE
Added hash option to yaml

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -37,6 +37,7 @@ A package source consists of a directory containing at least two files:
 
 - `image` _(string)_: *(mandatory)* The name of the image to build
 - `org` _(string)_: The hub/registry organisation to which this package belongs
+- `hash` _(string)_: The hash used for the resulting package (by default computed from the git commit)
 - `arches` _(list of string)_: The architectures which this package should be built for (valid entries are `GOARCH` names)
 - `extra-sources` _(list of strings)_: Additional sources for the package outside the package directory. The format is `src:dst`, where `src` can be relative to the package directory and `dst` is the destination in the build context. This is useful for sharing files, such as vendored go code, between packages.
 - `gitrepo` _(string)_: The git repository where the package source is kept.

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -18,6 +18,7 @@ import (
 type pkgInfo struct {
 	Image               string            `yaml:"image"`
 	Org                 string            `yaml:"org"`
+	Hash                string            `yaml:"hash"`
 	Arches              []string          `yaml:"arches"`
 	ExtraSources        []string          `yaml:"extra-sources"`
 	GitRepo             string            `yaml:"gitrepo"` // ??
@@ -224,17 +225,21 @@ func NewFromCLI(fs *flag.FlagSet, args ...string) (Pkg, error) {
 		dirty = dirty || gitDirty
 
 		if hash == "" {
-			if hash, err = git.treeHash(hashPath, hashCommit); err != nil {
-				return Pkg{}, err
-			}
+			if pi.Hash != "" {
+				hash = pi.Hash
+			} else {
+				if hash, err = git.treeHash(hashPath, hashCommit); err != nil {
+					return Pkg{}, err
+				}
 
-			if srcHashes != "" {
-				hash += srcHashes
-				hash = fmt.Sprintf("%x", sha1.Sum([]byte(hash)))
-			}
+				if srcHashes != "" {
+					hash += srcHashes
+					hash = fmt.Sprintf("%x", sha1.Sum([]byte(hash)))
+				}
 
-			if dirty {
-				hash += "-dirty"
+				if dirty {
+					hash += "-dirty"
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Peter Pulik <petopulik@gmail.com>

**- What I did**
I added the option to define package tag/hash in yaml file. I used the keyword "hash" for it to be consistent with a CLI argument name.

**- How I did it**
The priority is now:
CLI argument
YAML
hash value computed from GIT commit

**- How to verify it**
Try adding "hash: <HASH>" to any package yaml file

**- Description for the changelog**
Added hash option for package yaml.

**- A picture of a cute animal (not mandatory but encouraged)**
