### PR TITLE
alpine carry its own hash

### DIFF
--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -93,6 +93,8 @@ RUN set -e && \
 
 FROM alpine:3.13
 
+ARG TARGETARCH
+
 COPY --from=mirror /etc/apk/repositories /etc/apk/repositories
 COPY --from=mirror /etc/apk/repositories.upstream /etc/apk/repositories.upstream
 COPY --from=mirror /etc/apk/keys /etc/apk/keys/
@@ -103,5 +105,7 @@ COPY --from=mirror /go/src/github.com/containerd/containerd /go/src/github.com/c
 COPY --from=mirror /iucode_tool /usr/bin/
 
 RUN apk update && apk upgrade -a
+
+RUN echo Dockerfile /lib/apk/db/installed $(find /mirror -name '*.apk' -type f) $(find /go/bin -type f) | xargs cat | sha1sum | sed 's/ .*//' | sed 's/$/-${TARGETARCH}/' > /etc/alpine-hash
 
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -7,15 +7,12 @@ DEPS=packages
 ARCH := $(shell uname -m)
 ifeq ($(ARCH), x86_64)
 DEPS += packages.x86_64
-SUFFIX=-amd64
 endif
 ifeq ($(ARCH), aarch64)
 DEPS += packages.aarch64
-SUFFIX=-arm64
 endif
 ifeq ($(ARCH), s390x)
 DEPS += packages.s390x
-SUFFIX=-s390x
 endif
 
 default: push
@@ -27,7 +24,7 @@ iid: Dockerfile Makefile $(DEPS)
 	docker build --no-cache --iidfile iid .
 
 hash: Makefile iid
-	docker run --rm $(shell cat iid) sh -c 'echo Dockerfile /lib/apk/db/installed $$(find /mirror -name '*.apk' -type f) $$(find /go/bin -type f) | xargs cat | sha1sum' | sed 's/ .*//' | sed 's/$$/$(SUFFIX)/'> $@
+	docker run --rm $(shell cat iid) cat /etc/alpine-hash > $@
 
 versions.$(ARCH): Makefile hash iid
 	echo "# $(ORG)/$(IMAGE):$(shell cat hash)" > versions.$(ARCH)


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Small change: have linuxkit/alpine calculate and carry its own hash, and use it from makefile, rather than calculating it in the Makefile. As a nice side effect, it allows us to be working inside any linuxkit/alpine image and know precisely what tag ran it.

Also, `docker build` sets `TARGETARCH` for us, which gets rid of a few lines in the `Makefile`

Finally, if we ever change how we calculate it, that change will be inherent inside the image build itself 

**- How I did it**

Move some logic from `tools/alpine/Makefile` to `tools/alpine/Dockerfile`, and then change `Makefile` to consume it. 

**- How to verify it**

Run it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

linuxkit/alpine carries its own calculated hash tag with it.


