### PR TITLE
Add SharedConfigState opt to aws session

### DIFF
--- a/src/cmd/linuxkit/push_aws.go
+++ b/src/cmd/linuxkit/push_aws.go
@@ -52,7 +52,14 @@ func pushAWS(args []string) {
 		sriovNetFlag = nil
 	}
 
-	sess := session.Must(session.NewSession())
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
+
+	if err != nil {
+		log.Fatalf("Failed to stablish AWS session: %v", err)
+	}
+
 	storage := s3.New(sess)
 
 	ctx, cancelFn := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Enabled support for assuming roles to AWS session. Adding SharedConfigState to session options will instruct the SDK to enable support for assuming roles from shared config file. By default without this opt set the SDK will not be able to assume roles.

**- How I did it**

Added SharedConfigState opt to aws.Session

**- How to verify it**

Build an image i.e examples/aws.yml then load a AWS_PROFILE with assumed role. Then push the image to AWS. The  credentials profile for assuming a role should be as [described in AWS documentation](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_profiles.html). 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

- Add the ability of assume role when pushing the image to AWS

**- A picture of a cute animal**

![image](https://user-images.githubusercontent.com/707227/117008735-69492900-acc1-11eb-981f-0db49498b2a7.png)
"Please"

