### PR TITLE
report package cache contents at each stage of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,10 @@ jobs:
       run: |
         make OPTIONS="-v --skip-platforms linux/s390x" -C test/pkg build
 
+    - name: list cache contents
+      run: |
+        linuxkit cache ls
+
   test_packages:
     name: Packages Tests
     needs: [ build_packages, build ]
@@ -181,7 +185,10 @@ jobs:
         key: ${{ runner.os }}-linuxkit-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-linuxkit-
-
+    - name: list cache contents
+      run: |
+        linuxkit cache ls
+      
     - name: Run Tests
       run: make test TEST_SUITE=linuxkit.packages TEST_SHARD=${{ matrix.shard }}
 
@@ -234,6 +241,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-linuxkit-
 
+    - name: list cache contents
+      run: |
+        linuxkit cache ls
+      
     - name: Run Tests
       run: make test TEST_SUITE=linuxkit.kernel
 
@@ -286,6 +297,10 @@ jobs:
         sudo ln -s $(pwd)/bin/linuxkit-amd64-linux /usr/local/bin/linuxkit
         /usr/local/bin/linuxkit version
 
+    - name: list cache contents
+      run: |
+        linuxkit cache ls
+  
     - name: Run Tests
       run: make test TEST_SUITE=linuxkit.build
 
@@ -338,6 +353,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-linuxkit-
 
+    - name: list cache contents
+      run: |
+        linuxkit cache ls
+      
     - name: Run Tests
       run: make test TEST_SUITE=linuxkit.platforms
 
@@ -390,5 +409,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-linuxkit-
 
+    - name: list cache contents
+      run: |
+        linuxkit cache ls
+      
     - name: Run Tests
       run: make test TEST_SUITE=linuxkit.security


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

We have been having some issues with packages built in previous stages of CI, and cached, not showing up during build. The cache contents do cache and restore, apparently correctly, so this doesn't make sense.

I added `lkt cache ls` after building packages (before upload) and before each testing stage, so we can see if the contents make sense.

I probably will merge this in; it doesn't hurt.

**- How I did it**

Added a step to most of ci.yaml

**- How to verify it**

Let CI run.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
better output reporting during CI
