### PR TITLE
Skip build if no platforms

### DIFF
--- a/src/cmd/linuxkit/pkg_build.go
+++ b/src/cmd/linuxkit/pkg_build.go
@@ -158,6 +158,14 @@ func pkgBuildPush(args []string, withPush bool) {
 				pkgPlats = append(pkgPlats, imagespec.Platform{OS: "linux", Architecture: a})
 			}
 		}
+
+		// if there are no platforms to build for, do nothing.
+		// note that this is *not* an error; we simply skip it
+		if len(pkgPlats) == 0 {
+			fmt.Printf("Skipping %s with no architectures to build\n", p.Tag())
+			return
+		}
+
 		pkgOpts = append(pkgOpts, pkglib.WithBuildPlatforms(pkgPlats...))
 
 		var msg, action string


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

1. If there are no platforms at all to build, then do not even try to build or push. We use blank `arches:` in one or two places to indicate, "do not build this". However, that sometimes can cause an error when it tries to build or push and finds no arches or an index with no manifests. This ensures that it works correctly.
1. When doing `lkt pkg push`, check if the manifest/index tag you are pushing already exists on the registry, and if it does, skip the push if the digest is identical.

**- How I did it**

Changes to `src/cmd/linuxkit`.

**- How to verify it**

I tested the first part by trying to build and push bpftrace, which has blank `arches` and therefore disabled, and then with sysfs, which does not.

I tested the second part by trying to push sysfs, whose local manifest is identical to what already is there, and then changed it an stepped through until I saw that it wanted to push.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Build and push only if some arches are available.
Do not push if the identical manifest, determined by digest, already exists remotely.


