### PR TITLE
Fix acpid devices

### DIFF
--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -49,7 +49,7 @@ onboot:
 services:
   # Enable acpi to shutdown on power events
   - name: acpid
-    image: linuxkit/acpid:e9a94e593d6be2fc1b3eb6d566f23ac9ca9807fd
+    image: linuxkit/acpid:c05a368754f6436b326945dc16135ba547568d8d
   # Enable getty for easier debugging
   - name: getty
     image: linuxkit/getty:3c6e89681a988c3d4e2610fcd7aaaa0247ded3ec

--- a/pkg/acpid/build.yml
+++ b/pkg/acpid/build.yml
@@ -1,5 +1,9 @@
 image: acpid
 config:
   binds:
-  - /dev:/dev
+    - /dev:/dev
+  devices:
+    - path: all
+      type: c
+      major: 13
   pid: host

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -7,4 +7,4 @@ init:
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 services:
   - name: acpid
-    image: linuxkit/acpid:e9a94e593d6be2fc1b3eb6d566f23ac9ca9807fd
+    image: linuxkit/acpid:c05a368754f6436b326945dc16135ba547568d8d


### PR DESCRIPTION
**- What I did**

I fixed the bug #3738 by adding missing "devices" field on the acpid `build.yml`

**- How I did it**

By typing on my keyboard

**- How to verify it**

I checked the fix manually on real hardware, I can cleanly shutdown the machine by pressing the power button shortly.

I also checked the acpid logs, and verified that there was no errors

**- Description for the changelog**

Add missing "devices" field on the acpid service to allow input devices

**- A picture of a cute animal (not mandatory but encouraged)**

![tapir](https://actus.zoobeauval.com/wp-content/uploads/2021/04/2021_visuel_actu_journee_tapirs.jpg)

