### PR TITLE
extract hard-coded default image builders into file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.16
       uses: actions/setup-go@v2
       with:
-        go-version: 1.13.4
+        go-version: 1.16.7
       id: go
 
     - name: Check out code
@@ -110,7 +110,7 @@ jobs:
         key: ${{ runner.os }}-linuxkit-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-linuxkit-
-    
+
     - name: Build Packages
       run: |
         make -C pkg build
@@ -157,7 +157,7 @@ jobs:
         chmod ugo+x bin/linuxkit-amd64-linux
         sudo ln -s $(pwd)/bin/linuxkit-amd64-linux /usr/local/bin/linuxkit
         /usr/local/bin/linuxkit version
-    
+
     - name: Restore Package Cache
       uses: actions/cache@v2
       with:
@@ -165,7 +165,7 @@ jobs:
         key: ${{ runner.os }}-linuxkit-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-linuxkit-
- 
+
     - name: Run Tests
       run: |
           cd test

--- a/src/cmd/linuxkit/go.mod
+++ b/src/cmd/linuxkit/go.mod
@@ -1,6 +1,6 @@
 module github.com/linuxkit/linuxkit/src/cmd/linuxkit
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Azure/azure-sdk-for-go v50.1.0+incompatible

--- a/src/cmd/linuxkit/moby/images.yaml
+++ b/src/cmd/linuxkit/moby/images.yaml
@@ -1,0 +1,12 @@
+ iso:          linuxkit/mkimage-iso:f0ba58e54282f481a87a2b487a70568c702f001b
+ iso-bios:     linuxkit/mkimage-iso-bios:2fb7eea032a8f8ec76d9ca69592046875c50683c
+ iso-efi:      linuxkit/mkimage-iso-efi:71c9dfc7de921e4521adbce03c01ce8282c0a9a5
+ raw-bios:     linuxkit/mkimage-raw-bios:a0f4f6af871f9388639f2939a5e7bee5c467b736
+ raw-efi:      linuxkit/mkimage-raw-efi:bc5d55daccfe1e75bc7373b4f45fc08e3b9adea9
+ squashfs:     linuxkit/mkimage-squashfs:078f292e085fe31f508ff55a05eab958aec25e25
+ gcp:          linuxkit/mkimage-gcp:a7416d21d4ef642bb2ba560c8f7651250823546d
+ qcow2-efi:    linuxkit/mkimage-qcow2-efi:2a835e4ce894070268e5fa6f53be67007452095e
+ vhd:          linuxkit/mkimage-vhd:4cc60c4f46b07e11c64ba618e46b81fa0096c91f
+ dynamic-vhd:  linuxkit/mkimage-dynamic-vhd:99b9009ed54a793020d3ce8322a42e0cc06da71a
+ vmdk:         linuxkit/mkimage-vmdk:b55ea46297a16d8a4448ce7f5a2df987a9602b27
+ rpi3:         linuxkit/mkimage-rpi3:19c5354d6f8f68781adbc9bb62095ebb424222dc


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Extract the hard-coded image builders out of `moby/output.go` and into an `images.yaml` file, which is go-embedded.

Also required bumping go to 1.16, but we all use it anyways.

**- How I did it**

Create the new file, use go embedding

**- How to verify it**

Let CI run. I ran manually, both to build an image and to debug step through to make sure it gets created correctly. I might have missed a case (don't think so, but that is what CI is there for).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Extract hard-coded builder images from go file