### PR TITLE
Fix image pull with attestations

### DIFF
--- a/src/cmd/linuxkit/cache/errors.go
+++ b/src/cmd/linuxkit/cache/errors.go
@@ -1,0 +1,13 @@
+package cache
+
+import (
+	"fmt"
+)
+
+type noReferenceError struct {
+	reference string
+}
+
+func (e *noReferenceError) Error() string {
+	return fmt.Sprintf("no such reference: %s", e.reference)
+}

--- a/src/cmd/linuxkit/cache/pull.go
+++ b/src/cmd/linuxkit/cache/pull.go
@@ -15,8 +15,13 @@ const (
 	unknown = "unknown"
 )
 
-// ValidateImage given a reference, validate that it is complete. If not, pull down missing
-// components as necessary. It also calculates the hash of each component.
+// ValidateImage given a reference, validate that it is complete. If not, it will *not*
+// pull down missing content. This function is network-free. If you wish to validate
+// and fill in missing content, use PullImage.
+// If the reference is to an index, it will check the index for a manifest for the given
+// architecture, and any manifests that have no architecture at all. It will ignore manifests
+// for other architectures. If no architecture is provided, it will validate all manifests.
+// It also calculates the hash of each component.
 func (p *Provider) ValidateImage(ref *reference.Spec, architecture string) (lktspec.ImageSource, error) {
 	var (
 		imageIndex v1.ImageIndex
@@ -51,48 +56,39 @@ func (p *Provider) ValidateImage(ref *reference.Spec, architecture string) (lkts
 	case imageIndex == nil && image == nil:
 		// we did not find it yet - either because we were told not to look locally,
 		// or because it was not available - so get it from the remote
-		return ImageSource{}, errors.New("no such image")
+		return ImageSource{}, &noReferenceError{reference: imageName}
 	case imageIndex != nil:
 		// check that the index has a manifest for our arch, as well as any non-arch-specific ones
 		im, err := imageIndex.IndexManifest()
 		if err != nil {
-			return ImageSource{}, fmt.Errorf("could not get index manifest: %v", err)
+			return ImageSource{}, fmt.Errorf("could not get index manifest: %w", err)
 		}
-		var found bool
+		var architectures = make(map[string]bool)
+		// ignore only other architectures; manifest entries that have no architectures at all
+		// are going to be additional metadata, so we need to check them
 		for _, m := range im.Manifests {
-			if m.Platform == nil {
-				continue
-			}
-			if m.Platform.Architecture == architecture && m.Platform.OS == linux {
-				img, err := imageIndex.Image(m.Digest)
-				if err != nil {
-					return ImageSource{}, fmt.Errorf("unable to get image: %v", err)
-				}
-				if err := validate.Image(img); err != nil {
-					return ImageSource{}, fmt.Errorf("invalid image: %s", err)
-				}
-				found = true
-			}
-			if m.Platform.Architecture == unknown && m.Platform.OS == unknown {
-				img, err := imageIndex.Image(m.Digest)
-				if err != nil {
-					return ImageSource{}, fmt.Errorf("unable to get image: %v", err)
-				}
-				if err := validate.Image(img); err != nil {
-					return ImageSource{}, fmt.Errorf("invalid image: %s", err)
+			if m.Platform == nil || (m.Platform.Architecture == unknown && m.Platform.OS == unknown) {
+				if err := validateManifestContents(imageIndex, m.Digest); err != nil {
+					return ImageSource{}, fmt.Errorf("invalid image: %w", err)
 				}
 			}
-			if found {
-				return p.NewSource(
-					ref,
-					architecture,
-					desc,
-				), nil
+			if architecture != "" && m.Platform.Architecture == architecture && m.Platform.OS == linux {
+				if err := validateManifestContents(imageIndex, m.Digest); err != nil {
+					return ImageSource{}, fmt.Errorf("invalid image: %w", err)
+				}
+				architectures[architecture] = true
 			}
+		}
+		if architecture == "" || architectures[architecture] {
+			return p.NewSource(
+				ref,
+				architecture,
+				desc,
+			), nil
 		}
 		return ImageSource{}, fmt.Errorf("index for %s did not contain image for platform linux/%s", imageName, architecture)
 	case image != nil:
-		// we found a local image, make sure it is up to date, and that it matches our platform
+		// we found a local image, make sure it is up to date
 		if err := validate.Image(image); err != nil {
 			return ImageSource{}, fmt.Errorf("invalid image, %s", err)
 		}
@@ -104,4 +100,21 @@ func (p *Provider) ValidateImage(ref *reference.Spec, architecture string) (lkts
 	}
 	// if we made it to here, we had some strange error
 	return ImageSource{}, errors.New("should not have reached this point, image index and image were both empty and not-empty")
+}
+
+// validateManifestContents given an index and a digest, validate that the contents of the
+// manifest are a valid image. This function is network-free.
+// The only validation it does is checks that all of the parts of the image exist.
+func validateManifestContents(index v1.ImageIndex, digest v1.Hash) error {
+	img, err := index.Image(digest)
+	if err != nil {
+		return fmt.Errorf("unable to get image: %w", err)
+	}
+	if _, err := img.ConfigFile(); err != nil {
+		return fmt.Errorf("unable to get config: %w", err)
+	}
+	if _, err := img.Layers(); err != nil {
+		return fmt.Errorf("unable to get layers: %w", err)
+	}
+	return nil
 }

--- a/src/cmd/linuxkit/moby/build.go
+++ b/src/cmd/linuxkit/moby/build.go
@@ -173,7 +173,7 @@ func Build(m Moby, w io.Writer, opts BuildOpts) error {
 		log.Infof("Process init image: %s", ii)
 		err := ImageTar(ii, "", apkTar, resolvconfSymlink, opts)
 		if err != nil {
-			return fmt.Errorf("Failed to build init tarball from %s: %v", ii, err)
+			return fmt.Errorf("failed to build init tarball from %s: %v", ii, err)
 		}
 	}
 	if err := apkTar.WriteAPKDB(); err != nil {

--- a/src/cmd/linuxkit/moby/images.go
+++ b/src/cmd/linuxkit/moby/images.go
@@ -24,21 +24,12 @@ func imagePull(ref *reference.Spec, alwaysPull bool, cacheDir string, dockerCach
 		// docker is not required, so any error - image not available, no docker, whatever - just gets ignored
 	}
 
-	// next try the local cache
-	if !alwaysPull {
-		c, err := cache.NewProvider(cacheDir)
-		if err != nil {
-			return nil, err
-		}
-		if image, err := c.ValidateImage(ref, architecture); err == nil {
-			return image, nil
-		}
-	}
-
-	// if we made it here, we either did not have the image, or it was incomplete
+	// get a reference to the local cache; we either will find the ref there or will pull to it
 	c, err := cache.NewProvider(cacheDir)
 	if err != nil {
 		return nil, err
 	}
+
+	// if we made it here, we either did not have the image, or it was incomplete
 	return c.ImagePull(ref, ref.String(), architecture, alwaysPull)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes #3961

`validate.Image()` does not handle layers that are not actual tar+gzip, so in-toto attestations break it. Needed a workaround. Also makes it a lot simpler.

**- How I did it**

Changed source.

**- How to verify it**

CI is enough.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Handle attestations on pulls better.
