### PR TITLE
Update Moby schema for architecture

### DIFF
--- a/src/cmd/linuxkit/moby/config.go
+++ b/src/cmd/linuxkit/moby/config.go
@@ -24,7 +24,7 @@ type Moby struct {
 	Onshutdown   []*Image     `yaml:"onshutdown" json:"onshutdown"`
 	Services     []*Image     `yaml:"services" json:"services"`
 	Files        []File       `yaml:"files" json:"files"`
-	Architecture string
+	Architecture string       `yaml:"architecture" json:"architecture"`
 
 	initRefs []*reference.Spec
 }

--- a/src/cmd/linuxkit/moby/schema.go
+++ b/src/cmd/linuxkit/moby/schema.go
@@ -6,6 +6,9 @@ var schema = string(`
   "title": "Moby Config",
   "additionalProperties": false,
   "definitions": {
+    "architecture" : {
+      "type": "string"
+    },
     "kernel": {
       "type": "object",
       "additionalProperties": false,
@@ -319,6 +322,7 @@ var schema = string(`
     }
   },
   "properties": {
+    "architecture": { "$ref": "#/definitions/architecture" },
     "kernel": { "$ref": "#/definitions/kernel" },
     "init": { "$ref": "#/definitions/strings" },
     "onboot": { "$ref": "#/definitions/images" },


### PR DESCRIPTION
Signed-off-by: Michael Aldridge <aldridge.mac@gmail.com>

Resolves #3750 

**- What I did**

Updated the goschema schema.

**- How I did it**

Sheer dumb luck and guesswork.

**- How to verify it**

Honestly not sure, this really should have broken some test when the cache PR was merged, and the fact that it didn't really is a defect in and of itself.

**- Description for the changelog**
Provide schema value for architecture parameter.

The schema still includes lots of references to trust config.  I would argue that these should be removed, but that would break anyone who has trust stanzas in their config.  Whether or not that's something to care about is another matter, and I'd argue that since the default for linuxkit is to build from master it isn't something to worry about.