### PR TITLE
cmd: Remove s390x as a default arch

### DIFF
--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -26,7 +26,7 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib"]
   # make a swap file on the mounted disk
   - name: swap
-    image: linuxkit/swap:cf9b484598f197a31b570012815c679826145bc4
+    image: linuxkit/swap:d17a7f1c26ff768c26b3c206ccf3aa72349568df
     command: ["/swap.sh", "--path", "/var/lib/swap", "--size", "1024M"]
   # mount-vpnkit mounts the 9p share used by vpnkit to coordinate port forwarding
   - name: mount-vpnkit

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -18,7 +18,7 @@ onboot:
     image: linuxkit/mount:a8581e454f846690d09e2e7c6287d3c84ca53257
     command: ["/usr/bin/mountie", "/var/external"]
   - name: swap
-    image: linuxkit/swap:cf9b484598f197a31b570012815c679826145bc4
+    image: linuxkit/swap:d17a7f1c26ff768c26b3c206ccf3aa72349568df
     # to use unencrypted swap, use:
     # command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G"]
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -54,7 +54,7 @@ type PkglibConfig struct {
 func NewPkgInfo() pkgInfo {
 	return pkgInfo{
 		Org:          "linuxkit",
-		Arches:       []string{"amd64", "arm64", "s390x"},
+		Arches:       []string{"amd64", "arm64"},
 		GitRepo:      "https://github.com/linuxkit/linuxkit",
 		Network:      false,
 		DisableCache: false,


### PR DESCRIPTION
As discussed on https://github.com/linuxkit/linuxkit/issues/3909

Also see https://github.com/linuxkit/linuxkit/issues/3676 for an older discussionl. We may want to do more clean up and remove more references to s390x, possibly starting with the CI

![44a652c8-c3b5-48dd-b42a-59ef3da69be5_w948_r1 778_fpx51_fpy44](https://user-images.githubusercontent.com/3338098/218558350-c77556e8-18cd-4391-9cb1-9f84eb729bd4.jpg)
