### PR TITLE
ci: Enable linuxkit cross compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,22 @@ jobs:
     name: Build & Test
     strategy:
       matrix:
-        arch:
-          - amd64-linux
-          - arm64-linux
-          - s390x-linux
-          - amd64-darwin
-          - amd64-windows.exe
+        target:
+          - os: linux
+            arch: amd64
+            suffix: amd64-linux
+          - os: linux
+            arch: arm64
+            suffix: arm64-linux
+          - os: linux
+            arch: s390x
+            suffix: s390x-linux
+          - os: darwin
+            arch: amd64
+            suffix: amd64-darwin
+          - os: windows
+            arch: amd64
+            suffix: amd64-windows.exe
 
     runs-on: ubuntu-latest
     steps:
@@ -47,29 +57,29 @@ jobs:
 
     - name: Build
       run: |
-        make LOCAL_TARGET=bin/linuxkit-${{matrix.arch}} local-build
+        make GOARCH=${{matrix.target.arch}} GOOS=${{matrix.target.os}} LOCAL_TARGET=bin/linuxkit-${{matrix.target.suffix}} local-build
+        file bin/linuxkit-${{matrix.target.suffix}}
       env:
         GOPATH: ${{runner.workspace}}
 
     - name: Checksum
-      run: cd bin && sha256sum linuxkit-${{matrix.arch}} > linuxkit-${{matrix.arch}}.SHA256SUM
+      run: |
+        cd bin && sha256sum linuxkit-${{matrix.target.suffix}} > linuxkit-${{matrix.target.suffix}}.SHA256SUM
+        cat linuxkit-${{matrix.target.suffix}}.SHA256SUM
 
     - name: Test
       run: make local-test
       env:
         GOPATH: ${{runner.workspace}}
 
-    - name: Cache binary
-      uses: actions/cache@v1
-      with:
-        path: bin
-        key: linuxkit-${{matrix.arch}}-${{hashFiles('src/**')}}
-
     - name: Upload binary
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v2
       with:
-        name: linuxkit-${{matrix.arch}}
-        path: bin
+        name: linuxkit-${{matrix.target.suffix}}
+        path: |
+          bin/linuxkit-${{matrix.target.suffix}}
+          bin/linuxkit-${{matrix.target.suffix}}.SHA256SUM
+        if-no-files-found: error
 
   build_packages:
     name: Build Packages
@@ -81,15 +91,17 @@ jobs:
       with:
         path: ./src/github.com/linuxkit/linuxkit
 
-    - name: Restore LinuxKit From Cache
-      uses: actions/cache@v1
+    - name: Download linuxkit
+      uses: actions/download-artifact@v2
       with:
-        path: lkt
-        key: linuxkit-amd64-linux-${{hashFiles('src/**')}}
+        name: linuxkit-amd64-linux
+        path: bin
 
     - name: Symlink Linuxkit
       run: |
-        sudo ln -s `pwd`/lkt/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        chmod ugo+x bin/linuxkit-amd64-linux
+        sudo ln -s $(pwd)/bin/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        /usr/local/bin/linuxkit version
 
     - name: Build Packages
       run: |
@@ -113,7 +125,7 @@ jobs:
 
     - name: Restore RTF From Cache
       id: cache-rtf
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: bin
         key: rtf-${{hashFiles('Makefile')}}
@@ -124,17 +136,19 @@ jobs:
 
     - name: Symlink RTF
       run: |
-        sudo ln -s `pwd`/bin/rtf /usr/local/bin/rtf
+        sudo ln -s $(pwd)/bin/rtf /usr/local/bin/rtf
 
-    - name: Restore LinuxKit From Cache
-      uses: actions/cache@v1
+    - name: Download linuxkit
+      uses: actions/download-artifact@v2
       with:
-        path: lkt
-        key: linuxkit-amd64-linux-${{hashFiles('src/**')}}
+        name: linuxkit-amd64-linux
+        path: bin
 
     - name: Symlink Linuxkit
       run: |
-        sudo ln -s `pwd`/lkt/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        chmod ugo+x bin/linuxkit-amd64-linux
+        sudo ln -s $(pwd)/bin/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        /usr/local/bin/linuxkit version
 
     - name: Run Tests
       run: |
@@ -159,7 +173,7 @@ jobs:
 
     - name: Restore RTF From Cache
       id: cache-rtf
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: bin
         key: rtf-${{hashFiles('Makefile')}}
@@ -170,17 +184,19 @@ jobs:
 
     - name: Symlink RTF
       run: |
-        sudo ln -s `pwd`/bin/rtf /usr/local/bin/rtf
+        sudo ln -s $(pwd)/bin/rtf /usr/local/bin/rtf
 
-    - name: Restore LinuxKit From Cache
-      uses: actions/cache@v1
+    - name: Download linuxkit
+      uses: actions/download-artifact@v2
       with:
-        path: lkt
-        key: linuxkit-amd64-linux-${{hashFiles('src/**')}}
+        name: linuxkit-amd64-linux
+        path: bin
 
     - name: Symlink Linuxkit
       run: |
-        sudo ln -s `pwd`/lkt/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        chmod ugo+x bin/linuxkit-amd64-linux
+        sudo ln -s $(pwd)/bin/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        /usr/local/bin/linuxkit version
 
     - name: Run Tests
       run: |
@@ -205,7 +221,7 @@ jobs:
 
     - name: Restore RTF From Cache
       id: cache-rtf
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: bin
         key: rtf-${{hashFiles('Makefile')}}
@@ -216,17 +232,19 @@ jobs:
 
     - name: Symlink RTF
       run: |
-        sudo ln -s `pwd`/bin/rtf /usr/local/bin/rtf
+        sudo ln -s $(pwd)/bin/rtf /usr/local/bin/rtf
 
-    - name: Restore LinuxKit From Cache
-      uses: actions/cache@v1
+    - name: Download linuxkit
+      uses: actions/download-artifact@v2
       with:
-        path: lkt
-        key: linuxkit-amd64-linux-${{hashFiles('src/**')}}
+        name: linuxkit-amd64-linux
+        path: bin
 
     - name: Symlink Linuxkit
       run: |
-        sudo ln -s `pwd`/lkt/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        chmod ugo+x bin/linuxkit-amd64-linux
+        sudo ln -s $(pwd)/bin/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        /usr/local/bin/linuxkit version
 
     - name: Run Tests
       run: |
@@ -251,7 +269,7 @@ jobs:
 
     - name: Restore RTF From Cache
       id: cache-rtf
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: bin
         key: rtf-${{hashFiles('Makefile')}}
@@ -262,17 +280,19 @@ jobs:
 
     - name: Symlink RTF
       run: |
-        sudo ln -s `pwd`/bin/rtf /usr/local/bin/rtf
+        sudo ln -s $(pwd)/bin/rtf /usr/local/bin/rtf
 
-    - name: Restore LinuxKit From Cache
-      uses: actions/cache@v1
+    - name: Download linuxkit
+      uses: actions/download-artifact@v2
       with:
-        path: lkt
-        key: linuxkit-amd64-linux-${{hashFiles('src/**')}}
+        name: linuxkit-amd64-linux
+        path: bin
 
     - name: Symlink Linuxkit
       run: |
-        sudo ln -s `pwd`/lkt/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        chmod ugo+x bin/linuxkit-amd64-linux
+        sudo ln -s $(pwd)/bin/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        /usr/local/bin/linuxkit version
 
     - name: Run Tests
       run: |
@@ -297,7 +317,7 @@ jobs:
 
     - name: Restore RTF From Cache
       id: cache-rtf
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: bin
         key: rtf-${{hashFiles('Makefile')}}
@@ -308,17 +328,19 @@ jobs:
 
     - name: Symlink RTF
       run: |
-        sudo ln -s `pwd`/bin/rtf /usr/local/bin/rtf
+        sudo ln -s $(pwd)/bin/rtf /usr/local/bin/rtf
 
-    - name: Restore LinuxKit From Cache
-      uses: actions/cache@v1
+    - name: Download linuxkit
+      uses: actions/download-artifact@v2
       with:
-        path: lkt
-        key: linuxkit-amd64-linux-${{hashFiles('src/**')}}
+        name: linuxkit-amd64-linux
+        path: bin
 
     - name: Symlink Linuxkit
       run: |
-        sudo ln -s `pwd`/lkt/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        chmod ugo+x bin/linuxkit-amd64-linux
+        sudo ln -s $(pwd)/bin/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        /usr/local/bin/linuxkit version
 
     - name: Run Tests
       run: |


### PR DESCRIPTION
Currently the CI is just building Linux images and all the artefacts are identical. This PR changes the CI to invoke `make` with the right GOARCH/GOOS setting to cross compile for the targeted architectures/OS.

It also removes the cache for artefacts and downloads them from the first stage upload. The cache had issue and I couldn't get it to work reliably.

Downloaded the artefacts and I now get:
```
% for f in linuxkit-*; do file $f; done
linuxkit-amd64-darwin: Mach-O 64-bit executable x86_64
linuxkit-amd64-linux: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=bpg0BD4QnkF9sJqtKOY9/fHwLGn8E2euvrVY7D11s/8yeynCmEnS2RvUhMUnZf/UFc7fvn-2R0aKycEiSFG, not stripped
linuxkit-amd64-windows.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
linuxkit-arm64-linux: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=q3Dan7L1YF_qBo_xu8UI/-TEjhh98FhYy7DuS4uns/04lt8ZDAKq98Mr1NpvUi/c2okTM39_zKc10r93FFe, not stripped
linuxkit-s390x-linux: ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, Go BuildID=H_KP9mDVIhx3y7ixtvwu/c1blwi_gbBj4R3HKhV46/HQOio3lJNA283r1564Jo/OzK8OkxFB90s6Mmc--e1, not stripped
```

fixes https://github.com/linuxkit/linuxkit/issues/3522

![elephant](https://user-images.githubusercontent.com/3338098/113455701-3af6d600-9403-11eb-8846-607a5312fa9a.jpeg)
