### PR TITLE
kernel makefile target to replace tags using update-component-sha.sh

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -34,8 +34,10 @@ DIRTY:=$(shell git update-index -q --refresh && git diff-index --quiet HEAD -- $
 endif
 endif
 
+REPO_ROOT:=$(shell git rev-parse --show-toplevel)
+
 # Path to push-manifest.sh
-PUSH_MANIFEST:=$(shell git rev-parse --show-toplevel)/scripts/push-manifest.sh
+PUSH_MANIFEST:=$(REPO_ROOT)/scripts/push-manifest.sh
 
 # determine our architecture
 BUILDERARCH=
@@ -65,7 +67,10 @@ notdirty:
 # utility function
 SPACE := $(eval) $(eval)
 PERIOD := .
+# series - convert a version to a series, e.g. 6.6.13 -> 6.6.x
 series = $(word 1,$(subst ., ,$(1))).$(word 2,$(subst ., ,$(1))).x
+# serieswildcard - convert a version with or without a hash to a wildcard, e.g. 6.6.13-anbcd -> 6.6.-*
+serieswildcard = $(word 1,$(subst ., ,$(1))).$(word 2,$(subst ., ,$(1))).[0-9]+-[0-9a-f]+.*
 
 # word 1 is the release, word 2 is the tool
 RELEASESEP := PART
@@ -170,6 +175,31 @@ pushtool-%: buildtool-%
 	$(eval PLAIN_IMAGE=$(shell linuxkit pkg show-tag . --build-yml ./build-$(TOOL).yml --tag "$(KERNEL_VERSION)"))
 	linuxkit cache push $(HASHED_IMAGE)
 	linuxkit cache push $(HASHED_IMAGE) --remote-name $(PLAIN_IMAGE)
+
+#
+# targets for getting names of particular tags and replacing them, like what scripts/update-component-sha.sh does
+#
+
+# get the tag for the normal kernel for a particular version. Accepts version or series
+tag-plainkernel-%:
+	@linuxkit pkg show-tag . --build-yml ./build-kernel.yml --tag "$*-{{.Hash}}"
+
+# get the tag for the debug kernel for a particular version. Accepts version or series
+tag-debugkernel-%:
+	@linuxkit pkg show-tag . --build-yml ./build-kernel.yml --tag "$*-dbg-{{.Hash}}"
+
+# find and replace any usage of the normal kernel with hash for a particular series
+# will update hash for same semver and/or patch version
+update-kernel-hash-yaml-%:
+	$(eval NEWTAG=$(shell $(MAKE) tag-plainkernel-$*))
+	$(eval OLDTAG=$(call serieswildcard,$(NEWTAG)))
+	@cd $(REPO_ROOT) && ./scripts/update-component-sha.sh --hash $(OLDTAG) $(NEWTAG)
+
+# find and replace any usage of the normal kernel with semver for most recent series
+update-kernel-semver-yaml-%:
+	$(eval NEWTAG=linuxkit/kernel:$*)
+	$(eval OLDTAG=linuxkit/kernel:[0-9]+.[0-9]+.[0-9]+)
+	@cd $(REPO_ROOT) && ./scripts/update-component-sha.sh --hash $(OLDTAG) $(NEWTAG)
 
 # Target for kernel config
 kconfig:

--- a/scripts/update-component-sha.sh
+++ b/scripts/update-component-sha.sh
@@ -70,7 +70,7 @@ case "${mode}" in
         old=$1
         new=$2
 
-        git grep -w -l "\b$old\b" -- '*.yml' '*.yaml' '*.yml.in' '*.yaml.in' '*/Dockerfile' '*/Makefile' | grep -v /vendor/ | xargs sed -i.bak -e "s,$old,$new,g"
+        git grep -E -l "\b$old\b" -- '*.yml' '*.yaml' '*.yml.in' '*.yaml.in' '*/Dockerfile' '*/Makefile' | grep -v /vendor/ | while read -r file; do sed -ri.bak -e "s,$old,$new,g" "$file"; done
         ;;
 --image)
 	if [ $# -lt 1 ] ; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added `kernel/Makefile` targets to report the tag for the kernel and debug kernel, and to replace them using `update-component-sha.sh`.

Also updates the `update-component-sha.sh` to take regex for `--hash`.

The next PR will use this.

**- How I did it**

Changed Makefile

**- How to verify it**

Manually, no need for anything else, as this just adds some new capabilities.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
kernel Makefile tag management
