### PR TITLE
option to push local image to somewhere else

### DIFF
--- a/src/cmd/linuxkit/cache_push.go
+++ b/src/cmd/linuxkit/cache_push.go
@@ -8,6 +8,7 @@ import (
 )
 
 func cachePushCmd() *cobra.Command {
+	var remoteName string
 	cmd := &cobra.Command{
 		Use:   "push",
 		Short: "push images from the linuxkit cache",
@@ -25,13 +26,14 @@ func cachePushCmd() *cobra.Command {
 					log.Fatalf("unable to read a local cache: %v", err)
 				}
 
-				if err := p.Push(fullname, true); err != nil {
+				if err := p.Push(fullname, remoteName, true); err != nil {
 					log.Fatalf("unable to push image named %s: %v", name, err)
 				}
 			}
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&remoteName, "remote-name", "", "Push it under a different name, e.g. push local image foo/bar:mine as baz/bee:yours. If blank, uses same local name.")
 
 	return cmd
 }

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -513,7 +513,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	}
 
 	// push the manifest
-	if err := c.Push(p.FullTag(), bo.manifest); err != nil {
+	if err := c.Push(p.FullTag(), "", bo.manifest); err != nil {
 		return err
 	}
 
@@ -535,7 +535,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	if _, err := c.DescriptorWrite(&ref, *desc); err != nil {
 		return err
 	}
-	if err := c.Push(fullRelTag, bo.manifest); err != nil {
+	if err := c.Push(fullRelTag, "", bo.manifest); err != nil {
 		return err
 	}
 

--- a/src/cmd/linuxkit/pkglib/build_test.go
+++ b/src/cmd/linuxkit/pkglib/build_test.go
@@ -392,7 +392,7 @@ func (c *cacheMocker) IndexWrite(ref *reference.Spec, descriptors ...registry.De
 
 	return c.NewSource(ref, "", &desc), nil
 }
-func (c *cacheMocker) Push(name string, withManifest bool) error {
+func (c *cacheMocker) Push(name, remoteName string, withManifest bool) error {
 	if !c.enablePush {
 		return errors.New("push disabled")
 	}

--- a/src/cmd/linuxkit/spec/cache.go
+++ b/src/cmd/linuxkit/spec/cache.go
@@ -38,8 +38,10 @@ type CacheProvider interface {
 	// and replaces any existing one
 	DescriptorWrite(ref *reference.Spec, descriptors v1.Descriptor) (ImageSource, error)
 	// Push an image along with a multi-arch index from local cache to remote registry.
+	// name is the name as referenced in the local cache, remoteName is the name to give it remotely.
+	// If remoteName is empty, it is the same as name.
 	// if withManifest defined will push a multi-arch manifest
-	Push(name string, withManifest bool) error
+	Push(name, remoteName string, withManifest bool) error
 	// NewSource return an ImageSource for a specific ref and architecture in the cache.
 	NewSource(ref *reference.Spec, architecture string, descriptor *v1.Descriptor) ImageSource
 	// GetContent returns an io.Reader to the provided content as is, given a specific digest. It is


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added option to `lkt cache push foo` to provide a remote tag as `lkt cache push foo --remote-name bar`, which means, "take the local image or index foo, and push it to the remote bar".

This is morally equivalent to the classical "tag&push", but much simpler

**- How I did it**

Code

**- How to verify it**

I did. I pushed and tested

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Ability to name images remotely differently 
