### PR TITLE
Allowing linuxkit to recongnize linux/riscv64 arch

### DIFF
--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -352,12 +352,7 @@ func (p Pkg) buildArch(d dockerRunner, c lktspec.CacheProvider, arch string, arg
 		tagArch string
 		tag     = p.Tag()
 	)
-	switch arch {
-	case "amd64", "arm64", "s390x":
-		tagArch = tag + "-" + arch
-	default:
-		return nil, fmt.Errorf("Unknown arch %q", arch)
-	}
+	tagArch = tag + "-" + arch
 	fmt.Fprintf(writer, "Building for arch %s as %s\n", arch, tagArch)
 
 	if !bo.force {

--- a/src/cmd/linuxkit/pkglib/docker.go
+++ b/src/cmd/linuxkit/pkglib/docker.go
@@ -26,10 +26,6 @@ const (
 	buildkitBuilderName = "linuxkit"
 )
 
-var platforms = []string{
-	"linux/amd64", "linux/arm64", "linux/s390x",
-}
-
 type dockerRunner interface {
 	buildkitCheck() error
 	tag(ref, tag string) error


### PR DESCRIPTION
This is inspired by EVE OS's port to riscv64 https://github.com/lf-edge/eve/pull/2083 

**- What I did**

added linux/riscv64 as a recognizable architecture

**- How I did it**

just followed the breadcrumbs of what already is being done for `linux/s390x`

**- How to verify it**

one can try building EVE packages along the lines of https://github.com/lf-edge/eve/pull/2083 but until the Docker qemu-user bug for Mac OS is fixed -- this will require either workarounds on Docker Desktop side OR running it on Linux and Windows.

**- Description for the changelog**

Adding linux/riscv64 as a recognizable architecture

