### PR TITLE
Support metaldata metadata provider

### DIFF
--- a/examples/aws.yml
+++ b/examples/aws.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.8
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.8
+    image: linuxkit/metadata:2cf1db0f0d2c9916b4894318bd76f1c97d8c8f7b
 services:
   - name: rngd
     image: linuxkit/rngd:v0.8

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -11,7 +11,7 @@ init:
 onboot:
   # support metadata for optional config in /run/config
   - name: metadata
-    image: linuxkit/metadata:v0.8
+    image: linuxkit/metadata:2cf1db0f0d2c9916b4894318bd76f1c97d8c8f7b
   - name: sysctl
     image: linuxkit/sysctl:v0.8
   - name: sysfs

--- a/examples/gcp.yml
+++ b/examples/gcp.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.8
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.8
+    image: linuxkit/metadata:2cf1db0f0d2c9916b4894318bd76f1c97d8c8f7b
 services:
   - name: getty
     image: linuxkit/getty:v0.8

--- a/examples/hetzner.yml
+++ b/examples/hetzner.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.8
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.8
+    image: linuxkit/metadata:2cf1db0f0d2c9916b4894318bd76f1c97d8c8f7b
     command: ["/usr/bin/metadata", "hetzner"]
 services:
   - name: rngd

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.8
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.8
+    image: linuxkit/metadata:2cf1db0f0d2c9916b4894318bd76f1c97d8c8f7b
     command: ["/usr/bin/metadata", "openstack"]
 services:
   - name: rngd

--- a/examples/packet.yml
+++ b/examples/packet.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.8
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.8
+    image: linuxkit/metadata:2cf1db0f0d2c9916b4894318bd76f1c97d8c8f7b
     command: ["/usr/bin/metadata", "packet"]
 services:
   - name: rngd

--- a/examples/scaleway.yml
+++ b/examples/scaleway.yml
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.8
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.8
+    image: linuxkit/metadata:2cf1db0f0d2c9916b4894318bd76f1c97d8c8f7b
 services:
   - name: getty
     image: linuxkit/getty:v0.8

--- a/examples/vultr.yml
+++ b/examples/vultr.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:v0.8
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: metadata
-    image: linuxkit/metadata:v0.8
+    image: linuxkit/metadata:2cf1db0f0d2c9916b4894318bd76f1c97d8c8f7b
     command: ["/usr/bin/metadata", "vultr"]
 services:
   - name: getty

--- a/pkg/metadata/main.go
+++ b/pkg/metadata/main.go
@@ -78,7 +78,7 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	providers := []string{"aws", "gcp", "hetzner", "openstack", "scaleway", "vultr", "digitalocean", "packet", "cdrom"}
+	providers := []string{"aws", "gcp", "hetzner", "openstack", "scaleway", "vultr", "digitalocean", "packet", "metaldata", "cdrom"}
 	args := flag.Args()
 	if len(args) > 0 {
 		providers = args
@@ -101,6 +101,8 @@ func main() {
 			netProviders = append(netProviders, NewVultr())
 		case p == "digitalocean":
 			netProviders = append(netProviders, NewDigitalOcean())
+		case p == "metaldata":
+			netProviders = append(netProviders, NewMetalData())
 		case p == "cdrom":
 			cdromProviders = ListCDROMs()
 		case strings.HasPrefix(p, "file="):

--- a/pkg/metadata/provider_metaldata.go
+++ b/pkg/metadata/provider_metaldata.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"time"
+)
+
+const (
+	metaldataMetaDataURL = "http://metaldata/get/meta/"
+	metaldataUserDataURL = "http://metaldata/get/user"
+)
+
+// ProviderMetaldata is the type implementing the Provider interface for Metaldata
+type ProviderMetaldata struct {
+}
+
+// NewMetalData returns a new ProviderMetaldata
+func NewMetalData() *ProviderMetaldata {
+	return &ProviderMetaldata{}
+}
+
+func (p *ProviderMetaldata) String() string {
+	return "metaldata"
+}
+
+// Probe checks if we are running on Metaldata
+func (p *ProviderMetaldata) Probe() bool {
+	log.Println("Metaldata: Probing...")
+	// Getting the hostname should always work...
+	_, err := metaldataGet(metaldataMetaDataURL + "hostname")
+	return (err == nil)
+}
+
+// Extract gets both the Metaldata specific and generic userdata
+func (p *ProviderMetaldata) Extract() ([]byte, error) {
+	// Get host name. This must not fail
+	hostname, err := metaldataGet(metaldataMetaDataURL + "hostname")
+	if err != nil {
+		return nil, err
+	}
+	err = ioutil.WriteFile(path.Join(ConfigPath, Hostname), hostname, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("Metaldata: Failed to write hostname: %s", err)
+	}
+
+	// public ipv4
+	metaldataMetaGet("public-ipv4", "public_ipv4", 0644)
+
+	// private ipv4
+	metaldataMetaGet("private-ipv4", "private_ipv4", 0644)
+
+	// failure domain
+	metaldataMetaGet("failure-domain", "failure_domain", 0644)
+
+	// id
+	metaldataMetaGet("machine-id", "machine_id", 0644)
+
+	// type
+	metaldataMetaGet("machine-type", "machine_type", 0644)
+
+	// ssh
+	if err := p.handleSSH(); err != nil {
+		log.Printf("Metaldata: Failed to get ssh data: %s", err)
+	}
+
+	// Generic userdata
+	userData, err := metaldataGet(metaldataUserDataURL)
+	if err != nil {
+		log.Printf("Metaldata: Failed to get user-data: %s", err)
+		// This is not an error
+		return nil, nil
+	}
+	return userData, nil
+}
+
+// lookup a value (lookupName) in Metaldata metaservice and store in given fileName
+func metaldataMetaGet(lookupName string, fileName string, fileMode os.FileMode) {
+	if lookupValue, err := metaldataGet(metaldataMetaDataURL + lookupName); err == nil {
+		// we got a value from the metadata server, now save to filesystem
+		err = ioutil.WriteFile(path.Join(ConfigPath, fileName), lookupValue, fileMode)
+		if err != nil {
+			// we couldn't save the file for some reason
+			log.Printf("Metaldata: Failed to write %s:%s %s", fileName, lookupValue, err)
+		}
+	} else {
+		// we did not get a value back from the metadata server
+		log.Printf("Metaldata: Failed to get %s: %s", lookupName, err)
+	}
+}
+
+// metaldataGet requests and extracts the requested URL
+func metaldataGet(url string) ([]byte, error) {
+	var client = &http.Client{
+		Timeout: time.Second * 2,
+	}
+
+	req, err := http.NewRequest("", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Metaldata: http.NewRequest failed: %s", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Metaldata: Could not contact metadata service: %s", err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Metaldata: Status not ok: %d", resp.StatusCode)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Metaldata: Failed to read http response: %s", err)
+	}
+	return body, nil
+}
+
+// SSH keys:
+func (p *ProviderMetaldata) handleSSH() error {
+	sshKeys, err := metaldataGet(metaldataMetaDataURL + "authorized-keys")
+	if err != nil {
+		return fmt.Errorf("Failed to get sshKeys: %s", err)
+	}
+
+	if err := os.Mkdir(path.Join(ConfigPath, SSH), 0755); err != nil {
+		return fmt.Errorf("Failed to create %s: %s", SSH, err)
+	}
+
+	err = ioutil.WriteFile(path.Join(ConfigPath, SSH, "authorized_keys"), sshKeys, 0600)
+	if err != nil {
+		return fmt.Errorf("Failed to write ssh keys: %s", err)
+	}
+	return nil
+}

--- a/test/cases/040_packages/008_metadata/000_cidata/test.yml
+++ b/test/cases/040_packages/008_metadata/000_cidata/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:v0.8
 onboot:
   - name: metadata
-    image: linuxkit/metadata:v0.8
+    image: linuxkit/metadata:2cf1db0f0d2c9916b4894318bd76f1c97d8c8f7b
   - name: test
     image: alpine:3.11
     binds:


### PR DESCRIPTION
Signed-off-by: Michael Aldridge <aldridge.mac@gmail.com>

**- What I did**

I added a new metadata provider that supports the metaldata API provided by ResinStack MetalData.  This provider uses a DNS name which greatly simplifies the network topology by allowing the remote network to resolve a DNS name, optionally after canonicalizing it against a search domain.

**- How I did it**

I copied components of existing providers (AWS and Vultr) and modifying them to suit the API handled by MetalData.

**- How to verify it**

Get a metaldata server spun up (or don't, the API can be satisfied with a carefully laid out folder structure on disk) and configure your DNS to handle a request for 'metaldata' to point back to wherever this webserver is.  Once you've done this you can boot a machine and observe that the metaldata probe succeeds and information is summoned.

**- Description for the changelog**

Support MetalData metadata source.
