### PR TITLE
catch error with descriptor missing platform

### DIFF
--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -316,6 +316,9 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 			if desc == nil {
 				return fmt.Errorf("no valid descriptor returned for image for arch %s", platform.Architecture)
 			}
+			if desc.Platform == nil {
+				return fmt.Errorf("descriptor for platform %v has no information on the platform: %#v", platform, desc)
+			}
 			descs = append(descs, *desc)
 		}
 


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When reading the descriptors from the cache, sometimes we get a descriptor missing a platform. This causes all sort of other things to break downstream, including causing some SIGSEGV due to dereferencing the null pointer. 

This adds a check when using the descriptor that it contains a platform and, if not, returns an error that includes the descriptor in its entirety.

**- How I did it**

Added `if` statement to check for `desc.Platform`

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Safer handling of descriptors missing platform.
