### PR TITLE
always use canonical names in the linuxkit cache

### DIFF
--- a/src/cmd/linuxkit/moby/build.go
+++ b/src/cmd/linuxkit/moby/build.go
@@ -85,7 +85,7 @@ func OutputTypes() []string {
 
 func outputImage(image *Image, section string, prefix string, m Moby, idMap map[string]uint32, dupMap map[string]string, pull bool, iw *tar.Writer, cacheDir string, dockerCache bool) error {
 	log.Infof("  Create OCI config for %s", image.Image)
-	imageName := referenceExpand(image.Image)
+	imageName := util.ReferenceExpand(image.Image)
 	ref, err := reference.Parse(imageName)
 	if err != nil {
 		return fmt.Errorf("could not resolve references for image %s: %v", image.Image, err)

--- a/src/cmd/linuxkit/moby/config.go
+++ b/src/cmd/linuxkit/moby/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/reference"
+	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/util"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	log "github.com/sirupsen/logrus"
@@ -163,50 +164,37 @@ func uniqueServices(m Moby) error {
 	return nil
 }
 
-// referenceExpand expands "redis" to "docker.io/library/redis" so all images have a full domain
-func referenceExpand(ref string) string {
-	parts := strings.Split(ref, "/")
-	switch len(parts) {
-	case 1:
-		return "docker.io/library/" + ref
-	case 2:
-		return "docker.io/" + ref
-	default:
-		return ref
-	}
-}
-
 func extractReferences(m *Moby) error {
 	if m.Kernel.Image != "" {
-		r, err := reference.Parse(referenceExpand(m.Kernel.Image))
+		r, err := reference.Parse(util.ReferenceExpand(m.Kernel.Image))
 		if err != nil {
 			return fmt.Errorf("extract kernel image reference: %v", err)
 		}
 		m.Kernel.ref = &r
 	}
 	for _, ii := range m.Init {
-		r, err := reference.Parse(referenceExpand(ii))
+		r, err := reference.Parse(util.ReferenceExpand(ii))
 		if err != nil {
 			return fmt.Errorf("extract init image reference: %v", err)
 		}
 		m.initRefs = append(m.initRefs, &r)
 	}
 	for _, image := range m.Onboot {
-		r, err := reference.Parse(referenceExpand(image.Image))
+		r, err := reference.Parse(util.ReferenceExpand(image.Image))
 		if err != nil {
 			return fmt.Errorf("extract on boot image reference: %v", err)
 		}
 		image.ref = &r
 	}
 	for _, image := range m.Onshutdown {
-		r, err := reference.Parse(referenceExpand(image.Image))
+		r, err := reference.Parse(util.ReferenceExpand(image.Image))
 		if err != nil {
 			return fmt.Errorf("extract on shutdown image reference: %v", err)
 		}
 		image.ref = &r
 	}
 	for _, image := range m.Services {
-		r, err := reference.Parse(referenceExpand(image.Image))
+		r, err := reference.Parse(util.ReferenceExpand(image.Image))
 		if err != nil {
 			return fmt.Errorf("extract service image reference: %v", err)
 		}

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -163,7 +163,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	}
 
 	arch := runtime.GOARCH
-	ref, err := reference.Parse(p.Tag())
+	ref, err := reference.Parse(p.FullTag())
 	if err != nil {
 		return fmt.Errorf("could not resolve references for image %s: %v", p.Tag(), err)
 	}
@@ -295,7 +295,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	}
 
 	// get descriptor for root of manifest
-	desc, err := c.FindDescriptor(p.Tag())
+	desc, err := c.FindDescriptor(p.FullTag())
 	if err != nil {
 		return err
 	}
@@ -322,7 +322,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	}
 
 	// push the manifest
-	if err := c.Push(p.Tag()); err != nil {
+	if err := c.Push(p.FullTag()); err != nil {
 		return err
 	}
 
@@ -349,7 +349,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 
 	// tag in docker, if requested
 	if bo.targetDocker {
-		if err := d.tag(p.Tag(), relTag); err != nil {
+		if err := d.tag(p.FullTag(), relTag); err != nil {
 			return err
 		}
 	}
@@ -375,7 +375,7 @@ func (p Pkg) buildArch(d dockerRunner, c lktspec.CacheProvider, arch string, arg
 	fmt.Fprintf(writer, "Building for arch %s as %s\n", arch, tagArch)
 
 	if !bo.force {
-		ref, err := reference.Parse(p.Tag())
+		ref, err := reference.Parse(p.FullTag())
 		if err != nil {
 			return nil, fmt.Errorf("could not resolve references for image %s: %v", p.Tag(), err)
 		}
@@ -410,7 +410,7 @@ func (p Pkg) buildArch(d dockerRunner, c lktspec.CacheProvider, arch string, arg
 			}
 		}
 	)
-	ref, err := reference.Parse(tag)
+	ref, err := reference.Parse(p.FullTag())
 	if err != nil {
 		return nil, fmt.Errorf("could not resolve references for image %s: %v", tagArch, err)
 	}

--- a/src/cmd/linuxkit/pkglib/build_test.go
+++ b/src/cmd/linuxkit/pkglib/build_test.go
@@ -298,7 +298,6 @@ func TestBuild(t *testing.T) {
 		cache   *cacheMocker
 		err     string
 	}{
-		{"missing tag", Pkg{}, nil, nil, &dockerMocker{}, &cacheMocker{}, "could not resolve references"},
 		{"invalid tag", Pkg{image: "docker.io/foo/bar:abc:def:ghi"}, nil, nil, &dockerMocker{}, &cacheMocker{}, "could not resolve references"},
 		{"mismatched platforms", Pkg{org: "foo", image: "bar", hash: "abc", arches: []string{"arm64"}}, nil, []string{"amd64"}, nil, nil, fmt.Sprintf("arch %s not supported", "amd64")},
 		{"not at head", Pkg{org: "foo", image: "bar", hash: "abc", arches: []string{"amd64"}, commitHash: "foo"}, nil, []string{"amd64"}, &dockerMocker{supportBuildKit: false}, &cacheMocker{}, "Cannot build from commit hash != HEAD"},

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/moby"
+	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/util"
 )
 
 // Contains fields settable in the build.yml
@@ -274,6 +275,10 @@ func (p Pkg) Tag() string {
 		t = "latest"
 	}
 	return p.org + "/" + p.image + ":" + t
+}
+
+func (p Pkg) FullTag() string {
+	return util.ReferenceExpand(p.Tag())
 }
 
 // TrustEnabled returns true if trust is enabled

--- a/src/cmd/linuxkit/util/reference.go
+++ b/src/cmd/linuxkit/util/reference.go
@@ -1,0 +1,16 @@
+package util
+
+import "strings"
+
+// ReferenceExpand expands "redis" to "docker.io/library/redis" so all images have a full domain
+func ReferenceExpand(ref string) string {
+	parts := strings.Split(ref, "/")
+	switch len(parts) {
+	case 1:
+		return "docker.io/library/" + ref
+	case 2:
+		return "docker.io/" + ref
+	default:
+		return ref
+	}
+}


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Ensure that all image names in the lkt cache are canonicalized, to avoid issues where it will not recognize `foo/bar:abc` and `docker.io/foo/bar:abc` as the same, or `alpine:3` and `docker.io/library/alpine:3` as the same

Fixes #3634 

**- How I did it**

1. Extracted `Moby.referenceExpand()` to `util.ReferenceExpand()`, had everything point to it
2. Create `Pkg.FullTag()` which gives the expanded tag
3. Use `p.FullTag()` instead of `p.Tag()` whenever creating references to use in the cache

**- How to verify it**

Try building. It works.

CI too.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Handle image names universally canonicalized
