### PR TITLE
use proper null in script and not mispelled nul

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -208,7 +208,7 @@ buildtool-%: getbuilder
 	$(eval TARGETIMAGE=$(call toolimagehash,$*))
 	$(eval KERNELIMAGE=$(call toolkernelimage,$*))
 	$(eval TOOL=$(call toolname,$*))
-	([ -z "$(FORCE)" ] && docker manifest inspect $(TARGETIMAGE) >/dev/nul 2>&1) || \
+	([ -z "$(FORCE)" ] && docker manifest inspect $(TARGETIMAGE) >/dev/null 2>&1) || \
 		 docker build -f Dockerfile.$(TOOL) \
 			$(BUILDER_ARG) \
 			--platform linux/$(BUILDERARCH) \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed a script where output was redirected to `/dev/nul` instead of `/dev/null` (missing `/`)

**- How I did it**

Typing

**- How to verify it**

I ran it. This is so simple, not much more than that

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed typo in script with /dev/nul
