### PR TITLE
logread should not panic on an EOF, instead exiting gracefully

### DIFF
--- a/pkg/memlogd/cmd/logread/main.go
+++ b/pkg/memlogd/cmd/logread/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 	"time"
@@ -65,6 +67,9 @@ func main() {
 	decoder := json.NewDecoder(conn)
 	for {
 		if err := decoder.Decode(&entry); err != nil {
+			if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
+				return
+			}
 			panic(err)
 		}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

`logread` (in `pkg/memlogd`) has an option to `-f` and follow. If not, then it reads until the end of the stream and exits.

Except it does _not_ exit, it `panic()`, even if it is getting an `EOF`.

This changes it to exit sanely if it receives an `EOF`

**- How I did it**

Changed lines in `pkg/memlogd/cmd/logread/main.go`

**- How to verify it**

CI, and I did some manual testing. Beforehand, I got:

```
panic: EOF

goroutine 1 [running]:
main.main()
        /go/src/memlogd/cmd/logread/main.go:69 +0x426
```

After, it just exits cleanly

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Exit cleanly for logread when EOF