### PR TITLE
Include open-vm-tools packages

### DIFF
--- a/pkg/open-vm-tools/Dockerfile
+++ b/pkg/open-vm-tools/Dockerfile
@@ -1,9 +1,13 @@
-FROM linuxkit/alpine:0c069d0fd7defddb6e03925fcd4915407db0c9e1 AS mirror
+FROM linuxkit/alpine:b3028815dbf119404ab68a25acfcf84c585ab432 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
     busybox \
-    open-vm-tools 
+    open-vm-tools \
+    open-vm-tools-guestinfo \
+    open-vm-tools-deploypkg \
+    open-vm-tools-static \
+    open-vm-tools-vmbackup 
 
 # Remove apk residuals
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache


### PR DESCRIPTION
closes #3662 

In alpine version 3.12, the open-vm-tools package got split into new
smaller sub-packages. The implication of this is that features such as
reporting of hostname and ip address to vCenter stopped working.

**- What I did**
Installed the open-vm-tools packages in the open-vm-tools image. 

**- Description for the changelog**
Added the following packages to the open-vm-tools image:
* open-vm-tools-guestinfo
* open-vm-tools-deploypkg
* open-vm-tools-static
* open-vm-tools-vmbackup