### PR TITLE
docker: set oom score adjust to -500

### DIFF
--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -44,7 +44,8 @@ services:
       - /var/run:/var/run
       - /lib/modules:/lib/modules
       - /etc/docker/daemon.json:/etc/docker/daemon.json
-    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
+    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd", "--",
+              "--oom-score-adjust", "-500"]
   - name: cadvisor
     image: linuxkit/cadvisor:v0.8
 files:

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -101,6 +101,7 @@ services:
      - /usr/bin/vpnkit-iptables-wrapper:/usr/bin/iptables # iptables wrapper
     command: [ "/usr/local/bin/docker-init", "/usr/local/bin/dockerd", "--",
             "--config-file", "/var/config/docker/daemon.json",
+            "--oom-score-adjust", "-500",
             "--swarm-default-advertise-addr=eth0",
             "--userland-proxy-path", "/usr/bin/vpnkit-expose-port",
             "--storage-driver", "overlay2" ]

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -40,7 +40,8 @@ services:
      - /var/lib/docker:/var/lib/docker
      - /lib/modules:/lib/modules
      - /etc/docker/daemon.json:/etc/docker/daemon.json
-    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
+    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd", "--",
+              "--oom-score-adjust", "-500"]
 files:
   - path: var/lib/docker
     directory: true

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -42,7 +42,8 @@ services:
      - /lib/modules:/lib/modules
      - /var/run:/var/run
      - /etc/html:/var/html
-    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
+    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd", "--",
+              "--oom-score-adjust", "-500"]
   - name: compose
     image: linuxkitprojects/compose:111f9f32a933c9e7acbf3ccfc13fedbdfce8224f
     binds:

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -42,7 +42,8 @@ services:
      - /lib/modules:/lib/modules
      - /var/run:/var/run
      - /etc/html:/var/html
-    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
+    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd", "--",
+              "--oom-score-adjust", "-500"]
   - name: compose
     image: linuxkitprojects/compose:111f9f32a933c9e7acbf3ccfc13fedbdfce8224f
     binds:

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -32,7 +32,8 @@ services:
      - /var/lib/docker:/var/lib/docker
      - /lib/modules:/lib/modules
      - /run:/var/run
-    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
+    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd", "--",
+              "--oom-score-adjust", "-500"]
   - name: test-docker-bench
     image: linuxkit/test-docker-bench:51388c7c187cd8a39d4afcbdf18482ad2833299c
     ipc: host


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/41528

Currently, dockerd sets a "-500" oom-score-adjust for itself by default.

We're removing this default, and instead:

- for dockerd running as systemd unit, set the oom-score through systemd
- when manually running dockerd, require users to explicitly set a score

This patch is in preparation of those changes.
