### PR TITLE
login to docker hub before publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,6 +53,11 @@ jobs:
         key: ${{ runner.os }}-linuxkit-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-linuxkit-
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Publish Packages
       # this should only push changed ones:
       #  - unchanged: already in the registry
@@ -60,4 +65,3 @@ jobs:
       # Skip s390x as emulation is unreliable
       run: |
         make OPTIONS="--skip-platforms linux/s390x" -C pkg push PUSHOPTIONS="--nobuild"
-


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Ensure we log in to docker hub before trying to push packages.

**- How I did it**

Add docker/login action to `release.yaml`

**- How to verify it**

Merge to master and watch it work

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Login to docker hub to publish images

**- Extra notes**

We need the 2 secrets (`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`) to be created, using a production ID.