### PR TITLE
Allow build for darwin without CGO

### DIFF
--- a/docs/platform-virtualization-framework.md
+++ b/docs/platform-virtualization-framework.md
@@ -9,6 +9,7 @@ with updated versions of both.
 
 Alternatively, you can install Virtualization.Framework and VPNKit standalone and use it without Docker for Mac.
 
+Virtualization.Framework is enabled on macOS only when built with CGO enabled.
 
 ## Boot
 

--- a/src/cmd/linuxkit/Makefile
+++ b/src/cmd/linuxkit/Makefile
@@ -61,6 +61,7 @@ ifeq ($(STATIC), 1)
 endif
 
 # darwin needs CGO to build for virtualization framework
+# without CGO attempt to use virtualization framework will ends with error
 ifeq ($(GOOS), darwin)
 	CGO_ENABLED=1
 endif

--- a/src/cmd/linuxkit/run_virtualizationframework_darwin_cgo_disabled.go
+++ b/src/cmd/linuxkit/run_virtualizationframework_darwin_cgo_disabled.go
@@ -1,0 +1,14 @@
+//go:build darwin && !cgo
+// +build darwin,!cgo
+
+package main
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+// Process the run arguments and execute run
+func runVirtualizationFramework(args []string) {
+	log.Fatal("This build of linuxkit was compiled without virtualization framework capabilities. " +
+		"To perform 'linuxkit run' on macOS, please use a version of linuxkit compiled with virtualization framework.")
+}

--- a/src/cmd/linuxkit/run_virtualizationframework_darwin_cgo_enabled.go
+++ b/src/cmd/linuxkit/run_virtualizationframework_darwin_cgo_enabled.go
@@ -1,5 +1,5 @@
-//go:build darwin
-// +build darwin
+//go:build darwin && cgo
+// +build darwin,cgo
 
 package main
 


### PR DESCRIPTION
It is not easy to use cross-platform build with CGO enabled so lets allow build without cgo for darwin and use virtualization framework only if we built with CGO.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>