### PR TITLE
Removed extraneous "/" at end of PREFIX in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifneq ($(GOARCH),amd64)
 CROSS+=-e GOARCH=$(GOARCH)
 endif
 
-PREFIX?=/usr/local/
+PREFIX?=/usr/local
 
 .DELETE_ON_ERROR:
 


### PR DESCRIPTION
**- What I did**
I removed the extraneous "/" at the end of the `PREFIX` variable in the main `Makefile`. 

That way, instead of using `/usr/local//bin`, we use the correct `/usr/local/bin` path.

**- How I did it**
`vi Makefile`

**- How to verify it**
`make && sudo make install`

**- Description for the changelog**
I removed the extraneous "/" at the end of the `PREFIX` variable in the main `Makefile`. 
