### PR TITLE
Always enable cgroup namespace for containers

### DIFF
--- a/src/cmd/linuxkit/moby/config.go
+++ b/src/cmd/linuxkit/moby/config.go
@@ -875,7 +875,8 @@ func ConfigToOCI(yaml *Image, config imagespec.ImageConfig, idMap map[string]uin
 	// Always create a new mount namespace
 	namespaces = append(namespaces, specs.LinuxNamespace{Type: specs.MountNamespace})
 
-	// TODO cgroup namespaces
+	// Always create a new cgroup namespace
+	namespaces = append(namespaces, specs.LinuxNamespace{Type: specs.CgroupNamespace})
 
 	// Capabilities
 	capCheck := map[string]bool{}


### PR DESCRIPTION
Fix #3734

In cgroupv2 hierrachy, cgroup setup for nested containers (i.e. docker)
are incorrect without enabling cgroup namespace. This enables cgroup
namespace for all containers to fix the incorrect cgroup setup.