### PR TITLE
include openssh-client in sshd pkg

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -18,7 +18,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:v0.8
   - name: sshd
-    image: linuxkit/sshd:v0.8
+    image: linuxkit/sshd:666b4a1a323140aa1f332826164afba506abf597
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -15,7 +15,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.8
   - name: sshd
-    image: linuxkit/sshd:v0.8
+    image: linuxkit/sshd:666b4a1a323140aa1f332826164afba506abf597
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -22,7 +22,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:v0.8
   - name: sshd
-    image: linuxkit/sshd:v0.8
+    image: linuxkit/sshd:666b4a1a323140aa1f332826164afba506abf597
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/hetzner.yml
+++ b/examples/hetzner.yml
@@ -28,7 +28,7 @@ services:
     env:
      - INSECURE=true
   - name: sshd
-    image: linuxkit/sshd:v0.8
+    image: linuxkit/sshd:666b4a1a323140aa1f332826164afba506abf597
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -19,7 +19,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:v0.8
   - name: sshd
-    image: linuxkit/sshd:v0.8
+    image: linuxkit/sshd:666b4a1a323140aa1f332826164afba506abf597
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -28,7 +28,7 @@ services:
     env:
      - INSECURE=true
   - name: sshd
-    image: linuxkit/sshd:v0.8
+    image: linuxkit/sshd:666b4a1a323140aa1f332826164afba506abf597
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -22,7 +22,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.8
   - name: sshd
-    image: linuxkit/sshd:v0.8
+    image: linuxkit/sshd:666b4a1a323140aa1f332826164afba506abf597
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -19,7 +19,7 @@ onboot:
     command: ["sh", "-c", "mkdir /host_var/vpnkit && mount -v -t 9p -o trans=virtio,dfltuid=1001,dfltgid=50,version=9p2000 port /host_var/vpnkit"]
 services:
   - name: sshd
-    image: linuxkit/sshd:v0.8
+    image: linuxkit/sshd:666b4a1a323140aa1f332826164afba506abf597
   - name: vpnkit-forwarder
     image: linuxkit/vpnkit-forwarder:v0.8
     binds:

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -23,7 +23,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:v0.8
   - name: sshd
-    image: linuxkit/sshd:v0.8
+    image: linuxkit/sshd:666b4a1a323140aa1f332826164afba506abf597
     binds:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx

--- a/pkg/sshd/Dockerfile
+++ b/pkg/sshd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:e2391e0b164c57db9f6c4ae110ee84f766edc430 AS mirror
+FROM linuxkit/alpine:a3d78322152a8b341bdaecfe182a2689fdbdee53 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -7,6 +7,7 @@ RUN apk add --no-cache --initdb -p /out \
     busybox \
     ca-certificates \
     musl \
+    openssh-client \
     openssh-server \
     tini \
     util-linux \

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -28,7 +28,7 @@ onboot:
      - /lib:/lib     # for ifconfig
 services:
   - name: sshd
-    image: linuxkit/sshd:v0.8
+    image: linuxkit/sshd:666b4a1a323140aa1f332826164afba506abf597
   - name: getty
     image: linuxkit/getty:v0.8
     env:


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added the `openssh-client` package to `linuxkit/sshd`. This enables people to ssh _from_ being on the host (as opposed to ssh to, which you already can do), as well as scp from it and to it.

**- How I did it**

1. Added the `openssh-client` apk package from the linuxkit/alpine cache
1. built and pushed `pkg/sshd` on all platforms, and signed the manifest
1. ran `update-components-sha.sh`, which updated `projects/` and `examples/`

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

ssh client tools in linuxkit/sshd

