### PR TITLE
openntpd: the "-s" flag is obsolete, this generates some error messages in the ntpd logs

### DIFF
--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -28,7 +28,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:a44c6230f1620f1d6310b95a9e9f585de73a8bd7
   - name: ntpd
-    image: linuxkit/openntpd:3d4190529a74dc2a2c74635f5cac817206be65c7
+    image: linuxkit/openntpd:d6c36ac367ed26a6eeffd8db78334d9f8041b038
 
   - name: docker
     image: docker:20.10.6-dind

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -57,7 +57,7 @@ services:
         - INSECURE=true
   # Run ntpd to keep time synchronised in the VM
   - name: ntpd
-    image: linuxkit/openntpd:3d4190529a74dc2a2c74635f5cac817206be65c7
+    image: linuxkit/openntpd:d6c36ac367ed26a6eeffd8db78334d9f8041b038
   # VSOCK to unix domain socket forwarding. Forwards guest /var/run/docker.sock
   # to a socket on the host.
   - name: vsudd

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -26,7 +26,7 @@ services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:52d2c4df0311b182e99241cdc382ff726755c450
   - name: ntpd
-    image: linuxkit/openntpd:3d4190529a74dc2a2c74635f5cac817206be65c7
+    image: linuxkit/openntpd:d6c36ac367ed26a6eeffd8db78334d9f8041b038
   - name: docker
     image: docker:20.10.6-dind
     capabilities:

--- a/pkg/openntpd/Dockerfile
+++ b/pkg/openntpd/Dockerfile
@@ -15,4 +15,4 @@ CMD []
 WORKDIR /
 COPY --from=mirror /out/ /
 COPY etc/ /etc/
-CMD ["/usr/sbin/ntpd", "-d", "-s"]
+CMD ["/usr/sbin/ntpd", "-d"]

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -27,7 +27,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:a44c6230f1620f1d6310b95a9e9f585de73a8bd7
   - name: ntpd
-    image: linuxkit/openntpd:3d4190529a74dc2a2c74635f5cac817206be65c7
+    image: linuxkit/openntpd:d6c36ac367ed26a6eeffd8db78334d9f8041b038
   - name: docker
     image: docker:20.10.6-dind
     capabilities:

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -27,7 +27,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:a44c6230f1620f1d6310b95a9e9f585de73a8bd7
   - name: ntpd
-    image: linuxkit/openntpd:3d4190529a74dc2a2c74635f5cac817206be65c7
+    image: linuxkit/openntpd:d6c36ac367ed26a6eeffd8db78334d9f8041b038
   - name: docker
     image: docker:20.10.6-dind
     capabilities:


### PR DESCRIPTION
**- What I did**

Removed the "-s" flag in the ntpd command-line because the flag is obsolete and generate some error messages in the ntpd logs

**- How I did it**

Typed the backspace key

**- How to verify it**

Check the CI

**- Description for the changelog**

Removed the "-s" flag in openntpd package, because this flag is obsolete

**- A picture of a cute animal (not mandatory but encouraged)**

https://cdn.radiofrance.fr/s3/cruiser-production/2014/03/ea065e11-ac5b-11e3-907f-782bcb6744eb/640_marmotte-cc-benjamine92.jpg