### PR TITLE
contrib: add control-plane toleration for open-vm-tools

### DIFF
--- a/contrib/open-vm-tools/open-vm-tools-ds.yaml
+++ b/contrib/open-vm-tools/open-vm-tools-ds.yaml
@@ -25,6 +25,10 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       containers:
       - image: linuxkit/open-vm-tools:v0.8
         name: open-vm-tools


### PR DESCRIPTION
**- What I did**
Added `"node-role.kubernetes.io/control-plane"` key as `toleration` for `open-vm-tools`

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>


**- How I did it**
- Extended the array of `tolerations`

**- How to verify it**

From Kubernetes v1.20.0 Release notes:
The label applied to control-plane nodes "node-role.kubernetes.io/master"
is now deprecated and will be removed in a future release after a GA
deprecation period.

Introduce a new label "node-role.kubernetes.io/control-plane" that will
be applied in parallel to "node-role.kubernetes.io/master" until the
removal of the "node-role.kubernetes.io/master" label.

xref: https://kubernetes.io/docs/setup/release/notes/#no-really-you-must-read-this-before-you-upgrade

**- Description for the changelog**
contrib: add control-plane toleration for open-vm-tools


**- A picture of a cute animal (not mandatory but encouraged)**
