### PR TITLE
Write log entries as json

### DIFF
--- a/pkg/memlogd/cmd/logread/main.go
+++ b/pkg/memlogd/cmd/logread/main.go
@@ -15,13 +15,13 @@ const (
 	logDumpFollow
 )
 
-type LogEntry struct {
+type logEntry struct {
 	Time   time.Time `json:"time"`
 	Source string    `json:"source"`
 	Msg    string    `json:"msg"`
 }
 
-func (msg *LogEntry) String() string {
+func (msg *logEntry) String() string {
 	return fmt.Sprintf("%s;%s;%s", msg.Time.Format(time.RFC3339Nano), strings.ReplaceAll(msg.Source, `;`, `\;`), msg.Msg)
 }
 
@@ -61,7 +61,7 @@ func main() {
 		panic(err)
 	}
 
-	var entry LogEntry
+	var entry logEntry
 	decoder := json.NewDecoder(conn)
 	for {
 		if err := decoder.Decode(&entry); err != nil {

--- a/pkg/memlogd/cmd/memlogd/main_test.go
+++ b/pkg/memlogd/cmd/memlogd/main_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -16,7 +15,7 @@ func TestNonblock(t *testing.T) {
 	// Test that writes to the logger don't block because it is full
 	linesInBuffer := 10
 
-	logCh := make(chan logEntry)
+	logCh := make(chan LogEntry)
 	queryMsgChan := make(chan queryMessage)
 
 	go ringBufferHandler(linesInBuffer, linesInBuffer, logCh, queryMsgChan)
@@ -24,7 +23,7 @@ func TestNonblock(t *testing.T) {
 	// Overflow the log to make sure it doesn't block
 	for i := 0; i < 2*linesInBuffer; i++ {
 		select {
-		case logCh <- logEntry{time: time.Now(), source: "memlogd", msg: "hello TestNonblock"}:
+		case logCh <- LogEntry{Time: time.Now(), Source: "memlogd", Msg: "hello TestNonblock"}:
 			continue
 		case <-time.After(time.Second):
 			t.Errorf("write to the logger blocked for over 1s after %d (size was set to %d)", i, linesInBuffer)
@@ -36,14 +35,14 @@ func TestFinite(t *testing.T) {
 	// Test that the logger doesn't store more than its configured maximum size
 	linesInBuffer := 10
 
-	logCh := make(chan logEntry)
+	logCh := make(chan LogEntry)
 	queryMsgChan := make(chan queryMessage)
 
 	go ringBufferHandler(linesInBuffer, linesInBuffer, logCh, queryMsgChan)
 
 	// Overflow the log by 2x
 	for i := 0; i < 2*linesInBuffer; i++ {
-		logCh <- logEntry{time: time.Now(), source: "memlogd", msg: "hello TestFinite"}
+		logCh <- LogEntry{Time: time.Now(), Source: "memlogd", Msg: "hello TestFinite"}
 	}
 	a, b := loopback()
 	defer a.Close()
@@ -76,14 +75,14 @@ func TestFinite2(t *testing.T) {
 	linesInBuffer := 10
 	// the output buffer size will be 1/2 of the ring
 	outputBufferSize := linesInBuffer / 2
-	logCh := make(chan logEntry)
+	logCh := make(chan LogEntry)
 	queryMsgChan := make(chan queryMessage)
 
 	go ringBufferHandler(linesInBuffer, outputBufferSize, logCh, queryMsgChan)
 
 	// fill the ring
 	for i := 0; i < linesInBuffer; i++ {
-		logCh <- logEntry{time: time.Now(), source: "memlogd", msg: "hello TestFinite2"}
+		logCh <- LogEntry{Time: time.Now(), Source: "memlogd", Msg: "hello TestFinite2"}
 	}
 
 	a, b := loopback()
@@ -111,63 +110,6 @@ func TestFinite2(t *testing.T) {
 	if count != outputBufferSize {
 		t.Errorf("Read %d lines but expected %d", count, outputBufferSize)
 	}
-}
-
-func TestGoodName(t *testing.T) {
-	// Test that the source names can't contain ";"
-	linesInBuffer := 10
-	logCh := make(chan logEntry)
-	fdMsgChan := make(chan fdMessage)
-	queryMsgChan := make(chan queryMessage)
-
-	go ringBufferHandler(linesInBuffer, linesInBuffer, logCh, queryMsgChan)
-	go loggingRequestHandler(80, logCh, fdMsgChan)
-
-	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-	if err != nil {
-		log.Fatal("Unable to create socketpair: ", err)
-	}
-	a := fdToConn(fds[0])
-	b := fdToConn(fds[1])
-	defer a.Close()
-	defer b.Close()
-	// defer close fds
-
-	fdMsgChan <- fdMessage{
-		name: "semi-colons are banned;",
-		fd:   fds[0],
-	}
-	// although the fd should be rejected my memlogd the Write should be buffered
-	// by the kernel and not block.
-	if _, err := b.Write([]byte("hello\n")); err != nil {
-		log.Fatalf("Failed to write log message: %s", err)
-	}
-	c, d := loopback()
-	defer c.Close()
-	defer d.Close()
-	// this log should not be in the ring because the connection was rejected.
-	queryM := queryMessage{
-		conn: c,
-		mode: logDumpFollow,
-	}
-	queryMsgChan <- queryM
-	// The error log is generated asynchronously. It should be fast. On error time out
-	// after 5s.
-	d.SetDeadline(time.Now().Add(5 * time.Second))
-	r := bufio.NewReader(d)
-	for {
-		line, err := r.ReadString('\n')
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			log.Fatalf("Unexpected error reading from socket: %s", err)
-		}
-		if strings.Contains(line, "ERROR: cannot register log") {
-			return
-		}
-	}
-	t.Fatal("Failed to read error message when registering a log with a ;")
 }
 
 // caller must close fd themselves: closing the net.Conn will not close fd.

--- a/pkg/memlogd/cmd/memlogd/main_test.go
+++ b/pkg/memlogd/cmd/memlogd/main_test.go
@@ -15,7 +15,7 @@ func TestNonblock(t *testing.T) {
 	// Test that writes to the logger don't block because it is full
 	linesInBuffer := 10
 
-	logCh := make(chan LogEntry)
+	logCh := make(chan logEntry)
 	queryMsgChan := make(chan queryMessage)
 
 	go ringBufferHandler(linesInBuffer, linesInBuffer, logCh, queryMsgChan)
@@ -23,7 +23,7 @@ func TestNonblock(t *testing.T) {
 	// Overflow the log to make sure it doesn't block
 	for i := 0; i < 2*linesInBuffer; i++ {
 		select {
-		case logCh <- LogEntry{Time: time.Now(), Source: "memlogd", Msg: "hello TestNonblock"}:
+		case logCh <- logEntry{Time: time.Now(), Source: "memlogd", Msg: "hello TestNonblock"}:
 			continue
 		case <-time.After(time.Second):
 			t.Errorf("write to the logger blocked for over 1s after %d (size was set to %d)", i, linesInBuffer)
@@ -35,14 +35,14 @@ func TestFinite(t *testing.T) {
 	// Test that the logger doesn't store more than its configured maximum size
 	linesInBuffer := 10
 
-	logCh := make(chan LogEntry)
+	logCh := make(chan logEntry)
 	queryMsgChan := make(chan queryMessage)
 
 	go ringBufferHandler(linesInBuffer, linesInBuffer, logCh, queryMsgChan)
 
 	// Overflow the log by 2x
 	for i := 0; i < 2*linesInBuffer; i++ {
-		logCh <- LogEntry{Time: time.Now(), Source: "memlogd", Msg: "hello TestFinite"}
+		logCh <- logEntry{Time: time.Now(), Source: "memlogd", Msg: "hello TestFinite"}
 	}
 	a, b := loopback()
 	defer a.Close()
@@ -75,14 +75,14 @@ func TestFinite2(t *testing.T) {
 	linesInBuffer := 10
 	// the output buffer size will be 1/2 of the ring
 	outputBufferSize := linesInBuffer / 2
-	logCh := make(chan LogEntry)
+	logCh := make(chan logEntry)
 	queryMsgChan := make(chan queryMessage)
 
 	go ringBufferHandler(linesInBuffer, outputBufferSize, logCh, queryMsgChan)
 
 	// fill the ring
 	for i := 0; i < linesInBuffer; i++ {
-		logCh <- LogEntry{Time: time.Now(), Source: "memlogd", Msg: "hello TestFinite2"}
+		logCh <- logEntry{Time: time.Now(), Source: "memlogd", Msg: "hello TestFinite2"}
 	}
 
 	a, b := loopback()


### PR DESCRIPTION
This is the first step in supporting structured success/error data in `memlogd` log files.

Those log files are currently made of semicolon separated fields and, for each line, the list of fields is the same.

We would like to support multiple kinds of entries. Application logs, like we do already, but also structured success/error data. Those entries would have some fields in common and some based on the type of entry. 

Switching from semicolon separated fields to json gives us this flexibility without much added complexity. In fact, it even removes a constraint we currently have on `Source` field not containing a semicolon.

Signed-off-by: David Gageot <david.gageot@docker.com>