### PR TITLE
pkg/sshd: Remove default bind of /root/.ssh

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -63,6 +63,21 @@ This hierarchy can then be used by individual containers, who can bind
 mount the config sub-directory into their namespace where it is
 needed.
 
+## A note on SSH
+
+Supported providers will extract public keys from metadata to a file
+located at `/run/config/ssh/authorized_keys`.  You must bind this path
+into the `sshd` namespace in order to make use of these keys.  Use a
+configuration similar to the one shown below to enable root login
+based on keys from the metadata service:
+
+```
+  - name: sshd
+    image: linuxkit/sshd:4696ba61c3ec091328e1c14857d77e675802342f
+    binds.add:
+     - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
+```
+
 # Metadata image creation
 
 `linuxkit run` backends accept two options to pass metadata to the VM in a platform specific

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -20,7 +20,7 @@ services:
     image: linuxkit/rngd:4f85d8de3f6f45973a8c88dc8fba9ec596e5495a
   - name: sshd
     image: linuxkit/sshd:4696ba61c3ec091328e1c14857d77e675802342f
-    binds:
+    binds.add:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx
     image: nginx:1.13.8-alpine

--- a/examples/platform-aws.yml
+++ b/examples/platform-aws.yml
@@ -19,7 +19,7 @@ services:
     image: linuxkit/rngd:4f85d8de3f6f45973a8c88dc8fba9ec596e5495a
   - name: sshd
     image: linuxkit/sshd:4696ba61c3ec091328e1c14857d77e675802342f
-    binds:
+    binds.add:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx
     image: nginx:1.13.8-alpine

--- a/examples/platform-azure.yml
+++ b/examples/platform-azure.yml
@@ -16,6 +16,8 @@ services:
     image: linuxkit/dhcpcd:52d2c4df0311b182e99241cdc382ff726755c450
   - name: sshd
     image: linuxkit/sshd:4696ba61c3ec091328e1c14857d77e675802342f
+    binds.add:
+      - /root/.ssh:/root/.ssh
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/platform-gcp.yml
+++ b/examples/platform-gcp.yml
@@ -23,7 +23,7 @@ services:
     image: linuxkit/rngd:4f85d8de3f6f45973a8c88dc8fba9ec596e5495a
   - name: sshd
     image: linuxkit/sshd:4696ba61c3ec091328e1c14857d77e675802342f
-    binds:
+    binds.add:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx
     image: nginx:1.13.8-alpine

--- a/examples/platform-hetzner.yml
+++ b/examples/platform-hetzner.yml
@@ -29,6 +29,8 @@ services:
      - INSECURE=true
   - name: sshd
     image: linuxkit/sshd:4696ba61c3ec091328e1c14857d77e675802342f
+    binds.add:
+      - /root/.ssh:/root/.ssh
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/platform-packet.yml
+++ b/examples/platform-packet.yml
@@ -29,6 +29,8 @@ services:
      - INSECURE=true
   - name: sshd
     image: linuxkit/sshd:4696ba61c3ec091328e1c14857d77e675802342f
+    binds.add:
+      - /root/.ssh:/root/.ssh
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/platform-vultr.yml
+++ b/examples/platform-vultr.yml
@@ -24,7 +24,7 @@ services:
     image: linuxkit/rngd:4f85d8de3f6f45973a8c88dc8fba9ec596e5495a
   - name: sshd
     image: linuxkit/sshd:4696ba61c3ec091328e1c14857d77e675802342f
-    binds:
+    binds.add:
      - /run/config/ssh/authorized_keys:/root/.ssh/authorized_keys
   - name: nginx
     image: nginx:1.13.8-alpine

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -23,6 +23,8 @@ services:
     image: linuxkit/dhcpcd:52d2c4df0311b182e99241cdc382ff726755c450
   - name: sshd
     image: linuxkit/sshd:4696ba61c3ec091328e1c14857d77e675802342f
+    binds.add:
+      - /root/.ssh:/root/.ssh
 files:
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -20,6 +20,8 @@ onboot:
 services:
   - name: sshd
     image: linuxkit/sshd:4696ba61c3ec091328e1c14857d77e675802342f
+    binds.add:
+      - /root/.ssh:/root/.ssh
   - name: vpnkit-forwarder
     image: linuxkit/vpnkit-forwarder:ea4dded7386b09dd647e854664b029be0a4f420f
     binds:

--- a/pkg/sshd/build.yml
+++ b/pkg/sshd/build.yml
@@ -2,7 +2,6 @@ image: sshd
 config:
   pid: host
   binds:
-    - /root/.ssh:/root/.ssh
     - /etc/resolv.conf:/etc/resolv.conf
     - /run:/run
     - /tmp:/tmp


### PR DESCRIPTION
Signed-off-by: Michael Aldridge <aldridge.mac@gmail.com>

**- What I did**
Removed the default bind mount of `/root/.ssh` in the sshd package.  When using the metadata package to summon keys, the ssh directory will not be present in root's home folder on the host filesystem because the keys are summoned dynamically.  However, its not possible to just add the new bind for the `authorized_keys` file because the bind to the nonexistent directory prevents sshd from being able to start.  This change removes the default bind since it can be trivially added back using `binds.add` for anyone who wishes to statically provide an `authorized_keys` file at build time.

**- How I did it**
A single elegant emacs command.

**- How to verify it**
Observe the diff, see that the bind mount is no longer present in `build.yml`.

**- Description for the changelog**
Remove `/root/.ssh` default bind to improve portability.  Bind may be re-added with `binds.add`.
