### PR TITLE
remove need for maintainers to build packages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,42 @@
+# publish changes that are merged to master
+name: Packages Push
+on:
+  workflow_run:
+    workflows: [LinuxKit CI]
+    types: [completed]
+    branches: [master, main]
+
+jobs:
+  packages:
+    name: Publish Changed Packages
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v1
+      with:
+        path: ./src/github.com/linuxkit/linuxkit
+    - name: Download linuxkit
+      uses: actions/download-artifact@v2
+      with:
+        name: linuxkit-amd64-linux
+        path: bin
+    - name: Symlink Linuxkit
+      run: |
+        chmod ugo+x bin/linuxkit-amd64-linux
+        sudo ln -s $(pwd)/bin/linuxkit-amd64-linux /usr/local/bin/linuxkit
+        /usr/local/bin/linuxkit version
+    - name: Restore Package Cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.linuxkit/cache/
+        key: ${{ runner.os }}-linuxkit-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-linuxkit-
+    - name: Publish Packages
+      # this should only push changed ones:
+      #  - unchanged: already in the registry
+      #  - changed: already built and cached, so only will push
+      # Skip s390x as emulation is unreliable
+      run: |
+        make OPTIONS="--skip-platforms linux/s390x" -C pkg push PUSHOPTIONS="--nobuild"
+


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Removed the need for maintainers to push out packages.

**- How I did it**

2 changes:

1. On PR, it already did `lkt pkg build`, which forces it to download the image to lkt cache or, if not there, build it (or fail). Here we just need to tell maintainers "do NOT push it", which this does. Eventually, we should remove manual pushing capability.
2. Added a new GH actions workflow file that, when the build ci.yaml is done, and we are on `master` or `main` branch, pushes out every package. Since only changed ones will not already be in registry, this will push out only the changed ones.

**- How to verify it**

Requires a new PR that changes a package, have no one push it out, see that it works.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Eliminate the need for maintainers to manually build and push out packages.

**- some comments**

I am not 100% sure that this works, or if the approach is correct. It may slow things down, since it now depends on emulated builds, whereas maintainers were using Packet build servers.

On the other hand, getting human hands out of the critical path *absolutely* is the right thing.

Looking forward to feedback.