### PR TITLE
Use RFC3339Nano for timestamps

### DIFF
--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
-  - linuxkit/memlogd:55ba089dd98e96b0aeb24463852fb7539e2c2c1e
+  - linuxkit/memlogd:fe4a123b619a7dfffc2ba1297dd03b4ac90e3dd7
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:0dc8f792fc3a58afcebcb0fbe6b48de587265c17

--- a/pkg/memlogd/cmd/memlogd/main.go
+++ b/pkg/memlogd/cmd/memlogd/main.go
@@ -66,7 +66,7 @@ func logQueryHandler(l *connListener) {
 }
 
 func (msg *logEntry) String() string {
-	return fmt.Sprintf("%s,%s;%s", msg.time.Format(time.RFC3339), msg.source, msg.msg)
+	return fmt.Sprintf("%s,%s;%s", msg.time.Format(time.RFC3339Nano), msg.source, msg.msg)
 }
 
 func ringBufferHandler(ringSize, chanSize int, logCh chan logEntry, queryMsgChan chan queryMessage) {

--- a/test/cases/040_packages/011_kmsg/test.yml
+++ b/test/cases/040_packages/011_kmsg/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
-  - linuxkit/memlogd:55ba089dd98e96b0aeb24463852fb7539e2c2c1e
+  - linuxkit/memlogd:fe4a123b619a7dfffc2ba1297dd03b4ac90e3dd7
 services:
   - name: kmsg
     image: linuxkit/kmsg:2ed5334395ec64a7844a2cbd88837050fbd34880

--- a/test/cases/040_packages/012_logwrite/test.yml
+++ b/test/cases/040_packages/012_logwrite/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
-  - linuxkit/memlogd:55ba089dd98e96b0aeb24463852fb7539e2c2c1e
+  - linuxkit/memlogd:fe4a123b619a7dfffc2ba1297dd03b4ac90e3dd7
 services:
 # A service which generates logs of log messages
   - name: fill-the-logs


### PR DESCRIPTION
Signed-off-by: Emmanuel Briney <emmanuel.briney@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I changed time precision to use `RFC3339Nano` intead of `RFC3339` in memlogd messages because one second resolution is too low when you want to compare timestamp from two differents sources

**- How I did it**

I changed the `message.String()` func

**- How to verify it**

```
go test -v ./...
?       memlogd/cmd/logread     [no test files]
?       memlogd/cmd/logwrite    [no test files]
=== RUN   TestNonblock
2021-11-26T16:48:21.384944+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385035+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385194+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385196+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385204+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385205+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385215+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385215+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385227+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385228+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385238+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385239+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385246+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385247+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385255+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385255+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385268+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385278+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385317+01:00,memlogd;hello TestNonblock
2021-11-26T16:48:21.385318+01:00,memlogd;hello TestNonblock
--- PASS: TestNonblock (0.00s)
=== RUN   TestFinite
2021-11-26T16:48:21.385372+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385397+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385398+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.38543+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.38543+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385439+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.38544+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385447+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385448+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.38546+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.38546+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385474+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385474+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385485+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385486+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385496+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385496+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385504+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385504+01:00,memlogd;hello TestFinite
2021-11-26T16:48:21.385516+01:00,memlogd;hello TestFinite
--- PASS: TestFinite (0.00s)
=== RUN   TestFinite2
2021-11-26T16:48:21.38573+01:00,memlogd;hello TestFinite2
2021-11-26T16:48:21.385753+01:00,memlogd;hello TestFinite2
2021-11-26T16:48:21.385753+01:00,memlogd;hello TestFinite2
2021-11-26T16:48:21.385767+01:00,memlogd;hello TestFinite2
2021-11-26T16:48:21.385767+01:00,memlogd;hello TestFinite2
2021-11-26T16:48:21.385779+01:00,memlogd;hello TestFinite2
2021-11-26T16:48:21.38578+01:00,memlogd;hello TestFinite2
2021-11-26T16:48:21.385803+01:00,memlogd;hello TestFinite2
2021-11-26T16:48:21.385803+01:00,memlogd;hello TestFinite2
2021-11-26T16:48:21.385815+01:00,memlogd;hello TestFinite2
--- PASS: TestFinite2 (0.00s)
=== RUN   TestGoodName
2021-11-26T16:48:21.386036+01:00,memlogd;ERROR: cannot register log with name 'semi-colons are banned;' as it contains ;
--- PASS: TestGoodName (0.00s)
PASS
ok      memlogd/cmd/memlogd     0.197s
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
 - pkg/memlogd: use `RFC3339Nano` timestamp for better resolution

**- A picture of a cute animal (not mandatory but encouraged)*
![maxresdefault](https://user-images.githubusercontent.com/8415079/143605973-7741e879-9a9d-48dd-9cf5-6d6b002b7632.jpg)
*
