### PR TITLE
Update to proper go-compile hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION="v0.8+"
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 
-GO_COMPILE=linuxkit/go-compile:9f76f29606aec51f2f568984c4c6fe55da2dde10
+GO_COMPILE=linuxkit/go-compile:7b1f5a37d2a93cd4a9aa2a87db264d8145944006
 
 ifeq ($(OS),Windows_NT)
 LINUXKIT?=bin/linuxkit.exe

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -30,6 +30,6 @@ docker run -it --rm \
 -v $(pwd):/go/src/github.com/linuxkit/linuxkit \
 -w /go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit \
 --entrypoint=go
-linuxkit/go-compile:9f76f29606aec51f2f568984c4c6fe55da2dde10
+linuxkit/go-compile:7b1f5a37d2a93cd4a9aa2a87db264d8145944006
 mod vendor
 ```


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

For some reason #3643 had the wrong hash in `Makefile` and `docs/vendoring.md`. This fixes it.

**- How I did it**

Redid `lkt pkg push tools/go-compile` and then reran `./scripts/update-component-sha.sh --image $(lkt pkg show-tag ./tools/go-compile/)`

**- How to verify it**

CI run, run it manually

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Proper go-compile hash on dependencies

Thanks to @dave-tucker for finding this