### PR TITLE
Makefile: default to local arch, not amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,23 @@ ifeq ($(OS),Windows_NT)
 LINUXKIT?=$(CURDIR)/bin/linuxkit.exe
 RTF?=bin/rtf.exe
 GOOS?=windows
+GOARCH?=amd64
 else
 LINUXKIT?=$(CURDIR)/bin/linuxkit
 RTF?=bin/rtf
 GOOS?=$(shell uname -s | tr '[:upper:]' '[:lower:]')
+MACHINE := $(shell uname -m)
+ifeq ($(MACHINE),x86_64)
+GOARCH?=amd64
 endif
+ifeq ($(MACHINE),$(filter $(MACHINE),aarch64 arm64))
+GOARCH?=arm64
+endif
+ifeq ($(MACHINE),s390x)
+GOARCH?=s390x
+endif
+endif
+
 GOARCH?=amd64
 ifneq ($(GOOS),linux)
 CROSS+=-e GOOS=$(GOOS)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Made `make` and `make local-build` default to the local machine architecture. It's still possible to override by setting `GOARCH` in the environment as normal.

**- How I did it**

I borrowed runs from the `kernel/` Makefile and took @dave-tucker 's advice

> maybe we could add the default GOARCH?=amd64 to the existing Windows branch and use uname -m and map the result to GOARCH on mac/linux

**- How to verify it**

```
dave@m1 linuxkit % make local-build
make -C ./src/cmd/linuxkit local-build
CGO_ENABLED=0 go build -o /Users/dave/github.com/djs55/linuxkit/bin/linuxkit  --ldflags "-X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.GitCommit=c54ace566a81fa4c6094e971baf19ca2a0c338c8 -X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.Version="v0.8+""

dave@m1 linuxkit % file bin/linuxkit
bin/linuxkit: Mach-O 64-bit executable arm64

dave@m1 linuxkit % GOARCH=amd64 make local-build
make -C ./src/cmd/linuxkit local-build
CGO_ENABLED=0 go build -o /Users/dave/github.com/djs55/linuxkit/bin/linuxkit  --ldflags "-X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.GitCommit=c54ace566a81fa4c6094e971baf19ca2a0c338c8 -X github.com/linuxkit/linuxkit/src/cmd/linuxkit/version.Version="v0.8+""

dave@m1 linuxkit % file bin/linuxkit
bin/linuxkit: Mach-O 64-bit executable x86_64
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- `make` and `make local-build` default to building for the local architecture, previously `amd64` was assumed. The architecture can be overridden via the `GOARCH` environment variable.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/198586/120830626-9c980580-c556-11eb-98a7-cb32f9bdba26.png)
