### PR TITLE
when reading build-args from file, always trim whitespace for key and…

### DIFF
--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -416,7 +416,9 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 			if len(parts) != 2 {
 				return fmt.Errorf("invalid build-arg, must be in format 'arg=value': %s", buildArg)
 			}
-			imageBuildOpts.BuildArgs[parts[0]] = &parts[1]
+			key := strings.TrimSpace(parts[0])
+			val := strings.TrimSpace(parts[1])
+			imageBuildOpts.BuildArgs[key] = &val
 		}
 
 		// add in information about the build process that might be useful


### PR DESCRIPTION
… value

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When reading build-args from files, key and value always should have whitespace trimmed, or you can end up with a build arg whose name is ` MYARG` or one whose value is `25 `.

**- How I did it**

Added `TrimSpace()` before making part of the image build opts.

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Safer handling of build-args files with trimspace
