### PR TITLE
pass linkmode=external only for Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION="v0.8+"
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:ceff1817e4c670d253c7bd38da05daecaa513f5f
+GO_COMPILE=linuxkit/go-compile:9f76f29606aec51f2f568984c4c6fe55da2dde10
 
 ifeq ($(OS),Windows_NT)
 LINUXKIT?=bin/linuxkit.exe
@@ -37,7 +37,7 @@ $(RTF): tmp_rtf_bin.tar | bin
 	touch $@
 
 tmp_rtf_bin.tar: Makefile
-	docker run --rm --log-driver=none -e http_proxy=$(http_proxy) -e https_proxy=$(https_proxy) $(CROSS) $(GO_COMPILE) --clone-path github.com/linuxkit/rtf --clone https://github.com/linuxkit/rtf.git --commit $(RTF_COMMIT) --package github.com/linuxkit/rtf --ldflags "-X $(RTF_CMD).GitCommit=$(RTF_COMMIT) -X $(RTF_CMD).Version=$(RTF_VERSION) -linkmode=external" -o $(RTF) > $@
+	docker run --rm --log-driver=none -e http_proxy=$(http_proxy) -e https_proxy=$(https_proxy) $(CROSS) $(GO_COMPILE) --clone-path github.com/linuxkit/rtf --clone https://github.com/linuxkit/rtf.git --commit $(RTF_COMMIT) --package github.com/linuxkit/rtf --ldflags "-X $(RTF_CMD).GitCommit=$(RTF_COMMIT) -X $(RTF_CMD).Version=$(RTF_VERSION)" -o $(RTF) > $@
 
 # Manifest tool for multi-arch images
 MT_COMMIT=bfbd11963b8e0eb5f6e400afaebeaf39820b4e90
@@ -48,7 +48,7 @@ bin/manifest-tool: tmp_mt_bin.tar | bin
 	touch $@
 
 tmp_mt_bin.tar: Makefile
-	docker run --rm --log-driver=none -e http_proxy=$(http_proxy) -e https_proxy=$(https_proxy) $(CROSS) $(GO_COMPILE) --clone-path github.com/estesp/manifest-tool --clone $(MT_REPO) --commit $(MT_COMMIT) --package github.com/estesp/manifest-tool --ldflags "-X main.gitCommit=$(MT_COMMIT)  -linkmode=external" -o bin/manifest-tool > $@
+	docker run --rm --log-driver=none -e http_proxy=$(http_proxy) -e https_proxy=$(https_proxy) $(CROSS) $(GO_COMPILE) --clone-path github.com/estesp/manifest-tool --clone $(MT_REPO) --commit $(MT_COMMIT) --package github.com/estesp/manifest-tool --ldflags "-X main.gitCommit=$(MT_COMMIT)" -o bin/manifest-tool > $@
 
 LINUXKIT_DEPS=$(wildcard src/cmd/linuxkit/*.go) $(wildcard src/cmd/linuxkit/*/*.go) Makefile
 $(LINUXKIT): tmp_linuxkit_bin.tar
@@ -57,7 +57,7 @@ $(LINUXKIT): tmp_linuxkit_bin.tar
 	touch $@
 
 tmp_linuxkit_bin.tar: $(LINUXKIT_DEPS)
-	tar cf - -C src/cmd/linuxkit . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/linuxkit/linuxkit/src/cmd/linuxkit --ldflags "-X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.GitCommit=$(GIT_COMMIT) -X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.Version=$(VERSION) -linkmode=external" -o $(LINUXKIT) > $@
+	tar cf - -C src/cmd/linuxkit . | docker run --rm --net=none --log-driver=none -i $(CROSS) $(GO_COMPILE) --package github.com/linuxkit/linuxkit/src/cmd/linuxkit --ldflags "-X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.GitCommit=$(GIT_COMMIT) -X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.Version=$(VERSION)" -o $(LINUXKIT) > $@
 
 .PHONY: test-cross
 test-cross:

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -30,6 +30,6 @@ docker run -it --rm \
 -v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint=go
-linuxkit/go-compile:ceff1817e4c670d253c7bd38da05daecaa513f5f
+linuxkit/go-compile:9f76f29606aec51f2f568984c4c6fe55da2dde10
 mod vendor
 ```

--- a/tools/go-compile/compile.sh
+++ b/tools/go-compile/compile.sh
@@ -87,7 +87,7 @@ test -z $(GOOS=linux go vet $MOD_ARG -printf=false . 2>&1 | grep -v "^#" | grep 
 test -z $(find . -type f -name "*.go" -not -path "*/vendor/*" -not -name "*.pb.*" -exec golint {} \; | tee /dev/stderr)
 
 >&2 echo "ineffassign..."
-test -z $(find . -type f -name "*.go" -not -path "*/vendor/*" -not -name "*.pb.*" -exec ineffassign {} \; | tee /dev/stderr)
+test -z $(ineffassign ./... | tee /dev/stderr)
 
 >&2 echo "go build..."
 
@@ -100,7 +100,7 @@ then
 		go build $MOD_ARG -o $out -ldflags "${ldflags}" "$package"
 	fi
 else
-	go build $MOD_ARG -o $out -buildmode pie -ldflags "-s -w ${ldflags} -extldflags \"-static\"" "$package"
+	go build $MOD_ARG -o $out -buildmode pie -ldflags "-linkmode=external -s -w ${ldflags} -extldflags \"-static-pie\"" "$package"
 fi
 
 tar cf - $out


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When upgrading to go1.16 and gcc10.x, we ran into issue of conflict with `-buildmode=pie` creating dynamic linux binaries rather than static, since it uses go's new built-in linker, which creates dynamically-linked linux binaries. The solution is to put `-linkmode=external`, which causes it to use the external linker.

What we did worked, but it set `-linkmode=external` for _all_ builds, not just for linux. gcc handles most of those fine... except for Darwin arm64 (macOS M1). 

In truth, `-linkmode=external` really should only be used for the scenario when all of the above is true:

* building for linux
* `-buildmode=pie`

The only affected area is `tools/go-compile` and its dependencies, since everything that uses `go-compile.sh` from within `linuxkit/alpine` is building linux packages anyways. The only area that uses `tools/go-compile` is `Makefile`, and is referenced in `docs/`

This PR removes `-linkmode=external` from `Makefile`, places it inside `tools/go-compile/compile.sh`, but only when building for linux with `-buildmode=pie`.

**- How I did it**

1. Change `tools/go-compile/compile.sh` and check it in
2. Push out the `linuxkit/go-compile` image
3. Run `scripts/update-component-sha.sh`, which updates Makefile and one doc
4. Remove `-linkmode=external` from `Makefile`

**- How to verify it**

Run it. I did. CI is nice too.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Handle building from makefile for non-Linux when run from Makefile