### PR TITLE
allow setting cache dir via env var

### DIFF
--- a/src/cmd/linuxkit/cache_clean.go
+++ b/src/cmd/linuxkit/cache_clean.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -10,14 +11,15 @@ import (
 func cacheClean(args []string) {
 	flags := flag.NewFlagSet("clean", flag.ExitOnError)
 
-	cacheDir := flags.String("cache", defaultLinuxkitCache(), "Directory for caching and finding cached image")
+	cacheDir := flagOverEnvVarOverDefaultString{def: defaultLinuxkitCache(), envVar: envVarCacheDir}
+	flags.Var(&cacheDir, "cache", fmt.Sprintf("Directory for caching and finding cached image, overrides env var %s", envVarCacheDir))
 
 	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
 	}
 
-	if err := os.RemoveAll(*cacheDir); err != nil {
-		log.Fatalf("Unable to clean cache %s: %v", *cacheDir, err)
+	if err := os.RemoveAll(cacheDir.String()); err != nil {
+		log.Fatalf("Unable to clean cache %s: %v", cacheDir, err)
 	}
-	log.Infof("Cache cleaned: %s", *cacheDir)
+	log.Infof("Cache cleaned: %s", cacheDir)
 }

--- a/src/cmd/linuxkit/cache_export.go
+++ b/src/cmd/linuxkit/cache_export.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"runtime"
@@ -15,7 +16,8 @@ import (
 func cacheExport(args []string) {
 	fs := flag.NewFlagSet("export", flag.ExitOnError)
 
-	cacheDir := fs.String("cache", defaultLinuxkitCache(), "Directory for caching and finding cached image")
+	cacheDir := flagOverEnvVarOverDefaultString{def: defaultLinuxkitCache(), envVar: envVarCacheDir}
+	fs.Var(&cacheDir, "cache", fmt.Sprintf("Directory for caching and finding cached image, overrides env var %s", envVarCacheDir))
 	arch := fs.String("arch", runtime.GOARCH, "Architecture to resolve an index to an image, if the provided image name is an index")
 	outfile := fs.String("outfile", "", "Path to file to save output, '-' for stdout")
 	format := fs.String("format", "oci", "export format, one of 'oci', 'filesystem'")
@@ -33,7 +35,7 @@ func cacheExport(args []string) {
 	name := names[0]
 	fullname := util.ReferenceExpand(name)
 
-	p, err := cachepkg.NewProvider(*cacheDir)
+	p, err := cachepkg.NewProvider(cacheDir.String())
 	if err != nil {
 		log.Fatalf("unable to read a local cache: %v", err)
 	}

--- a/src/cmd/linuxkit/cache_ls.go
+++ b/src/cmd/linuxkit/cache_ls.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 
 	cachepkg "github.com/linuxkit/linuxkit/src/cmd/linuxkit/cache"
 	log "github.com/sirupsen/logrus"
@@ -10,14 +11,15 @@ import (
 func cacheList(args []string) {
 	flags := flag.NewFlagSet("list", flag.ExitOnError)
 
-	cacheDir := flags.String("cache", defaultLinuxkitCache(), "Directory for caching and finding cached image")
+	cacheDir := flagOverEnvVarOverDefaultString{def: defaultLinuxkitCache(), envVar: envVarCacheDir}
+	flags.Var(&cacheDir, "cache", fmt.Sprintf("Directory for caching and finding cached image, overrides env var %s", envVarCacheDir))
 
 	if err := flags.Parse(args); err != nil {
 		log.Fatal("Unable to parse args")
 	}
 
 	// list all of the images and content in the cache
-	p, err := cachepkg.Get(*cacheDir)
+	p, err := cachepkg.Get(cacheDir.String())
 	if err != nil {
 		log.Fatalf("unable to read a local cache: %v", err)
 	}

--- a/src/cmd/linuxkit/util.go
+++ b/src/cmd/linuxkit/util.go
@@ -114,6 +114,31 @@ func stringToIntArray(l string, sep string) ([]int, error) {
 	return i, nil
 }
 
+// handle string with built-in default, overridden by env var, overridden by CLI flag
+type flagOverEnvVarOverDefaultString struct {
+	value  string
+	def    string
+	envVar string
+}
+
+func (f *flagOverEnvVarOverDefaultString) String() string {
+	val := f.def
+	if f.envVar != "" {
+		if e := os.Getenv(f.envVar); e != "" {
+			val = e
+		}
+	}
+	if f.value != "" {
+		val = f.value
+	}
+	return val
+}
+
+func (f *flagOverEnvVarOverDefaultString) Set(value string) error {
+	f.value = value
+	return nil
+}
+
 // Convert a multi-line string into an array of strings
 func splitLines(in string) []string {
 	res := []string{}


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

We already can set the location of the linuxkit cache via `--cache`; this just adds the env var `LINUXKIT_CACHE`. The order of priority is the usual sane one: CLI flag >> env var >> default (`$HOME/.linuxkit/cache`)

**- How I did it**

1. Created a struct that knows about env vars and can handle the order of priority
2. Used that as `FlagSet.Var()` instead of `FlagSet.String()`

I could have replaced several others - I think env vars should be widely available - but the right approach probably is to replace everything with spf13/cobra or similar. That was too much for this one PR.

**- How to verify it**

CI and manual. I did manual.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Support for LINUXKIT_CACHE env var to set cache dir.


