### PR TITLE
handle image already in cache

### DIFF
--- a/src/cmd/linuxkit/cache/pull.go
+++ b/src/cmd/linuxkit/cache/pull.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ValidateImage given a reference, validate that it is complete. If not, pull down missing
-// components as necessary.
+// components as necessary. It also calculates the hash of each component.
 func (p *Provider) ValidateImage(ref *reference.Spec, architecture string) (lktspec.ImageSource, error) {
 	var (
 		imageIndex v1.ImageIndex

--- a/src/cmd/linuxkit/main.go
+++ b/src/cmd/linuxkit/main.go
@@ -4,9 +4,11 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	stdlog "log"
 	"os"
 	"path/filepath"
 
+	ggcrlog "github.com/google/go-containerregistry/pkg/logs"
 	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/version"
 
 	log "github.com/sirupsen/logrus"
@@ -104,7 +106,11 @@ func main() {
 		// Switch back to the standard formatter
 		log.SetFormatter(defaultLogFormatter)
 		log.SetLevel(log.DebugLevel)
+		// set go-containerregistry logging as well
+		ggcrlog.Warn = stdlog.New(log.StandardLogger().WriterLevel(log.WarnLevel), "", 0)
+		ggcrlog.Debug = stdlog.New(log.StandardLogger().WriterLevel(log.DebugLevel), "", 0)
 	}
+	ggcrlog.Progress = stdlog.New(log.StandardLogger().WriterLevel(log.InfoLevel), "", 0)
 
 	args := flag.Args()
 	if len(args) < 1 {

--- a/src/cmd/linuxkit/moby/images.go
+++ b/src/cmd/linuxkit/moby/images.go
@@ -36,15 +36,9 @@ func imagePull(ref *reference.Spec, alwaysPull bool, cacheDir string, dockerCach
 	}
 
 	// if we made it here, we either did not have the image, or it was incomplete
-	return imageLayoutWrite(cacheDir, ref, architecture)
-}
-
-// imageLayoutWrite takes an image name and pulls it down, writing it locally
-func imageLayoutWrite(cacheDir string, ref *reference.Spec, architecture string) (lktspec.ImageSource, error) {
-	image := ref.String()
 	c, err := cache.NewProvider(cacheDir)
 	if err != nil {
 		return nil, err
 	}
-	return c.ImagePull(ref, image, architecture)
+	return c.ImagePull(ref, ref.String(), architecture, alwaysPull)
 }

--- a/src/cmd/linuxkit/pkglib/build_test.go
+++ b/src/cmd/linuxkit/pkglib/build_test.go
@@ -101,7 +101,7 @@ type cacheMocker struct {
 	hashes                 map[string][]byte
 }
 
-func (c *cacheMocker) ImagePull(ref *reference.Spec, trustedRef, architecture string) (lktspec.ImageSource, error) {
+func (c *cacheMocker) ImagePull(ref *reference.Spec, trustedRef, architecture string, alwaysPull bool) (lktspec.ImageSource, error) {
 	if !c.enableImagePull {
 		return nil, errors.New("ImagePull disabled")
 	}

--- a/src/cmd/linuxkit/spec/cache.go
+++ b/src/cmd/linuxkit/spec/cache.go
@@ -10,7 +10,7 @@ import (
 // CacheProvider interface for a provide of a cache.
 type CacheProvider interface {
 	FindDescriptor(name string) (*v1.Descriptor, error)
-	ImagePull(ref *reference.Spec, trustedRef, architecture string) (ImageSource, error)
+	ImagePull(ref *reference.Spec, trustedRef, architecture string, alwaysPull bool) (ImageSource, error)
 	IndexWrite(ref *reference.Spec, descriptors ...v1.Descriptor) (ImageSource, error)
 	ImageLoad(ref *reference.Spec, architecture string, r io.Reader) (ImageSource, error)
 	DescriptorWrite(ref *reference.Spec, descriptors ...v1.Descriptor) (ImageSource, error)


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

* Add check if an image exists locally before building with `lkt pkg build`. Beforehand, it had just looked on the registry; now it checks both, and validates the local image if found (all components exist, hashes valid, diffids valid). As before, can be overridden by `--force`.
* Add pull/push logging to `lkt pkg` activities via the underlying library, using the existing streams and config

**- How I did it**

* when calling `cache.ImagePull()`, have an option to `alwaysPull` and, if false, check locally and validate if found before going to remote and, eventually, build/
* Tied the logging to the container registry libraries to our own logging setup in `main.go

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Check local cache before building images with override option; verbose push logging


FYI, I would like #3637 (or #3623, which #3637 should replace) to go in first, in case it has any conflicts and causes a rebase. #3637 is an enormous lift to rebase. So this is good for review and CI, but let me handle the merge once approved and CI is green.