### PR TITLE
verbosity for pkg build and error catching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Build Packages
       # Skip s390x as emulation is unreliable
       run: |
-        make OPTIONS="--skip-platforms linux/s390x" -C pkg build
+        make OPTIONS="-v --skip-platforms linux/s390x" -C pkg build
 
   test_packages:
     name: Packages Tests

--- a/src/cmd/linuxkit/cache/write.go
+++ b/src/cmd/linuxkit/cache/write.go
@@ -13,7 +13,7 @@ import (
 	"github.com/containerd/containerd/reference"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/match"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
@@ -200,6 +200,9 @@ func (p *Provider) ImageLoad(ref *reference.Spec, architecture string, r io.Read
 func (p *Provider) IndexWrite(ref *reference.Spec, descriptors ...v1.Descriptor) (lktspec.ImageSource, error) {
 	image := ref.String()
 	log.Debugf("writing an index for %s", image)
+	if len(descriptors) < 1 {
+		return ImageSource{}, errors.New("cannot create index without any manifests")
+	}
 
 	ii, err := p.cache.ImageIndex()
 	if err != nil {

--- a/src/cmd/linuxkit/main.go
+++ b/src/cmd/linuxkit/main.go
@@ -4,11 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	stdlog "log"
 	"os"
 	"path/filepath"
 
-	ggcrlog "github.com/google/go-containerregistry/pkg/logs"
+	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/util"
 	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/version"
 
 	log "github.com/sirupsen/logrus"
@@ -86,31 +85,13 @@ func main() {
 		fmt.Printf("Options:\n")
 		flag.PrintDefaults()
 	}
-	flagQuiet := flag.Bool("q", false, "Quiet execution")
-	flagVerbose := flag.Bool("v", false, "Verbose execution")
 
 	readConfig()
 
 	// Set up logging
-	log.SetFormatter(new(infoFormatter))
-	log.SetLevel(log.InfoLevel)
+	util.AddLoggingFlags(nil)
 	flag.Parse()
-	if *flagQuiet && *flagVerbose {
-		fmt.Printf("Can't set quiet and verbose flag at the same time\n")
-		os.Exit(1)
-	}
-	if *flagQuiet {
-		log.SetLevel(log.ErrorLevel)
-	}
-	if *flagVerbose {
-		// Switch back to the standard formatter
-		log.SetFormatter(defaultLogFormatter)
-		log.SetLevel(log.DebugLevel)
-		// set go-containerregistry logging as well
-		ggcrlog.Warn = stdlog.New(log.StandardLogger().WriterLevel(log.WarnLevel), "", 0)
-		ggcrlog.Debug = stdlog.New(log.StandardLogger().WriterLevel(log.DebugLevel), "", 0)
-	}
-	ggcrlog.Progress = stdlog.New(log.StandardLogger().WriterLevel(log.InfoLevel), "", 0)
+	util.SetupLogging()
 
 	args := flag.Args()
 	if len(args) < 1 {

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -102,7 +102,11 @@ func NewFromCLI(fs *flag.FlagSet, args ...string) ([]Pkg, error) {
 	fs.BoolVar(&dirty, "force-dirty", false, "Force the pkg(s) to be considered dirty")
 	fs.BoolVar(&devMode, "dev", false, "Force org and hash to $USER and \"dev\" respectively")
 
+	util.AddLoggingFlags(fs)
+
 	_ = fs.Parse(args)
+
+	util.SetupLogging()
 
 	if fs.NArg() < 1 {
 		return nil, fmt.Errorf("At least one pkg directory is required")

--- a/src/cmd/linuxkit/util/flags.go
+++ b/src/cmd/linuxkit/util/flags.go
@@ -1,0 +1,68 @@
+package util
+
+import (
+	"flag"
+	"fmt"
+	stdlog "log"
+	"os"
+
+	ggcrlog "github.com/google/go-containerregistry/pkg/logs"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	defaultLogFormatter = &log.TextFormatter{}
+)
+
+// infoFormatter overrides the default format for Info() log events to
+// provide an easier to read output
+type infoFormatter struct {
+}
+
+func (f *infoFormatter) Format(entry *log.Entry) ([]byte, error) {
+	if entry.Level == log.InfoLevel {
+		return append([]byte(entry.Message), '\n'), nil
+	}
+	return defaultLogFormatter.Format(entry)
+}
+
+var (
+	flagQuiet, flagVerbose *bool
+)
+
+// AddLoggingFlags add the logging flags to a flagset, or, if none given,
+// the default flag package
+func AddLoggingFlags(fs *flag.FlagSet) {
+	// if we have no flagset, add it to the default flag package
+	if fs == nil {
+		flagQuiet = flag.Bool("q", false, "Quiet execution")
+		flagVerbose = flag.Bool("v", false, "Verbose execution")
+	} else {
+		flagQuiet = fs.Bool("q", false, "Quiet execution")
+		flagVerbose = fs.Bool("v", false, "Verbose execution")
+	}
+}
+
+// SetupLogging once the flags have been parsed, setup the logging
+func SetupLogging() {
+	// Set up logging
+	log.SetFormatter(new(infoFormatter))
+	log.SetLevel(log.InfoLevel)
+	flag.Parse()
+	if *flagQuiet && *flagVerbose {
+		fmt.Printf("Can't set quiet and verbose flag at the same time\n")
+		os.Exit(1)
+	}
+	if *flagQuiet {
+		log.SetLevel(log.ErrorLevel)
+	}
+	if *flagVerbose {
+		// Switch back to the standard formatter
+		log.SetFormatter(defaultLogFormatter)
+		log.SetLevel(log.DebugLevel)
+		// set go-containerregistry logging as well
+		ggcrlog.Warn = stdlog.New(log.StandardLogger().WriterLevel(log.WarnLevel), "", 0)
+		ggcrlog.Debug = stdlog.New(log.StandardLogger().WriterLevel(log.DebugLevel), "", 0)
+	}
+	ggcrlog.Progress = stdlog.New(log.StandardLogger().WriterLevel(log.InfoLevel), "", 0)
+}


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

1. Added an extra safety check when writing the index to cache. This should help prevent errors like [this one](https://github.com/linuxkit/linuxkit/runs/7711447521?check_suite_focus=true)
2. Extracted the `-v` for verbose (aka debug) execution into separate `util.` set of funcs, so that we can reuse it in other areas.
3. make CI execution verbose with -v

The problem that caused the second is that we use straight flags, so I can do `lkt -v pkg build` but not `lkt pkg build -v`, which creates headaches when passing options in vars like in our makefiles. This now lets us run `lkt pkg build -v` or `lkt -v pkg build`.

This would be much easier if we used something with persistent flags, like spf13/cobra, but not tackling that now.

**- How I did it**

Changes ot src

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

More verbose execution during CI; safety checks during index write.
