### PR TITLE
Dockerfile in build yml and CLI; tag templates

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -50,6 +50,7 @@ A package source consists of a directory containing at least two files:
 
 - `image` _(string)_: *(mandatory)* The name of the image to build
 - `org` _(string)_: The hub/registry organisation to which this package belongs
+- `dockerfile` _(string)_: The dockerfile to use to build this package, must be in this directory or below (default: `Dockerfile`)
 - `arches` _(list of string)_: The architectures which this package should be built for (valid entries are `GOARCH` names)
 - `extra-sources` _(list of strings)_: Additional sources for the package outside the package directory. The format is `src:dst`, where `src` can be relative to the package directory and `dst` is the destination in the build context. This is useful for sharing files, such as vendored go code, between packages.
 - `gitrepo` _(string)_: The git repository where the package source is kept.

--- a/src/cmd/linuxkit/pkg.go
+++ b/src/cmd/linuxkit/pkg.go
@@ -22,6 +22,7 @@ func pkgCmd() *cobra.Command {
 		hashPath        string
 		dirty           bool
 		devMode         bool
+		tag             string
 	)
 
 	cmd := &cobra.Command{
@@ -36,6 +37,7 @@ func pkgCmd() *cobra.Command {
 				HashPath:   hashPath,
 				Dirty:      dirty,
 				Dev:        devMode,
+				Tag:        tag,
 			}
 			if cmd.Flags().Changed("disable-cache") && cmd.Flags().Changed("enable-cache") {
 				return errors.New("cannot set but disable-cache and enable-cache")
@@ -85,6 +87,7 @@ func pkgCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&argOrg, "org", piBase.Org, "Override the hub org")
 	cmd.PersistentFlags().StringVar(&buildYML, "build-yml", "build.yml", "Override the name of the yml file")
 	cmd.PersistentFlags().StringVar(&hash, "hash", "", "Override the image hash (default is to query git for the package's tree-sh)")
+	cmd.PersistentFlags().StringVar(&tag, "tag", "{{.Hash}}", "Override the tag using fixed strings and/or text templates. Acceptable are .Hash for the hash")
 	cmd.PersistentFlags().StringVar(&hashCommit, "hash-commit", "HEAD", "Override the git commit to use for the hash")
 	cmd.PersistentFlags().StringVar(&hashPath, "hash-path", "", "Override the directory to use for the image hash, must be a parent of the package dir (default is to use the package dir)")
 	cmd.PersistentFlags().BoolVar(&dirty, "force-dirty", false, "Force the pkg(s) to be considered dirty")

--- a/src/cmd/linuxkit/pkg_build.go
+++ b/src/cmd/linuxkit/pkg_build.go
@@ -45,6 +45,7 @@ func addCmdRunPkgBuildPush(cmd *cobra.Command, withPush bool) *cobra.Command {
 		manifest       bool
 		cacheDir       = flagOverEnvVarOverDefaultString{def: defaultLinuxkitCache(), envVar: envVarCacheDir}
 		sbomScanner    string
+		dockerfile     string
 	)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -92,6 +93,7 @@ func addCmdRunPkgBuildPush(cmd *cobra.Command, withPush bool) *cobra.Command {
 		if sbomScanner != "false" {
 			opts = append(opts, pkglib.WithBuildSbomScanner(sbomScanner))
 		}
+		opts = append(opts, pkglib.WithDockerfile(dockerfile))
 
 		// skipPlatformsMap contains platforms that should be skipped
 		skipPlatformsMap := make(map[string]bool)
@@ -128,12 +130,12 @@ func addCmdRunPkgBuildPush(cmd *cobra.Command, withPush bool) *cobra.Command {
 		// look for builders env var
 		buildersMap, err = buildPlatformBuildersMap(os.Getenv(buildersEnvVar), buildersMap)
 		if err != nil {
-			return fmt.Errorf("error in environment variable %s: %w\n", buildersEnvVar, err)
+			return fmt.Errorf("error in environment variable %s: %w", buildersEnvVar, err)
 		}
 		// any CLI options override env var
 		buildersMap, err = buildPlatformBuildersMap(builders, buildersMap)
 		if err != nil {
-			return fmt.Errorf("error in --builders flag: %w\n", err)
+			return fmt.Errorf("error in --builders flag: %w", err)
 		}
 		opts = append(opts, pkglib.WithBuildBuilders(buildersMap))
 		opts = append(opts, pkglib.WithBuildBuilderImage(builderImage))
@@ -202,6 +204,7 @@ func addCmdRunPkgBuildPush(cmd *cobra.Command, withPush bool) *cobra.Command {
 	cmd.Flags().BoolVar(&nobuild, "nobuild", false, "Skip building the image before pushing, conflicts with -force")
 	cmd.Flags().BoolVar(&manifest, "manifest", true, "Create and push multi-arch manifest")
 	cmd.Flags().StringVar(&sbomScanner, "sbom-scanner", "", "SBOM scanner to use, must match the buildkit spec; set to blank to use the buildkit default; set to 'false' for no scanning")
+	cmd.Flags().StringVar(&dockerfile, "dockerfile", "", "Dockerfile to use for building the image, must be in this directory or below, overrides what is in build.yml")
 
 	return cmd
 }

--- a/src/cmd/linuxkit/pkglib/build_test.go
+++ b/src/cmd/linuxkit/pkglib/build_test.go
@@ -534,6 +534,7 @@ func TestBuild(t *testing.T) {
 				}
 				opts = append(opts, WithBuildPlatforms(targets...))
 			}
+			tt.p.dockerfile = "testdata/Dockerfile"
 			err := tt.p.Build(opts...)
 			switch {
 			case (tt.err == "" && err != nil) || (tt.err != "" && err == nil) || (tt.err != "" && err != nil && !strings.HasPrefix(err.Error(), tt.err)):

--- a/src/cmd/linuxkit/pkglib/build_test.go
+++ b/src/cmd/linuxkit/pkglib/build_test.go
@@ -58,7 +58,7 @@ func (d *dockerMocker) contextSupportCheck() error {
 func (d *dockerMocker) builder(_ context.Context, _, _, _ string, _ bool) (*buildkitClient.Client, error) {
 	return nil, fmt.Errorf("not implemented")
 }
-func (d *dockerMocker) build(ctx context.Context, tag, pkg, dockerContext, builderImage, platform string, builderRestart bool, c lktspec.CacheProvider, r io.Reader, stdout io.Writer, sbomScan bool, sbomScannerImage string, imageBuildOpts dockertypes.ImageBuildOptions) error {
+func (d *dockerMocker) build(ctx context.Context, tag, pkg, dockerfile, dockerContext, builderImage, platform string, builderRestart bool, c lktspec.CacheProvider, r io.Reader, stdout io.Writer, sbomScan bool, sbomScannerImage string, imageBuildOpts dockertypes.ImageBuildOptions) error {
 	if !d.enableBuild {
 		return errors.New("build disabled")
 	}

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -18,6 +18,7 @@ import (
 type pkgInfo struct {
 	Image        string            `yaml:"image"`
 	Org          string            `yaml:"org"`
+	Dockerfile   string            `yaml:"dockerfile"`
 	Arches       []string          `yaml:"arches"`
 	ExtraSources []string          `yaml:"extra-sources"`
 	GitRepo      string            `yaml:"gitrepo"` // ??
@@ -51,6 +52,7 @@ type PkglibConfig struct {
 	Dev          bool
 }
 
+// NewPkInfo returns a new pkgInfo with default values
 func NewPkgInfo() pkgInfo {
 	return pkgInfo{
 		Org:          "linuxkit",
@@ -58,6 +60,7 @@ func NewPkgInfo() pkgInfo {
 		GitRepo:      "https://github.com/linuxkit/linuxkit",
 		Network:      false,
 		DisableCache: false,
+		Dockerfile:   "Dockerfile",
 	}
 }
 
@@ -84,6 +87,7 @@ type Pkg struct {
 
 	// Internal state
 	path       string
+	dockerfile string
 	hash       string
 	dirty      bool
 	commitHash string
@@ -265,6 +269,7 @@ func NewFromConfig(cfg PkglibConfig, args ...string) ([]Pkg, error) {
 			dockerDepends: dockerDepends,
 			dirty:         dirty,
 			path:          pkgPath,
+			dockerfile:    pi.Dockerfile,
 			git:           git,
 		})
 	}

--- a/test/cases/000_build/055_dockerfiles/000_missing_in_yml/Dockerfile
+++ b/test/cases/000_build/055_dockerfiles/000_missing_in_yml/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.19

--- a/test/cases/000_build/055_dockerfiles/000_missing_in_yml/build.yml
+++ b/test/cases/000_build/055_dockerfiles/000_missing_in_yml/build.yml
@@ -1,0 +1,3 @@
+org: linuxkit
+image: missing-in-yml
+dockerfile: Dockerfilenotexist

--- a/test/cases/000_build/055_dockerfiles/000_missing_in_yml/test.sh
+++ b/test/cases/000_build/055_dockerfiles/000_missing_in_yml/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# SUMMARY: Check that tar output format build is reproducible
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+set +e
+linuxkit pkg build --force .
+command_status=$?
+set -e
+
+if [ $command_status -eq 0 ]; then
+    echo "Command should have failed"
+    exit 1
+fi
+
+exit 0

--- a/test/cases/000_build/055_dockerfiles/001_missing_in_yml_found_cli/Dockerfile
+++ b/test/cases/000_build/055_dockerfiles/001_missing_in_yml_found_cli/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.19

--- a/test/cases/000_build/055_dockerfiles/001_missing_in_yml_found_cli/build.yml
+++ b/test/cases/000_build/055_dockerfiles/001_missing_in_yml_found_cli/build.yml
@@ -1,0 +1,3 @@
+org: linuxkit
+image: missing-in-yml
+dockerfile: Dockerfilenotexist

--- a/test/cases/000_build/055_dockerfiles/001_missing_in_yml_found_cli/test.sh
+++ b/test/cases/000_build/055_dockerfiles/001_missing_in_yml_found_cli/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# SUMMARY: Check that tar output format build is reproducible
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+linuxkit pkg build --force --dockerfile Dockerfile .
+
+exit 0

--- a/test/cases/000_build/055_dockerfiles/002_found_in_yml_missing_cli/Dockerfile
+++ b/test/cases/000_build/055_dockerfiles/002_found_in_yml_missing_cli/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.19

--- a/test/cases/000_build/055_dockerfiles/002_found_in_yml_missing_cli/build.yml
+++ b/test/cases/000_build/055_dockerfiles/002_found_in_yml_missing_cli/build.yml
@@ -1,0 +1,3 @@
+org: linuxkit
+image: missing-in-yml
+dockerfile: Dockerfile

--- a/test/cases/000_build/055_dockerfiles/002_found_in_yml_missing_cli/test.sh
+++ b/test/cases/000_build/055_dockerfiles/002_found_in_yml_missing_cli/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# SUMMARY: Check that tar output format build is reproducible
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+set +e
+linuxkit pkg build --force --dockerfile nosuchfile .
+command_status=$?
+set -e
+
+if [ $command_status -eq 0 ]; then
+    echo "Command should have failed"
+    exit 1
+fi
+
+exit 0

--- a/test/cases/000_build/055_dockerfiles/003_default/Dockerfile
+++ b/test/cases/000_build/055_dockerfiles/003_default/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.19

--- a/test/cases/000_build/055_dockerfiles/003_default/build.yml
+++ b/test/cases/000_build/055_dockerfiles/003_default/build.yml
@@ -1,0 +1,2 @@
+org: linuxkit
+image: missing-in-yml

--- a/test/cases/000_build/055_dockerfiles/003_default/test.sh
+++ b/test/cases/000_build/055_dockerfiles/003_default/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# SUMMARY: Check that tar output format build is reproducible
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+linuxkit pkg build --force .
+
+exit 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added two build options to `lkt pkg build`

* dockerfile can be specified both in `build.yaml` and as `--dockerfile` CLI flag
* added option to override the tag when building or show-tag via `--tag <tag>`

For the dockerfile specification, this fits perfectly with the linuxkit philosophy. Everything is reproducible as it is files on the disk. The same way you can specify a different `build.yml`, you can reference the specific dockerfile.

For the tag, we allow lots of flexibility in naming the generated image. This now lets you specify the actual tag, including using templates, e.g. `--tag "version2-{{.Hash}}`. Right now, only `.Hash` is supported, but we could add a more things if they fit.

**- How I did it**

Changes

**- How to verify it**

I tested manually, and added tests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Dockerfile selection support, tag flexibility

