### PR TITLE
ensure passing context when creating builder runner

### DIFF
--- a/src/cmd/linuxkit/pkglib/docker.go
+++ b/src/cmd/linuxkit/pkglib/docker.go
@@ -319,10 +319,10 @@ func (dr *dockerRunnerImpl) builderEnsureContainer(ctx context.Context, name, im
 	}
 	if recreate {
 		// create the builder
-		args := []string{"container", "run", "-d", "--name", name, "--privileged", image, "--allow-insecure-entitlement", "network.host", "--addr", fmt.Sprintf("unix://%s", buildkitSocketPath), "--debug"}
+		args := []string{"--context", dockerContext, "container", "run", "-d", "--name", name, "--privileged", image, "--allow-insecure-entitlement", "network.host", "--addr", fmt.Sprintf("unix://%s", buildkitSocketPath), "--debug"}
 		msg := fmt.Sprintf("creating builder container '%s' in context '%s'", name, dockerContext)
 		fmt.Println(msg)
-		if err := dr.command(nil, io.Discard, io.Discard, args...); err != nil {
+		if err := dr.command(nil, nil, nil, args...); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When we restart a builder runner, we forgot to add the context, so docker gets confused and tries to run it locally, which can fail in odd ways.

**- How I did it**

Add 2 args to the docker runner line

**- How to verify it**

CI. Plus I ran it manually.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Ensure pass docker context when restarting remote runner
