### PR TITLE
fix network build modes

### DIFF
--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -282,6 +282,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 			imageBuildOpts.Labels["org.opencontainers.image.revision"] = commit
 		}
 
+		imageBuildOpts.NetworkMode = "default"
 		if !p.network {
 			imageBuildOpts.NetworkMode = "none"
 		}

--- a/src/cmd/linuxkit/pkglib/docker.go
+++ b/src/cmd/linuxkit/pkglib/docker.go
@@ -432,7 +432,15 @@ func (dr *dockerRunnerImpl) build(ctx context.Context, tag, pkg, dockerContext, 
 	}
 
 	// network
-	frontendAttrs["network"] = imageBuildOpts.NetworkMode
+	// translate to net modes understood by buildkit dockerfile frontend
+	switch imageBuildOpts.NetworkMode {
+	case "host", "none":
+		frontendAttrs["force-network-mode"] = imageBuildOpts.NetworkMode
+	case "default":
+		frontendAttrs["force-network-mode"] = "sandbox"
+	default:
+		return fmt.Errorf("unsupported network mode %q", imageBuildOpts.NetworkMode)
+	}
 
 	for k, v := range imageBuildOpts.Labels {
 		frontendAttrs[fmt.Sprintf("label:%s", k)] = v


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Since the transition to direct buildkit, `linuxkit pkg build` was ignoring the `network` setting in `build.yml` and always letting it be enabled. This fixes it.

**- How I did it**

Changes to `FrontendAttr`.

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Proper configuration of network mode in package build.

