### PR TITLE
Push arch-specific tags, always build index from registry

### DIFF
--- a/src/cmd/linuxkit/cache/push.go
+++ b/src/cmd/linuxkit/cache/push.go
@@ -7,64 +7,8 @@ import (
 	namepkg "github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/registry"
+	log "github.com/sirupsen/logrus"
 )
-
-// PushWithManifest push an image along with, optionally, a multi-arch index.
-func (p *Provider) PushWithManifest(name, suffix string, pushImage, pushManifest bool) error {
-	var (
-		err     error
-		options []remote.Option
-	)
-	imageName := name + suffix
-	ref, err := namepkg.ParseReference(imageName)
-	if err != nil {
-		return err
-	}
-
-	if pushImage {
-		fmt.Printf("Pushing %s\n", imageName)
-		// do we even have the given one?
-		root, err := p.FindRoot(imageName)
-		if err != nil {
-			return err
-		}
-		options = append(options, remote.WithAuthFromKeychain(authn.DefaultKeychain))
-		img, err1 := root.Image()
-		ii, err2 := root.ImageIndex()
-		switch {
-		case err1 == nil:
-			if err := remote.Write(ref, img, options...); err != nil {
-				return err
-			}
-			fmt.Printf("Pushed image %s\n", imageName)
-		case err2 == nil:
-			if err := remote.WriteIndex(ref, ii, options...); err != nil {
-				return err
-			}
-			fmt.Printf("Pushed index %s\n", imageName)
-		default:
-			return fmt.Errorf("name %s unknown in cache", imageName)
-		}
-	} else {
-		fmt.Print("Image push disabled, skipping...\n")
-	}
-
-	auth, err := registry.GetDockerAuth()
-	if err != nil {
-		return fmt.Errorf("failed to get auth: %v", err)
-	}
-
-	if pushManifest {
-		fmt.Printf("Pushing %s to manifest %s\n", imageName, name)
-		_, _, err = registry.PushManifest(name, auth)
-		if err != nil {
-			return err
-		}
-	} else {
-		fmt.Print("Manifest push disabled, skipping...\n")
-	}
-	return nil
-}
 
 // Push push an image along with a multi-arch index.
 func (p *Provider) Push(name string) error {
@@ -88,17 +32,61 @@ func (p *Provider) Push(name string) error {
 	ii, err2 := root.ImageIndex()
 	switch {
 	case err1 == nil:
+		log.Debugf("pushing image %s", name)
 		if err := remote.Write(ref, img, options...); err != nil {
 			return err
 		}
 		fmt.Printf("Pushed image %s\n", name)
 	case err2 == nil:
+		log.Debugf("pushing index %s", name)
+		// this is an index, so we not only want to write the index, but tags for each arch-specific image in it
 		if err := remote.WriteIndex(ref, ii, options...); err != nil {
 			return err
 		}
 		fmt.Printf("Pushed index %s\n", name)
+		manifest, err := ii.IndexManifest()
+		if err != nil {
+			return fmt.Errorf("successfully pushed index, but could not read images in index: %v", err)
+		}
+		log.Debugf("pushing individual images in the index %s", name)
+		for _, m := range manifest.Manifests {
+			if m.Platform == nil || m.Platform.Architecture == "" {
+				continue
+			}
+			archTag := fmt.Sprintf("%s-%s", name, m.Platform.Architecture)
+			tag, err := namepkg.NewTag(archTag)
+			if err != nil {
+				return fmt.Errorf("could not create a valid arch-specific tag %s: %v", archTag, err)
+			}
+			image, err := p.FindRoot(archTag)
+			if err != nil {
+				return fmt.Errorf("could not find arch-specific image in cache %s: %v", archTag, err)
+			}
+			img, err := image.Image()
+			if err != nil {
+				return fmt.Errorf("found arch-specific image in cache %s, but could not resolve to actual image: %v", archTag, err)
+			}
+			log.Debugf("pushing image %s", tag)
+			if err := remote.Tag(tag, img, options...); err != nil {
+				return fmt.Errorf("error creating tag %s: %v", archTag, err)
+			}
+		}
 	default:
 		return fmt.Errorf("name %s unknown in cache", name)
 	}
+
+	// Even though we may have pushed the index, we want to be sure that we have an index that includes every architecture on the registry,
+	// not just those that were in our local cache. So we use manifest-tool library to build a broad index
+	auth, err := registry.GetDockerAuth()
+	if err != nil {
+		return fmt.Errorf("failed to get auth: %v", err)
+	}
+
+	fmt.Printf("Pushing index based on all arch-specific images in registry %s\n", name)
+	_, _, err = registry.PushManifest(name, auth)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/src/cmd/linuxkit/registry/manifest.go
+++ b/src/cmd/linuxkit/registry/manifest.go
@@ -11,15 +11,23 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var platforms = []string{
-	"linux/amd64", "linux/arm64", "linux/s390x",
+// these platforms are used only as the source for registry.PushManifestList(). Since it is
+// configured to ignore missing, we could include dozens if we wanted; it doesn't hurt, adding maybe a few seconds to
+// the whole run.
+// Ideally, we could just look for all tags that start with linuxkit/foo:<hash>-*, but the registry API
+// only supports "list all the tags" and "get a specific tag", no "get by pattern". The "get a specific tag"
+// is exactly what registry.PushManifestList() uses, so no benefit to use doing that in advance,
+// while "list all tags" is slow, and has to cycle through all of the (growing numbers of) tags
+// before we know what exists. Might as well leave it as is.
+var platformsToSearchForIndex = []string{
+	"linux/amd64", "linux/arm64", "linux/s390x", "linux/riscv64", "linux/ppc64le",
 }
 
 // PushManifest create a manifest that supports each of the provided platforms and push it out.
 func PushManifest(img string, auth dockertypes.AuthConfig) (hash string, length int, err error) {
 	srcImages := []types.ManifestEntry{}
 
-	for i, platform := range platforms {
+	for i, platform := range platformsToSearchForIndex {
 		osArchArr := strings.Split(platform, "/")
 		if len(osArchArr) != 2 && len(osArchArr) != 3 {
 			return hash, length, fmt.Errorf("platform argument %d is not of form 'os/arch': '%s'", i, platform)


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

* ensured that tags for arch-specific pkg images exist. We used to have `linuxkit/foo:abc-amd64`, `linuxkit/foo:abc-arm64`, etc., in addition to the multi-arch index `linuxkit/foo:abc`. With the move to linuxkit cache, we stopped pushing those tags out. They turn out to be rather useful, so this pushes the tags out again.
* always rebuilds the multi-arch index (after pushing) from every known architecture in the registry. We used to do that when we had to build and push on each arch. Now that we don't _have_ to, it would just push whatever was local. However, if you _wanted_ to - or even just pushed out on one arch - it would replace the index that was there with one that pointed just to that arch. Oops. With this change, whenever it creates an index, it will look for every arch known under the sun and see if a tag exists for it, then create the index. This provides the least chance of error.

**- How I did it**

Changes to the `linuxkit` command, specifically `cache.Push()` and `registry.PushManifest()`

**- How to verify it**

Push out some images. I did. It was fun.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Ensure tagged images per architecture, and index always includes every arch in registry

