### PR TITLE
Add CAP_NET_ADMIN capability to sysctl

### DIFF
--- a/pkg/sysctl/build.yml
+++ b/pkg/sysctl/build.yml
@@ -4,3 +4,4 @@ config:
   readonly: true
   capabilities:
     - CAP_SYS_ADMIN
+    - CAP_NET_ADMIN


### PR DESCRIPTION
With linux kernel 5.15+ change of /proc/sys/net/ipv4/ip_forward require
CAP_NET_ADMIN (https://github.com/torvalds/linux/commit/8292d7f6). We do
 not use ip_forward now, but we should be ready for future changes of
 conf files.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>
