### PR TITLE
replace Build many args with opts struct

### DIFF
--- a/src/cmd/linuxkit/build.go
+++ b/src/cmd/linuxkit/build.go
@@ -204,7 +204,7 @@ func build(args []string) {
 	if moby.Streamable(buildFormats[0]) {
 		tp = buildFormats[0]
 	}
-	err = moby.Build(m, w, *buildPull, tp, *buildDecompressKernel, cacheDir, *buildDocker, *buildArch)
+	err = moby.Build(m, w, moby.BuildOpts{Pull: *buildPull, BuilderType: tp, DecompressKernel: *buildDecompressKernel, CacheDir: cacheDir, DockerCache: *buildDocker, Arch: *buildArch})
 	if err != nil {
 		log.Fatalf("%v", err)
 	}

--- a/src/cmd/linuxkit/moby/build.go
+++ b/src/cmd/linuxkit/moby/build.go
@@ -83,14 +83,14 @@ func OutputTypes() []string {
 	return ts
 }
 
-func outputImage(image *Image, section string, prefix string, m Moby, idMap map[string]uint32, dupMap map[string]string, pull bool, iw *tar.Writer, cacheDir string, dockerCache bool, arch string) error {
+func outputImage(image *Image, section string, prefix string, m Moby, idMap map[string]uint32, dupMap map[string]string, iw *tar.Writer, opts BuildOpts) error {
 	log.Infof("  Create OCI config for %s", image.Image)
 	imageName := util.ReferenceExpand(image.Image)
 	ref, err := reference.Parse(imageName)
 	if err != nil {
 		return fmt.Errorf("could not resolve references for image %s: %v", image.Image, err)
 	}
-	src, err := imagePull(&ref, pull, cacheDir, dockerCache, arch)
+	src, err := imagePull(&ref, opts.Pull, opts.CacheDir, opts.DockerCache, opts.Arch)
 	if err != nil {
 		return fmt.Errorf("Could not pull image %s: %v", image.Image, err)
 	}
@@ -108,7 +108,7 @@ func outputImage(image *Image, section string, prefix string, m Moby, idMap map[
 	}
 	path := path.Join("containers", section, prefix+image.Name)
 	readonly := oci.Root.Readonly
-	err = ImageBundle(path, image.ref, config, runtime, iw, pull, readonly, dupMap, cacheDir, dockerCache, arch)
+	err = ImageBundle(path, image.ref, config, runtime, iw, readonly, dupMap, opts)
 	if err != nil {
 		return fmt.Errorf("Failed to extract root filesystem for %s: %v", image.Image, err)
 	}
@@ -116,7 +116,7 @@ func outputImage(image *Image, section string, prefix string, m Moby, idMap map[
 }
 
 // Build performs the actual build process
-func Build(m Moby, w io.Writer, pull bool, tp string, decompressKernel bool, cacheDir string, dockerCache bool, arch string) error {
+func Build(m Moby, w io.Writer, opts BuildOpts) error {
 	if MobyDir == "" {
 		MobyDir = defaultMobyConfigDir()
 	}
@@ -129,7 +129,7 @@ func Build(m Moby, w io.Writer, pull bool, tp string, decompressKernel bool, cac
 	iw := tar.NewWriter(w)
 
 	// add additions
-	addition := additions[tp]
+	addition := additions[opts.BuilderType]
 
 	// allocate each container a uid, gid that can be referenced by name
 	idMap := map[string]uint32{}
@@ -153,8 +153,8 @@ func Build(m Moby, w io.Writer, pull bool, tp string, decompressKernel bool, cac
 	if m.Kernel.ref != nil {
 		// get kernel and initrd tarball and ucode cpio archive from container
 		log.Infof("Extract kernel image: %s", m.Kernel.ref)
-		kf := newKernelFilter(iw, m.Kernel.Cmdline, m.Kernel.Binary, m.Kernel.Tar, m.Kernel.UCode, decompressKernel)
-		err := ImageTar(m.Kernel.ref, "", kf, pull, "", cacheDir, dockerCache, arch)
+		kf := newKernelFilter(iw, m.Kernel.Cmdline, m.Kernel.Binary, m.Kernel.Tar, m.Kernel.UCode, opts.DecompressKernel)
+		err := ImageTar(m.Kernel.ref, "", kf, "", opts)
 		if err != nil {
 			return fmt.Errorf("Failed to extract kernel image and tarball: %v", err)
 		}
@@ -170,7 +170,7 @@ func Build(m Moby, w io.Writer, pull bool, tp string, decompressKernel bool, cac
 	}
 	for _, ii := range m.initRefs {
 		log.Infof("Process init image: %s", ii)
-		err := ImageTar(ii, "", iw, pull, resolvconfSymlink, cacheDir, dockerCache, arch)
+		err := ImageTar(ii, "", iw, resolvconfSymlink, opts)
 		if err != nil {
 			return fmt.Errorf("Failed to build init tarball from %s: %v", ii, err)
 		}
@@ -181,7 +181,7 @@ func Build(m Moby, w io.Writer, pull bool, tp string, decompressKernel bool, cac
 	}
 	for i, image := range m.Onboot {
 		so := fmt.Sprintf("%03d", i)
-		if err := outputImage(image, "onboot", so+"-", m, idMap, dupMap, pull, iw, cacheDir, dockerCache, arch); err != nil {
+		if err := outputImage(image, "onboot", so+"-", m, idMap, dupMap, iw, opts); err != nil {
 			return err
 		}
 	}
@@ -191,7 +191,7 @@ func Build(m Moby, w io.Writer, pull bool, tp string, decompressKernel bool, cac
 	}
 	for i, image := range m.Onshutdown {
 		so := fmt.Sprintf("%03d", i)
-		if err := outputImage(image, "onshutdown", so+"-", m, idMap, dupMap, pull, iw, cacheDir, dockerCache, arch); err != nil {
+		if err := outputImage(image, "onshutdown", so+"-", m, idMap, dupMap, iw, opts); err != nil {
 			return err
 		}
 	}
@@ -200,7 +200,7 @@ func Build(m Moby, w io.Writer, pull bool, tp string, decompressKernel bool, cac
 		log.Infof("Add service containers:")
 	}
 	for _, image := range m.Services {
-		if err := outputImage(image, "services", "", m, idMap, dupMap, pull, iw, cacheDir, dockerCache, arch); err != nil {
+		if err := outputImage(image, "services", "", m, idMap, dupMap, iw, opts); err != nil {
 			return err
 		}
 	}

--- a/src/cmd/linuxkit/moby/linuxkit.go
+++ b/src/cmd/linuxkit/moby/linuxkit.go
@@ -57,7 +57,7 @@ func ensureLinuxkitImage(name, cache string) error {
 		return err
 	}
 	defer os.Remove(tf.Name())
-	if err := Build(m, tf, false, "", false, cache, true, arch); err != nil {
+	if err := Build(m, tf, BuildOpts{Pull: false, BuilderType: "", DecompressKernel: false, CacheDir: cache, DockerCache: true, Arch: arch}); err != nil {
 		return err
 	}
 	if err := tf.Close(); err != nil {

--- a/src/cmd/linuxkit/moby/opts.go
+++ b/src/cmd/linuxkit/moby/opts.go
@@ -1,0 +1,11 @@
+package moby
+
+// BuildOpts options that control the linuxkit build process
+type BuildOpts struct {
+	Pull             bool
+	BuilderType      string
+	DecompressKernel bool
+	CacheDir         string
+	DockerCache      bool
+	Arch             string
+}


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Replaced the signature of `Moby.Build(lots, of args, here, and, keep, changing)` with an `BuiltOpts struct`

**- How I did it**

Replace, test

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Simpler `moby.Build` signature

**- Notes for maintainers**

I am not sure how much this buys. We never really intended `moby.Build()` to be used by the public, but it is; implicit API and all that.

This does clean it up at least somewhat, by giving it a signature of:

```go
func Build(m Moby, w io.Writer, opts BuildOpts) error {
```

That strikes me as better and easier to understand.

However, once inside `moby.Build`, we call `ImageTar()` once and `outputImage()` 3 times, each of which just takes lots of those parameters.

The question for maintainers:

1. Is this worth it? I think yes, but open question.
2. Should we also change how we pass things to the non-exported `outputImage()` and the exported `ImageTar()`?
