### PR TITLE
Fix examples/platform-aws.yml: add dhcpcd service to keep instance reachable after lease

### DIFF
--- a/examples/platform-aws.yml
+++ b/examples/platform-aws.yml
@@ -17,6 +17,9 @@ onboot:
 services:
   - name: rngd
     image: linuxkit/rngd:4f85d8de3f6f45973a8c88dc8fba9ec596e5495a
+  - name: dhcpcd2
+    image: linuxkit/dhcpcd:52d2c4df0311b182e99241cdc382ff726755c450
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf"]
   - name: sshd
     image: linuxkit/sshd:4696ba61c3ec091328e1c14857d77e675802342f
     binds:


### PR DESCRIPTION
**- What I did**

add dhcpcd as a service as well in order to have the instance not invariably become unreachable after the lease expires

**- How to verify it**

1. Follow the instructions in the docs to create an AMI
2. create an instance from the AMI
3. wait 3600 seconds (or however long the lease is in your case)
4. observe how the instance loses connectivity _at the very second_ after the lease expires
5. now create another AMI, but with this fix and observe how the instance stays up (I have one instance that hasn't become unreachable, with an up time of over 22 hours)