### PR TITLE
enable import of images from tar files

### DIFF
--- a/src/cmd/linuxkit/cache.go
+++ b/src/cmd/linuxkit/cache.go
@@ -25,5 +25,6 @@ func cacheCmd() *cobra.Command {
 	cmd.AddCommand(cacheRmCmd())
 	cmd.AddCommand(cacheLsCmd())
 	cmd.AddCommand(cacheExportCmd())
+	cmd.AddCommand(cacheImportCmd())
 	return cmd
 }

--- a/src/cmd/linuxkit/cache/blob.go
+++ b/src/cmd/linuxkit/cache/blob.go
@@ -1,0 +1,11 @@
+package cache
+
+import (
+	"io"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func (p *Provider) GetContent(hash v1.Hash) (io.ReadCloser, error) {
+	return p.cache.Blob(hash)
+}

--- a/src/cmd/linuxkit/cache_import.go
+++ b/src/cmd/linuxkit/cache_import.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"io"
+	"os"
+
+	cachepkg "github.com/linuxkit/linuxkit/src/cmd/linuxkit/cache"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func cacheImportCmd() *cobra.Command {
+	var (
+		inputFile string
+	)
+	cmd := &cobra.Command{
+		Use:   "import",
+		Short: "import individual images to the linuxkit cache",
+		Long: `Import individual images from tar file to the linuxkit cache.
+		Can provide the file on the command-line or via stdin with filename '-'.
+		
+		Example:
+		linuxkit cache import myimage.tar
+		cat myimage.tar | linuxkit cache import -
+
+		Tarfile format must be the OCI v1 file format, see https://github.com/opencontainers/image-spec/blob/main/image-layout.md
+		`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			paths := args
+			infile := paths[0]
+
+			p, err := cachepkg.NewProvider(cacheDir)
+			if err != nil {
+				log.Fatalf("unable to read a local cache: %v", err)
+			}
+
+			var reader io.ReadCloser
+			if inputFile == "-" {
+				reader = os.Stdin
+			} else {
+				f, err := os.Open(infile)
+				if err != nil {
+					log.Fatalf("unable to open %s: %v", infile, err)
+				}
+				defer f.Close()
+				reader = f
+			}
+			defer reader.Close()
+
+			if _, err := p.ImageLoad(reader); err != nil {
+				log.Fatalf("unable to load image: %v", err)
+			}
+
+			return err
+		},
+	}
+
+	return cmd
+}

--- a/src/cmd/linuxkit/spec/cache.go
+++ b/src/cmd/linuxkit/spec/cache.go
@@ -33,7 +33,7 @@ type CacheProvider interface {
 	IndexWrite(ref *reference.Spec, descriptors ...v1.Descriptor) (ImageSource, error)
 	// ImageLoad takes an OCI format image tar stream in the io.Reader and writes it to the cache. It should be
 	// efficient and only write missing blobs, based on their content hash.
-	ImageLoad(ref *reference.Spec, architecture string, r io.Reader) ([]v1.Descriptor, error)
+	ImageLoad(r io.Reader) ([]v1.Descriptor, error)
 	// DescriptorWrite writes a descriptor to the cache index; it validates that it has a name
 	// and replaces any existing one
 	DescriptorWrite(ref *reference.Spec, descriptors v1.Descriptor) (ImageSource, error)
@@ -42,6 +42,9 @@ type CacheProvider interface {
 	Push(name string, withManifest bool) error
 	// NewSource return an ImageSource for a specific ref and architecture in the cache.
 	NewSource(ref *reference.Spec, architecture string, descriptor *v1.Descriptor) ImageSource
+	// GetContent returns an io.Reader to the provided content as is, given a specific digest. It is
+	// up to the caller to validate it.
+	GetContent(hash v1.Hash) (io.ReadCloser, error)
 	// Store get content.Store referencing the cache
 	Store() (content.Store, error)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

* Simplified how `cache.ImageLoad()` works
* used it to create `linuxkit cache import`
* Removed accidental adding of too many manifests to cache `index.json` because of how it processed `ImageLoad()`

**- How I did it**

Lots of hard work.

**- How to verify it**

CI tests most of this. I also ran manual tests on a clean cache and on a populated cache

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Simplified ImageLoad, support for importing to cache
