### PR TITLE
Fix go-compile for go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION="v0.8+"
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:b1446b2ba407225011f97ae1dba0f512ae7f9b84
+GO_COMPILE=linuxkit/go-compile:6d73c4723ae2b58af22e3736b2b0f0292e18eb6d
 
 ifeq ($(OS),Windows_NT)
 LINUXKIT?=bin/linuxkit.exe

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -30,6 +30,6 @@ docker run -it --rm \
 -v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint=go
-linuxkit/go-compile:b1446b2ba407225011f97ae1dba0f512ae7f9b84
+linuxkit/go-compile:6d73c4723ae2b58af22e3736b2b0f0292e18eb6d
 mod vendor
 ```

--- a/tools/go-compile/compile.sh
+++ b/tools/go-compile/compile.sh
@@ -73,12 +73,15 @@ fi
 
 cd "$dir"
 
+# Use '-mod=vendor' for builds which have switched to go modules
+[ -f go.mod ] && MOD_ARG="-mod=vendor"
+
 # lint before building
 >&2 echo "gofmt..."
 test -z $(gofmt -s -l .| grep -v .pb. | grep -v vendor/ | tee /dev/stderr)
 
 >&2 echo "govet..."
-test -z $(GOOS=linux go vet -printf=false . 2>&1 | grep -v "^#" | grep -v vendor/ | tee /dev/stderr)
+test -z $(GOOS=linux go vet $MOD_ARG -printf=false . 2>&1 | grep -v "^#" | grep -v vendor/ | tee /dev/stderr)
 
 >&2 echo "golint..."
 test -z $(find . -type f -name "*.go" -not -path "*/vendor/*" -not -name "*.pb.*" -exec golint {} \; | tee /dev/stderr)
@@ -92,12 +95,12 @@ if [ "$GOOS" = "darwin" -o "$GOOS" = "windows" ]
 then
 	if [ -z "$ldflags" ]
 	then
-		go build -o $out "$package"
+		go build $MOD_ARG -o $out "$package"
 	else
-		go build -o $out -ldflags "${ldflags}" "$package"
+		go build $MOD_ARG -o $out -ldflags "${ldflags}" "$package"
 	fi
 else
-	go build -o $out -buildmode pie -ldflags "-s -w ${ldflags} -extldflags \"-static\"" "$package"
+	go build $MOD_ARG -o $out -buildmode pie -ldflags "-s -w ${ldflags} -extldflags \"-static\"" "$package"
 fi
 
 tar cf - $out


### PR DESCRIPTION
Use `-mod=vendor` in the go-compile package when using go modules.

Fixes https://github.com/linuxkit/linuxkit/issues/3599

![cat](https://user-images.githubusercontent.com/3338098/113440611-ada48900-93e4-11eb-8886-a6603c8543ce.jpg)
