### PR TITLE
download artifact from other workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,10 +16,26 @@ jobs:
       with:
         path: ./src/github.com/linuxkit/linuxkit
     - name: Download linuxkit
-      uses: actions/download-artifact@v2
+      uses: actions/github-script@v3.1.0
       with:
-        name: linuxkit-amd64-linux
-        path: bin
+        script: |
+          var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+          });
+          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "linuxkit-amd64-linux"
+          })[0];
+          var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+          });
+          var fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/bin/linuxkit-amd64-linux.zip', Buffer.from(download.data));
+    - run: cd bin && unzip linuxkit-amd64-linux.zip
     - name: Symlink Linuxkit
       run: |
         chmod ugo+x bin/linuxkit-amd64-linux


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix the cross-workflow download of artifact

**- How I did it**

Replace the standard GitHub `actions/download-artifact` (which does not support cross-workflow downloads) with an explicit `actions/github-script` which does.

**- How to verify it**

CI will not change. We will need to merge into `master` to know that it works.

