### PR TITLE
push sboms as well

### DIFF
--- a/src/cmd/linuxkit/cache/source.go
+++ b/src/cmd/linuxkit/cache/source.go
@@ -15,16 +15,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	lktspec "github.com/linuxkit/linuxkit/src/cmd/linuxkit/spec"
+	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/util"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const (
-	annotationDockerReferenceType   = "vnd.docker.reference.type"
-	annotationAttestationManifest   = "attestation-manifest"
-	annotationDockerReferenceDigest = "vnd.docker.reference.digest"
-	annotationInTotoPredicateType   = "in-toto.io/predicate-type"
-	annotationSPDXDoc               = "https://spdx.dev/Document"
-	inTotoJsonMediaType             = "application/vnd.in-toto+json"
+	inTotoJsonMediaType = "application/vnd.in-toto+json"
 )
 
 // ImageSource a source for an image in the OCI distribution cache.
@@ -143,8 +139,8 @@ func (c ImageSource) SBoMs() ([]io.ReadCloser, error) {
 	desc := descs[0]
 
 	annotations := map[string]string{
-		annotationDockerReferenceType:   annotationAttestationManifest,
-		annotationDockerReferenceDigest: desc.Digest.String(),
+		util.AnnotationDockerReferenceType:   util.AnnotationAttestationManifest,
+		util.AnnotationDockerReferenceDigest: desc.Digest.String(),
 	}
 	descs, err = partial.FindManifests(index, matchAllAnnotations(annotations))
 	if err != nil {
@@ -183,7 +179,7 @@ func (c ImageSource) SBoMs() ([]io.ReadCloser, error) {
 	var readers []io.ReadCloser
 	for i, layer := range manifest.Layers {
 		annotations := layer.Annotations
-		if annotations[annotationInTotoPredicateType] != annotationSPDXDoc || layer.MediaType != inTotoJsonMediaType {
+		if annotations[util.AnnotationInTotoPredicateType] != util.AnnotationSPDXDoc || layer.MediaType != inTotoJsonMediaType {
 			continue
 		}
 		// get the actual blob of the layer
@@ -201,7 +197,7 @@ func (c ImageSource) SBoMs() ([]io.ReadCloser, error) {
 		if err := json.Unmarshal(buf.Bytes(), &stmt); err != nil {
 			return nil, err
 		}
-		if stmt.PredicateType != annotationSPDXDoc {
+		if stmt.PredicateType != util.AnnotationSPDXDoc {
 			return nil, fmt.Errorf("unexpected predicate type %s", stmt.PredicateType)
 		}
 		sbom := stmt.Predicate

--- a/src/cmd/linuxkit/cache/write.go
+++ b/src/cmd/linuxkit/cache/write.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	lktspec "github.com/linuxkit/linuxkit/src/cmd/linuxkit/spec"
+	lktutil "github.com/linuxkit/linuxkit/src/cmd/linuxkit/util"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	log "github.com/sirupsen/logrus"
 )
@@ -320,7 +321,7 @@ func (p *Provider) IndexWrite(ref *reference.Spec, descriptors ...v1.Descriptor)
 				appliedManifests[m.Digest] = true
 				continue
 			}
-			value, ok := m.Annotations[annotationDockerReferenceDigest]
+			value, ok := m.Annotations[lktutil.AnnotationDockerReferenceDigest]
 			if !ok {
 				manifest.Manifests = append(manifest.Manifests, m)
 				appliedManifests[m.Digest] = true

--- a/src/cmd/linuxkit/util/index.go
+++ b/src/cmd/linuxkit/util/index.go
@@ -1,0 +1,97 @@
+package util
+
+import (
+	"fmt"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+const (
+	AnnotationDockerReferenceDigest = "vnd.docker.reference.digest"
+	AnnotationDockerReferenceType   = "vnd.docker.reference.type"
+	AnnotationAttestationManifest   = "attestation-manifest"
+	AnnotationInTotoPredicateType   = "in-toto.io/predicate-type"
+	AnnotationSPDXDoc               = "https://spdx.dev/Document"
+)
+
+// AppendIndex appends the elements of secondary ImageIndex into primary ImageIndex,
+// returning the updated primary ImageIndex.
+// In the case of conflicts, the primary ImageIndex wins.
+// For example, if both have a manifest for a specific platform, then use the one from primary.
+// The append is aware of the buildkit-style attestations, and will keep any attestations that point to a valid
+// manifest in the list, discarding any that do not.
+func AppendIndex(primary, secondary v1.ImageIndex) (v1.ImageIndex, error) {
+	primaryManifest, err := primary.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+	secondaryManifest, err := secondary.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+	// figure out what already is in the index, and what should be overwritten
+	// what should be checked in the existing index:
+	// 1. platform - if it is in remote index but not in local, add to local
+	// 2. attestation - after all platforms, does it point to something in the updated index?
+	//      If not, remove
+
+	// make a map of all the digests already in the index, so we can know what is there
+	var (
+		manifestMap = map[v1.Hash]bool{}
+		platformMap = map[string]bool{}
+	)
+	for _, m := range primaryManifest.Manifests {
+		if m.Platform == nil || m.Platform.Architecture == "" {
+			continue
+		}
+		platformKey := fmt.Sprintf("%s/%s/%s", m.Platform.Architecture, m.Platform.OS, m.Platform.Variant)
+		manifestMap[m.Digest] = true
+		platformMap[platformKey] = true
+	}
+
+	for _, m := range secondaryManifest.Manifests {
+		// ignore any of those without a platform for this run (we will deal witb attestations in a second pass)
+		if m.Platform == nil || m.Platform.Architecture == "" || (m.Platform.Architecture == "unknown" && m.Platform.OS == "unknown") {
+			continue
+		}
+		platformKey := fmt.Sprintf("%s/%s/%s", m.Platform.Architecture, m.Platform.OS, m.Platform.Variant)
+		// primary wins if we already have this platform covered
+		if _, ok := platformMap[platformKey]; ok {
+			continue
+		}
+		if _, ok := manifestMap[m.Digest]; ok {
+			// we already have this one, so we can skip it
+			continue
+		}
+		primaryManifest.Manifests = append(primaryManifest.Manifests, m)
+		manifestMap[m.Digest] = true
+	}
+
+	// now we have assured that all of the images in the remote index are in the local index
+	// or overridden by matching local ones
+	// next we have to make sure that any sboms already on the remote index are still valid
+	// we either add them to the local index, or remove them if they are no longer valid
+	// we assume the ones in the local index are valid because they would have been generated now
+	for _, m := range secondaryManifest.Manifests {
+		if m.Platform == nil || m.Platform.Architecture != "unknown" || m.Platform.OS == "unknown" || m.Annotations == nil || m.Annotations[AnnotationDockerReferenceDigest] == "" {
+			continue
+		}
+		// if we already have this one, we are good
+		if _, ok := manifestMap[m.Digest]; ok {
+			continue
+		}
+		// the hash to which this attestation points
+		hash := m.Annotations[AnnotationDockerReferenceDigest]
+		dig, err := v1.NewHash(hash)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse hash %s: %v", hash, err)
+		}
+		// if this points at something not in the local index, do not bother adding it
+		if _, ok := manifestMap[dig]; !ok {
+			continue
+		}
+		primaryManifest.Manifests = append(primaryManifest.Manifests, m)
+		manifestMap[m.Digest] = true
+	}
+	return primary, nil
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This is a follow-up to #3954 ; that added sbom support to `lkt pkg build` and `lkt build`, but missed it for `lkt pkg push`. When it rebuilds and validates the index in the remote registry, it forgets to ensure that it holds onto existing attestations, as well as pushing ones from local cache.

This fixes it

**- How I did it**

Changes to `PushManifest()` and `Build()` to ensure it keeps them.

While I was at it, made the index merging much more robust, by validating each one on the remote, as well as attestations.

**- How to verify it**

CI does fine, and I tested manually as well on remote registry.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

push sboms
