### PR TITLE
calculate manifest using same method as lkt pkg push via git ls-tree

### DIFF
--- a/tools/alpine/Makefile
+++ b/tools/alpine/Makefile
@@ -15,10 +15,19 @@ ifeq ($(ARCH), s390x)
 DEPS += packages.s390x
 endif
 
+ORG?=linuxkit
+IMAGE?=alpine
+TAG?=$(shell git ls-tree --full-tree HEAD -- $(PWD) | awk '{print $$3}')
+DIRTY?=$(shell git diff-index HEAD -- $(PWD))
+ifneq ($(DIRTY),)
+TAG := $(TAG)-dirty
+endif
+
+
 default: push
 
 show-tag:
-	@sed -n -e '1s/# \(.*\/.*:[0-9a-f]\{40\}\)/\1/p;q' versions.$(ARCH)
+	@echo "$(ORG)/$(IMAGE):$(TAG)"
 
 iid: Dockerfile Makefile $(DEPS)
 	docker build --no-cache --iidfile iid .
@@ -34,8 +43,10 @@ push: hash iid versions.$(ARCH)
 	docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \
 		(docker tag $(shell cat iid) $(ORG)/$(IMAGE):$(shell cat hash) && \
 		 docker push $(ORG)/$(IMAGE):$(shell cat hash))
-	./push-manifest.sh $(ORG) $(IMAGE)
 	rm -f iid
+
+push-manifest:
+	./push-manifest.sh $(ORG) $(IMAGE)
 
 build: hash iid versions.$(ARCH)
 	docker pull $(ORG)/$(IMAGE):$(shell cat hash) || \

--- a/tools/alpine/push-manifest.sh
+++ b/tools/alpine/push-manifest.sh
@@ -17,8 +17,13 @@ IMAGE=$2
 IMG_X86_64=$(head -1 versions.x86_64 | sed 's,[#| ]*,,')
 IMG_ARM64=$(head -1 versions.aarch64 | sed 's,[#| ]*,,')
 IMG_s390x=$(head -1 versions.s390x | sed 's,[#| ]*,,')
-# Extract the TAG from the x86_64 name and build the manifest target name
-TAG=$(echo "$IMG_X86_64" | sed 's,\-.*$,,' | cut -d':' -f2)
+# Extract the TAG from the tree hash - just like how "linuxkit pkg show-tag" does it - name and build the manifest target name
+TAG=$(git ls-tree --full-tree HEAD -- $(pwd) | awk '{print $3}')
+DIRTY=$(git diff-index HEAD -- $(pwd))
+if [ -n "$DIRTY"]; then
+  echo "will not push out manifest when git tree is dirty" >&2
+  exit 1
+fi
 TARGET="$ORG/$IMAGE:$TAG"
 
 YAML=$(mktemp)


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Changed the calculation of `linuxkit/alpine` tag from "let's just use whatever is in x86_64" to "let's reuse `lkt pkg show-tag`, which calculates it based on the git tree.

This has 2 advantages:

1. It ensures we capture any changes - all of the hashes of per-arch ones already are checked in in `versions.<arch>`; this ensures that if we change, e.g. arm64 but not amd64 that we capture the change.
2. Keeps it consistent across the packages

This doesn't quite bring us to being able to do `lkt pkg build tools/alpine` - we may never get there - but it at least reuses some of the logic while doing a better job capturing changes.

**- How I did it**

Added  `tools/alpine/build.yml` (necessary for `show-tag` to work), then changed `push-manifest.sh` to just call `lkt pkg show-tag`

**- How to verify it**

Build it, try it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Unify hash calculation for alpine index with the rest of linuxkit

