### PR TITLE
Fix a merge conflict in openstack.yml example

### DIFF
--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,11 +2,7 @@ kernel:
   image: linuxkit/kernel:5.10.92
   cmdline: "console=ttyS0"
 init:
-<<<<<<< HEAD
   - linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7
-=======
-  - linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7
->>>>>>> 01725ea17 (update dependencies of pkg/init and pkg/containerd)
   - linuxkit/runc:f01b88c7033180d50ae43562d72707c6881904e4
   - linuxkit/containerd:de1b18eed76a266baa3092e5c154c84f595e56da
   - linuxkit/ca-certificates:c1c73ef590dffb6a0138cf758fe4a4305c9864f4


### PR DESCRIPTION
In openstack.yml, there was the left overs from a merge conflict that hadn't been resolved properly. This PR resolves it by using the current change as the change looks to be the same. 