### PR TITLE
allow multiple packages for show-tag

### DIFF
--- a/src/cmd/linuxkit/pkg_showtag.go
+++ b/src/cmd/linuxkit/pkg_showtag.go
@@ -11,11 +11,12 @@ func pkgShowTagCmd() *cobra.Command {
 	var canonical bool
 	cmd := &cobra.Command{
 		Use:   "show-tag",
-		Short: "show the tag for a package based on its source directory",
-		Long: `Show the tag for a package based on its source directory.
+		Short: "show the tag for packages based on its source directory",
+		Long: `Show the tag for one or more packages based on their source directories.
 		'path' specifies the path to the package source directory.
 `,
-		Args: cobra.ExactArgs(1),
+		Args:    cobra.MinimumNArgs(1),
+		Example: "linuxkit pkg show-tag path/to/package [path/to/another/package] [path/to/yet/another/package]",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pkgs, err := pkglib.NewFromConfig(pkglibConfig, args...)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Allow more than one packages to `lkt pkg show-tag`. It used to do that, a previous PR accidentally limited it back to 1. This fixes it.

**- How I did it**

Change one file

**- How to verify it**

Run it. I did.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Multiple packages to show-tag