### PR TITLE
use latest go-compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION="v0.8+"
 TEST_SUITE ?=
 TEST_SHARD ?=
 
-GO_COMPILE=linuxkit/go-compile:7b1f5a37d2a93cd4a9aa2a87db264d8145944006
+GO_COMPILE=linuxkit/go-compile:c97703655e8510b7257ffc57f25e40337b0f0813
 
 ifeq ($(OS),Windows_NT)
 LINUXKIT?=$(CURDIR)/bin/linuxkit.exe
@@ -34,7 +34,7 @@ export VERSION GO_COMPILE GOOS GOARCH LOCAL_TARGET LINUXKIT
 default: linuxkit $(RTF)
 all: default
 
-RTF_COMMIT=1b6277593346dea7e6039d528c4e8321a4bd9eaf
+RTF_COMMIT=b74a4f7c78e5cddcf7e6d2e6be7be312b9f645fc
 RTF_CMD=github.com/linuxkit/rtf/cmd
 RTF_VERSION=0.0
 $(RTF): tmp_rtf_bin.tar | bin

--- a/src/cmd/linuxkit/Makefile
+++ b/src/cmd/linuxkit/Makefile
@@ -1,6 +1,6 @@
 VERSION?="v0.0-dev"
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
-GO_COMPILE?=linuxkit/go-compile:7b1f5a37d2a93cd4a9aa2a87db264d8145944006
+GO_COMPILE?=linuxkit/go-compile:c97703655e8510b7257ffc57f25e40337b0f0813
 export GO_FLAGS=-mod=vendor
 
 ifeq ($(OS),Windows_NT)
@@ -78,7 +78,7 @@ LOCAL_TARGET ?= $(LINUXKIT)
 local-check: $(LINUXKIT_DEPS)
 	@echo gofmt... && o=$$(gofmt -s -l $(filter %.go,$(LINUXKIT_DEPS))) && if [ -n "$$o" ] ; then echo $$o ; exit 1 ; fi
 	@echo govet... && go vet -printf=false ./...
-	@echo golint... && set -e ; for i in $(filter %.go,$(LINUXKIT_DEPS)); do golint $$i ; done
+	@echo golangci-lint... && golangci-lint run ./...
 	@echo ineffassign... && ineffassign ./...
 
 local-build:

--- a/tools/go-compile/Dockerfile
+++ b/tools/go-compile/Dockerfile
@@ -4,12 +4,21 @@ RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
     busybox \
+    curl \
     git \
     go \
     musl-dev
-# Hack to work around an issue wirh go on arm64 requiring gcc
+
+# curl to install golangci-lint
+RUN apk add --no-cache curl
+
+# Hack to work around an issue with go on arm64 requiring gcc
 RUN [ $(uname -m) = aarch64 ] && apk add --no-cache --initdb -p /out gcc || true
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+# installing golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /out/go/bin v1.50.1
+
 
 FROM scratch
 ENV GOPATH=/go PATH=$PATH:/go/bin

--- a/tools/go-compile/build.yml
+++ b/tools/go-compile/build.yml
@@ -1,1 +1,2 @@
 image: go-compile
+network: true

--- a/tools/go-compile/compile.sh
+++ b/tools/go-compile/compile.sh
@@ -84,7 +84,7 @@ test -z $(gofmt -s -l .| grep -v .pb. | grep -v vendor/ | tee /dev/stderr)
 test -z $(GOOS=linux go vet $MOD_ARG -printf=false . 2>&1 | grep -v "^#" | grep -v vendor/ | tee /dev/stderr)
 
 >&2 echo "golint..."
-test -z $(find . -type f -name "*.go" -not -path "*/vendor/*" -not -name "*.pb.*" -exec golint {} \; | tee /dev/stderr)
+test -z $(golangci-lint run ./... | tee /dev/stderr)
 
 >&2 echo "ineffassign..."
 test -z $(ineffassign ./... | tee /dev/stderr)


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes #3885 

Updates the Makefiles to use the latest `linuxkit/go-compile`. While at it, replaces the internal linting from `golint` (deprecated) to `golangci-lint` (which we use in CI anyways).

**- How I did it**

1. Update `tools/go-compile`
2. Update `Makefile` and `src/cmd/linuxkit/Makefile`

**- How to verify it**

I ran builds, let CI run as well

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Update go-compile