### PR TITLE
in kernel makefile tag update, ensure we only replace non-hashed semver

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -201,7 +201,7 @@ update-kernel-hash-yaml-%:
 # find and replace any usage of the normal kernel with semver for most recent series
 update-kernel-semver-yaml-%:
 	$(eval NEWTAG=linuxkit/kernel:$*)
-	$(eval OLDTAG=linuxkit/kernel:[0-9]+.[0-9]+.[0-9]+)
+	$(eval OLDTAG=linuxkit/kernel:[0-9]+.[0-9]+.[0-9]+$$$$)
 	@cd $(REPO_ROOT) && ./scripts/update-component-sha.sh --hash "$(OLDTAG)" "$(NEWTAG)"
 
 # update-kernel-yamls updates the latest hash for each supported series,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix `kernel/Makefile`, which was replacing _all_ semver with latest, rather than server-without-hash with latest

**- How I did it**

Added some $ signs to Makefile

**- How to verify it**

Run it. I did.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
kernel Makefile regex fix
