### PR TITLE
trim-after-delete: avoid building on s390x

### DIFF
--- a/pkg/trim-after-delete/build.yml
+++ b/pkg/trim-after-delete/build.yml
@@ -1,4 +1,7 @@
 image: trim-after-delete
+arches:
+  - amd64
+  - arm64
 config:
   binds:
     - /var/run:/var/run


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Limit `trim-after-delete` to non-`s390x`

**- How I did it**

By modifying the `build.yml` :)

**- How to verify it**

`linuxkit pkg build pkg/trim-after-delete`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Only build `trim-after-delete` on `arm64` and `amd64`


**- A picture of a cute animal (not mandatory but encouraged)**

🐱 