### PR TITLE
use correct manifest name when pushing

### DIFF
--- a/src/cmd/linuxkit/cache/push.go
+++ b/src/cmd/linuxkit/cache/push.go
@@ -61,7 +61,7 @@ func PushWithManifest(dir string, name, suffix string, pushImage, pushManifest b
 
 	if pushManifest {
 		fmt.Printf("Pushing %s to manifest %s\n", imageName, name)
-		_, _, err = registry.PushManifest(imageName, auth)
+		_, _, err = registry.PushManifest(name, auth)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed how manifests are created with `linuxkit pkg push`

**- How I did it**

Passed the name of the manifest, rather than the name of the arch-specific image, to `ManifestPush()`

**- How to verify it**

Run it. I just did, it works.

Also, CI is a nice thing.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix pushing of packages

