### PR TITLE
Add virtiofs command line option for qemu run

### DIFF
--- a/src/cmd/linuxkit/run_virtualizationframework.go
+++ b/src/cmd/linuxkit/run_virtualizationframework.go
@@ -14,23 +14,25 @@ const (
 )
 
 type virtualizationFramwworkConfig struct {
-	cpus       uint
-	mem        uint64
-	disks      Disks
-	data       string
-	dataPath   string
-	state      string
-	networking string
-	kernelBoot bool
+	cpus           uint
+	mem            uint64
+	disks          Disks
+	data           string
+	dataPath       string
+	state          string
+	networking     string
+	kernelBoot     bool
+	virtiofsShares []string
 }
 
 func runVirtualizationFrameworkCmd() *cobra.Command {
 	var (
-		data       string
-		dataPath   string
-		state      string
-		networking string
-		kernelBoot bool
+		data           string
+		dataPath       string
+		state          string
+		networking     string
+		kernelBoot     bool
+		virtiofsShares []string
 	)
 
 	cmd := &cobra.Command{
@@ -43,14 +45,15 @@ func runVirtualizationFrameworkCmd() *cobra.Command {
 		Example: "linuxkit run virtualization [options] prefix",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := virtualizationFramwworkConfig{
-				cpus:       uint(cpus),
-				mem:        uint64(mem) * 1024 * 1024,
-				disks:      disks,
-				data:       data,
-				dataPath:   dataPath,
-				state:      state,
-				networking: networking,
-				kernelBoot: kernelBoot,
+				cpus:           uint(cpus),
+				mem:            uint64(mem) * 1024 * 1024,
+				disks:          disks,
+				data:           data,
+				dataPath:       dataPath,
+				state:          state,
+				networking:     networking,
+				kernelBoot:     kernelBoot,
+				virtiofsShares: virtiofsShares,
 			}
 			return runVirtualizationFramework(cfg, args[0])
 		},
@@ -63,6 +66,7 @@ func runVirtualizationFrameworkCmd() *cobra.Command {
 	cmd.Flags().StringVar(&networking, "networking", virtualizationNetworkingDefault, "Networking mode. Valid options are 'default', 'vmnet' and 'none'. 'vmnet' uses the Apple vmnet framework. 'none' disables networking.`")
 
 	cmd.Flags().BoolVar(&kernelBoot, "kernel", false, "Boot image is kernel+initrd+cmdline 'path'-kernel/-initrd/-cmdline")
+	cmd.Flags().StringArrayVar(&virtiofsShares, "virtiofs", []string{}, "Directory shared on virtiofs")
 
 	return cmd
 }

--- a/src/cmd/linuxkit/run_virtualizationframework_darwin_cgo_enabled.go
+++ b/src/cmd/linuxkit/run_virtualizationframework_darwin_cgo_enabled.go
@@ -239,6 +239,30 @@ func runVirtualizationFramework(cfg virtualizationFramwworkConfig, path string) 
 	config.SetSocketDevicesVirtualMachineConfiguration([]vz.SocketDeviceConfiguration{
 		socketDeviceConfiguration,
 	})
+
+	if len(cfg.virtiofsShares) > 0 {
+		var cs []vz.DirectorySharingDeviceConfiguration
+
+		for idx, share := range cfg.virtiofsShares {
+			tag := fmt.Sprintf("virtiofs%d", idx)
+			device, err := vz.NewVirtioFileSystemDeviceConfiguration(tag)
+			if err != nil {
+				log.Fatal("virtiofs device configuration failed", err)
+			}
+			dir, err := vz.NewSharedDirectory(share, false)
+			if err != nil {
+				log.Fatal("virtiofs shared directory failed", err)
+			}
+			single, err := vz.NewSingleDirectoryShare(dir)
+			if err != nil {
+				log.Fatal("virtiofs single directory share failed", err)
+			}
+			device.SetDirectoryShare(single)
+			cs = append(cs, device)
+		}
+		config.SetDirectorySharingDevicesVirtualMachineConfiguration(cs)
+	}
+
 	validated, err := config.Validate()
 	if !validated || err != nil {
 		log.Fatal("validation failed", err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

On linux, it requires root to start the virtiofsd and add some options to qemu processes for file sharing. I could test the C version of virtiofsd on Linux, `virtiofsd` is installed as part of `qemu-system-common` on an ubuntu system.
On Mac, it requires macOS 12+ and should do nothing on earlier OSes.

Let me know what you think.

**- How I did it**

Add an option to qemu command
Add an option to virtualization command

**- How to verify it**
```
 (sleep 5; echo "mount -t virtiofs virtiofs0 /mnt && ls /mnt && poweroff" ) | sudo ./src/cmd/linuxkit/linuxkit run qemu --mem 2048 --virtiofs $HOME linuxkit

 (sleep 5; echo "mount -t virtiofs virtiofs0 /mnt && ls /mnt && poweroff" ) | ./src/cmd/linuxkit/linuxkit run virtualization --mem 2048 --virtiofs $HOME linuxkit
```

**- Description for the changelog**

Add a `--virtiofs` option to `linuxkit run qemu` to create virtiofs mounts.
Add a `--virtiofs` option to `linuxkit run virtualization` to create virtiofs mounts.

**- A picture of a cute animal (not mandatory but encouraged)**
