### PR TITLE
correctly use target-arch

### DIFF
--- a/tools/alpine/Dockerfile
+++ b/tools/alpine/Dockerfile
@@ -106,6 +106,6 @@ COPY --from=mirror /iucode_tool /usr/bin/
 
 RUN apk update && apk upgrade -a
 
-RUN echo Dockerfile /lib/apk/db/installed $(find /mirror -name '*.apk' -type f) $(find /go/bin -type f) | xargs cat | sha1sum | sed 's/ .*//' | sed 's/$/-${TARGETARCH}/' > /etc/alpine-hash
+RUN echo Dockerfile /lib/apk/db/installed $(find /mirror -name '*.apk' -type f) $(find /go/bin -type f) | xargs cat | sha1sum | sed 's/ .*//' | sed 's/$/-'"${TARGETARCH}"'/' > /etc/alpine-hash-arch
 
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -24,7 +24,7 @@ iid: Dockerfile Makefile $(DEPS)
 	docker build --no-cache --iidfile iid .
 
 hash: Makefile iid
-	docker run --rm $(shell cat iid) cat /etc/alpine-hash > $@
+	docker run --rm $(shell cat iid) cat /etc/alpine-hash-arch > $@
 
 versions.$(ARCH): Makefile hash iid
 	echo "# $(ORG)/$(IMAGE):$(shell cat hash)" > versions.$(ARCH)


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

In PR #3650 we moved the logic for calculating the hash for an arch-specific alpine image from inside `tools/alpine/Makefile` to inside `tools/alpine/Dockerfile` and then consumed it. This was a good idea, but the implementation had two issues:

* The actual usage of `TARGETARCH` did so in a way that left it as a literal `${TARGETARCH}` rather than interpolated correctly by the Dockerfile
* The file was named `/etc/alpine-hash`, which implied that it was the generic, multi-arch index, when really it is just the arch-specific one

This PR corrects both of the above. It ensures that `TARGETARCH` is interpolated by the Dockerfile, and it saves the file as `/etc/alpine-hash-arch`.

This does not resolve the question of having an alpine image carry the multi-arch tag, likely in `/etc/alpine-hash`, as that is a more complicated issue, and something we never had before (one step up). Instead, it just fixes a regression from #3650 so that this all works correctly.

If I can figure out a sane way to get `/etc/alpine-hash` before this PR goes in, I will update this PR, else it will be the subject of a separate one (potentially).

**- How I did it**

Modified `tools/alpine/Makefile` and `tools/alpine./Dockerfile`

**- How to verify it**

CI is your friend. Also, you can do what I did, which is to build `linuxkit/alpine` manually on different platforms and check the content of `/etc/alpine-hash-arch`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix alpine hash file generation