### PR TITLE
include source repo, revision and go package version as build-args

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -264,6 +264,23 @@ linuxkit pkg build --platforms=linux/arm64 --builders linux/arm64=my-remote-arm6
 
 linuxkit will try to build for `linux/arm64` using the context `my-remote-arm64`. Since that context does not exist, you will get an error.
 
+##### Preset build arguments
+
+When building packages, the following build-args automatically are set for you:
+
+* `SOURCE` - the source repository of the package
+* `REVISION` - the git commit that was used for the build
+* `GOPKGVERSION` - the go package version or pseudo-version per https://go.dev/ref/mod#glos-pseudo-version
+
+Note that the above are set **only** if you do not set them in `build.yaml`. Your settings _always_
+override these built-in ones.
+
+To use them, simply address them in your `Dockerfile`:
+
+```dockerfile
+ARG SOURCE
+```
+
 ### Build packages as a maintainer
 
 All official LinuxKit packages are multi-arch manifests and most of

--- a/test/cases/000_build/031_fixed_build_args/Dockerfile
+++ b/test/cases/000_build/031_fixed_build_args/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.17
+
+ARG SOURCE=FAILED
+ARG REVISION=FAILED
+ARG GOPKGVERSION=FAILED
+
+RUN echo "printf \"Build-arg test source $SOURCE\\n\"" >> check.sh
+RUN echo "printf \"Build-arg test revision $REVISION\\n\"" >> check.sh
+RUN echo "printf \"Build-arg test gopkgversion $GOPKGVERSION\\n\"" >> check.sh
+
+ENTRYPOINT ["/bin/sh", "/check.sh"]

--- a/test/cases/000_build/031_fixed_build_args/build.yml
+++ b/test/cases/000_build/031_fixed_build_args/build.yml
@@ -1,0 +1,5 @@
+image: build-args-test
+network: true
+arches:
+    - amd64
+    - arm64

--- a/test/cases/000_build/031_fixed_build_args/test.sh
+++ b/test/cases/000_build/031_fixed_build_args/test.sh
@@ -11,8 +11,8 @@ set -ex
 
 # Test code goes here
 echo Linuxkit is "$(which linuxkit)"
-RESULT="$(2>&1 linuxkit pkg build --force . | grep PASSED)"
+RESULT="$(2>&1 linuxkit pkg build --force . | grep 'Build-arg test' || echo)"
 echo RESULT="${RESULT}"
-echo "${RESULT}" | grep  "Build-arg test PASSED"
+echo "${RESULT}" | grep  -v "FAILED"
 
 exit 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added some fixed default build-args that `linuxkit pkg build` passes to the docker build. These are

* `SOURCE`
* `REVISION`
* `GOPKGVERSION`

They are in the docs as well. 

These are set **only** if the user does not override them in `build.yaml`.

Also added a test, of course.

Note that I picked build-args that are tied to the filesystem and commit. Thus, they do not interfere with reproducible builds.

I did consider adding the username and host that built, but wasn't sure if that violated our "reproducible always" requirement.

**- How I did it**

Changes to `git.go` and `build.go`

**- How to verify it**

CI. I added tests. And I tested manually.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Pass build-context information to package builds via `--builg-arg`

**- Note**

I have a follow on for several packages to take advantage of this.