### PR TITLE
add sharding option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
     name: Packages Tests
     needs: [ build_packages, build ]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1/10,2/10,3/10,4/10,5/10,6/10,7/10,8/10,9/10,10/10]
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -174,7 +177,7 @@ jobs:
           ${{ runner.os }}-linuxkit-
 
     - name: Run Tests
-      run: make test TEST_SUITE=linuxkit.packages
+      run: make test TEST_SUITE=linuxkit.packages TEST_SHARD=${{ matrix.shard }}
 
   test_kernel:
     name: Kernel Tests

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ VERSION="v0.8+"
 
 # test suite to run, blank for all
 TEST_SUITE ?=
+TEST_SHARD ?=
 
 GO_COMPILE=linuxkit/go-compile:7b1f5a37d2a93cd4a9aa2a87db264d8145944006
 
@@ -33,7 +34,7 @@ export VERSION GO_COMPILE GOOS GOARCH LOCAL_TARGET LINUXKIT
 default: linuxkit $(RTF)
 all: default
 
-RTF_COMMIT=2351267f358ce6621c0c0d9a069f361268dba5fc
+RTF_COMMIT=1b6277593346dea7e6039d528c4e8321a4bd9eaf
 RTF_CMD=github.com/linuxkit/rtf/cmd
 RTF_VERSION=0.0
 $(RTF): tmp_rtf_bin.tar | bin
@@ -81,7 +82,7 @@ sign:
 
 .PHONY: test
 test:
-	$(MAKE) -C test TEST_SUITE=$(TEST_SUITE)
+	$(MAKE) -C test TEST_SUITE=$(TEST_SUITE) TEST_SHARD=$(TEST_SHARD)
 
 .PHONY: ci ci-tag ci-pr
 ci: test-cross

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,6 +9,13 @@ LINUXKIT:=$(shell command -v linuxkit 2> /dev/null)
 RTF:=$(shell command -v rtf 2> /dev/null)
 # test suite to run, blank for all
 TEST_SUITE ?=
+# test shard to run, must be in format <this>/<total>, e.g. 1/10 means "first shard out of 10"
+# uses total count to figure out which one to run
+TEST_SHARD ?=
+TEST_SHARD_ARG =
+ifneq ($(TEST_SHARD),)
+override TEST_SHARD_ARG=-s $(TEST_SHARD)
+endif
 
 .PHONY: check-deps
 check-deps:
@@ -34,6 +41,6 @@ ltp: $(LINUXKIT) test-ltp.img.tar.gz
 ### ------
 
 test:
-	@rtf -l build -v run -x $(TEST_SUITE)
+	@rtf -l build -v=2 run -x $(TEST_SUITE) $(TEST_SHARD_ARG)
 
 test-pr: test


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added sharding of packages tests, to try and get it from 90 mins serial to up to 10 parallel shards in ~9 mins each.

**- How I did it**

1. Updated rtf to support shards
2. Updated to latest rtf version
3. Add shard support to `Makefile` and `tests/Makefile`
4. Add matrix to GHA under packages tests so that it has 10 shards

**- How to verify it**

Run CI and then see if the results are as expected

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Sharding support for much faster tests