### PR TITLE
Print docker run stderr in-case of error

### DIFF
--- a/src/cmd/linuxkit/moby/docker.go
+++ b/src/cmd/linuxkit/moby/docker.go
@@ -35,15 +35,17 @@ func dockerRun(input io.Reader, output io.Writer, img string, args ...string) er
 		return err
 	}
 
+	var errbuf strings.Builder
 	args = append([]string{"run", "--network=none", "--log-driver=none", "--rm", "-i", img}, args...)
 	cmd := exec.Command(docker, args...)
+	cmd.Stderr = &errbuf
 	cmd.Stdin = input
 	cmd.Stdout = output
 	cmd.Env = env
 
 	if err := cmd.Run(); err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			return fmt.Errorf("docker run %s failed: %v output:\n%s", img, err, exitError.Stderr)
+		if _, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("docker run %s failed: %v output:\n%s", img, err, errbuf.String())
 		}
 		return err
 	}


### PR DESCRIPTION
**- What I did**
Fixed `docker run` error printing so it is easier troubleshoot problematic docker images.

**- How to verify it**
Try build iso-bios from https://github.com/rancher/os/blob/master/scripts/moby/rancheros.yml with command `linuxkit build -format iso-bios rancheros.yml`

Without this change error message looks like this:
```
FATA[0006] Error writing outputs: Error writing iso-bios output: docker run linuxkit/mkimage-iso-bios:2fb7eea032a8f8ec76d9ca69592046875c50683c failed: exit status 1 output: 
```
and after this change like this:
```
FATA[0024] Error writing outputs: Error writing iso-bios output: docker run linuxkit/mkimage-iso-bios:2fb7eea032a8f8ec76d9ca69592046875c50683c failed: exit status 1 output:
dist: Can't replace existing directory with non-directory
bsdtar: Error exit delayed from previous errors. 
```