### PR TITLE
Update buildkit version to speed up start time

### DIFF
--- a/src/cmd/linuxkit/pkg_build.go
+++ b/src/cmd/linuxkit/pkg_build.go
@@ -14,9 +14,10 @@ import (
 const (
 	buildersEnvVar = "LINUXKIT_BUILDERS"
 	envVarCacheDir = "LINUXKIT_CACHE"
-	// this is the most recent manifest pointed to by moby/buildkit:master as of 2022-07-22, so it includes
-	// our required commit. Once there is a normal semver tag later than this, we should switch to it.
-	defaultBuilderImage = "moby/buildkit@sha256:19c4637f8809f21af01dedf65f7f0d64636165d8191381ec9d5150fccedbae48"
+	// this is the most recent manifest pointed to by moby/buildkit:master as of 2022-11-11, with the latest commit
+	// d3f26c63389c2ad66600ae5c884d6cbde627d6d8.
+	// Once there is a normal semver tag later than this, we should switch to it.
+	defaultBuilderImage = "moby/buildkit@sha256:a44defefec23a24cfc250116c4862e0e47c8d0339cefc4c7ab0ca7f3837618e3"
 )
 
 func pkgBuild(args []string) {


### PR DESCRIPTION
**- What I did**

I checked and compared linuxkit-builder startup time for current and upstream versions of buildkit.

**- How I did it**

- I cleaned `linuxkit-builder` (buildkit) container with `docker rm -f --volumes linuxkit-builder`
- I filled the volume of `linuxkit-builder` (buildkit) with the artifacts from [EVE-OS](https://github.com/lf-edge/eve) (`make pkg/alpine pkg/acrn pkg/acrn-kernel pkg/fw pkg/pillar eve`) to have lots of data inside (16G as du indicates).
- I stopped the linuxkit-builder builder using docker commands and start it again.
- I measured the time difference before starting of `linuxkit-builder` container and the line `running server on /run/buildkit/buildkitd.sock` in `docker logs linuxkit-builder`.

For current version I get about 20 seconds to start.
For upstream version I get about 3 seconds to start.

**- Description for the changelog**

Let's update buildkit version to include startup speed fix https://github.com/moby/buildkit/commit/0bb8505e86ca28508776d4b4734cdd4911c14332
