### PR TITLE
noop to force pkg rebuild

### DIFF
--- a/examples/addbinds.yml
+++ b/examples/addbinds.yml
@@ -2,19 +2,19 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     binds.add:
       # this will keep all of the existing ones as well
       - /var/tmp:/var/tmp

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -22,7 +22,7 @@ onboot:
 
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
       - INSECURE=true
   - name: rngd

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -34,7 +34,7 @@ onboot:
       - /var:/var
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -28,7 +28,7 @@ onboot:
       - /var:/var
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,16 +4,16 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:c61565ee34e58823aaf7c05fd6359a8fd889137f # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   # support metadata for optional config in /run/config
   - name: metadata
     image: linuxkit/metadata:501144d47215671e77b9cac44748a04f21236195
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: sysfs
     image: linuxkit/sysfs:5fd982d39ff7bec8e480c67a110acb2d3794c291
   - name: binfmt
@@ -52,7 +52,7 @@ services:
     image: linuxkit/acpid:548f8f1c8bda31cdbefb65bdb0747f97c17639d2
   # Enable getty for easier debugging
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
         - INSECURE=true
   # Run ntpd to keep time synchronised in the VM

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: sysfs
     image: linuxkit/sysfs:5fd982d39ff7bec8e480c67a110acb2d3794c291
   - name: format
@@ -18,7 +18,7 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,19 +2,19 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     # to make insecure with passwordless root login, uncomment following lines
     #env:
     # - INSECURE=true

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -18,7 +18,7 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
     runtime:

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: dhcpcd
@@ -12,7 +12,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: influxdb

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,21 +3,21 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
-  - linuxkit/memlogd:9fe3a579b45200edeb3dce7ce3e95a40878c374b
+  - linuxkit/memlogd:1a00c05fea660cf66b9f532c98f718ef63698cb5
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
 # Inside the getty type `/proc/1/root/usr/bin/logread -F` to follow the log
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
 # A service which generates log messages for testing

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,15 +2,15 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,12 +2,12 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/platform-aws.yml
+++ b/examples/platform-aws.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/examples/platform-azure.yml
+++ b/examples/platform-azure.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
 services:
   - name: rngd
     image: linuxkit/rngd:310c16ec5315bd07d4b8f5332cfa7dc5cbc7d368

--- a/examples/platform-gcp.yml
+++ b/examples/platform-gcp.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -16,7 +16,7 @@ onboot:
     image: linuxkit/metadata:501144d47215671e77b9cac44748a04f21236195
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/platform-hetzner.yml
+++ b/examples/platform-hetzner.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
   - linuxkit/firmware:a17106a98940006529c714a3783eb03238c335a7
 onboot:
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/rngd:310c16ec5315bd07d4b8f5332cfa7dc5cbc7d368
     command: ["/sbin/rngd", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -24,7 +24,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:310c16ec5315bd07d4b8f5332cfa7dc5cbc7d368
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: sshd

--- a/examples/platform-packet.arm64.yml
+++ b/examples/platform-packet.arm64.yml
@@ -10,5 +10,5 @@ kernel:
   ucode: ""
 onboot:
   - name: modprobe
-    image: linuxkit/modprobe:767664e0e8b4a4ae34dac4ee7907a98d18fffe28
+    image: linuxkit/modprobe:ff76e806a0da0ea35f16951541cf3d24094b52c9
     command: ["modprobe", "nicvf"]

--- a/examples/platform-packet.yml
+++ b/examples/platform-packet.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
   - linuxkit/firmware:a17106a98940006529c714a3783eb03238c335a7
 onboot:
@@ -13,7 +13,7 @@ onboot:
     image: linuxkit/rngd:310c16ec5315bd07d4b8f5332cfa7dc5cbc7d368
     command: ["/sbin/rngd", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -24,7 +24,7 @@ services:
   - name: rngd
     image: linuxkit/rngd:310c16ec5315bd07d4b8f5332cfa7dc5cbc7d368
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: sshd

--- a/examples/platform-rt-for-vmware.yml
+++ b/examples/platform-rt-for-vmware.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:5.11.4-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/platform-scaleway.yml
+++ b/examples/platform-scaleway.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: rngd1
     image: linuxkit/rngd:310c16ec5315bd07d4b8f5332cfa7dc5cbc7d368
     command: ["/sbin/rngd", "-1"]
@@ -19,7 +19,7 @@ onboot:
     image: linuxkit/metadata:501144d47215671e77b9cac44748a04f21236195
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/platform-vmware.yml
+++ b/examples/platform-vmware.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/platform-vultr.yml
+++ b/examples/platform-vultr.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -17,7 +17,7 @@ onboot:
     command: ["/usr/bin/metadata", "vultr"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,16 +4,16 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   # Currently redis:4.0.6-alpine has trust issue with multi-arch

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,19 +2,19 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: rngd1
     image: linuxkit/rngd:310c16ec5315bd07d4b8f5332cfa7dc5cbc7d368
     command: ["/sbin/rngd", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/static-ip.yml
+++ b/examples/static-ip.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 onboot:
   - name: ip
     image: linuxkit/ip:c88e3272e3b12edec454e4720da8bb70a7655bc7
@@ -13,7 +13,7 @@ onboot:
     command: ["ip", "-b", "/etc/ip/eth0.conf"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
 files:     

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -24,7 +24,7 @@ onboot:
     command: ["/swap.sh", "--path", "/var/external/swap", "--size", "1G", "--encrypt"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,19 +2,19 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: tss

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -40,7 +40,7 @@ onboot:
           net: /run/netns/wg1
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
     net: /run/netns/wg1

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.15.27
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -18,7 +18,7 @@ onshutdown:
     command: ["/bin/echo", "so long and thanks for all the fish"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile to build linuxkit/containerd
+# Dockerfile to build linuxkit/containerd for linuxkit
 FROM linuxkit/alpine:316c3f9d85c21fdd8bc7479e81d290f85bf60eb0 as alpine
 
 RUN apk add tzdata binutils

--- a/pkg/getty/Dockerfile
+++ b/pkg/getty/Dockerfile
@@ -1,3 +1,4 @@
+# Dockerfile to build linuxkit/getty for linuxkit
 FROM linuxkit/alpine:316c3f9d85c21fdd8bc7479e81d290f85bf60eb0 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile to build linuxkit/init
+# Dockerfile to build linuxkit/init for linuxkit
 FROM linuxkit/containerd-dev:ee5755eb38c0a6b6aef2658b757652d82556c30c AS containerd-dev
 FROM linuxkit/alpine:316c3f9d85c21fdd8bc7479e81d290f85bf60eb0 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers

--- a/pkg/memlogd/Dockerfile
+++ b/pkg/memlogd/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile to build linuxkit/memlogd
+# Dockerfile to build linuxkit/memlogd for linuxkit
 FROM linuxkit/alpine:316c3f9d85c21fdd8bc7479e81d290f85bf60eb0 AS build
 
 RUN apk add --no-cache go musl-dev

--- a/pkg/modprobe/Dockerfile
+++ b/pkg/modprobe/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile to build linuxkit/modprobe
+# Dockerfile to build linuxkit/modprobe for linuxkit
 FROM linuxkit/alpine:316c3f9d85c21fdd8bc7479e81d290f85bf60eb0 AS mirror
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile to build linuxkit/runc
+# Dockerfile to build linuxkit/runc for linuxkit
 FROM linuxkit/alpine:316c3f9d85c21fdd8bc7479e81d290f85bf60eb0 as alpine
 RUN \
   apk add \

--- a/pkg/sysctl/Dockerfile
+++ b/pkg/sysctl/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile to build linuxkit/sysctl
+# Dockerfile to build linuxkit/sysctl for linuxkit
 FROM linuxkit/alpine:316c3f9d85c21fdd8bc7479e81d290f85bf60eb0 AS mirror
 
 RUN apk add --no-cache go musl-dev

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: sysfs
     image: linuxkit/sysfs:5fd982d39ff7bec8e480c67a110acb2d3794c291
   - name: dhcpcd
@@ -21,7 +21,7 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: sysfs
     image: linuxkit/sysfs:5fd982d39ff7bec8e480c67a110acb2d3794c291
   - name: dhcpcd
@@ -21,7 +21,7 @@ onboot:
     command: ["/usr/bin/mountie", "/var/lib/docker"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,14 +2,14 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,16 +2,16 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
 trust:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,17 +2,17 @@ kernel:
   image: linuxkit/kernel:4.9.34
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
   - samoht/fdd
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,12 +2,12 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcp-client
     image: miragesdk/dhcp-client:22aa9d527820534295a8cd59901c0c5197af6585
     net: host
@@ -30,7 +30,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:62036c2a279715d05e8298b9269a0659964f2619
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
 files:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,18 +2,18 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
 services:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
 trust:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,19 +2,19 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
     env:
      - INSECURE=true
   - name: rngd

--- a/src/cmd/linuxkit/moby/mkimage.yaml
+++ b/src/cmd/linuxkit/moby/mkimage.yaml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:4.9.39
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:43a37c8c98dfb4cdf9639223fa1baacf305eb5e7

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 
 onboot:
   - name: dhcpcd

--- a/test/cases/000_build/020_binds/test.yml
+++ b/test/cases/000_build/020_binds/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.30
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: mount
     image: linuxkit/mount:f671cb94a8999a65e33b3fe79f3def58e3d58b07

--- a/test/cases/000_build/050_sbom/test.yml
+++ b/test/cases/000_build/050_sbom/test.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 
 onboot:
   - name: package1

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:992d9c7531166fe071d945e8b2728d8b61eb8d5a

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:992d9c7531166fe071d945e8b2728d8b61eb8d5a

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:992d9c7531166fe071d945e8b2728d8b61eb8d5a

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:992d9c7531166fe071d945e8b2728d8b61eb8d5a

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:992d9c7531166fe071d945e8b2728d8b61eb8d5a

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:992d9c7531166fe071d945e8b2728d8b61eb8d5a

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:992d9c7531166fe071d945e8b2728d8b61eb8d5a

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:992d9c7531166fe071d945e8b2728d8b61eb8d5a

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:992d9c7531166fe071d945e8b2728d8b61eb8d5a

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:992d9c7531166fe071d945e8b2728d8b61eb8d5a

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 services:
   - name: acpid
     image: linuxkit/acpid:548f8f1c8bda31cdbefb65bdb0747f97c17639d2

--- a/test/cases/010_platforms/110_gcp/000_run/test.yml
+++ b/test/cases/010_platforms/110_gcp/000_run/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:992d9c7531166fe071d945e8b2728d8b61eb8d5a

--- a/test/cases/020_kernel/011_config_5.4.x/test.yml
+++ b/test/cases/020_kernel/011_config_5.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.172
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:6f722f5b4f25152e7cf465df79ae6b2aefd3a007

--- a/test/cases/020_kernel/013_config_5.10.x/test.yml
+++ b/test/cases/020_kernel/013_config_5.10.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:6f722f5b4f25152e7cf465df79ae6b2aefd3a007

--- a/test/cases/020_kernel/016_config_5.15.x/test.yml
+++ b/test/cases/020_kernel/016_config_5.15.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.15.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:6f722f5b4f25152e7cf465df79ae6b2aefd3a007

--- a/test/cases/020_kernel/111_kmod_5.4.x/test.yml
+++ b/test/cases/020_kernel/111_kmod_5.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.172
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/113_kmod_5.10.x/test.yml
+++ b/test/cases/020_kernel/113_kmod_5.10.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/116_kmod_5.15.x/test.yml
+++ b/test/cases/020_kernel/116_kmod_5.15.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.15.27
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/200_namespace/common.yml
+++ b/test/cases/020_kernel/200_namespace/common.yml
@@ -2,5 +2,5 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: sysfs
     image: linuxkit/sysfs:5fd982d39ff7bec8e480c67a110acb2d3794c291
   - name: format

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: test
     image: alpine:3.13

--- a/test/cases/040_packages/001_dummy/test.yml
+++ b/test/cases/040_packages/001_dummy/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: dummy
     image: linuxkit/dummy:b3004c5c8ecf05f8a315bef99078fe0a6deffcea

--- a/test/cases/040_packages/002_bcc/test.yml
+++ b/test/cases/040_packages/002_bcc/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
   - linuxkit/kernel-bcc:5.4.113
 onboot:
   - name: check-bcc

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:af88a591f9cc896a52ce596b9cf7ca26a061ef97

--- a/test/cases/040_packages/002_bpftrace/test.yml
+++ b/test/cases/040_packages/002_bpftrace/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
   - linuxkit/bpftrace:aa3c430a9998399875e6cf3511e38fd3ab07cc5f
 onboot:
   - name: bpftrace-test

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: test

--- a/test/cases/040_packages/003_cgroupv2/test.yml
+++ b/test/cases/040_packages/003_cgroupv2/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "linuxkit.unified_cgroup_hierarchy=1 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: test
     image: alpine:3.13

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,16 +2,16 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25
   - name: mount

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115

--- a/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: dm-crypt
     image: linuxkit/dm-crypt:526d32351c8246431be8e1a168cb514ff3c365af

--- a/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: dm-crypt
     image: linuxkit/dm-crypt:526d32351c8246431be8e1a168cb514ff3c365af

--- a/test/cases/040_packages/004_dm-crypt/002_key/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/002_key/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: dm-crypt
     image: linuxkit/dm-crypt:526d32351c8246431be8e1a168cb514ff3c365af

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: extend
     image: linuxkit/extend:aa486645c16e6465015970722bf6c9c19534d97e

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: modprobe
-    image: linuxkit/modprobe:767664e0e8b4a4ae34dac4ee7907a98d18fffe28
+    image: linuxkit/modprobe:ff76e806a0da0ea35f16951541cf3d24094b52c9
     command: ["modprobe", "btrfs"]
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: modprobe
-    image: linuxkit/modprobe:767664e0e8b4a4ae34dac4ee7907a98d18fffe28
+    image: linuxkit/modprobe:ff76e806a0da0ea35f16951541cf3d24094b52c9
     command: ["modprobe", "btrfs"]
   - name: extend
     image: linuxkit/extend:aa486645c16e6465015970722bf6c9c19534d97e

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: extend
     image: linuxkit/extend:aa486645c16e6465015970722bf6c9c19534d97e

--- a/test/cases/040_packages/005_extend/003_gpt/test-create.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25

--- a/test/cases/040_packages/005_extend/003_gpt/test.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: extend
     image: linuxkit/extend:aa486645c16e6465015970722bf6c9c19534d97e

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: modprobe
-    image: linuxkit/modprobe:767664e0e8b4a4ae34dac4ee7907a98d18fffe28
+    image: linuxkit/modprobe:ff76e806a0da0ea35f16951541cf3d24094b52c9
     command: ["modprobe", "btrfs"]
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25

--- a/test/cases/040_packages/006_format_mount/006_gpt/test.yml
+++ b/test/cases/040_packages/006_format_mount/006_gpt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: format
     image: linuxkit/format:5161fe240e5824da04d51bcf5e00afcb0c18dc25

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: dhcpcd
@@ -12,7 +12,7 @@ onboot:
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
-    image: linuxkit/getty:4fbbfb7d2e78c8da9be51fc93b78b96685fb1809
+    image: linuxkit/getty:e74e6cad132403d1a6d6cd25b136a7c69c99f3f7
 files:
   - path: etc/getty.shadow
     # sample sets password for root to "abcdefgh" (without quotes)

--- a/test/cases/040_packages/009_init_containerd/test.yml
+++ b/test/cases/040_packages/009_init_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 services:
   - name: test

--- a/test/cases/040_packages/011_kmsg/test.yml
+++ b/test/cases/040_packages/011_kmsg/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
-  - linuxkit/memlogd:9fe3a579b45200edeb3dce7ce3e95a40878c374b
+  - linuxkit/memlogd:1a00c05fea660cf66b9f532c98f718ef63698cb5
 services:
   - name: kmsg
     image: linuxkit/kmsg:ba81a0a3029b4bb7ee455f73892da9667397ca5b

--- a/test/cases/040_packages/012_logwrite/test.yml
+++ b/test/cases/040_packages/012_logwrite/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
-  - linuxkit/memlogd:9fe3a579b45200edeb3dce7ce3e95a40878c374b
+  - linuxkit/memlogd:1a00c05fea660cf66b9f532c98f718ef63698cb5
 services:
 # A service which generates logs of log messages
   - name: fill-the-logs

--- a/test/cases/040_packages/012_losetup/test.yml
+++ b/test/cases/040_packages/012_losetup/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: losetup
     image: linuxkit/losetup:fcee8e453684d45c3c411fe8c28ecb2210158638

--- a/test/cases/040_packages/013_metadata/000_cidata/test.yml
+++ b/test/cases/040_packages/013_metadata/000_cidata/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: metadata
     image: linuxkit/metadata:501144d47215671e77b9cac44748a04f21236195

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:43a37c8c98dfb4cdf9639223fa1baacf305eb5e7

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:992d9c7531166fe071d945e8b2728d8b61eb8d5a

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,11 +2,11 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:0aa4b1141fb890d260bb1f8f43c399f2c5419b04
+    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
   - name: test
     image: alpine:3.13
     net: host

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
   - linuxkit/ca-certificates:4de36e93dc87f7ccebd20db616ed10d381911d32
 onboot:
   - name: dhcpcd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
-  - linuxkit/containerd:4703525398adfe47764efbee8b36af79b4a6b097
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
+  - linuxkit/containerd:95d5f0d2d8dc63bd87e96b7b39cf026cb86125c9
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:2a8ed08fea442909ba10f950d458191ed3647115

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:5.10.104
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:aa44b2891ae0273bd194bcf261dc75425713c034
-  - linuxkit/runc:d02dbf3e72632831246ca9e2bc45772e2c3c02b8
+  - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04
+  - linuxkit/runc:2aabf16bc8a1b94e015ee53fa2e7a77ab1883a80
 onboot:
   - name: test-ns
     image: linuxkit/test-ns:bd163e189ce4985a798aa422c5509ef44e031756


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Following #3954, and the most recent fix to it to ensure `lkt pkg push` works with #3957, we need to repeat the noop change of #3956 to ensure the packages are pushed out with sboms.

**- How I did it**

I added noop changes to 7 packages to start: containerd, runc, getty, init, sysctl, memlogd, modprobe. These are commonly used in a lot of places. Eventually, we may get to the rest.

I also ran update-component-sha.sh to update any dependencies on them.

**- How to verify it**

Since I ran update-component-sha.sh, all of the tests were updated, so CI is more than sufficient.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

SBoMs included with some packages.
