### PR TITLE
Append dirty tag with content hash

### DIFF
--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -250,7 +250,15 @@ func NewFromCLI(fs *flag.FlagSet, args ...string) ([]Pkg, error) {
 				}
 
 				if dirty {
-					pkgHash += "-dirty"
+					contentHash, err := git.contentHash()
+					if err != nil {
+						return nil, err
+					}
+					if len(contentHash) < 7 {
+						return nil, fmt.Errorf("unexpected hash len: %d", len(contentHash))
+					}
+					// construct <ls-tree>-dirty-<content hash> tag
+					pkgHash += fmt.Sprintf("-dirty-%s", contentHash[0:7])
 				}
 			}
 		}


### PR DESCRIPTION
To be able to identify successive file changes without commit, we should use their hash in tag alongside with dirty flag ([ls-tree]-dirty-[content hash]).

Fixes #3817 
