### PR TITLE
performance regression on hyperkit

### DIFF
--- a/kernel/patches-5.10.x/0001-Revert-x86-tsc-Set-LAPIC-timer-period-to-crystal-clo.patch
+++ b/kernel/patches-5.10.x/0001-Revert-x86-tsc-Set-LAPIC-timer-period-to-crystal-clo.patch
@@ -1,0 +1,35 @@
+From a08c878b14c36a07fc2cfd0e1e3fb668428c0b78 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Fr=C3=A9d=C3=A9ric=20Dalleau?= <fred@dalleau.re>
+Date: Fri, 19 Mar 2021 09:15:03 +0100
+Subject: [PATCH] Revert "x86/tsc: Set LAPIC timer period to crystal clock
+ frequency"
+
+This reverts commit 2420a0b1798d7a78d1f9b395f09f3c80d92cc588.
+---
+ arch/x86/kernel/tsc.c | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/arch/x86/kernel/tsc.c b/arch/x86/kernel/tsc.c
+index f70dffc2771f..b52d85658fb5 100644
+--- a/arch/x86/kernel/tsc.c
++++ b/arch/x86/kernel/tsc.c
+@@ -679,16 +679,6 @@ unsigned long native_calibrate_tsc(void)
+ 	if (boot_cpu_data.x86_model == INTEL_FAM6_ATOM_GOLDMONT)
+ 		setup_force_cpu_cap(X86_FEATURE_TSC_RELIABLE);
+ 
+-#ifdef CONFIG_X86_LOCAL_APIC
+-	/*
+-	 * The local APIC appears to be fed by the core crystal clock
+-	 * (which sounds entirely sensible). We can set the global
+-	 * lapic_timer_period here to avoid having to calibrate the APIC
+-	 * timer later.
+-	 */
+-	lapic_timer_period = crystal_khz * 1000 / HZ;
+-#endif
+-
+ 	return crystal_khz * ebx_numerator / eax_denominator;
+ }
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
While testing a newer 5.10 kernel on docker desktop we found hyperkit was performing slower
than virtualization framework by about 30%.

The benchmark mode of p7zip provided get some measurements :
BENCH="apt -y update && apt -y install p7zip-full && 7z b"
docker run -it --rm debian:buster-slim sh -c "$BENCH"
it also occured with `linuxkit run kyperkit -cpus 2`

Curiously, /proc/cpuinfo was showing a bogomips difference between multiple cpus:
(ns: getty) linuxkit-025000000002:~# uname -srv ; grep bogomips /proc/cpuinfo
Linux 5.10.31-linuxkit #1 SMP Sun Apr 18 17:44:33 UTC 2021
bogomips	: 6999.82
bogomips	: 1250.81
(also occurs with 5.11.15)

The 4.19 kernel not showing this difference, a bisect pointed to:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=2420a0b1798d
A revert fixed the issue.

**- What I did**

Identify and fix an issue occuring on hyperkit (only)

**- How I did it**

Kernel bisect and revert
Tested hyperkit and apple virtualization

**- How to verify it**

Run the latest kernel on hyperkit with multiple processors, and check the bogomips in /proc/cpuinfo, or benchmark the performances.
Compare with other VM on same machine.

**- Description for the changelog**

Fix performance regression on hyperkit

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/79831213/116091485-2675c880-a6a5-11eb-91d8-3790fdb726fb.png)
