### PR TITLE
pass target architecture explicitly

### DIFF
--- a/src/cmd/linuxkit/build.go
+++ b/src/cmd/linuxkit/build.go
@@ -180,7 +180,6 @@ func build(args []string) {
 		if err != nil {
 			log.Fatalf("Invalid config: %v", err)
 		}
-		c.Architecture = *buildArch
 		m, err = moby.AppendConfig(m, c)
 		if err != nil {
 			log.Fatalf("Cannot append config files: %v", err)
@@ -205,7 +204,7 @@ func build(args []string) {
 	if moby.Streamable(buildFormats[0]) {
 		tp = buildFormats[0]
 	}
-	err = moby.Build(m, w, *buildPull, tp, *buildDecompressKernel, cacheDir, *buildDocker)
+	err = moby.Build(m, w, *buildPull, tp, *buildDecompressKernel, cacheDir, *buildDocker, *buildArch)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}

--- a/src/cmd/linuxkit/moby/config.go
+++ b/src/cmd/linuxkit/moby/config.go
@@ -18,13 +18,12 @@ import (
 
 // Moby is the type of a Moby config file
 type Moby struct {
-	Kernel       KernelConfig `kernel:"cmdline,omitempty" json:"kernel,omitempty"`
-	Init         []string     `init:"cmdline" json:"init"`
-	Onboot       []*Image     `yaml:"onboot" json:"onboot"`
-	Onshutdown   []*Image     `yaml:"onshutdown" json:"onshutdown"`
-	Services     []*Image     `yaml:"services" json:"services"`
-	Files        []File       `yaml:"files" json:"files"`
-	Architecture string
+	Kernel     KernelConfig `kernel:"cmdline,omitempty" json:"kernel,omitempty"`
+	Init       []string     `init:"cmdline" json:"init"`
+	Onboot     []*Image     `yaml:"onboot" json:"onboot"`
+	Onshutdown []*Image     `yaml:"onshutdown" json:"onshutdown"`
+	Services   []*Image     `yaml:"services" json:"services"`
+	Files      []File       `yaml:"files" json:"files"`
 
 	initRefs []*reference.Spec
 }
@@ -311,7 +310,6 @@ func AppendConfig(m0, m1 Moby) (Moby, error) {
 	moby.Services = append(moby.Services, m1.Services...)
 	moby.Files = append(moby.Files, m1.Files...)
 	moby.initRefs = append(moby.initRefs, m1.initRefs...)
-	moby.Architecture = m1.Architecture
 
 	return moby, uniqueServices(moby)
 }

--- a/src/cmd/linuxkit/moby/linuxkit.go
+++ b/src/cmd/linuxkit/moby/linuxkit.go
@@ -50,14 +50,14 @@ func ensureLinuxkitImage(name, cache string) error {
 	}
 	// This is just a local utility used for conversion, so it does not matter what architecture we use.
 	// Might as well just use our local one.
-	m.Architecture = runtime.GOARCH
+	arch := runtime.GOARCH
 	// TODO pass through --pull to here
 	tf, err := ioutil.TempFile("", "")
 	if err != nil {
 		return err
 	}
 	defer os.Remove(tf.Name())
-	if err := Build(m, tf, false, "", false, cache, true); err != nil {
+	if err := Build(m, tf, false, "", false, cache, true, arch); err != nil {
 		return err
 	}
 	if err := tf.Close(); err != nil {


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed #3750 

`type Moby` contained a field `Architecture` to pass around what arch we are building for. However, that does not correctly reflect the yaml file, which should be usable across architectures. It only was added as a convenience, to avoid passing another parameter to several functions.

This removes that non-yaml property and passes it around explicitly where needed.

**- How I did it**

Removed the field, added it as arg to several functions.

**- How to verify it**

CI is your friend.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Align Moby type with yaml by moving extraneous fields out and passing explicitly.


