### PR TITLE
add support for build-arg files

### DIFF
--- a/src/cmd/linuxkit/pkglib/docker.go
+++ b/src/cmd/linuxkit/pkglib/docker.go
@@ -473,10 +473,11 @@ func (dr *dockerRunnerImpl) build(ctx context.Context, tag, pkg, dockerfile, doc
 		solveOpts.Session = append(solveOpts.Session, up)
 	} else {
 		solveOpts.LocalDirs = map[string]string{
-			builder.DefaultLocalNameDockerfile: path.Join(pkg, dockerfile),
+			builder.DefaultLocalNameDockerfile: pkg,
 			builder.DefaultLocalNameContext:    pkg,
 		}
 	}
+	frontendAttrs["filename"] = dockerfile
 
 	// go through the dockerfile to see if we have any provided images cached
 	if c != nil {

--- a/test/cases/000_build/056_build_args/000_build_arg_yaml/Dockerfile
+++ b/test/cases/000_build/056_build_args/000_build_arg_yaml/Dockerfile
@@ -1,0 +1,2 @@
+ARG IMAGE
+FROM ${IMAGE}

--- a/test/cases/000_build/056_build_args/000_build_arg_yaml/build.yml
+++ b/test/cases/000_build/056_build_args/000_build_arg_yaml/build.yml
@@ -1,0 +1,4 @@
+org: linuxkit
+image: image-in-build-args
+buildArgs:
+- IMAGE=alpine:3.19

--- a/test/cases/000_build/056_build_args/000_build_arg_yaml/test.sh
+++ b/test/cases/000_build/056_build_args/000_build_arg_yaml/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# SUMMARY: Check that tar output format build is reproducible
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+linuxkit pkg build --force .
+
+exit 0

--- a/test/cases/000_build/056_build_args/001_build_arg_cli/Dockerfile
+++ b/test/cases/000_build/056_build_args/001_build_arg_cli/Dockerfile
@@ -1,0 +1,2 @@
+ARG IMAGE
+FROM ${IMAGE}

--- a/test/cases/000_build/056_build_args/001_build_arg_cli/build-args
+++ b/test/cases/000_build/056_build_args/001_build_arg_cli/build-args
@@ -1,0 +1,1 @@
+IMAGE=alpine:3.19

--- a/test/cases/000_build/056_build_args/001_build_arg_cli/build.yml
+++ b/test/cases/000_build/056_build_args/001_build_arg_cli/build.yml
@@ -1,0 +1,2 @@
+org: linuxkit
+image: test-image-in-yaml-build-args

--- a/test/cases/000_build/056_build_args/001_build_arg_cli/test.sh
+++ b/test/cases/000_build/056_build_args/001_build_arg_cli/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# SUMMARY: Check that tar output format build is reproducible
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+linuxkit pkg build --force --build-arg-file build-args .
+
+exit 0

--- a/test/cases/000_build/056_build_args/002_build_arg_cli_over_yaml/Dockerfile
+++ b/test/cases/000_build/056_build_args/002_build_arg_cli_over_yaml/Dockerfile
@@ -1,0 +1,2 @@
+ARG IMAGE
+FROM ${IMAGE}

--- a/test/cases/000_build/056_build_args/002_build_arg_cli_over_yaml/build-args
+++ b/test/cases/000_build/056_build_args/002_build_arg_cli_over_yaml/build-args
@@ -1,0 +1,1 @@
+IMAGE=alpine:3.19

--- a/test/cases/000_build/056_build_args/002_build_arg_cli_over_yaml/build.yml
+++ b/test/cases/000_build/056_build_args/002_build_arg_cli_over_yaml/build.yml
@@ -1,0 +1,4 @@
+org: linuxkit
+image: test-image-in-yaml-build-args-with-cli-override
+buildArgs:
+- IMAGE=non-existent:foo

--- a/test/cases/000_build/056_build_args/002_build_arg_cli_over_yaml/test.sh
+++ b/test/cases/000_build/056_build_args/002_build_arg_cli_over_yaml/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# SUMMARY: Check that tar output format build is reproducible
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+linuxkit pkg build --force --build-arg-file build-args .
+
+exit 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added support for specifying build args to a package build from another file as `--build-arg-file file1`. You can specify multiple files as `--build-arg-file file1 --build-arg-file file2 ...`.

This allows interesting patterns, like a `build.yaml` that is usable for multiple structures and versions of something (kernel builds are on my mind) while changing some build args.

```sh
linuxkit pkg build --build-yml build.yaml --build-arg-file build-args-1 ./pkg/foo
linuxkit pkg build --build-yml build.yaml --build-arg-file build-args-2 ./pkg/foo
```

Or if you want to get kernel-specific:

```sh
linuxkit pkg build --build-yml build-kernel.yaml --build-arg-file build-args-6.6.x ./kernel
linuxkit pkg build --build-yml build-kernel.yaml --build-arg-file build-args-5.15.x ./kernel
linuxkit pkg build --build-yml build-kernel.yaml --build-arg-file build-args-6.6.x --build-arg-file build-args-debug ./kernel
```

It fits very well with the linuxkit philosophy, as everything still is in files, and can be tracked via VCS.

In theory, I could have achieved the same result by allowing stacking of `build.yml` files, but that is messy to do. Maybe in the future.

I added tests, of course.

**- How I did it**

Writing code. Writing tests. Happy they pass.

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Support for multiple build-args files
