### PR TITLE
Upgrade runc to 1.0.3

### DIFF
--- a/examples/addbinds.yml
+++ b/examples/addbinds.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -5,7 +5,7 @@ kernel:
 init:
   - linuxkit/vpnkit-expose-port:87ac61469247b2a0483cbd1fd2915f220e078b78 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
   - linuxkit/memlogd:fe4a123b619a7dfffc2ba1297dd03b4ac90e3dd7

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 onboot:
   - name: dhcpcd

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 services:
   - name: getty

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/platform-aws.yml
+++ b/examples/platform-aws.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/platform-azure.yml
+++ b/examples/platform-azure.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/platform-gcp.yml
+++ b/examples/platform-gcp.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/platform-hetzner.yml
+++ b/examples/platform-hetzner.yml
@@ -4,7 +4,7 @@ kernel:
   ucode: intel-ucode.cpio
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
   - linuxkit/firmware:8f89601312327c78999a880ee104ceae9a25d20e

--- a/examples/platform-packet.yml
+++ b/examples/platform-packet.yml
@@ -4,7 +4,7 @@ kernel:
   ucode: intel-ucode.cpio
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
   - linuxkit/firmware:8f89601312327c78999a880ee104ceae9a25d20e

--- a/examples/platform-rt-for-vmware.yml
+++ b/examples/platform-rt-for-vmware.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/platform-scaleway.yml
+++ b/examples/platform-scaleway.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/platform-vmware.yml
+++ b/examples/platform-vmware.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/platform-vultr.yml
+++ b/examples/platform-vultr.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -5,7 +5,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 onboot:
   - name: dhcpcd

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/static-ip.yml
+++ b/examples/static-ip.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 onboot:
   - name: ip

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 onboot:
   - name: dhcpcd

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 onboot:
   - name: dhcpcd

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -12,7 +12,7 @@ RUN \
   make \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin GO111MODULE=off
-ENV RUNC_COMMIT=v1.0.2
+ENV RUNC_COMMIT=v1.0.3
 RUN mkdir -p $GOPATH/src/github.com/opencontainers && \
   cd $GOPATH/src/github.com/opencontainers && \
   git clone https://github.com/opencontainers/runc.git

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 onboot:
   - name: dhcpcd

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
   - samoht/fdd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 onboot:
   - name: sysctl

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=tty0 page_poison=1"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/src/cmd/linuxkit/moby/config.go
+++ b/src/cmd/linuxkit/moby/config.go
@@ -747,6 +747,9 @@ func ConfigToOCI(yaml *Image, config imagespec.ImageConfig, idMap map[string]uin
 	// default options match what Docker does
 	procOptions := []string{"nosuid", "nodev", "noexec", "relatime"}
 	devOptions := []string{"nosuid", "strictatime", "mode=755", "size=65536k"}
+	if readonly {
+		devOptions = append(devOptions, "ro")
+	}
 	ptsOptions := []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620"}
 	sysOptions := []string{"nosuid", "noexec", "nodev"}
 	if readonly {

--- a/src/cmd/linuxkit/moby/mkimage.yaml
+++ b/src/cmd/linuxkit/moby/mkimage.yaml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:ef008e6ec914daf0accbb02f5319fa2435d46133

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:52d2c4df0311b182e99241cdc382ff726755c450

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 
 onboot:

--- a/test/cases/000_build/020_binds/test.yml
+++ b/test/cases/000_build/020_binds/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: mount
     image: linuxkit/mount:43a2c1fb1ee19d0b2fe696655844cd6800e76aff

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 services:
   - name: acpid

--- a/test/cases/010_platforms/110_gcp/000_run/test.yml
+++ b/test/cases/010_platforms/110_gcp/000_run/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c

--- a/test/cases/020_kernel/011_config_5.4.x/test.yml
+++ b/test/cases/020_kernel/011_config_5.4.x/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:41aa03790ea637624a3f9737187e0c878766474b

--- a/test/cases/020_kernel/013_config_5.10.x/test.yml
+++ b/test/cases/020_kernel/013_config_5.10.x/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:41aa03790ea637624a3f9737187e0c878766474b

--- a/test/cases/020_kernel/015_config_5.12.x/test.yml
+++ b/test/cases/020_kernel/015_config_5.12.x/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:41aa03790ea637624a3f9737187e0c878766474b

--- a/test/cases/020_kernel/111_kmod_5.4.x/test.yml
+++ b/test/cases/020_kernel/111_kmod_5.4.x/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/113_kmod_5.10.x/test.yml
+++ b/test/cases/020_kernel/113_kmod_5.10.x/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/115_kmod_5.12.x/test.yml
+++ b/test/cases/020_kernel/115_kmod_5.12.x/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/200_namespace/common.yml
+++ b/test/cases/020_kernel/200_namespace/common.yml
@@ -3,4 +3,4 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: test
     image: alpine:3.13

--- a/test/cases/040_packages/002_bcc/test.yml
+++ b/test/cases/040_packages/002_bcc/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/kernel-bcc:5.4.113
 onboot:
   - name: check-bcc

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:e392d51db0ff8209b6021955b20c316f8a62bf25

--- a/test/cases/040_packages/002_bpftrace/test.yml
+++ b/test/cases/040_packages/002_bpftrace/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/bpftrace:a5c57a3791a87e96aea456f78fd88973ea9904d0
 onboot:
   - name: bpftrace-test

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:
   - name: test

--- a/test/cases/040_packages/003_cgroupv2/test.yml
+++ b/test/cases/040_packages/003_cgroupv2/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "linuxkit.unified_cgroup_hierarchy=1 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: test
     image: alpine:3.13

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:52d2c4df0311b182e99241cdc382ff726755c450

--- a/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: dm-crypt
     image: linuxkit/dm-crypt:908d3a270650aff7388092a307673c44d86e1ed0

--- a/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: dm-crypt
     image: linuxkit/dm-crypt:908d3a270650aff7388092a307673c44d86e1ed0

--- a/test/cases/040_packages/004_dm-crypt/002_key/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/002_key/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: dm-crypt
     image: linuxkit/dm-crypt:908d3a270650aff7388092a307673c44d86e1ed0

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: format
     image: linuxkit/format:b2c5f160916ba4793fda7bdc9fe66c68df116a61

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: extend
     image: linuxkit/extend:e521b228017344df9188ccf246719593e7039737

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:1b59b4f2ebb877085ea0d8d3a41cf06f64c09a15

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:1b59b4f2ebb877085ea0d8d3a41cf06f64c09a15

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: format
     image: linuxkit/format:b2c5f160916ba4793fda7bdc9fe66c68df116a61

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: extend
     image: linuxkit/extend:e521b228017344df9188ccf246719593e7039737

--- a/test/cases/040_packages/005_extend/003_gpt/test-create.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test-create.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: format
     image: linuxkit/format:b2c5f160916ba4793fda7bdc9fe66c68df116a61

--- a/test/cases/040_packages/005_extend/003_gpt/test.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: extend
     image: linuxkit/extend:e521b228017344df9188ccf246719593e7039737

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: format
     image: linuxkit/format:b2c5f160916ba4793fda7bdc9fe66c68df116a61

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: format
     image: linuxkit/format:b2c5f160916ba4793fda7bdc9fe66c68df116a61

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: format
     image: linuxkit/format:b2c5f160916ba4793fda7bdc9fe66c68df116a61

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:1b59b4f2ebb877085ea0d8d3a41cf06f64c09a15

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: format
     image: linuxkit/format:b2c5f160916ba4793fda7bdc9fe66c68df116a61

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: format
     image: linuxkit/format:b2c5f160916ba4793fda7bdc9fe66c68df116a61

--- a/test/cases/040_packages/006_format_mount/006_gpt/test.yml
+++ b/test/cases/040_packages/006_format_mount/006_gpt/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: format
     image: linuxkit/format:b2c5f160916ba4793fda7bdc9fe66c68df116a61

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: format
     image: linuxkit/format:b2c5f160916ba4793fda7bdc9fe66c68df116a61

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/test/cases/040_packages/009_init_containerd/test.yml
+++ b/test/cases/040_packages/009_init_containerd/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 services:

--- a/test/cases/040_packages/011_kmsg/test.yml
+++ b/test/cases/040_packages/011_kmsg/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
   - linuxkit/memlogd:fe4a123b619a7dfffc2ba1297dd03b4ac90e3dd7

--- a/test/cases/040_packages/012_logwrite/test.yml
+++ b/test/cases/040_packages/012_logwrite/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
   - linuxkit/memlogd:fe4a123b619a7dfffc2ba1297dd03b4ac90e3dd7

--- a/test/cases/040_packages/012_losetup/test.yml
+++ b/test/cases/040_packages/012_losetup/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: losetup
     image: linuxkit/losetup:43e40be0c82cbccf171ebd2a8065246e2e84f66e

--- a/test/cases/040_packages/013_metadata/000_cidata/test.yml
+++ b/test/cases/040_packages/013_metadata/000_cidata/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: metadata
     image: linuxkit/metadata:84727a54a54e24099104849cb1e7fc5ef1ade7a2

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:ef008e6ec914daf0accbb02f5319fa2435d46133

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:0dc8f792fc3a58afcebcb0fbe6b48de587265c17

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4
 onboot:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 onboot:
   - name: ltp

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -5,7 +5,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
   - linuxkit/containerd:2f0907913dd54ab5186006034eb224a0da12443e
 onboot:
   - name: dhcpcd

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0"
 init:
   - linuxkit/init:eb597ef74d808b5320ad1060b1620a6ac31e7ced
-  - linuxkit/runc:21dbbda709ae138de0af6b0c7e4ae49525db5e88
+  - linuxkit/runc:9f7aad4eb5e4360cc9ed8778a5c501cce6e21601
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:07a17973bb80d30d5924a440a33bfaaf475500ca


### PR DESCRIPTION
**- What I did**

- Update runc package run 1.0.3
- Remove the RO workaround that prevented container start
- update all examples and yamls to use images of new runc (with help from @djs55)

**- How I did it**

- update the version number
- revert the workaround patch (git revert)
- run scripts/update-component-sha.sh

**- How to verify it**
First ensure the RO issues is still a reality on runc 1.0.2 by checking out only the revert (only the first patch of this PR) and then using the command below :
 `cd ~/linuxkit/src/cmd/linuxkit && go build . && ./linuxkit build ../../../linuxkit.yml && ./linuxkit run qemu -kernel linuxkit`

The system will boot and show error.
```
INFO[2021-12-21T15:26:42.136250559Z] shim disconnected                             id=rngd
ERRO[2021-12-21T15:26:42.136718017Z] copy shim log                                 error="read /proc/self/fd/23: file already closed"
ERRO[0000] failed to create task                         error="OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: rootfs_linux.go:76: mounting \"devpts\" to rootfs at \"/dev/pts\" caused: mkdir /containers/services/rngd/rootfs/dev/pts: read-only file system: unknown"
time="2021-12-21T15:26:42.141640559Z" level=info msg="starting signal loop" namespace=services.linuxkit path=/run/containerd/io.containerd.runtime.v2.task/services.linuxkit/shutdown pid=525
```
We can see in `ctr -n services.linuxkit t ls` that rngd service failed to start.

Then checking out this PR to upgrade runc and upgrade the runc package SHA in all recipes, and run the command line again.
No error message appears.
The rngd container started (and stopped) properly.

**- Description for the changelog**

Upgrade runc to 1.0.3

**- A picture of a cute animal (not mandatory but encouraged)**
