### PR TITLE
Propagate manifest option into push

### DIFF
--- a/src/cmd/linuxkit/cache/push.go
+++ b/src/cmd/linuxkit/cache/push.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Push push an image along with a multi-arch index.
-func (p *Provider) Push(name string) error {
+func (p *Provider) Push(name string, withManifest bool) error {
 	var (
 		err     error
 		options []remote.Option
@@ -113,6 +113,9 @@ func (p *Provider) Push(name string) error {
 		return fmt.Errorf("name %s unknown in cache", name)
 	}
 
+	if !withManifest {
+		return nil
+	}
 	// Even though we may have pushed the index, we want to be sure that we have an index that includes every architecture on the registry,
 	// not just those that were in our local cache. So we use manifest-tool library to build a broad index
 	auth, err := registry.GetDockerAuth()

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -419,7 +419,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	}
 
 	// push the manifest
-	if err := c.Push(p.FullTag()); err != nil {
+	if err := c.Push(p.FullTag(), bo.manifest); err != nil {
 		return err
 	}
 
@@ -441,7 +441,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	if _, err := c.DescriptorWrite(&ref, *desc); err != nil {
 		return err
 	}
-	if err := c.Push(fullRelTag); err != nil {
+	if err := c.Push(fullRelTag, bo.manifest); err != nil {
 		return err
 	}
 

--- a/src/cmd/linuxkit/pkglib/build_test.go
+++ b/src/cmd/linuxkit/pkglib/build_test.go
@@ -219,7 +219,7 @@ func (c *cacheMocker) IndexWrite(ref *reference.Spec, descriptors ...registry.De
 
 	return c.NewSource(ref, "", &desc), nil
 }
-func (c *cacheMocker) Push(name string) error {
+func (c *cacheMocker) Push(name string, withManifest bool) error {
 	if !c.enablePush {
 		return errors.New("push disabled")
 	}

--- a/src/cmd/linuxkit/spec/cache.go
+++ b/src/cmd/linuxkit/spec/cache.go
@@ -37,8 +37,9 @@ type CacheProvider interface {
 	// DescriptorWrite writes a descriptor to the cache index; it validates that it has a name
 	// and replaces any existing one
 	DescriptorWrite(ref *reference.Spec, descriptors v1.Descriptor) (ImageSource, error)
-	// Push push an image along with a multi-arch index from local cache to remote registry.
-	Push(name string) error
+	// Push an image along with a multi-arch index from local cache to remote registry.
+	// if withManifest defined will push a multi-arch manifest
+	Push(name string, withManifest bool) error
 	// NewSource return an ImageSource for a specific ref and architecture in the cache.
 	NewSource(ref *reference.Spec, architecture string, descriptor *v1.Descriptor) ImageSource
 	// Store get content.Store referencing the cache


### PR DESCRIPTION
We have distinct manifest option which is not used. Let's implement different behavior.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>