### PR TITLE
Include open-vm-tools packages

### DIFF
--- a/tools/alpine/packages.x86_64
+++ b/tools/alpine/packages.x86_64
@@ -2,6 +2,10 @@ gummiboot
 libunwind-dev
 luajit-dev
 open-vm-tools
+open-vm-tools-guestinfo
+open-vm-tools-deploypkg
+open-vm-tools-static
+open-vm-tools-vmbackup
 ovmf
 strace
 syslinux

--- a/tools/alpine/versions.aarch64
+++ b/tools/alpine/versions.aarch64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:3f3f1159e07077cdcf1544f536cfee5052fffa89-arm64
+# linuxkit/alpine:4967a81f63c6fab8cfa686ba051ebe8e0f0fd8ee-
 # automatically generated list of installed packages
 abuild-3.7.0-r0
 alpine-baselayout-3.2.0-r8
@@ -92,7 +92,7 @@ gmp-6.2.1-r0
 gmp-dev-6.2.1-r0
 gnupg-2.2.27-r0
 gnutls-3.7.1-r0
-go-1.16.3-r0
+go-1.16.4-r0
 grep-3.6-r0
 guile-2.0.14-r2
 guile-libs-2.0.14-r2
@@ -209,7 +209,7 @@ libusb-1.0.24-r1
 libuuid-2.36.1-r1
 libuv-1.40.0-r0
 libverto-0.3.1-r1
-libwbclient-4.13.7-r0
+libwbclient-4.13.8-r0
 libx11-1.7.0-r0
 libxau-1.0.9-r0
 libxcb-1.14-r1
@@ -282,7 +282,7 @@ pixman-0.40.0-r2
 pkgconf-1.7.3-r0
 popt-1.18-r0
 python2-2.7.18-r1
-python3-3.8.8-r0
+python3-3.8.10-r0
 qemu-5.2.0-r3
 qemu-aarch64-5.2.0-r3
 qemu-arm-5.2.0-r3
@@ -299,7 +299,7 @@ rpcbind-openrc-1.2.5-r0
 rsync-3.2.3-r1
 rsync-openrc-3.2.3-r1
 s6-ipcserver-2.10.0.0-r0
-samba-util-libs-4.13.7-r0
+samba-util-libs-4.13.8-r0
 scanelf-1.2.8-r0
 sed-4.8-r0
 setpriv-2.36.1-r1

--- a/tools/alpine/versions.s390x
+++ b/tools/alpine/versions.s390x
@@ -1,4 +1,4 @@
-# linuxkit/alpine:402fc1afd8927bed534bc910f1695c7af194a67b-s390x
+# linuxkit/alpine:9708a9b3d80a167a80091144e2ee03aa96dcd70d-
 # automatically generated list of installed packages
 abuild-3.7.0-r0
 alpine-baselayout-3.2.0-r8
@@ -92,7 +92,7 @@ gmp-6.2.1-r0
 gmp-dev-6.2.1-r0
 gnupg-2.2.27-r0
 gnutls-3.7.1-r0
-go-1.16.3-r0
+go-1.16.4-r0
 grep-3.6-r0
 guile-2.0.14-r2
 guile-libs-2.0.14-r2
@@ -210,7 +210,7 @@ libusb-1.0.24-r1
 libuuid-2.36.1-r1
 libuv-1.40.0-r0
 libverto-0.3.1-r1
-libwbclient-4.13.7-r0
+libwbclient-4.13.8-r0
 libx11-1.7.0-r0
 libxau-1.0.9-r0
 libxcb-1.14-r1
@@ -282,7 +282,7 @@ pixman-0.40.0-r2
 pkgconf-1.7.3-r0
 popt-1.18-r0
 python2-2.7.18-r1
-python3-3.8.8-r0
+python3-3.8.10-r0
 qemu-5.2.0-r3
 qemu-aarch64-5.2.0-r3
 qemu-arm-5.2.0-r3
@@ -299,7 +299,7 @@ rpcbind-openrc-1.2.5-r0
 rsync-3.2.3-r1
 rsync-openrc-3.2.3-r1
 s6-ipcserver-2.10.0.0-r0
-samba-util-libs-4.13.7-r0
+samba-util-libs-4.13.8-r0
 scanelf-1.2.8-r0
 sed-4.8-r0
 setpriv-2.36.1-r1

--- a/tools/alpine/versions.x86_64
+++ b/tools/alpine/versions.x86_64
@@ -1,4 +1,4 @@
-# linuxkit/alpine:2be490394653b7967c250e86fd42cef88de428ba-amd64
+# linuxkit/alpine:b3028815dbf119404ab68a25acfcf84c585ab432-
 # automatically generated list of installed packages
 abuild-3.7.0-r0
 alpine-baselayout-3.2.0-r8
@@ -92,7 +92,7 @@ gmp-6.2.1-r0
 gmp-dev-6.2.1-r0
 gnupg-2.2.27-r0
 gnutls-3.7.1-r0
-go-1.16.3-r0
+go-1.16.4-r0
 grep-3.6-r0
 guile-2.0.14-r2
 guile-libs-2.0.14-r2
@@ -180,6 +180,7 @@ libltdl-2.4.6-r7
 libmagic-5.39-r0
 libmnl-1.0.4-r1
 libmount-2.36.1-r1
+libmspack-0.10.1_alpha-r0
 libnfsidmap-2.5.2-r0
 libnftnl-libs-1.1.8-r0
 libnl3-3.5.0-r0
@@ -215,7 +216,7 @@ libusb-1.0.24-r1
 libuuid-2.36.1-r1
 libuv-1.40.0-r0
 libverto-0.3.1-r1
-libwbclient-4.13.7-r0
+libwbclient-4.13.8-r0
 libx11-1.7.0-r0
 libxau-1.0.9-r0
 libxcb-1.14-r1
@@ -267,7 +268,11 @@ open-iscsi-libs-2.1.3-r0
 open-iscsi-openrc-2.1.3-r0
 open-isns-lib-0.100-r0
 open-vm-tools-11.2.0-r0
+open-vm-tools-deploypkg-11.2.0-r0
+open-vm-tools-guestinfo-11.2.0-r0
 open-vm-tools-openrc-11.2.0-r0
+open-vm-tools-static-11.2.0-r0
+open-vm-tools-vmbackup-11.2.0-r0
 openntpd-6.8_p1-r0
 openrc-0.42.1-r19
 openresolv-3.12.0-r0
@@ -293,7 +298,7 @@ pixman-0.40.0-r2
 pkgconf-1.7.3-r0
 popt-1.18-r0
 python2-2.7.18-r1
-python3-3.8.8-r0
+python3-3.8.10-r0
 qemu-5.2.0-r3
 qemu-aarch64-5.2.0-r3
 qemu-arm-5.2.0-r3
@@ -309,7 +314,7 @@ rpcbind-openrc-1.2.5-r0
 rsync-3.2.3-r1
 rsync-openrc-3.2.3-r1
 s6-ipcserver-2.10.0.0-r0
-samba-util-libs-4.13.7-r0
+samba-util-libs-4.13.8-r0
 scanelf-1.2.8-r0
 sed-4.8-r0
 setpriv-2.36.1-r1


### PR DESCRIPTION
In alpine version 3.12, the open-vm-tools package got split into new
smaller sub-packages. The implication of this is that features such as
reporting of hostname and ip address to vCenter stopped working.

relates to #3662
part of #3663

![chimp](https://user-images.githubusercontent.com/3338098/117570270-48b61000-b0c1-11eb-8ff8-229db80e5cf8.jpg)
