### PR TITLE
move rtf commands from GHA into make test; remove unused artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,9 +174,7 @@ jobs:
           ${{ runner.os }}-linuxkit-
 
     - name: Run Tests
-      run: |
-          cd test
-          rtf -l build -v run -x linuxkit.packages
+      run: make test TEST_SUITE=linuxkit.packages
 
   test_kernel:
     name: Kernel Tests
@@ -220,9 +218,7 @@ jobs:
         /usr/local/bin/linuxkit version
 
     - name: Run Tests
-      run: |
-          cd test
-          rtf -l build -v run -x linuxkit.kernel
+      run: make test TEST_SUITE=linuxkit.kernel
 
   test_linuxkit:
     name: LinuxKit Build Tests
@@ -266,9 +262,7 @@ jobs:
         /usr/local/bin/linuxkit version
 
     - name: Run Tests
-      run: |
-          cd test
-          rtf -l build -v run -x linuxkit.build
+      run: make test TEST_SUITE=linuxkit.build
 
   test_platforms:
     name: Platform Tests
@@ -312,9 +306,7 @@ jobs:
         /usr/local/bin/linuxkit version
 
     - name: Run Tests
-      run: |
-          cd test
-          rtf -l build -v run -x linuxkit.platforms
+      run: make test TEST_SUITE=linuxkit.platforms
 
   test_security:
     name: Security Tests
@@ -358,6 +350,4 @@ jobs:
         /usr/local/bin/linuxkit version
 
     - name: Run Tests
-      run: |
-          cd test
-          rtf -l build -v run -x linuxkit.security
+      run: make test TEST_SUITE=linuxkit.security

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 VERSION="v0.8+"
 
+# test suite to run, blank for all
+TEST_SUITE ?=
+
 GO_COMPILE=linuxkit/go-compile:7b1f5a37d2a93cd4a9aa2a87db264d8145944006
 
 ifeq ($(OS),Windows_NT)
@@ -78,10 +81,7 @@ sign:
 
 .PHONY: test
 test:
-	$(MAKE) -C test
-
-.PHONY: collect-artifacts
-collect-artifacts: artifacts/test.img.tar.gz artifacts/test-ltp.img.tar.gz
+	$(MAKE) -C test TEST_SUITE=$(TEST_SUITE)
 
 .PHONY: ci ci-tag ci-pr
 ci: test-cross

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,6 +7,8 @@ all: check-deps test-pr ltp
 
 LINUXKIT:=$(shell command -v linuxkit 2> /dev/null)
 RTF:=$(shell command -v rtf 2> /dev/null)
+# test suite to run, blank for all
+TEST_SUITE ?=
 
 .PHONY: check-deps
 check-deps:
@@ -17,17 +19,6 @@ ifndef RTF
 	$(error "rtf is not available. please install it!")
 endif
 
-
-# TODO: Remove this section once we no longer depend on this in CI
-### -------
-# Currently the linuxkit-ci runs GCP tests outside of rtf and expects some
-# files in ../artifacts. This hacky target puts them there until
-# the CI can use rtf for running GCP tests
-gcp-hack: ../artifacts/test.img.tar.gz
-../artifacts/test.img.tar.gz:
-	rm -rf ../artifacts
-	mkdir -p ../artifacts
-	$(LINUXKIT) build -format gcp -pull -name ../artifacts/test hack/test.yml
 
 define check_test_log
 	@cat $1 |grep -q 'test suite PASSED'
@@ -42,8 +33,7 @@ ltp: $(LINUXKIT) test-ltp.img.tar.gz
 	$(call check_test_log, test-ltp.log)
 ### ------
 
-test: gcp-hack
-	@rtf -l build -v run -x
+test:
+	@rtf -l build -v run -x $(TEST_SUITE)
 
-test-pr: gcp-hack
-	@rtf -l build -v run -x
+test-pr: test


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

* eliminated unused gcp artifact hack in `test/Makefile`
* added support for specifying test suites in `make test`
* replaced all direct calls to `rtf` in GHA workflows with `make test` calls

This is worth it on its own. Once it is done, I will use matrix to create parallel packages tests, which should speed up CI.

**- How I did it**

Changes to the two Makefiles in `ci.yaml`

**- How to verify it**

CI. If it works, then nothing has broken.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

rtf call refactor
