### PR TITLE
Rationalize build pull

### DIFF
--- a/src/cmd/linuxkit/pkg_build.go
+++ b/src/cmd/linuxkit/pkg_build.go
@@ -58,7 +58,6 @@ func pkgBuildPush(args []string, withPush bool) {
 	// pkg push --force            - always builds even if is in cache
 	// pkg push --nobuild          - skips build; if not in cache, fails
 	// pkg push --nobuild --force  - nonsensical
-	// pkg pull                    - pull from registry if available, otherwise fail
 
 	var (
 		release           *string

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -27,6 +27,7 @@ import (
 type buildOpts struct {
 	skipBuild      bool
 	force          bool
+	pull           bool
 	ignoreCache    bool
 	push           bool
 	release        string
@@ -57,6 +58,14 @@ func WithBuildSkip() BuildOpt {
 func WithBuildForce() BuildOpt {
 	return func(bo *buildOpts) error {
 		bo.force = true
+		return nil
+	}
+}
+
+// WithBuildPull pull down the image to cache if it already exists in registry
+func WithBuildPull() BuildOpt {
+	return func(bo *buildOpts) error {
+		bo.pull = true
 		return nil
 	}
 }
@@ -225,6 +234,12 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	}
 
 	var platformsToBuild []imagespec.Platform
+	switch {
+	case bo.force:
+	case bo.pull:
+	case !bo.skipBuild:
+	}
+
 	if bo.force {
 		platformsToBuild = bo.platforms
 	} else if !bo.skipBuild {

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -98,6 +98,7 @@ func WithRelease(r string) BuildOpt {
 func WithBuildTargetDockerCache() BuildOpt {
 	return func(bo *buildOpts) error {
 		bo.targetDocker = true
+		bo.pull = true // if we are to load it into docker, it must be in local cache
 		return nil
 	}
 }
@@ -235,34 +236,60 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 
 	var platformsToBuild []imagespec.Platform
 	switch {
+	case bo.force && bo.skipBuild:
+		return errors.New("cannot force build and skip build")
 	case bo.force:
-	case bo.pull:
-	case !bo.skipBuild:
-	}
-
-	if bo.force {
+		// force local build
 		platformsToBuild = bo.platforms
-	} else if !bo.skipBuild {
-		fmt.Fprintf(writer, "checking for %s in local cache, fallback to remote registry...\n", ref)
+	case bo.skipBuild:
+		// do not build anything if we explicitly did skipBuild
+		platformsToBuild = nil
+	default:
+		// check local cache, fallback to check registry / pull image from registry, fallback to build
+		fmt.Fprintf(writer, "checking for %s in local cache...\n", ref)
 		for _, platform := range bo.platforms {
-			if _, err := c.ImagePull(&ref, "", platform.Architecture, false); err == nil {
-				fmt.Fprintf(writer, "%s found or pulled\n", ref)
-				if bo.targetDocker {
-					archRef, err := reference.Parse(fmt.Sprintf("%s-%s", p.FullTag(), platform.Architecture))
-					if err != nil {
-						return err
+			if exists, err := c.ImageInCache(&ref, "", platform.Architecture); err == nil && exists {
+				fmt.Fprintf(writer, "found %s in local cache, skipping build\n", ref)
+				continue
+			}
+			if bo.pull {
+				// need to pull the image from the registry, else build
+				fmt.Fprintf(writer, "%s %s not found in local cache, trying to pull\n", ref, platform.Architecture)
+				if _, err := c.ImagePull(&ref, "", platform.Architecture, false); err == nil {
+					fmt.Fprintf(writer, "%s pulled\n", ref)
+					if bo.targetDocker {
+						archRef, err := reference.Parse(fmt.Sprintf("%s-%s", p.FullTag(), platform.Architecture))
+						if err != nil {
+							return err
+						}
+						fmt.Fprintf(writer, "checking for %s in local cache, fallback to remote registry...\n", archRef)
+						if _, err := c.ImagePull(&archRef, "", platform.Architecture, false); err == nil {
+							fmt.Fprintf(writer, "%s found or pulled\n", archRef)
+						} else {
+							fmt.Fprintf(writer, "%s not found, will build: %s\n", archRef, err)
+							platformsToBuild = append(platformsToBuild, platform)
+						}
 					}
-					fmt.Fprintf(writer, "checking for %s in local cache, fallback to remote registry...\n", archRef)
-					if _, err := c.ImagePull(&archRef, "", platform.Architecture, false); err == nil {
-						fmt.Fprintf(writer, "%s found or pulled\n", archRef)
-					} else {
-						fmt.Fprintf(writer, "%s not found, will build: %s\n", archRef, err)
-						platformsToBuild = append(platformsToBuild, platform)
-					}
+					// successfully pulled, no need to build, continue with next platform
+					continue
 				}
-			} else {
 				fmt.Fprintf(writer, "%s not found, will build: %s\n", ref, err)
 				platformsToBuild = append(platformsToBuild, platform)
+			} else {
+				// do not pull, just check if it exists in a registry
+				fmt.Fprintf(writer, "%s %s not found in local cache, checking registry\n", ref, platform.Architecture)
+				exists, err := c.ImageInRegistry(&ref, "", platform.Architecture)
+				if err != nil {
+					return fmt.Errorf("error checking remote registry for %s: %v", ref, err)
+				}
+
+				if exists {
+					fmt.Fprintf(writer, "%s %s found on registry\n", ref, platform.Architecture)
+					continue
+				}
+				fmt.Fprintf(writer, "%s %s not found, will build\n", ref, platform.Architecture)
+				platformsToBuild = append(platformsToBuild, platform)
+
 			}
 		}
 	}

--- a/src/cmd/linuxkit/pkglib/build_test.go
+++ b/src/cmd/linuxkit/pkglib/build_test.go
@@ -112,6 +112,24 @@ func (c *cacheMocker) ImagePull(ref *reference.Spec, trustedRef, architecture st
 	return c.imageWriteStream(ref, architecture, bytes.NewReader(b))
 }
 
+func (c *cacheMocker) ImageInCache(ref *reference.Spec, trustedRef, architecture string) (bool, error) {
+	image := ref.String()
+	desc, ok := c.images[image]
+	if !ok {
+		return false, nil
+	}
+	for _, d := range desc {
+		if d.Platform != nil && d.Platform.Architecture == architecture {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (c *cacheMocker) ImageInRegistry(ref *reference.Spec, trustedRef, architecture string) (bool, error) {
+	return false, nil
+}
+
 func (c *cacheMocker) ImageLoad(ref *reference.Spec, architecture string, r io.Reader) (lktspec.ImageSource, error) {
 	if !c.enableImageLoad {
 		return nil, errors.New("ImageLoad disabled")

--- a/src/cmd/linuxkit/spec/cache.go
+++ b/src/cmd/linuxkit/spec/cache.go
@@ -20,6 +20,12 @@ type CacheProvider interface {
 	// efficient and only write missing blobs, based on their content hash. If the ref already
 	// exists in the cache, it should not pull anything, unless alwaysPull is set to true.
 	ImagePull(ref *reference.Spec, trustedRef, architecture string, alwaysPull bool) (ImageSource, error)
+	// ImageInCache takes an image name and checks if it exists in the cache, including checking that the given
+	// architecture is complete. Like ImagePull, it should be efficient and only write missing blobs, based on
+	// their content hash.
+	ImageInCache(ref *reference.Spec, trustedRef, architecture string) (bool, error)
+	// ImageInRegistry takes an image name and checks if it exists in the registry.
+	ImageInRegistry(ref *reference.Spec, trustedRef, architecture string) (bool, error)
 	// IndexWrite takes an image name and creates an index for the descriptors to which it points.
 	// Cache implementation determines whether it should pull missing blobs from a remote registry.
 	// If the provided reference already exists and it is an index, updates the manifests in the


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

The current `lkt pkg build` process is treated as:

1. See if the pkg is in the cache
2. If it is not, try to pull it from the registry
3. If not in the registry, build it

That is not quite as efficient as it could be. There is no reason to pull it from registry to local cache unless you really want it. Much of the time, `pkg build` really is just saying, "I want to build it if it doesn't exist anywhere", not "I also need it in my cache." This tends to bloat the cache unnecessarily.

The change now does the following:

1. See if the pkg is in the cache
2. It it is not, see if it it is in the registry (unless overridden with `--pull`, in which case pull too)
3. If not in the registry, build it

You still can get the current behaviour with `lkt pkg build --pull`, but now package building is not confused by default with cache filling.

Of course, when you actually build an image with `lkt build`, it checks in the cache and, if not found, pulls it down anyways, so `lkt build` is unchanged.

**- How I did it**

Added an option to `pkg build --pull` and changed the pull logic.

**- How to verify it**

Run CI. Also tested manually.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Default for building packages is not to pull from registry unless explicitly requested.