### PR TITLE
Add Alumni to MAINTAINERS and update Authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Brice Figureau <brice-puppet@daysofwonder.com>
 Carlton-Semple <carlton.semple@ibm.com>
 Chanwit Kaewkasi <chanwit@gmail.com>
 Christian Wuerdig <christian.wuerdig@gmail.com>
+Clovis Durand <cd.clovel19@gmail.com>
 Craig Ingram <cingram@heroku.com>
 Damiano Donati <damiano.donati@gmail.com>
 Dan Finneran <dan@thebsdbox.co.uk>
@@ -46,6 +47,7 @@ Eric Briand <eric.briand@gmail.com>
 Evan Hazlett <ejhazlett@gmail.com>
 Federico Pellegatta <12744504+federico-pellegatta@users.noreply.github.com>
 French Ben <frenchben@docker.com>
+Frédéric Dalleau <frederic.dalleau@docker.com>
 functor <meehow@gmail.com>
 Gabriel Chabot <gabriel.chabot@qarnot-computing.com>
 Garth Bushell <garth.bushell@oracle.com>
@@ -94,6 +96,7 @@ Mathieu Pasquet <mathieu.pasquet@alterway.fr>
 Matt Bajor <matt.bajor@workday.com>
 Matt Bentley <matt.bentley@docker.com>
 Matt Johnson <matjohn2@cisco.com>
+Michael Aldridge <aldridge.mac@gmail.com>
 Michel Courtine <michel.courtine@docker.com>
 Mickaël Salaün <mic@digikod.net>
 Mindy Preston <mindy.preston@docker.com>
@@ -108,6 +111,7 @@ Olaf Bergner <olaf.bergner@gmx.de>
 Olaf Flebbe <of@oflebbe.de>
 Omar Ramadan <omar.ramadan93@gmail.com>
 Patrik Cyvoct <patrik@ptrk.io>
+Petr Fedchenkov <giggsoff@gmail.com>
 Phil Estes <estesp@linux.vnet.ibm.com>
 Pierre Gayvallet <pierre.gayvallet@docker.com>
 Pratik Mallya <mallya@us.ibm.com>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -167,6 +167,16 @@ on disputes for technical matters."
 			"rn",
 		]
 
+	[Org.Alumni]
+
+	# This list contains maintainers that are no longer active on the project.
+	# It is thanks to these people that the project has become what it is today.
+	# Thank you!
+
+		people = [
+			"riyazdf",
+		]
+
 [people]
 
 # A reference list of all people associated with the project.
@@ -198,6 +208,11 @@ on disputes for technical matters."
 	Name = "Justin Cormack"
 	Email = "justin.cormack@docker.com"
 	GitHub = "justincormack"
+
+	[people.riyazdf]
+	Name = "Riyaz Faizullabhoy"
+	Email = "riyaz@docker.com"
+	GitHub = "riyazdf"
 
 	[people.rn]
 	Name = "Rolf Neugebauer"


### PR DESCRIPTION
I noticed we don't have a Alumni section in the MAINTAINERS file and while adding it also updated the constributors

![cat](https://user-images.githubusercontent.com/3338098/115954114-24660b00-a4e7-11eb-8ec4-756391b53081.jpg)

