### PR TITLE
Include ethtool in linuxkit ip image.

### DIFF
--- a/examples/static-ip.yml
+++ b/examples/static-ip.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/containerd:eeb3aaf497c0b3f6c67f3a245d61ea5a568ca718
 onboot:
   - name: ip
-    image: linuxkit/ip:c88e3272e3b12edec454e4720da8bb70a7655bc7
+    image: linuxkit/ip:f25100f6347d8259886ffb7f914b3bf9c966c2d0
     binds:
      - /etc/ip:/etc/ip
     command: ["ip", "-b", "/etc/ip/eth0.conf"]

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:c88e3272e3b12edec454e4720da8bb70a7655bc7
+    image: linuxkit/ip:f25100f6347d8259886ffb7f914b3bf9c966c2d0
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -26,7 +26,7 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:c88e3272e3b12edec454e4720da8bb70a7655bc7
+    image: linuxkit/ip:f25100f6347d8259886ffb7f914b3bf9c966c2d0
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard

--- a/pkg/ip/Dockerfile
+++ b/pkg/ip/Dockerfile
@@ -11,7 +11,8 @@ RUN apk add --no-cache --initdb -p /out \
     ipvsadm \
     bridge-utils \
     musl \
-    wireguard-tools
+    wireguard-tools \
+    ethtool
 
 # We grab our version of wg-quick, called lk-wg-config.sh
 RUN curl -sSL -o /out/usr/bin/lk-wg-config https://gist.githubusercontent.com/zx2c4/3624de869ab7eaef3de5ea8f2b867be9/raw/de72b018f4f4548858ce6aae2898b34db0474221/lk-wg-config.sh && chmod 755 /out/usr/bin/lk-wg-config

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -18,7 +18,7 @@ onboot:
 
 services:
   - name: testservice
-    image: linuxkit/ip:c88e3272e3b12edec454e4720da8bb70a7655bc7
+    image: linuxkit/ip:f25100f6347d8259886ffb7f914b3bf9c966c2d0
     # Some environments
     env:
       - BENV=true

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -11,7 +11,7 @@ onboot:
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: wg0
-    image: linuxkit/ip:c88e3272e3b12edec454e4720da8bb70a7655bc7
+    image: linuxkit/ip:f25100f6347d8259886ffb7f914b3bf9c966c2d0
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard
@@ -24,7 +24,7 @@ onboot:
       bindNS:
           net: /run/netns/wg0
   - name: wg1
-    image: linuxkit/ip:c88e3272e3b12edec454e4720da8bb70a7655bc7
+    image: linuxkit/ip:f25100f6347d8259886ffb7f914b3bf9c966c2d0
     net: new
     binds:
       - /etc/wireguard:/etc/wireguard


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Include the ethtool in the Linuxkit "ip" image.

**- How I did it**

Add the "ethtool" package to the ip image Dockerfile.

**- How to verify it**

Generate the ip image, run ethtool from within it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Include the ethtool in the Linuxkit "ip" image; this allows configuring ethernet interfaces using this image.

**- A picture of a cute animal (not mandatory but encouraged)**
