### PR TITLE
add support for pushing and pulling images

### DIFF
--- a/src/cmd/linuxkit/cache.go
+++ b/src/cmd/linuxkit/cache.go
@@ -26,5 +26,7 @@ func cacheCmd() *cobra.Command {
 	cmd.AddCommand(cacheLsCmd())
 	cmd.AddCommand(cacheExportCmd())
 	cmd.AddCommand(cacheImportCmd())
+	cmd.AddCommand(cachePullCmd())
+	cmd.AddCommand(cachePushCmd())
 	return cmd
 }

--- a/src/cmd/linuxkit/cache_pull.go
+++ b/src/cmd/linuxkit/cache_pull.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	cachepkg "github.com/linuxkit/linuxkit/src/cmd/linuxkit/cache"
+	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/util"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func cachePullCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pull",
+		Short: "pull images to the linuxkit cache from registry",
+		Long: `Pull named images from their registry to the linuxkit cache. Can provide short name, like linuxkit/kernel:6.6.13
+		or nginx, or canonical name, like docker.io/library/nginx:latest. Will be saved into cache as canonical.
+		Will replace in cache if found. Blobs with the same content are not replaced.`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			names := args
+			for _, name := range names {
+				fullname := util.ReferenceExpand(name, util.ReferenceWithTag())
+
+				p, err := cachepkg.NewProvider(cacheDir)
+				if err != nil {
+					log.Fatalf("unable to read a local cache: %v", err)
+				}
+
+				if err := p.Pull(fullname, true); err != nil {
+					log.Fatalf("unable to push image named %s: %v", name, err)
+				}
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/src/cmd/linuxkit/cache_push.go
+++ b/src/cmd/linuxkit/cache_push.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	cachepkg "github.com/linuxkit/linuxkit/src/cmd/linuxkit/cache"
+	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/util"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func cachePushCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "push",
+		Short: "push images from the linuxkit cache",
+		Long: `Push named images from the linuxkit cache to registry. Can provide short name, like linuxkit/kernel:6.6.13
+		or nginx, or canonical name, like docker.io/library/nginx:latest.
+		It is efficient, as blobs with the same content are not replaced.`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			names := args
+			for _, name := range names {
+				fullname := util.ReferenceExpand(name)
+
+				p, err := cachepkg.NewProvider(cacheDir)
+				if err != nil {
+					log.Fatalf("unable to read a local cache: %v", err)
+				}
+
+				if err := p.Push(fullname, true); err != nil {
+					log.Fatalf("unable to push image named %s: %v", name, err)
+				}
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/src/cmd/linuxkit/util/reference.go
+++ b/src/cmd/linuxkit/util/reference.go
@@ -2,15 +2,37 @@ package util
 
 import "strings"
 
+type refOpts struct {
+	withTag bool
+}
+type ReferenceOption func(r *refOpts)
+
+// ReferenceWithTag returns a ReferenceOption that ensures a tag is filled. If the tag is not provided,
+// the default is added
+func ReferenceWithTag() ReferenceOption {
+	return func(r *refOpts) {
+		r.withTag = true
+	}
+}
+
 // ReferenceExpand expands "redis" to "docker.io/library/redis" so all images have a full domain
-func ReferenceExpand(ref string) string {
+func ReferenceExpand(ref string, options ...ReferenceOption) string {
+	var opts refOpts
+	for _, opt := range options {
+		opt(&opts)
+	}
+	var ret string
 	parts := strings.Split(ref, "/")
 	switch len(parts) {
 	case 1:
-		return "docker.io/library/" + ref
+		ret = "docker.io/library/" + ref
 	case 2:
-		return "docker.io/" + ref
+		ret = "docker.io/" + ref
 	default:
-		return ref
+		ret = ref
 	}
+	if opts.withTag && !strings.Contains(ret, ":") {
+		ret += ":latest"
+	}
+	return ret
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added ability to pull images from registry directly into cache, or push from cache to registry, based on image name.
Handles both concise names (like `nginx`) and fully qualified names (like `docker.io/library/nginx:latest`).

Fixes #3990 

**- How I did it**

Added the commands.

**- How to verify it**

Tested by pulling and pushing

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
cache pull and push by names support
