### PR TITLE
kernels Makefile support custom builders and archs

### DIFF
--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -191,6 +191,68 @@ Anyone modifying a kernel should:
 1. A maintainer should run `make push` to push out the images.
 1. Run (or rerun) the tests.
 
+#### Build options
+
+The targets and variants for building are as follows:
+
+* `make build` - make all kernels in the version list and their variants
+* `make build-<version>` - make all variants of a specific kernel version
+* `make buildkernel-<version>` - make all variants of a specific kernel version
+* `make buildplainkernel-<version>` - make just the provided version's kernel
+* `make builddebugkernel-<version>` - make just the provided version's debug kernel
+* `make buildtools-<version>` - make just the provided version's tools
+
+To push:
+
+* `make push` - push all kernels in the version list and their variants
+* `make push-<version>` - push all variants of a specific kernel version
+
+Finally, for convenience:
+
+* `make list` - list all kernels in the version list
+
+By default, it builds for all supported architectures. To build just for a specific
+architecture:
+
+```sh
+make build ARCH=amd64
+```
+
+The variable `ARCH` should use the golang variants only, i.e. `amd64` and `arm64`.
+
+To build for multiple architectures, call it multiple times:
+
+```sh
+make build ARCH=amd64
+make build ARCH=arm64
+```
+
+When building for a specific architecture, the build process will use your local
+Docker, passing it `--platforms` for the architecture. If you have a builder on a different
+architecture, e.g. you are running on an Apple Silicon Mac (arm64) and want to build for
+`x86_64` without emulating (which can be very slow), you can use the `BUILDER` variable:
+
+```sh
+make build ARCH=x86_64 BUILDER=remote-amd64-builder
+```
+
+Builder also supports a builder pattern. If `BUILDER` contains the string `{{.Arch}}`,
+it will be replaced with the architecture being built.
+
+For example:
+
+```sh
+make build ARCH=x86_64 BUILDER=remote-{{.Arch}}-builder
+make build ARCH=aarch64 BUILDER=remote-{{.Arch}}-builder
+```
+
+will build `x86_64` on `remote-amd64-builder` and `aarch64` on `remote-arm64-builder`.
+
+Finally, if no `BUILDER` is specified, the build will look for a builder named
+`linuxkit-linux-{{.Arch}}-builder`, e.g. `linuxkit-linux-amd64-builder` or
+`linuxkit-linux-arm64-builder`. If that builder does not exist, it will fall back to
+your local Docker setup.
+
 ### Modifying the kernel config
 
 The process of modifying the kernel configuration is as follows:

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -40,14 +40,18 @@ endif
 # Path to push-manifest.sh
 PUSH_MANIFEST:=$(shell git rev-parse --show-toplevel)/scripts/push-manifest.sh
 
+# determine our architecture
+BUILDERARCH=
 ARCH := $(shell uname -m)
 ifeq ($(ARCH),$(filter $(ARCH),x86_64 amd64))
 SUFFIX=-amd64
-ARCH=x86_64
+override ARCH=x86_64
+BUILDERARCH=amd64
 endif
 ifeq ($(ARCH),$(filter $(ARCH),aarch64 arm64))
 SUFFIX=-arm64
-ARCH=aarch64
+override ARCH=aarch64
+BUILDERARCH=arm64
 endif
 
 HASHTAG=$(HASH)$(DIRTY)
@@ -111,10 +115,14 @@ TOOLS=bcc perf
 # kernel versions used for kconfig
 KERNEL_VERSIONS=$(call uniq,$(foreach l,$(KERNELS),$(word 1,$(subst -, ,$(l)))))
 
-.PHONY: build push setforce show-tags
-# Targets:
-# build: Builds all kernels
-# push:  Pushes and sign all tagged kernel images to hub
+.PHONY: build push setforce show-tags list
+
+list:
+	@echo "Arch: $(ARCH)"
+	@echo "Kernels: $(KERNELS)"
+	@echo "Deprecated: $(DEPRECATED)"
+	@echo "Tools: $(TOOLS)"
+
 setforce:
 	$(eval FORCE=1)
 build: $(addprefix build-,$(KERNELS))
@@ -127,18 +135,42 @@ buildkernel-%: buildkerneldeps-% buildplainkernel-% builddebugkernel-%;
 
 buildkerneldeps-%: Dockerfile Makefile $(wildcard patches-$(call series,$*)/*) $(wildcard config-$(call series,$*)*) ;
 
-buildplainkernel-%: buildkerneldeps-% 
+BUILDER?=
+BUILDER_TEMPLATE = linuxkit-linux-{{.Arch}}-builder
+BULDER_ARG =
+
+
+# Phony target for conditional logic
+.PHONY: getbuilder
+# determine the builder
+# if it was set by user, just add `--builder <builder>`.
+# If not, see if our default builder pattern is available, and use that, else
+# fall back to usual docker.
+getbuilder:
+ifeq ($(BUILDER),)
+	$(eval BUILDERNAME=$(subst {{.Arch}},$(BUILDERARCH),$(BUILDER_TEMPLATE)))
+	$(eval BUILDER_FOUND=$(shell docker builder inspect $(BUILDERNAME) 2>/dev/null || true))
+	$(eval BUILDER_ARG=$(if $(BUILDER_FOUND),--builder $(BUILDERNAME),))
+else
+	$(eval BUILDERNAME=$(subst {{.Arch}},$(BUILDERARCH),$(BUILDER)))
+	$(eval BUILDER_ARG=--builder $(BUILDERNAME))
+endif
+
+buildplainkernel-%: buildkerneldeps-% getbuilder
 	$(eval BASEIMAGE=$(call baseimage,$*))
 	$(eval TARGETIMAGE=$(BASEIMAGE)-$(HASHTAG)$(SUFFIX))
 	$(eval EXTRATOOL=$(addprefix -,$(word 2,$(subst -, ,$*))))
-	([ -z "$(FORCE)" ] && docker pull $(TARGETIMAGE)) || \
+	([ -z "$(FORCE)" ] && docker manifest inspect $(TARGETIMAGE) >/dev/null 2>&1) || \
 		docker build \
+			$(BUILDER_ARG) \
+			--platform linux/$(BUILDERARCH) \
 			--build-arg KERNEL_VERSION=$* \
 			--build-arg KERNEL_SERIES=$(call series,$*) \
 			--build-arg EXTRA=$(EXTRATOOL) \
 			--build-arg DEBUG=$(DEBUG) \
 			--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
 			$(LABELS) \
+			--load \
 			--no-cache -t $(TARGETIMAGE) .
 
 builddebugkernel-%: buildkerneldeps-%
@@ -157,7 +189,7 @@ pushtagpush-%:
 	$(eval HASHIMAGE=$(BASEIMAGE)-$(HASHTAG))
 	$(eval SUFFIXEDIMAGE=$(BASEIMAGE)$(SUFFIX))
 	$(eval HASHANDSUFFIXIMAGE=$(HASHIMAGE)$(SUFFIX))
-	([ -z "$(FORCE)" ] && docker pull $(HASHANDSUFFIXIMAGE)) || \
+	([ -z "$(FORCE)" ] && docker manifest inspect $(HASHANDSUFFIXIMAGE) >/dev/null 2>&1) || \
 		(docker push $(HASHANDSUFFIXIMAGE) && \
 		 docker tag $(HASHANDSUFFIXIMAGE) $(SUFFIXEDIMAGE) && \
 		 docker push $(SUFFIXEDIMAGE) && \
@@ -172,14 +204,17 @@ show-tag-%:
 
 buildtools-%: $(addprefix buildtool-%$(RELEASESEP),$(TOOLS));
 
-buildtool-%:
+buildtool-%: getbuilder
 	$(eval TARGETIMAGE=$(call toolimagehash,$*))
 	$(eval KERNELIMAGE=$(call toolkernelimage,$*))
 	$(eval TOOL=$(call toolname,$*))
-	([ -z "$(FORCE)" ] && docker pull $(TARGETIMAGE)) || \
+	([ -z "$(FORCE)" ] && docker manifest inspect $(TARGETIMAGE) >/dev/nul 2>&1) || \
 		 docker build -f Dockerfile.$(TOOL) \
+			$(BUILDER_ARG) \
+			--platform linux/$(BUILDERARCH) \
 			--build-arg IMAGE=$(KERNELIMAGE) \
 			--build-arg BUILD_IMAGE=$(IMAGE_BUILDER) \
+			--load \
 			--no-cache $(LABEL) -t $(TARGETIMAGE) .
 
 pushtools-%: $(addprefix pushtool-%$(RELEASESEP),$(TOOLS));


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

For kernel Makefile 

* Added option to build for other ARCH, e.g. `make build-6.6.13 ARCH=amd64`
* Added option to specify a docker builder, and, if one is not specified, to fall back to `linuxkit-linux-{{.Arch}}-builder`
* Added `make list` to list all of the outputs and targets
* Documented it all in `kernels.md`

**- How I did it**

Changes in Makefile

**- How to verify it**

Run it and see; I did 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Better kernel Makefile options
