### PR TITLE
fix deprecation of set-env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,13 @@ jobs:
       with:
         path: ./src/github.com/linuxkit/linuxkit
 
+    - name: Set path
+      run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      env:
+         GOPATH: ${{runner.workspace}}
+
     - name: Get pre-requisites
       run: |
-            echo "::set-env name=PATH::$PATH:$(go env GOPATH)/bin"
             go get -u golang.org/x/lint/golint
             go get -u github.com/gordonklaus/ineffassign
       env:


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

fix the GitHub Actions [set-env deprecation](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) that was causing CI to fail

**- How I did it**

Replaced `set-env` in our `ci.yaml` with a new step, per the GitHub recommendation

**- How to verify it**

CI runs

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

update CI per GitHub set-env deprecation

