### PR TITLE
extract more hard-coded yaml

### DIFF
--- a/src/cmd/linuxkit/moby/linuxkit.go
+++ b/src/cmd/linuxkit/moby/linuxkit.go
@@ -2,6 +2,7 @@ package moby
 
 import (
 	"crypto/sha256"
+	_ "embed"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,22 +14,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var linuxkitYaml = map[string]string{"mkimage": `
-kernel:
-  image: linuxkit/kernel:4.9.39
-  cmdline: "console=ttyS0"
-init:
-  - linuxkit/init:43c52456571369d62882605e4d510f0df3ed93de
-  - linuxkit/runc:5f9941eed05f58293f928c9f2f0b6a3f9f6f55c1
-onboot:
-  - name: mkimage
-    image: linuxkit/mkimage:fa71899c159d8c1ae63a02a22fe8db113c4e540c
-  - name: poweroff
-    image: linuxkit/poweroff:afe4b3ab865afe1e3ed5c88e58f57808f4f5119f
-trust:
-  org:
-    - linuxkit
-`}
+//go:embed mkimage.yaml
+var linuxkitYamlStr string
+var linuxkitYaml = map[string]string{"mkimage": linuxkitYamlStr}
 
 func imageFilename(name string) string {
 	yaml := linuxkitYaml[name]

--- a/src/cmd/linuxkit/moby/mkimage.yaml
+++ b/src/cmd/linuxkit/moby/mkimage.yaml
@@ -1,0 +1,14 @@
+kernel:
+  image: linuxkit/kernel:4.9.39
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:43c52456571369d62882605e4d510f0df3ed93de
+  - linuxkit/runc:5f9941eed05f58293f928c9f2f0b6a3f9f6f55c1
+onboot:
+  - name: mkimage
+    image: linuxkit/mkimage:fa71899c159d8c1ae63a02a22fe8db113c4e540c
+  - name: poweroff
+    image: linuxkit/poweroff:afe4b3ab865afe1e3ed5c88e58f57808f4f5119f
+trust:
+  org:
+    - linuxkit


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Continuing #3727 , this extracts one more chunk of hard-coded yaml out of a `.go` file and places it in a yaml that is pulled in using go embed.

**- How I did it**

Extract and go embed.

**- How to verify it**

Ran manually, ran via debugger to see that it was populated, let CI run.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Last hard-coding out of go files.

