### PR TITLE
Add a target for building kernel with buildx

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -103,7 +103,7 @@ RUN set -e && \
     fi
 
 # Save kernel source
-RUN tar cJf /out/src/linux.tar.xz /linux
+RUN XZ_DEFAULTS="-T0" tar cJf /out/src/linux.tar.xz /linux
 
 # Kernel config
 RUN case $(uname -m) in \

--- a/kernel/Dockerfile.kconfigx
+++ b/kernel/Dockerfile.kconfigx
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1.3-labs
+
+ARG BUILD_IMAGE
+
+FROM ${BUILD_IMAGE} AS kernel-build
+ARG KERNEL_VERSIONS
+ARG TARGETARCH
+
+RUN apk add \
+    argp-standalone \
+    bison \
+    build-base \
+    curl \
+    diffutils \
+    flex \
+    gmp-dev \
+    libarchive-tools \
+    mpc1-dev \
+    mpfr-dev \
+    ncurses-dev \
+    patch \
+    xz
+
+COPY / /
+
+# Unpack kernels (download if not present)
+RUN <<EOF
+set -e
+for VERSION in ${KERNEL_VERSIONS}; do
+        MAJOR=$(echo ${VERSION} | cut -d . -f 1)
+        MAJOR=v${MAJOR}.x
+        echo "Downloading/Unpacking $VERSION"
+        KERNEL_SOURCE=https://www.kernel.org/pub/linux/kernel/${MAJOR}/linux-${VERSION}.tar.xz
+        if [ ! -f sources/linux-${VERSION}.tar.xz ] ; then
+		curl -fSLo sources/linux-${VERSION}.tar.xz --create-dirs ${KERNEL_SOURCE}
+	fi
+        bsdtar xf sources/linux-${VERSION}.tar.xz
+done
+EOF
+
+# Apply patches to all kernels and move config files into place
+RUN <<EOF
+set -e
+for VERSION in ${KERNEL_VERSIONS}; do
+	SERIES=${VERSION%.*}.x
+	echo "Patching $VERSION $SERIES"
+	cd /linux-${VERSION}
+	if [ -d /patches-${SERIES} ]; then
+		for patch in /patches-${SERIES}/*.patch; do
+			echo "Applying $patch"
+			patch -t -F0 -N -u -p1 < "$patch"
+		done
+	fi
+	if [ ${TARGETARCH} = "amd64" ] ; then
+		 cp /config-${SERIES}-x86_64 .config
+		ARCH=x86 make oldconfig
+		ls
+	elif [ ${TARGETARCH} = "arm64" ] ; then
+		cp /config-${SERIES}-aarch64 .config
+		ARCH=arm64 make oldconfig
+	fi
+done
+EOF
+
+ENTRYPOINT ["/bin/sh"]
+
+FROM scratch
+ARG KERNEL_VERSIONS
+ARG TARGETARCH
+WORKDIR /
+COPY --from=kernel-build /linux-${KERNEL_VERSIONS}/.config config-${KERNEL_VERSIONS}-$TARGETARCH

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -98,6 +98,18 @@ ifeq ($(4),)
 KERNEL_VERSIONS+=$(1)
 endif
 
+buildx_$(2)$(3)$(4): Dockerfile Makefile $(wildcard patches-$(2)/*) $(wildcard config-$(2)*) config-dbg
+	docker pull $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) || \
+		docker buildx build \
+			--platform=linux/amd64,linux/arm64 --push \
+			--build-arg KERNEL_VERSION=$(1) \
+			--build-arg KERNEL_SERIES=$(2) \
+			--build-arg EXTRA=$(3) \
+			--build-arg DEBUG=$(4) \
+			--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
+			$(LABELS) \
+			--no-cache -t $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) .
+
 build_$(2)$(3)$(4): Dockerfile Makefile $(wildcard patches-$(2)/*) $(wildcard config-$(2)*) config-dbg
 	docker pull $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) || \
 		docker build \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -14,6 +14,7 @@
 
 # Name and Org on Hub
 ORG?=linuxkit
+PLATFORMS?=linux/amd64,linux/arm64
 IMAGE:=kernel
 IMAGE_BCC:=kernel-bcc
 IMAGE_PERF:=kernel-perf
@@ -101,7 +102,7 @@ endif
 buildx_$(2)$(3)$(4): Dockerfile Makefile $(wildcard patches-$(2)/*) $(wildcard config-$(2)*) config-dbg
 	docker pull $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) || \
 		docker buildx build \
-			--platform=linux/amd64,linux/arm64 --push \
+			--platform=$(PLATFORMS) --push \
 			--build-arg KERNEL_VERSION=$(1) \
 			--build-arg KERNEL_SERIES=$(2) \
 			--build-arg EXTRA=$(3) \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -100,7 +100,7 @@ KERNEL_VERSIONS+=$(1)
 endif
 
 buildx_$(2)$(3)$(4): Dockerfile Makefile $(wildcard patches-$(2)/*) $(wildcard config-$(2)*) config-dbg
-	docker pull $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) || \
+	docker pull $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG) || \
 		docker buildx build \
 			--platform=$(PLATFORMS) --push \
 			--build-arg KERNEL_VERSION=$(1) \
@@ -109,7 +109,7 @@ buildx_$(2)$(3)$(4): Dockerfile Makefile $(wildcard patches-$(2)/*) $(wildcard c
 			--build-arg DEBUG=$(4) \
 			--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
 			$(LABELS) \
-			--no-cache -t $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) .
+			--no-cache -t $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG) .
 
 build_$(2)$(3)$(4): Dockerfile Makefile $(wildcard patches-$(2)/*) $(wildcard config-$(2)*) config-dbg
 	docker pull $(ORG)/$(IMAGE):$(1)$(3)$(4)-$(TAG)$(SUFFIX) || \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -295,3 +295,22 @@ else
 		--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
 		-t linuxkit/kconfig:${KCONFIG_TAG}  .
 endif
+
+kconfigx:
+ifeq (${KCONFIG_TAG},)
+	docker buildx build --no-cache -f Dockerfile.kconfigx \
+		--platform=$(PLATFORMS) \
+		--output . \
+		--build-arg KERNEL_VERSIONS="$(KERNEL_VERSIONS)" \
+		--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
+		-t linuxkit/kconfigx  .
+	cp linux_arm64/config-${KERNEL_VERSIONS}-arm64 config-${KERNEL_SERIES}-aarch64
+	cp linux_amd64/config-${KERNEL_VERSIONS}-amd64 config-${KERNEL_SERIES}-x86_64
+else
+	docker buildx build --no-cache -f Dockerfile.kconfigx \
+		--platform=$(PLATFORMS) --push \
+		--output . \
+		--build-arg KERNEL_VERSIONS="$(KERNEL_VERSIONS)" \
+		--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
+		-t linuxkit/kconfigx:${KCONFIG_TAG}  .
+endif

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -15,7 +15,7 @@
 # Name and Org on Hub
 ORG?=linuxkit
 PLATFORMS?=linux/amd64,linux/arm64
-IMAGE:=kernel
+IMAGE?=kernel
 IMAGE_BCC:=kernel-bcc
 IMAGE_PERF:=kernel-perf
 IMAGE_ZFS:=zfs-kmod

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:5.10.104
+  image: linuxkit/kernel:5.15.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:8f1e6a0747acbbb4d7e24dc98f97faa8d1c6cec7


### PR DESCRIPTION
**- What I did**
this pr contains various improvements
* Add a target that uses buildx to generate a multiarch images. buildx enables remote builders to build multiarch images.
* Upgrade the kernel used in the sample linuxkit image
* Parallelize compression of the kernel source archive. That saves several minutes.

**- How I did it**
Add a new target in the makefile

**- How to verify it**
`ORG=yourorg IMAGE=yourimage PLATFORMS=linux/arm64,linux/amd64 make -C kernel buildx_5.10.x`

**- Description for the changelog**
kernel: Add a target for building kernel with buildx

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/79831213/174849875-32619395-ef66-4d14-9468-879296f14cd1.png)
