### PR TITLE
in kernel build, have ARG in correct place to be usable

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -178,8 +178,8 @@ RUN DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdept
 
 RUN printf "${BUILD_IMAGE}" > /out/kernel-builder
 
-ARG BUILD_IMAGE
 FROM scratch
+ARG BUILD_IMAGE
 ENTRYPOINT []
 CMD []
 WORKDIR /

--- a/test/cases/020_kernel/tags.sh
+++ b/test/cases/020_kernel/tags.sh
@@ -62,6 +62,7 @@ fi
 
 # Check that for each architecture we have the kernel for builder and the builder label points to the same thing
 for ARCH in ${KERNEL_ARCHES}; do
+    [ "$ARCH" = "unknown" ] && continue
     BUILDER_ARCH_DIGEST=$(echo ${BUILDER_MANIFEST} | jq -r --arg ARCH "$ARCH" '.[] | select (.platform.architecture == $ARCH) | .digest')
     BUILDER_LABEL_ARCH_DIGEST=$(echo ${BUILDER_LABEL_MANIFEST} | jq -r --arg ARCH "$ARCH" '.[] | select (.platform.architecture == $ARCH) | .digest')
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

kernel was missing the builder LABEL, got lost in #3993; this restores it

**- How I did it**

Changed a single line in Dockerfile

**- How to verify it**

Build, push, check that the label exists (it does)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
restore missing label in kernel
