### PR TITLE
Warn about potential incomplete layer downloads in cache

### DIFF
--- a/src/cmd/linuxkit/hyperv_fallback.go
+++ b/src/cmd/linuxkit/hyperv_fallback.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main

--- a/src/cmd/linuxkit/util/util_unix.go
+++ b/src/cmd/linuxkit/util/util_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package util


### PR DESCRIPTION
**- What I did**

I encountered an issue with "invalid index" after stopping an image pull with an interrupt.

```
$ linuxkit build linuxkit.yml
Extract kernel image: docker.io/linuxkit/kernel:5.10.76
Image docker.io/linuxkit/kernel:5.10.76 not found in local cache, pulling
^C                                                                                                                     

$ linuxkit build linuxkit.yml
Extract kernel image: docker.io/linuxkit/kernel:5.10.76
Image docker.io/linuxkit/kernel:5.10.76 not found in local cache, pulling
FATA[0022] Failed to extract kernel image and tarball: Could not pull image docker.io/linuxkit/kernel:5.10.76: invalid index       
```

The error wasn't very useful and it took me awhile to realize that a file in `~/.linuxkit/cache/blobs/sha256` was smaller than it should be.

Verbose output also wasn't particularly useful.

```
$ linuxkit -v build linuxkit.yml
time="2021-12-22T14:42:41-05:00" level=debug msg="Formats selected: [kernel+initrd]"
time="2021-12-22T14:42:41-05:00" level=debug msg="validating output: [kernel+initrd]"
time="2021-12-22T14:42:41-05:00" level=info msg="Extract kernel image: docker.io/linuxkit/kernel:5.10.76"
time="2021-12-22T14:42:41-05:00" level=debug msg="image tar: docker.io/linuxkit/kernel:5.10.76 "
time="2021-12-22T14:42:45-05:00" level=debug msg="ImagePull to cache docker.io/linuxkit/kernel:5.10.76 trusted reference docker.io/linuxkit/kernel:5.10.76"
time="2021-12-22T14:42:49-05:00" level=info msg="Image docker.io/linuxkit/kernel:5.10.76 not found in local cache, pulling"

...

time="2021-12-22T14:42:56-05:00" level=debug msg="<-- 200 https://production.cloudflare.docker.com/registry-v2/docker/registry/v2/blobs/sha256/47/476eaf3f642da71f069d62e736164bf85db1148c8ce95b98a58362b2e4aaf4a6/data?verify=1640205176-A2ksdpXKc%2Bw8H%2FWiix7BR8ncUdc%3D (1.088881975s)"
time="2021-12-22T14:42:56-05:00" level=debug msg="HTTP/2.0 200 OK"
time="2021-12-22T14:42:56-05:00" level=debug msg="Content-Length: 1104"
time="2021-12-22T14:42:56-05:00" level=debug msg="Accept-Ranges: bytes"
time="2021-12-22T14:42:56-05:00" level=debug msg="Age: 16095"
time="2021-12-22T14:42:56-05:00" level=debug msg="Cache-Control: public, max-age=14400"
time="2021-12-22T14:42:56-05:00" level=debug msg="Cf-Cache-Status: HIT"
time="2021-12-22T14:42:56-05:00" level=debug msg="Cf-Ray: 6c1bd611296d252c-SJC"
time="2021-12-22T14:42:56-05:00" level=debug msg="Content-Type: application/octet-stream"
time="2021-12-22T14:42:56-05:00" level=debug msg="Date: Wed, 22 Dec 2021 19:42:56 GMT"
time="2021-12-22T14:42:56-05:00" level=debug msg="Etag: \"adf1587a8c32779ccdefbcf1afa52da3\""
time="2021-12-22T14:42:56-05:00" level=debug msg="Expect-Ct: max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""
time="2021-12-22T14:42:56-05:00" level=debug msg="Expires: Wed, 22 Dec 2021 23:42:56 GMT"
time="2021-12-22T14:42:56-05:00" level=debug msg="Last-Modified: Mon, 08 Nov 2021 11:42:36 GMT"
time="2021-12-22T14:42:56-05:00" level=debug msg="Server: cloudflare"
time="2021-12-22T14:42:56-05:00" level=debug msg="Vary: Accept-Encoding"
time="2021-12-22T14:42:56-05:00" level=debug msg="X-Amz-Id-2: kGzFjLMCjX9GuoD9YdupXF0LdlfMiyaDeMXhHkIFN2KAtiw2YyBPXwt+HBZ7Qu16ZI9m6ioWVG8="
time="2021-12-22T14:42:56-05:00" level=debug msg="X-Amz-Request-Id: QHAW76336Z6C1SMN"
time="2021-12-22T14:42:56-05:00" level=debug msg="X-Amz-Version-Id: oBXtWVpolFH2CQUH.GPUM2jge_XkdbUR"
time="2021-12-22T14:42:56-05:00" level=debug
time="2021-12-22T14:42:56-05:00" level=debug msg="{\"architecture\":\"arm64\",\"config\":{\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"WorkingDir\":\"/\",\"Labels\":{\"org.mobyproject.linuxkit.kernel.buildimage\":\"linuxkit/alpine:2be490394653b7967c250e86fd42cef88de428ba\",\"org.opencontainers.image.revision\":\"56c08df66bc4496dd856e588f9559224ace08279\",\"org.opencontainers.image.source\":\"https://github.com/linuxkit/linuxkit\"},\"ArgsEscaped\":true,\"OnBuild\":null},\"created\":\"2021-11-08T11:39:57.833975129Z\",\"history\":[{\"created\":\"2021-11-08T11:39:57.833975129Z\",\"created_by\":\"ENTRYPOINT []\",\"comment\":\"buildkit.dockerfile.v0\",\"empty_layer\":true},{\"created\":\"2021-11-08T11:39:57.833975129Z\",\"created_by\":\"CMD []\",\"comment\":\"buildkit.dockerfile.v0\",\"empty_layer\":true},{\"created\":\"2021-11-08T11:39:57.833975129Z\",\"created_by\":\"WORKDIR /\",\"comment\":\"buildkit.dockerfile.v0\",\"empty_layer\":true},{\"created\":\"2021-11-08T11:39:57.833975129Z\",\"created_by\":\"COPY /out/* / # buildkit\",\"comment\":\"buildkit.dockerfile.v0\"}],\"os\":\"linux\",\"rootfs\":{\"type\":\"layers\",\"diff_ids\":[\"sha256:bc347e483ed23251bd80081de38c54c305b79c45150a9c87cfb9a79296bdb594\"]}}"
time="2021-12-22T14:43:01-05:00" level=fatal msg="Failed to extract kernel image and tarball: Could not pull image docker.io/linuxkit/kernel:5.10.76: invalid index"
```

**- How I did it**

I added logs to the vendored code for `github.com/google/go-containerregistry/pkg/v1/validate` until it was clear that a tar archive was being created and then read. The `tar.Reader` for this archive spat out an `io.ErrUnexpectedEOF` on a call to `Next()`. When moving to the header of the next file, it hit the end of the archive before discarding enough bytes. The header was correct, but the content (an image layer) was incomplete.

**- How to verify it**

See in "What I did" and start with a clean cache. Technically, you need to time it so that a large layer is being downloaded, but this should almost always be the case.

With this branch, you will see the new output with a warning.

```
$ make local && ./bin/linuxkit build linuxkit.yml 
make -C ./src/cmd/linuxkit local
make[1]: Entering directory '/home/bkrieger/go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit'
gofmt...
govet...
golint...
ineffassign...
CGO_ENABLED=0 go build -o /home/bkrieger/go/src/github.com/linuxkit/linuxkit/bin/linuxkit  --ldflags "-X github.com/li"
go test -mod=vendor ./...
?       github.com/linuxkit/linuxkit/src/cmd/linuxkit   [no test files]
?       github.com/linuxkit/linuxkit/src/cmd/linuxkit/cache     [no test files]
?       github.com/linuxkit/linuxkit/src/cmd/linuxkit/docker    [no test files]
?       github.com/linuxkit/linuxkit/src/cmd/linuxkit/initrd    [no test files]
ok      github.com/linuxkit/linuxkit/src/cmd/linuxkit/moby      0.011s
?       github.com/linuxkit/linuxkit/src/cmd/linuxkit/pad4      [no test files]
ok      github.com/linuxkit/linuxkit/src/cmd/linuxkit/pkglib    0.154s
?       github.com/linuxkit/linuxkit/src/cmd/linuxkit/registry  [no test files]
?       github.com/linuxkit/linuxkit/src/cmd/linuxkit/spec      [no test files]
?       github.com/linuxkit/linuxkit/src/cmd/linuxkit/util      [no test files]
?       github.com/linuxkit/linuxkit/src/cmd/linuxkit/version   [no test files]
make[1]: Leaving directory '/home/bkrieger/go/src/github.com/linuxkit/linuxkit/src/cmd/linuxkit'
Extract kernel image: docker.io/linuxkit/kernel:5.10.76
WARN[0004] A file in your linuxkit cache seems to be incomplete. You may want to try clearing your cache. 
WARN[0008] A file in your linuxkit cache seems to be incomplete. You may want to try clearing your cache. 
Image docker.io/linuxkit/kernel:5.10.76 not found in local cache, pulling
WARN[0019] A file in your linuxkit cache seems to be incomplete. You may want to try clearing your cache. 
FATA[0019] Failed to extract kernel image and tarball: Could not pull image docker.io/linuxkit/kernel:5.10.76: invalid index
```

**- Description for the changelog**

Warn about potential incomplete layer downloads in cache


**- A picture of a cute animal (not mandatory but encouraged)**

```
( )_( )
(='.'=)
(")_(")
```