### PR TITLE
when no archs for pkg to build, should continue rather than return

### DIFF
--- a/src/cmd/linuxkit/pkg_build.go
+++ b/src/cmd/linuxkit/pkg_build.go
@@ -163,7 +163,7 @@ func pkgBuildPush(args []string, withPush bool) {
 		// note that this is *not* an error; we simply skip it
 		if len(pkgPlats) == 0 {
 			fmt.Printf("Skipping %s with no architectures to build\n", p.Tag())
-			return
+			continue
 		}
 
 		pkgOpts = append(pkgOpts, pkglib.WithBuildPlatforms(pkgPlats...))


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

#3787 skips a build if it has no archs. Which is good. Except instead of continuing to the next package, it exits.
This fixes it.

**- How I did it**

Change `return` for `continue`

**- How to verify it**

CI, and I ran it manually

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Continue for all packages after skipping packages with no architectures
