### PR TITLE
handle conflict with name and output

### DIFF
--- a/src/cmd/linuxkit/build.go
+++ b/src/cmd/linuxkit/build.go
@@ -59,7 +59,7 @@ The generated image can be in one of multiple formats which can be run on variou
 		Example: `  linuxkit build [options] <file>[.yml]`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if name == "" {
+			if name == "" && outputFile == "" {
 				conf := args[len(args)-1]
 				if conf == "-" {
 					name = defaultNameForStdin


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When calling `lkt build`, if you do not provide `--name`, it calculates it. But later it checks if you provided `--output` and, if so, and you also have `name` set, it errors out.

It should calculate `name` if and only if `outputFile` also is not set.

**- How I did it**

Fixes a single file.

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix conflicts among CLI flags