### PR TITLE
Bump Intel microcode version to 20210216

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -72,7 +72,7 @@ WORKDIR /tmp
 # Download Intel ucode, create a CPIO archive for it, and keep it in the build context
 # so the firmware can also be referenced with CONFIG_EXTRA_FIRMWARE
 ENV UCODE_REPO=https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files
-ENV UCODE_COMMIT=microcode-20191115
+ENV UCODE_COMMIT=microcode-20210216
 RUN set -e && \
     if [ $(uname -m) == x86_64 ]; then \
         git clone ${UCODE_REPO} ucode && \


### PR DESCRIPTION
Signed-off-by: Yoann Ricordel <yoann.ricordel@qarnot-computing.com>

**- What I did**

Bump the version of the pulled Intel microcode from `20191115` to `20210216`

**- How I did it**

Changed the checked out tag in `kernel/Dockerfile`

**- How to verify it**

I guess by trusting that the change is trivial (look at the diff) and just check that a kernel it still builds.

**- Description for the changelog**
Bump Intel microcode from `20191115` to `20210216`

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://live.staticflickr.com/3824/11130281834_8378c778e7_b.jpg)
