### PR TITLE
strip containerd binaries

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -216,7 +216,7 @@ tag, so you are looking for the size and hash of whatever the tag points to, man
 If you pushed the image tag using `docker push`, the very last line of output will give you the hash and size:
 
 ```console
-$ docker push linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+$ docker push linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 The push refers to repository [docker.io/linuxkit/containerd]
 fce5742422e4: Layer already exists
 48a02e7b3096: Layer already exists
@@ -252,8 +252,8 @@ For example, inspecting just a single arch manifest gives us the hash on the sec
 size:
 
 ```console
-$ manifest-tool inspect linuxkit/containerd:v0.8-amd64
-Name: linuxkit/containerd:v0.8-amd64 (Type: application/vnd.docker.distribution.manifest.v2+json)
+$ manifest-tool inspect linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106-amd64
+Name: linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106-amd64 (Type: application/vnd.docker.distribution.manifest.v2+json)
       Digest: sha256:0dc4f37966e23c0dffa6961119f29100c6d181b221e748c4688a280c08ab52a8
           OS: linux
         Arch: amd64
@@ -270,8 +270,8 @@ index, but finding the right entry, for example the first one is `amd64`, gives 
 `Mfst Length: 1357`:
 
 ```console
-$ manifest-tool inspect linuxkit/containerd:v0.8
-Name:   linuxkit/containerd:v0.8 (Type: application/vnd.docker.distribution.manifest.list.v2+json)
+$ manifest-tool inspect linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
+Name:   linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106 (Type: application/vnd.docker.distribution.manifest.list.v2+json)
 Digest: sha256:247e1eb712c2f5e9d80bb1a9ddf9bb5479b3f785a7e0dd4a8844732bbaa96851
  * Contains 3 manifest references:
 1    Mfst Type: application/vnd.docker.distribution.manifest.v2+json
@@ -332,8 +332,8 @@ report the hash and size.
 For an index:
 
 ```console
-$ ocidist manifest docker.io/linuxkit/containerd:v0.8 --detail
-2020/11/12 11:00:03 ref name.Tag{Repository:name.Repository{Registry:name.Registry{insecure:false, registry:"index.docker.io"}, repository:"linuxkit/containerd"}, tag:"v0.8", original:"docker.io/linuxkit/containerd:v0.8"}
+$ ocidist manifest docker.io/linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106 --detail
+2020/11/12 11:00:03 ref name.Tag{Repository:name.Repository{Registry:name.Registry{insecure:false, registry:"index.docker.io"}, repository:"linuxkit/containerd"}, tag:"v0.8", original:"docker.io/linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106"}
 2020/11/12 11:00:03 advanced API
 2020/11/12 11:00:06 referenced manifest hash sha256:247e1eb712c2f5e9d80bb1a9ddf9bb5479b3f785a7e0dd4a8844732bbaa96851 size 1052
 {
@@ -374,8 +374,8 @@ $ ocidist manifest docker.io/linuxkit/containerd:v0.8 --detail
 For a single manifest:
 
 ```console
-$ ocidist manifest docker.io/linuxkit/containerd:v0.8-amd64 --detail
-2020/11/12 10:59:08 ref name.Tag{Repository:name.Repository{Registry:name.Registry{insecure:false, registry:"index.docker.io"}, repository:"linuxkit/containerd"}, tag:"v0.8-amd64", original:"docker.io/linuxkit/containerd:v0.8-amd64"}
+$ ocidist manifest docker.io/linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106-amd64 --detail
+2020/11/12 10:59:08 ref name.Tag{Repository:name.Repository{Registry:name.Registry{insecure:false, registry:"index.docker.io"}, repository:"linuxkit/containerd"}, tag:"v0.8-amd64", original:"docker.io/linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106-amd64"}
 2020/11/12 10:59:08 advanced API
 2020/11/12 10:59:11 referenced manifest hash sha256:0dc4f37966e23c0dffa6961119f29100c6d181b221e748c4688a280c08ab52a8 size 1357
 {

--- a/examples/addbinds.yml
+++ b/examples/addbinds.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:f79954950022fea76b8b6f10de58cb48e4fb3878
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:abfc6701b9ca17e34ac9439ce5946a247e720ff5
 onboot:
   - name: sysctl

--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/azure.yml
+++ b/examples/azure.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/vpnkit-expose-port:v0.8 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   # support metadata for optional config in /run/config

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/hetzner.yml
+++ b/examples/hetzner.yml
@@ -5,7 +5,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
   - linuxkit/firmware:v0.8
 onboot:

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: dhcpcd

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -5,7 +5,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
   - linuxkit/memlogd:v0.8
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.8

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 services:
   - name: getty
     image: linuxkit/getty:v0.8

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -5,7 +5,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
   - linuxkit/firmware:v0.8
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -6,7 +6,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.8

--- a/examples/rt-for-vmware.yml
+++ b/examples/rt-for-vmware.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/static-ip.yml
+++ b/examples/static-ip.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 onboot:
   - name: ip
     image: linuxkit/ip:v0.8

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/vmware.yml
+++ b/examples/vmware.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.8

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.8

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,8 +1,10 @@
 FROM linuxkit/alpine:a3d78322152a8b341bdaecfe182a2689fdbdee53 as alpine
-RUN apk add tzdata
+RUN apk add tzdata binutils
 
 WORKDIR $GOPATH/src/github.com/containerd/containerd
 RUN cp bin/containerd bin/ctr bin/containerd-shim bin/containerd-shim-runc-v2 /usr/bin/
+
+RUN strip /usr/bin/containerd /usr/bin/ctr /usr/bin/containerd-shim /usr/bin/containerd-shim-runc-v2
 
 RUN mkdir -p /etc/init.d && ln -s /usr/bin/service /etc/init.d/020-containerd
 

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.8

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.8

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -5,7 +5,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 
 onboot:
   - name: dhcpcd

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 services:
   - name: acpid
     image: linuxkit/acpid:v0.8

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/020_init_containerd/test.yml
+++ b/test/cases/040_packages/020_init_containerd/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 services:
   - name: test

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/030_logwrite/test.yml
+++ b/test/cases/040_packages/030_logwrite/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
   - linuxkit/memlogd:v0.8
 services:

--- a/test/cases/040_packages/031_kmsg/test.yml
+++ b/test/cases/040_packages/031_kmsg/test.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
   - linuxkit/ca-certificates:v0.8
   - linuxkit/memlogd:v0.8
 services:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -4,7 +4,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -6,7 +6,7 @@ kernel:
 init:
   - linuxkit/init:a68f9fa0c1d9dbfc9c23663749a0b7ac510cbe1c
   - linuxkit/runc:v0.8
-  - linuxkit/containerd:a4aa19c608556f7d786852557c36136255220c1f
+  - linuxkit/containerd:1ae8f054e9fe792d1dbdb9a65f1b5e14491cb106
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.8


### PR DESCRIPTION
Removing of debug info inside containerd reduces binaries size from 118MB to 90MB. It seems reasonable to reduce the size of the images built using linuxkit.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>
