### PR TITLE
Fix github.com/docker/go-units import

### DIFF
--- a/src/cmd/linuxkit/go.mod
+++ b/src/cmd/linuxkit/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/docker/buildx v0.8.2
 	github.com/docker/cli v20.10.17+incompatible
 	github.com/docker/docker v20.10.17+incompatible
+	github.com/docker/go-units v0.4.0
 	github.com/estesp/manifest-tool/v2 v2.0.6-0.20220728154431-89d791ab7966
 	github.com/google/go-containerregistry v0.6.1-0.20211105150418-5c9c442d5d68
 	github.com/google/uuid v1.3.0

--- a/src/cmd/linuxkit/vendor/modules.txt
+++ b/src/cmd/linuxkit/vendor/modules.txt
@@ -215,6 +215,7 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-metrics v0.0.1
 github.com/docker/go-metrics
 # github.com/docker/go-units v0.4.0
+## explicit
 github.com/docker/go-units
 # github.com/estesp/manifest-tool/v2 v2.0.6-0.20220728154431-89d791ab7966
 ## explicit


### PR DESCRIPTION
I can see 
```
pkg_build.go:10:2: package github.com/linuxkit/linuxkit/src/cmd/linuxkit/pkglib imports github.com/docker/go-units from implicitly required module; to add missing requirements, run:
        go get github.com/docker/go-units@v0.4.0
```
after #3823 merged.
Let's fix this.