### PR TITLE
Fix `linuxkit run qemu` on macOS on Apple Silicon

### DIFF
--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -445,7 +445,15 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 		case "s390x":
 			qemuArgs = append(qemuArgs, "-machine", fmt.Sprintf("s390-ccw-virtio,accel=%s", config.Accel))
 		case "aarch64":
-			qemuArgs = append(qemuArgs, "-machine", fmt.Sprintf("virt,gic_version=host,accel=%s", config.Accel))
+			gic := ""
+			// VCPU supports less PA bits (36) than requested by the memory map (40)
+			highmem := "highmem=off,"
+			if runtime.GOOS == "linux" {
+				// gic-version=host requires KVM, which implies Linux
+				gic = "gic_version=host,"
+				highmem = ""
+			}
+			qemuArgs = append(qemuArgs, "-machine", fmt.Sprintf("virt,%s%saccel=%s", gic, highmem, config.Accel))
 		default:
 			qemuArgs = append(qemuArgs, "-machine", fmt.Sprintf("q35,accel=%s", config.Accel))
 		}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Make `linuxkit run qemu` work on Darwin on Apple Silicon. Note there's no `hyperkit` on arm64.

**- How I did it**

I adjusted the qemu command line to make it work. I had to make the same changes for Docker Desktop.

I assume the arguments already worked on Linux/arm64, so I adjusted them only for non-Linux.

**- How to verify it**

On an M1 machine: (needs recent `qemu-system-aarch64` from `brew`)
```
linuxkit build examples/getty.yml
linuxkit run qemu getty
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Make `linuxkit run qemu` work on Apple Silicon

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/198586/137170846-56db69b3-4799-4a4d-bba8-9358e48f3df1.png)
