### PR TITLE
restrict update to just yaml files

### DIFF
--- a/scripts/update-component-sha.sh
+++ b/scripts/update-component-sha.sh
@@ -49,7 +49,7 @@ updateImage() {
                 hash=$2
                 ;;
         esac
-        git grep -E -l "[[:space:]]$image:" | grep -v /vendor/ | xargs sed -i.bak -E -e "s,([[:space:]])($image):([^[:space:]]+), $image:$hash,g"
+        git grep -E -l "[[:space:]]$image:" -- '*.yml' '*.yaml' '*.yml.in' '*.yaml.in' '*/Dockerfile' '*/Makefile' | grep -v /vendor/ | xargs sed -i.bak -E -e "s,([[:space:]])($image):([^[:space:]]+), $image:$hash,g"
 }
 
 # backwards compatibility
@@ -70,7 +70,7 @@ case "${mode}" in
         old=$1
         new=$2
 
-        git grep -w -l "\b$old\b" | grep -v /vendor/ | xargs sed -i.bak -e "s,$old,$new,g"
+        git grep -w -l "\b$old\b" -- '*.yml' '*.yaml' '*.yml.in' '*.yaml.in' '*/Dockerfile' '*/Makefile' | grep -v /vendor/ | xargs sed -i.bak -e "s,$old,$new,g"
         ;;
 --image)
 	if [ $# -lt 1 ] ; then


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Restrict `update-component-sha.sh` to only change files that end in `yml`/`yaml`/`yml.in`/`yaml.in`, as discussed [here](https://github.com/linuxkit/linuxkit/pull/3723#discussion_r739785144) with @djs55 and @rn 

By the way, this is not _strictly_ necessary. It would continue to work without this. But it seems to make sense.

**- How I did it**

Modified the single script.

**- How to verify it**

Run it. It works. I did. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

update-component-sha.sh only affects yaml files

**Note:** I found one other place where we have the hashes embedded in a `.go` file, PR for that should go in first #3729 