### PR TITLE
add option to override tag name when exporting

### DIFF
--- a/src/cmd/linuxkit/cache/source.go
+++ b/src/cmd/linuxkit/cache/source.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/containerd/containerd/reference"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	lktspec "github.com/linuxkit/linuxkit/src/cmd/linuxkit/spec"
@@ -73,10 +73,13 @@ func (c ImageSource) TarReader() (io.ReadCloser, error) {
 }
 
 // V1TarReader return an io.ReadCloser to read the image as a v1 tarball
-func (c ImageSource) V1TarReader() (io.ReadCloser, error) {
+func (c ImageSource) V1TarReader(overrideName string) (io.ReadCloser, error) {
 	imageName := c.ref.String()
-
-	refName, err := name.ParseReference(imageName)
+	saveName := imageName
+	if overrideName != "" {
+		saveName = overrideName
+	}
+	refName, err := name.ParseReference(saveName)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing image name: %v", err)
 	}

--- a/src/cmd/linuxkit/cache_export.go
+++ b/src/cmd/linuxkit/cache_export.go
@@ -19,6 +19,7 @@ func cacheExport(args []string) {
 	arch := fs.String("arch", runtime.GOARCH, "Architecture to resolve an index to an image, if the provided image name is an index")
 	outfile := fs.String("outfile", "", "Path to file to save output, '-' for stdout")
 	format := fs.String("format", "oci", "export format, one of 'oci', 'filesystem'")
+	tagName := fs.String("name", "", "override the provided image name in the exported tar file; useful only for format=oci")
 
 	if err := fs.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
@@ -49,7 +50,11 @@ func cacheExport(args []string) {
 	var reader io.ReadCloser
 	switch *format {
 	case "oci":
-		reader, err = src.V1TarReader()
+		fullTagName := fullname
+		if *tagName != "" {
+			fullTagName = util.ReferenceExpand(*tagName)
+		}
+		reader, err = src.V1TarReader(fullTagName)
 	case "filesystem":
 		reader, err = src.TarReader()
 	default:

--- a/src/cmd/linuxkit/docker/source.go
+++ b/src/cmd/linuxkit/docker/source.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"github.com/containerd/containerd/reference"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -78,8 +78,12 @@ func (d ImageSource) TarReader() (io.ReadCloser, error) {
 }
 
 // V1TarReader return an io.ReadCloser to read the save of the image
-func (d ImageSource) V1TarReader() (io.ReadCloser, error) {
-	return Save(d.ref.String())
+func (d ImageSource) V1TarReader(overrideName string) (io.ReadCloser, error) {
+	saveName := d.ref.String()
+	if overrideName != "" {
+		saveName = overrideName
+	}
+	return Save(saveName)
 }
 
 // Descriptor return the descriptor of the image.

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -352,7 +352,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 				return err
 			}
 			cacheSource := c.NewSource(&archRef, platform.Architecture, desc)
-			reader, err := cacheSource.V1TarReader()
+			reader, err := cacheSource.V1TarReader("")
 			if err != nil {
 				return fmt.Errorf("unable to get reader from cache: %v", err)
 			}

--- a/src/cmd/linuxkit/pkglib/build_test.go
+++ b/src/cmd/linuxkit/pkglib/build_test.go
@@ -283,7 +283,7 @@ func (c cacheMockerSource) Config() (imagespec.ImageConfig, error) {
 func (c cacheMockerSource) TarReader() (io.ReadCloser, error) {
 	return nil, errors.New("unsupported")
 }
-func (c cacheMockerSource) V1TarReader() (io.ReadCloser, error) {
+func (c cacheMockerSource) V1TarReader(overrideName string) (io.ReadCloser, error) {
 	_, found := c.c.images[c.ref.String()]
 	if !found {
 		return nil, fmt.Errorf("no image found with ref: %s", c.ref.String())

--- a/src/cmd/linuxkit/spec/image.go
+++ b/src/cmd/linuxkit/spec/image.go
@@ -3,7 +3,7 @@ package spec
 import (
 	"io"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -12,10 +12,10 @@ import (
 type ImageSource interface {
 	// Config get the config for the image
 	Config() (imagespec.ImageConfig, error)
-	// TarReader get the flattened filesystem of the image as a tar stream/
+	// TarReader get the flattened filesystem of the image as a tar stream
 	TarReader() (io.ReadCloser, error)
 	// Descriptor get the v1.Descriptor of the image
 	Descriptor() *v1.Descriptor
-	// V1TarReader get the image as v1 tarball, also compatibel with `docker load`
-	V1TarReader() (io.ReadCloser, error)
+	// V1TarReader get the image as v1 tarball, also compatible with `docker load`. If name arg is not "", override name of image in tarfile from default of image.
+	V1TarReader(overrideName string) (io.ReadCloser, error)
 }


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

We already support `docker cache export <image>`, which creates a tar file export of the image and its config, layers, etc. This is consumable by `docker load` as well.

Whatever the `<image>` is, that is what it is called inside the tar file, and what `docker load` uses to name the image.

However, if you want to save it under a different name, you are stuck. When using `docker save` it is fine, since you can do `docker tag <image> ><newName>` and then `docker save <newName>`, but lkt cache doesn't have it.

This adds an option to override the name as saved in the tar file.

**- How I did it**

Changes to `docker cache export`.

**- How to verify it**

CI and run manually.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Option to override image name in cache export tar file.