### PR TITLE
Allow store to docker multiarch builds

### DIFF
--- a/src/cmd/linuxkit/pkglib/docker.go
+++ b/src/cmd/linuxkit/pkglib/docker.go
@@ -288,7 +288,7 @@ func (dr *dockerRunnerImpl) builderEnsureContainer(ctx context.Context, name, im
 	}
 	// create the builder
 	args := []string{"container", "run", "-d", "--name", name, "--privileged", image, "--allow-insecure-entitlement", "network.host", "--addr", fmt.Sprintf("unix://%s", buildkitSocketPath), "--debug"}
-	msg := fmt.Sprintf("creating builder container '%s' in context '%s", name, dockerContext)
+	msg := fmt.Sprintf("creating builder container '%s' in context '%s'", name, dockerContext)
 	fmt.Println(msg)
 	if err := dr.command(nil, ioutil.Discard, ioutil.Discard, args...); err != nil {
 		return nil, err


### PR DESCRIPTION
We do not allow to load into docker images that are targets another
platform differ from current arch. Assume this is because of no support
of manifest. But we can keep all images in place by adding arch suffix
and using tag without arch suffix to point onto current system arch. It
will help to use images from docker for another arch.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>
