### PR TITLE
Declare build-args in build.yml

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -41,6 +41,7 @@ A package source consists of a directory containing at least two files:
 - `gitrepo` _(string)_: The git repository where the package source is kept.
 - `network` _(bool)_: Allow network access during the package build (default: no)
 - `disable-cache` _(bool)_: Disable build cache for this package (default: no)
+- `buildArgs` will forward a list of build arguments down to docker. As if `--build-arg` was specified during `docker build`
 - `config`: _(struct `github.com/moby/tool/src/moby.ImageConfig`)_: Image configuration, marshalled to JSON and added as `org.mobyproject.config` label on image (default: no label)
 - `depends`: Contains information on prerequisites which must be satisfied in order to build the package. Has subfields:
     - `docker-images`: Docker images to be made available (as `tar` files via `docker image save`) within the package build context. Contains the following nested fields:

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -257,6 +257,12 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 		args = append(args, "--label=org.mobyproject.linuxkit.version="+version.Version)
 		args = append(args, "--label=org.mobyproject.linuxkit.revision="+version.GitCommit)
 
+		if p.buildArgs != nil {
+			for _, buildArg := range *p.buildArgs {
+				args = append(args, "--build-arg", buildArg)
+			}
+		}
+
 		// build for each arch and save in the linuxkit cache
 		for _, platform := range bo.platforms {
 			desc, err := p.buildArch(d, c, platform.Architecture, args, writer, bo)

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -26,6 +26,7 @@ type pkgInfo struct {
 	Network      bool              `yaml:"network"`
 	DisableCache bool              `yaml:"disable-cache"`
 	Config       *moby.ImageConfig `yaml:"config"`
+	BuildArgs    *[]string         `yaml:"buildArgs,omitempty"`
 	Depends      struct {
 		DockerImages struct {
 			TargetDir string   `yaml:"target-dir"`
@@ -54,6 +55,7 @@ type Pkg struct {
 	trust         bool
 	cache         bool
 	config        *moby.ImageConfig
+	buildArgs     *[]string
 	dockerDepends dockerDepends
 
 	// Internal state
@@ -260,6 +262,7 @@ func NewFromCLI(fs *flag.FlagSet, args ...string) ([]Pkg, error) {
 			network:       pi.Network,
 			cache:         !pi.DisableCache,
 			config:        pi.Config,
+			buildArgs:     pi.BuildArgs,
 			dockerDepends: dockerDepends,
 			dirty:         dirty,
 			path:          pkgPath,

--- a/test/cases/000_build/030_build_args/Dockerfile
+++ b/test/cases/000_build/030_build_args/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.13
+
+ARG TEST_RESULT=FAILED
+
+RUN echo "printf \"Build-arg test $TEST_RESULT\\n\"" >> check.sh
+
+ENTRYPOINT ["/bin/sh", "/check.sh"]

--- a/test/cases/000_build/030_build_args/build.yml
+++ b/test/cases/000_build/030_build_args/build.yml
@@ -1,0 +1,7 @@
+image: build-args-test
+network: true
+arches:
+    - amd64
+    - arm64
+buildArgs:
+    - TEST_RESULT=PASSED

--- a/test/cases/000_build/030_build_args/test.sh
+++ b/test/cases/000_build/030_build_args/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# SUMMARY: Check that the build-args are correctly passed to Dockerfiles
+# LABELS:
+# REPEAT:
+
+set -ex
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+# Test code goes here
+echo Linuxkig is "$(which linuxkit)"
+RESULT="$(2>&1 linuxkit pkg build --force . | grep PASSED)"
+echo RESULT="${RESULT}"
+echo "${RESULT}" | grep  "Build-arg test PASSED"
+
+exit 0


### PR DESCRIPTION
Related to #3394

This allows multiple build flavors for a single codebase, without
sacrificing reproducible builds. The build-args are set in build.yml,
which is typically under the source control (if it is not, then no
reproducible builds are possible anyways). Meaning that mutating
build-args would result in setting “dirty” flag.

Intended use of this commit is to switch between build flavors by
specifying a different yaml file (presumably also under the version
control)  by  `-build-yml` option.

**- What I did**
Allow forwarding build-args to Dockerfiles 

**- How I did it**
By adding parsing of buildArgs in build.yml

**- How to verify it**
Add a section in the Dockerfile:
```
ARG FOO=bar
RUN echo "FOO=$FOO"
```
and to `build.yml`:
```
  buildArgs:
    - FOO=xxx
```

Run `linuxkit pkg build -platforms linux/amd64 --force .`, find the following line in the output:
```
=> [build  2/21] RUN echo "FOO=xxx"
```
**- Description for the changelog**
Declare build-args in build.yml

