### PR TITLE
tag kernel with builder version; simplify Makefile

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,7 +50,7 @@ You must copy an existing `group.sh` in to this folder and adjust as required or
 [example](https://github.com/linuxkit/rtf/tree/master/etc/templates/group.sh)
 
 To write your test, create a folder within the group using the `000_name` format as described above.
-You should then copy an existing `test.sh` in to this directory and amdend it,
+You should then copy an existing `test.sh` in to this directory and amend it,
 or start from an [example](http://github.com/linuxkit/rtf/tree/master/etc/templates/test.sh)
 
 If your test can only be run when certain conditions are met, you should consider adding a label to

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -1,4 +1,6 @@
-FROM linuxkit/alpine:2be490394653b7967c250e86fd42cef88de428ba AS kernel-build
+ARG BUILD_IMAGE
+FROM ${BUILD_IMAGE} AS kernel-build
+ARG BUILD_IMAGE
 RUN apk add \
     argp-standalone \
     automake \
@@ -209,7 +211,8 @@ RUN DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdept
     ( cd /tmp && tar cf /out/kernel-dev.tar usr/src )
 
 RUN printf "KERNEL_SOURCE=${KERNEL_SOURCE}\n" > /out/kernel-source-info
-
+RUN printf "${BUILD_IMAGE}" > /out/kernel-builder
+LABEL org.mobyproject.linuxkit.kernel.buildimage ${BUILD_IMAGE}
 
 FROM scratch
 ENTRYPOINT []

--- a/kernel/Dockerfile.bcc
+++ b/kernel/Dockerfile.bcc
@@ -1,7 +1,8 @@
 ARG IMAGE
 FROM ${IMAGE} as ksrc
 
-FROM linuxkit/alpine:2be490394653b7967c250e86fd42cef88de428ba AS build
+ARG BUILD_IMAGE
+FROM ${BUILD_IMAGE} AS build
 RUN apk update && apk upgrade -a && \
   apk add --no-cache \
   argp-standalone \
@@ -102,7 +103,7 @@ RUN mkdir -p /out/usr/bin && \
 RUN mkdir -p /out/usr/local/share/ && \
     cp -a /usr/local/share/lua /out/usr/local/share/
 
-FROM linuxkit/alpine:2be490394653b7967c250e86fd42cef88de428ba as mirror
+FROM ${BUILD_IMAGE} as mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk update && apk upgrade -a && \
   apk add --no-cache --initdb -p /out \

--- a/kernel/Dockerfile.kconfig
+++ b/kernel/Dockerfile.kconfig
@@ -1,4 +1,5 @@
-FROM linuxkit/alpine:2be490394653b7967c250e86fd42cef88de428ba AS kernel-build
+ARG BUILD_IMAGE
+FROM ${BUILD_IMAGE} AS kernel-build
 RUN apk add \
     argp-standalone \
     bison \

--- a/kernel/Dockerfile.perf
+++ b/kernel/Dockerfile.perf
@@ -3,7 +3,8 @@
 ARG IMAGE
 FROM ${IMAGE} AS ksrc
 
-FROM linuxkit/alpine:2be490394653b7967c250e86fd42cef88de428ba AS build
+ARG BUILD_IMAGE
+FROM ${BUILD_IMAGE} AS build
 RUN apk add \
     argp-standalone \
     bash \

--- a/kernel/Dockerfile.zfs
+++ b/kernel/Dockerfile.zfs
@@ -1,6 +1,8 @@
 ARG IMAGE
 FROM ${IMAGE} AS ksrc
-FROM linuxkit/alpine:2be490394653b7967c250e86fd42cef88de428ba AS build
+
+ARG BUILD_IMAGE
+FROM ${BUILD_IMAGE} AS build
 RUN apk add \
     attr-dev \
     autoconf \
@@ -42,7 +44,7 @@ RUN ./autogen.sh && \
 
 # Run depmod against the new module directory.
 RUN cd /lib/modules && \
-    depmod -ae * 
+    depmod -ae *
 
 FROM scratch
 ENTRYPOINT []

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -18,6 +18,7 @@ IMAGE:=kernel
 IMAGE_BCC:=kernel-bcc
 IMAGE_PERF:=kernel-perf
 IMAGE_ZFS:=zfs-kmod
+IMAGE_BUILDER=linuxkit/alpine:2be490394653b7967c250e86fd42cef88de428ba
 
 # You can specify an extra options for the Makefile. This will:
 # - append a config$(EXTRA) to the kernel config for your kernel/arch
@@ -73,6 +74,11 @@ KERNEL_VERSIONS=
 build:
 push:
 
+.PHONY: notdirty
+notdirty:
+	@if [ x"$(DIRTY)" !=  x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+
+
 # A template for defining kernel build
 # Arguments:
 # $1: Full kernel version, e.g., 4.9.22
@@ -99,8 +105,10 @@ build_$(2)$(3)$(4): Dockerfile Makefile $(wildcard patches-$(2)/*) $(wildcard co
 			--build-arg KERNEL_SERIES=$(2) \
 			--build-arg EXTRA=$(3) \
 			--build-arg DEBUG=$(4) \
+			--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
 			$(LABELS) \
 			--no-cache -t $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) .
+
 
 forcebuild_$(2)$(3)$(4): Dockerfile Makefile $(wildcard patches-$(2)/*) $(wildcard config-$(2)*) config-dbg
 	docker build \
@@ -108,11 +116,11 @@ forcebuild_$(2)$(3)$(4): Dockerfile Makefile $(wildcard patches-$(2)/*) $(wildca
 		--build-arg KERNEL_SERIES=$(2) \
 		--build-arg EXTRA=$(3) \
 		--build-arg DEBUG=$(4) \
+		--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
 		$(LABELS) \
 		--no-cache -t $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) .
 
-push_$(2)$(3)$(4): build_$(2)$(3)$(4)
-	@if [ x"$(DIRTY)" !=  x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+push_$(2)$(3)$(4): notdirty build_$(2)$(3)$(4)
 	docker pull $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) || \
 		(docker push $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) && \
 		 docker tag $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) $(ORG)/$(IMAGE):$(1)$(3)$(4)$(SUFFIX) && \
@@ -120,21 +128,30 @@ push_$(2)$(3)$(4): build_$(2)$(3)$(4)
 		 $(PUSH_MANIFEST) $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG) $(DOCKER_CONTENT_TRUST) && \
 		 $(PUSH_MANIFEST) $(ORG)/$(IMAGE):$(1)$(3)$(4) $(DOCKER_CONTENT_TRUST))
 
-forcepush_$(2)$(3)$(4): forcebuild_$(2)$(3)$(4)
-	@if [ x"$(DIRTY)" !=  x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+forcepush_$(2)$(3)$(4): notdirty forcebuild_$(2)$(3)$(4)
 	docker push $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) && \
 	 docker tag $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) $(ORG)/$(IMAGE):$(1)$(3)$(4)$(SUFFIX) && \
 	 docker push $(ORG)/$(IMAGE):$(1)$(3)$(4)$(SUFFIX) && \
 	 $(PUSH_MANIFEST) $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG) $(DOCKER_CONTENT_TRUST) && \
 	 $(PUSH_MANIFEST) $(ORG)/$(IMAGE):$(1)$(3)$(4) $(DOCKER_CONTENT_TRUST)
 
+# tag the builder and create the manifest
+tagbuilder_$(2)$(3)$(4): notdirty
+	docker tag $(IMAGE_BUILDER) $(ORG)/$(IMAGE):$(1)$(3)$(4)-builder$(SUFFIX) && \
+	docker push $(ORG)/$(IMAGE):$(1)$(3)$(4)-builder$(SUFFIX) && \
+	$(PUSH_MANIFEST) $(ORG)/$(IMAGE):$(1)$(3)$(4)-builder $(DOCKER_CONTENT_TRUST)
+
+
 show-tag_$(2)$(3)$(4):
 	@echo $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)
 
 build: build_$(2)$(3)$(4)
 forcebuild: forcebuild_$(2)$(3)$(4)
-push: push_$(2)$(3)$(4)
-forcepush: forcepush_$(2)$(3)$(4)
+push: push_image tagbuilder
+push_image: push_$(2)$(3)$(4)
+forcepush: forcepush_image tagbuilder
+forcepush_image: forcepush_$(2)$(3)$(4)
+tagbuilder: tagbuilder_$(2)$(3)$(4)
 show-tags: show-tag_$(2)$(3)$(4)
 
 # FIXME: We no longer use DOCKER_CONENT_TRUST=1
@@ -152,15 +169,16 @@ build_perf_$(2)$(3)$(4): build_$(2)$(3)$(4)
 	docker pull $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4)-$(TAG)$(SUFFIX) || \
 		 DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile.perf \
 			--build-arg IMAGE=$(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) \
+			--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
 			--no-cache --network=none $(LABEL) -t $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4)-$(TAG)$(SUFFIX) .
 
 forcebuild_perf_$(2)$(3)$(4): build_$(2)$(3)$(4)
 	 DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile.perf \
 		--build-arg IMAGE=$(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) \
+		--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
 		--no-cache --network=none $(LABEL) -t $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4)-$(TAG)$(SUFFIX) .
 
-push_perf_$(2)$(3)$(4): build_perf_$(2)$(3)$(4)
-	@if [ x"$(DIRTY)" != x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+push_perf_$(2)$(3)$(4): notdirty build_perf_$(2)$(3)$(4)
 	docker pull $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4)-$(TAG)$(SUFFIX) || \
 		(docker push $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4)-$(TAG)$(SUFFIX) && \
 		 docker tag $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4)-$(TAG)$(SUFFIX) $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4)$(SUFFIX) && \
@@ -168,8 +186,7 @@ push_perf_$(2)$(3)$(4): build_perf_$(2)$(3)$(4)
 		 $(PUSH_MANIFEST) $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4)-$(TAG) $(DOCKER_CONTENT_TRUST) && \
 		 $(PUSH_MANIFEST) $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4) $(DOCKER_CONTENT_TRUST))
 
-forcepush_perf_$(2)$(3)$(4): forcebuild_perf_$(2)$(3)$(4)
-	@if [ x"$(DIRTY)" != x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+forcepush_perf_$(2)$(3)$(4): notdirty forcebuild_perf_$(2)$(3)$(4)
 	docker push $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4)-$(TAG)$(SUFFIX) && \
 	docker tag $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4)-$(TAG)$(SUFFIX) $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4)$(SUFFIX) && \
 	docker push $(ORG)/$(IMAGE_PERF):$(1)$(3)$(4)$(SUFFIX) && \
@@ -190,15 +207,16 @@ build_bcc_$(2)$(3)$(4): build_$(2)$(3)$(4)
 	docker pull $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4)-$(TAG)$(SUFFIX) || \
 		 DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile.bcc \
 			--build-arg IMAGE=$(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) \
+			--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
 			--no-cache $(LABEL) -t $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4)-$(TAG)$(SUFFIX) .
 
 forcebuild_bcc_$(2)$(3)$(4): build_$(2)$(3)$(4)
 	 DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile.bcc \
 		--build-arg IMAGE=$(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) \
+		--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
 		--no-cache $(LABEL) -t $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4)-$(TAG)$(SUFFIX) .
 
-push_bcc_$(2)$(3)$(4): build_bcc_$(2)$(3)$(4)
-	@if [ x"$(DIRTY)" != x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+push_bcc_$(2)$(3)$(4): notdirty build_bcc_$(2)$(3)$(4)
 	docker pull $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4)-$(TAG)$(SUFFIX) || \
 		(docker push $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4)-$(TAG)$(SUFFIX) && \
 		 docker tag $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4)-$(TAG)$(SUFFIX) $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4)$(SUFFIX) && \
@@ -206,8 +224,7 @@ push_bcc_$(2)$(3)$(4): build_bcc_$(2)$(3)$(4)
 		 $(PUSH_MANIFEST) $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4)-$(TAG) $(DOCKER_CONTENT_TRUST) && \
 		 $(PUSH_MANIFEST) $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4) $(DOCKER_CONTENT_TRUST))
 
-forcepush_bcc_$(2)$(3)$(4): forcebuild_bcc_$(2)$(3)$(4)
-	@if [ x"$(DIRTY)" != x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+forcepush_bcc_$(2)$(3)$(4): notdirty forcebuild_bcc_$(2)$(3)$(4)
 	docker push $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4)-$(TAG)$(SUFFIX) && \
 	docker tag $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4)-$(TAG)$(SUFFIX) $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4)$(SUFFIX) && \
 	docker push $(ORG)/$(IMAGE_BCC):$(1)$(3)$(4)$(SUFFIX) && \
@@ -229,10 +246,10 @@ build_zfs_$(2)$(3): build_$(2)$(3)
 	docker pull $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) || \
 		 DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile.zfs \
 			--build-arg IMAGE=$(ORG)/$(IMAGE):$(1)$(3)-$(TAG)$(SUFFIX) \
+			--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
 			--no-cache $(LABEL) -t $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) .
 
-push_zfs_$(2)$(3): build_zfs_$(2)$(3)
-	@if [ x"$(DIRTY)" != x ]; then echo "Your repository is not clean. Will not push image"; exit 1; fi
+push_zfs_$(2)$(3): notdirty build_zfs_$(2)$(3)
 	docker pull $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) || \
 		(docker push $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) && \
 		 docker tag $(ORG)/$(IMAGE_ZFS):$(1)$(3)-$(TAG)$(SUFFIX) $(ORG)/$(IMAGE_ZFS):$(1)$(3)$(SUFFIX) && \
@@ -269,9 +286,11 @@ kconfig:
 ifeq (${KCONFIG_TAG},)
 	docker build --no-cache -f Dockerfile.kconfig \
 		--build-arg KERNEL_VERSIONS="$(KERNEL_VERSIONS)" \
+		--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
 		-t linuxkit/kconfig  .
 else
 	docker build --no-cache -f Dockerfile.kconfig \
 		--build-arg KERNEL_VERSIONS="$(KERNEL_VERSIONS)" \
+		--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
 		-t linuxkit/kconfig:${KCONFIG_TAG}  .
 endif

--- a/test/cases/020_kernel/111_kmod_5.4.x/Dockerfile
+++ b/test/cases/020_kernel/111_kmod_5.4.x/Dockerfile
@@ -6,7 +6,7 @@
 FROM linuxkit/kernel:5.4.116 AS ksrc
 
 # Extract headers and compile module
-FROM linuxkit/alpine:2be490394653b7967c250e86fd42cef88de428ba AS build
+FROM linuxkit/kernel:5.4.116-builder AS build
 RUN apk add build-base elfutils-dev
 
 COPY --from=ksrc /kernel-dev.tar /

--- a/test/cases/020_kernel/113_kmod_5.10.x/Dockerfile
+++ b/test/cases/020_kernel/113_kmod_5.10.x/Dockerfile
@@ -6,7 +6,7 @@
 FROM linuxkit/kernel:5.10.34 AS ksrc
 
 # Extract headers and compile module
-FROM linuxkit/alpine:2be490394653b7967c250e86fd42cef88de428ba AS build
+FROM linuxkit/kernel:5.10.34-builder AS build
 RUN apk add build-base elfutils-dev
 
 COPY --from=ksrc /kernel-dev.tar /

--- a/test/cases/020_kernel/114_kmod_5.11.x/Dockerfile
+++ b/test/cases/020_kernel/114_kmod_5.11.x/Dockerfile
@@ -6,7 +6,7 @@
 FROM linuxkit/kernel:5.11.18 AS ksrc
 
 # Extract headers and compile module
-FROM linuxkit/alpine:2be490394653b7967c250e86fd42cef88de428ba AS build
+FROM linuxkit/kernel:5.11.18-builder AS build
 RUN apk add build-base elfutils-dev
 
 COPY --from=ksrc /kernel-dev.tar /

--- a/test/cases/020_kernel/211_tags_5.4.x/test.sh
+++ b/test/cases/020_kernel/211_tags_5.4.x/test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# SUMMARY: Test existence and correctness of kernel builder tag, label and file
+# LABELS:
+# REPEAT:
+
+set -e
+
+KERNEL=linuxkit/kernel:5.4.116
+
+# just include the common test
+. ../tags.sh

--- a/test/cases/020_kernel/213_tags_5.10.x/test.sh
+++ b/test/cases/020_kernel/213_tags_5.10.x/test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# SUMMARY: Test existence and correctness of kernel builder tag, label and file
+# LABELS:
+# REPEAT:
+
+set -e
+
+KERNEL=linuxkit/kernel:5.10.34
+
+# just include the common test
+. ../tags.sh

--- a/test/cases/020_kernel/214_tags_5.11.x/test.sh
+++ b/test/cases/020_kernel/214_tags_5.11.x/test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# SUMMARY: Test existence and correctness of kernel builder tag, label and file
+# LABELS:
+# REPEAT:
+
+set -e
+
+KERNEL=linuxkit/kernel:5.11.18
+
+# just include the common test
+. ../tags.sh

--- a/test/cases/020_kernel/tags.sh
+++ b/test/cases/020_kernel/tags.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# common tags tests
+
+#!/bin/sh
+# SUMMARY: Test existence and correctness of kernel builder tag, label and file
+# LABELS:
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+if [ -z "${KERNEL}" ]; then
+	echo "KERNEL env var must be set"
+	exit 1
+fi
+
+NAME=tags
+
+clean_up() {
+	docker rm ${ctrid}
+	/bin/rm -f ${BUILDERFILE}
+}
+trap clean_up EXIT
+
+# check the kernel images for tags, labels, files
+BUILDER=${KERNEL}-builder
+BUILDERFILE=/tmp/kernel-builder-$$
+
+docker pull ${KERNEL}
+docker pull ${BUILDER}
+BUILDERLABEL=$(docker inspect -f '{{index .Config.Labels "org.mobyproject.linuxkit.kernel.buildimage"}}'  ${KERNEL})
+# create the container; /bin/sh does not exist, but that does not prevent us from indicating what the command
+#   *would* be. Indeed, you *must* have a command for `docker create` to work
+ctrid=$(docker create $KERNEL /bin/sh)
+docker cp ${ctrid}:/etc/kernel-builder ${BUILDERFILE}
+FILECONTENTS=$(cat ${BUILDERFILE})
+
+# get the manifests for the referenced tag and for the referenced builder.
+# these are not guaranated to be identical, since the orders can change. So we need to account for that.
+sumtag=$(docker manifest inspect ${BUILDER} | jq  -c '.manifests | sort_by(.digest)' | sha256sum | awk '{print $1}')
+sumlabel=$(docker manifest inspect ${BUILDERLABEL} | jq  -c '.manifests | sort_by(.digest)' | sha256sum | awk '{print $1}')
+
+# these two files should be identical
+echo "builder label: ${BUILDERLABEL}"
+echo "builder file: ${FILECONTENTS}"
+echo "builder tag: ${BUILDER}"
+echo "builder tag sha256: ${sumtag}"
+echo "builder label sha256: ${sumlabel}"
+
+# check that the label and file contents match
+if [ "${BUILDERLABEL}" != "${FILECONTENTS}" ]; then
+	echo "label vs file contents mismatch"
+	exit 1
+fi
+# check that the tag actually points to the manifest
+if [ "${sumtag}" != "${sumlabel}" ]; then
+	echo "tag ${BUILDER} and label ${BUILDERLABEL} have mismatched contents"
+	exit 1
+fi
+
+
+exit 0


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

A few things in `kernel/`:

* some simplifications in `Makefile` to eliminate redundant code (mainly so it was easier for me to grasp)
* removed all references to `linuxkit/alpine:<hash>` in all of the kernel Dockerfiles, replaced with an `ARG`, which is passed by `docker build` (which already had some `--build-arg`) from the `Makefile`
* save the name of the builder image in the final kernel image as `/kernel-builder`
* save the name of the builder image in the final kernel image as a label `org.mobyproject.linuxkit.kernel.builder ${BUILDER}`

The purpose is to have the image carry its matched builder in the appropriate location, so you can get it, whether you are already inside the container (from the file) or outside (from the docker label).

**- How I did it**

Removed all references to linuxkit/alpine from the kernel Dockerfiles, replaced them with `ARG BUILDER`, and then passed it from Makefile.

Added two lines at the end, one a `RUN echo` and one a `LABEL`.

**- How to verify it**

We should build the kernels, some suggestion from @rn would be appreciated

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Include kernel builder image version with kernel
