### PR TITLE
when cannot get remote manifest in checking registry, that is just a …

### DIFF
--- a/src/cmd/linuxkit/cache/write.go
+++ b/src/cmd/linuxkit/cache/write.go
@@ -375,7 +375,8 @@ func (p *Provider) ImageInRegistry(ref *reference.Spec, trustedRef, architecture
 
 	desc, err := remote.Get(remoteRef, remoteOptions...)
 	if err != nil {
-		return false, fmt.Errorf("error getting manifest for image %s: %v", image, err)
+		log.Debugf("Retrieving image %s returned an error, ignoring: %v", image, err)
+		return false, nil
 	}
 	// first attempt as an index
 	ii, err := desc.ImageIndex()


### PR DESCRIPTION
…sign that it does not exist there

Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When checking if image is in registry for `pkg build`, it failed on errors, when it should treat errors as, "I could not find it there, so go ahead and build."

**- How I did it**

Change handling of `if err != nil`

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Proper registry error handling
