### PR TITLE
Ignore detected block sizes in cdrom provider

### DIFF
--- a/pkg/metadata/provider_cdrom.go
+++ b/pkg/metadata/provider_cdrom.go
@@ -82,6 +82,7 @@ func FindCIs() []string {
 			log.Debugf("failed to open device read-only: %s: %v", dev, err)
 			continue
 		}
+		disk.DefaultBlocks = true
 		fs, err := disk.GetFilesystem(0)
 		if err != nil {
 			log.Debugf("failed to get filesystem on partition 0 for device: %s: %v", dev, err)


### PR DESCRIPTION
**- What I did**

Ignored detected blocksizes in go-diskfs.
We were running into an issue where the detection is wrong (https://github.com/diskfs/go-diskfs/issues/104) which causes a panic in `metadata` (https://github.com/diskfs/go-diskfs/issues/103)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
