### PR TITLE
test pkg/dummy

### DIFF
--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,4 +1,4 @@
-DIRS = $(dir $(shell find . -maxdepth 2 -mindepth 2 -type f -name build.yml))
+DIRS = $(dir $(shell find . -maxdepth 2 -mindepth 2 -type f -name build.yml | sort))
 .PHONY: push force-push build forcebuild show-tag clean
 
 OPTIONS ?=
@@ -10,18 +10,18 @@ PUSHOPTIONS += -release $(LK_RELEASE)
 endif
 
 push:
-	@linuxkit pkg push $(OPTIONS) $(PUSHOPTIONS) $(DIRS)
+	linuxkit pkg push $(OPTIONS) $(PUSHOPTIONS) $(DIRS)
 
 forcepush:
-	@linuxkit pkg push $(OPTIONS) $(PUSHOPTIONS) --force $(DIRS)
+	linuxkit pkg push $(OPTIONS) $(PUSHOPTIONS) --force $(DIRS)
 
 build:
-	@linuxkit pkg build $(OPTIONS) $(DIRS)
+	linuxkit pkg build $(OPTIONS) $(DIRS)
 
 forcebuild:
-	@linuxkit pkg build $(OPTIONS) --force $(DIRS)
+	linuxkit pkg build $(OPTIONS) --force $(DIRS)
 
 show-tag:
-	@linuxkit pkg show-tag $(OPTIONS) $(DIRS)
+	linuxkit pkg show-tag $(OPTIONS) $(DIRS)
 
 clean:

--- a/pkg/dummy/Dockerfile
+++ b/pkg/dummy/Dockerfile
@@ -1,0 +1,9 @@
+FROM linuxkit/alpine:5d89cd05a567f9bfbe4502be1027a422d46f4a75 AS build
+RUN apk add --no-cache --initdb make
+
+FROM scratch
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=build /usr/bin/make /usr/bin/
+COPY infile infile

--- a/pkg/dummy/build.yml
+++ b/pkg/dummy/build.yml
@@ -1,0 +1,1 @@
+image: dummy

--- a/pkg/dummy/infile
+++ b/pkg/dummy/infile
@@ -1,0 +1,1 @@
+This is a silly input file for testing.

--- a/test/cases/040_packages/001_dummy/test.sh
+++ b/test/cases/040_packages/001_dummy/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# SUMMARY: Check that the dummy pkg exists
+# LABELS:
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+NAME=dummy
+
+clean_up() {
+	rm -rf ${NAME}-*
+}
+trap clean_up EXIT
+
+# Test code goes here
+linuxkit build -format kernel+initrd -name "${NAME}" test.yml
+# all we are checking is that we can build using the dummy package, which
+# was not pushed out
+
+exit 0

--- a/test/cases/040_packages/001_dummy/test.yml
+++ b/test/cases/040_packages/001_dummy/test.yml
@@ -1,0 +1,12 @@
+kernel:
+  image: linuxkit/kernel:5.10.104
+  cmdline: "console=ttyS0 console=ttyAMA0"
+init:
+  - linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7
+  - linuxkit/runc:f01b88c7033180d50ae43562d72707c6881904e4
+onboot:
+  - name: dummy
+    image: linuxkit/dummy:611bf5a6f37a3f508c3b8c7be5fb57fd70132c3e
+  - name: poweroff
+    image: linuxkit/poweroff:39d99e5909b6f8faccedc78d6d2646cdb6c9ed9c
+    command: ["/bin/sh", "/poweroff.sh", "10"]


### PR DESCRIPTION
Just a test of the build system. Will let CI run, tests should pass, and then will merge to PR, should push out new `linuxkit/dummy` image.

Once it is done, I will open a PR to delete `pkg/dummy` and manually delete the image.