### PR TITLE
Retain /lib/apk/db for SBOM tools

### DIFF
--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -12,3 +12,5 @@ COPY --from=containerd-dev /usr/bin/containerd /usr/bin/ctr /usr/bin/containerd-
 COPY --from=alpine /usr/share/zoneinfo/UTC /etc/localtime
 COPY --from=alpine /etc/init.d/ /etc/init.d/
 COPY etc etc/
+COPY --from=alpine /etc/apk /etc/apk/
+COPY --from=alpine /lib/apk /lib/apk/

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -27,8 +27,8 @@ RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl
 # Add /etc/ssl/certs so it can be bind-mounted into metadata package
 RUN mkdir -p /out/etc/ssl/certs
 
-# Remove apk residuals. We have a read-only rootfs, so apk is of no use.
-RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+# Remove cache residuals. We retain apk for SBOM tools
+RUN rm -rf /out/var/cache
 
 FROM scratch
 ENTRYPOINT []

--- a/pkg/memlogd/Dockerfile
+++ b/pkg/memlogd/Dockerfile
@@ -19,3 +19,5 @@ COPY --from=build /go/bin/logread usr/bin/logread
 COPY --from=build /go/bin/logwrite usr/bin/logwrite
 # We'll start from init.d
 COPY etc/ /etc/
+COPY --from=build /etc/apk /etc/apk/
+COPY --from=build /lib/apk /lib/apk/

--- a/pkg/modprobe/Dockerfile
+++ b/pkg/modprobe/Dockerfile
@@ -3,7 +3,7 @@ FROM linuxkit/alpine:316c3f9d85c21fdd8bc7479e81d290f85bf60eb0 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     busybox
-RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+RUN rm -rf /out/var/cache
 
 FROM scratch
 ENTRYPOINT []

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -30,3 +30,5 @@ ENTRYPOINT []
 COPY --from=alpine /usr/bin/runc /usr/bin/
 COPY --from=alpine /etc/init.d/ /etc/init.d/
 COPY --from=alpine /etc/shutdown.d/ /etc/shutdown.d/
+COPY --from=alpine /etc/apk /etc/apk/
+COPY --from=alpine /lib/apk /lib/apk/

--- a/pkg/sysctl/Dockerfile
+++ b/pkg/sysctl/Dockerfile
@@ -14,4 +14,6 @@ CMD []
 WORKDIR /
 COPY --from=mirror /go/bin/sysctl /usr/bin/sysctl
 COPY etc/ /etc/
+COPY --from=mirror /etc/apk /etc/apk/
+COPY --from=mirror /lib/apk /lib/apk/
 CMD ["/usr/bin/sysctl"]


### PR DESCRIPTION

**- What I did**
This allows SBOM tools to look at /lib/apk/db/installed to determine which package versions are included in the container. This should probably be applied across all of the linuxkit containers.

**- How I did it**

Preserve /etc/apk and /lib/apk by copying it to the container

**- How to verify it**

Inspect the produced containers to check that they have /lib/apk/db/installed

**- Description for the changelog**
Retain /lib/apk/db for SBOM tools
