### PR TITLE
provide wildcards to ineffassign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ local-check: $(LINUXKIT_DEPS)
 	@echo gofmt... && o=$$(gofmt -s -l $(filter %.go,$(LINUXKIT_DEPS))) && if [ -n "$$o" ] ; then echo $$o ; exit 1 ; fi
 	@echo govet... && go vet -printf=false ./src/cmd/linuxkit/...
 	@echo golint... && set -e ; for i in $(filter %.go,$(LINUXKIT_DEPS)); do golint $$i ; done
-	@echo ineffassign... && ineffassign  $(filter %.go,$(LINUXKIT_DEPS))
+	@echo ineffassign... && ineffassign ./src/cmd/linuxkit/...
 
 local-build: local-static
 


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Replaced the arg to `ineffassign` from a list of individual `.go` files to `./src/cmd/linuxkit/...`

The latest ineffassign doesn't accept individual files that are in different directories, so have to switch to `/...`
See [here](https://github.com/gordonklaus/ineffassign/commit/8eed68eb605f2ddf507412accb8dd7a595b5c114)

**- How I did it**

Replaced a single line in Makefile

**- How to verify it**

1. Change a few files to introduce the error
2. Run `ineffassign`
3. See that it catches them

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Support latest ineffassign args

cc @giggsoff