### PR TITLE
option to show canonical tag

### DIFF
--- a/src/cmd/linuxkit/pkg_showtag.go
+++ b/src/cmd/linuxkit/pkg_showtag.go
@@ -18,6 +18,7 @@ func pkgShowTag(args []string) {
 		fmt.Fprintf(os.Stderr, "\n")
 		flags.PrintDefaults()
 	}
+	canonical := flags.Bool("canonical", false, "Show canonical name, e.g. docker.io/linuxkit/foo:1234, instead of the default, e.g. linuxkit/foo:1234")
 
 	pkgs, err := pkglib.NewFromCLI(flags, args...)
 	if err != nil {
@@ -25,6 +26,10 @@ func pkgShowTag(args []string) {
 		os.Exit(1)
 	}
 	for _, p := range pkgs {
-		fmt.Println(p.Tag())
+		tag := p.Tag()
+		if *canonical {
+			tag = p.FullTag()
+		}
+		fmt.Println(tag)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add option `lkt pkg show-tag --canonical`, which, instead of the simple image name, e.g. `linuxkit/getty:abc`, provides the canonical name `docker.io/linuxkit/getty:abc`.

**- How I did it**

Added an option to a single file.

**- How to verify it**

Run it. It works.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Option to show canonical tag.
