### PR TITLE
Add an automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: LinuxKit CI
+
+on:
+  create:
+    tags:
+      - v*
+
+jobs:
+  build:
+    name: Build all targets
+    runs-on: macos-latest
+    steps:
+
+    - name: Set up Go 1.16
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.7
+      id: go
+
+    - name: Check out code
+      uses: actions/checkout@v1
+      with:
+        path: ./src/github.com/linuxkit/linuxkit
+
+    - name: Set path
+      run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      env:
+         GOPATH: ${{runner.workspace}}
+
+    - name: Build
+      run: |
+        make build-all-targets
+      env:
+        GOPATH: ${{runner.workspace}}
+
+    - name: GitHub Release
+      uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        draft: true
+        files: bin/*

--- a/Makefile
+++ b/Makefile
@@ -117,3 +117,19 @@ endif
 	for img in $(tags); do \
 		./scripts/update-component-sha.sh --image $${img}$(image); \
 	done
+
+.PHONY: build-all-targets
+build-all-targets: bin
+	$(MAKE) GOOS=darwin GOARCH=arm64 LOCAL_TARGET=$(CURDIR)/bin/linuxkit-darwin-arm64 local-build
+	file bin/linuxkit-darwin-arm64
+	$(MAKE) GOOS=darwin GOARCH=amd64 LOCAL_TARGET=$(CURDIR)/bin/linuxkit-darwin-amd64 local-build
+	file bin/linuxkit-darwin-amd64
+	$(MAKE) GOOS=linux GOARCH=arm64 LOCAL_TARGET=$(CURDIR)/bin/linuxkit-linux-arm64 local-build
+	file bin/linuxkit-linux-arm64
+	$(MAKE) GOOS=linux GOARCH=amd64 LOCAL_TARGET=$(CURDIR)/bin/linuxkit-linux-amd64 local-build
+	file bin/linuxkit-linux-amd64
+	$(MAKE) GOOS=linux GOARCH=s390x LOCAL_TARGET=$(CURDIR)/bin/linuxkit-linux-s390x local-build
+	file bin/linuxkit-linux-s390x
+	$(MAKE) GOOS=windows GOARCH=amd64 LOCAL_TARGET=$(CURDIR)/bin/linuxkit-windows-amd64.exe local-build
+	file bin/linuxkit-windows-amd64.exe
+	cd bin && openssl sha256 -r linuxkit-* | tr -d '*' > checksums.txt


### PR DESCRIPTION
Signed-off-by: David Gageot <david.gageot@docker.com>

**- What I did**

This adds a GitHub Actions workflow that should trigger on each tag creation, 
if the tag starts with the letter `v`.
It'll build linuxkit for all os/arch targets, create a checksum file and create a draft release on GitHub.

**- How to verify it**

I couldn't test the very last part because I'm not authorised to create a release.
We should try and create a v0.9.0 tag or something.

See https://github.com/linuxkit/linuxkit/issues/3833

**- A picture of a cute animal (not mandatory but encouraged)**
![otis](https://user-images.githubusercontent.com/153495/194539248-86f0e39f-fa17-489e-8584-3be43b9cbe7f.jpeg)
