### PR TITLE
logread: do not close socket too early

### DIFF
--- a/pkg/memlogd/cmd/logread/main.go
+++ b/pkg/memlogd/cmd/logread/main.go
@@ -67,7 +67,6 @@ func StreamLogs(socketPath string, follow, dump bool) (<-chan LogEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	var n int
 	switch {
@@ -85,6 +84,7 @@ func StreamLogs(socketPath string, follow, dump bool) (<-chan LogEntry, error) {
 
 	c := make(chan LogEntry)
 	go func(c chan<- LogEntry) {
+		defer conn.Close()
 		var (
 			entry   LogEntry
 			decoder = json.NewDecoder(conn)


### PR DESCRIPTION
only close socket once reading is finished

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix bug where `logread` does not return anything

**- How I did it**
Closing socket only after reading from socket is finished.

**- How to verify it**
Run `logread` in eve and see that it now prints out log messages.

**- Description for the changelog**
Fix logread bug but not closing socket before reading.


**- A picture of a cute animal (not mandatory but encouraged)**

https://www.youtube.com/watch?v=AV9z0c1hjnA&pp=ygUPYmVzdCByYXQgdHJpY2tz