### PR TITLE
hash for kernel changed, updating in test cases

### DIFF
--- a/test/cases/020_kernel/019_config_6.6.x/test.yml
+++ b/test/cases/020_kernel/019_config_6.6.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:6.6.13-4f0f536b9a057590102379043a0815d2f0e28209
+  image: linuxkit/kernel:6.6.13-93250a118b43a85609ca27778784c161977024e6
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04

--- a/test/cases/020_kernel/119_kmod_6.6.x/Dockerfile
+++ b/test/cases/020_kernel/119_kmod_6.6.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:6.6.13-4f0f536b9a057590102379043a0815d2f0e28209 AS ksrc
+FROM linuxkit/kernel:6.6.13-93250a118b43a85609ca27778784c161977024e6 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/kernel:6.6.13-builder AS build

--- a/test/cases/020_kernel/119_kmod_6.6.x/test.yml
+++ b/test/cases/020_kernel/119_kmod_6.6.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:6.6.13-4f0f536b9a057590102379043a0815d2f0e28209
+  image: linuxkit/kernel:6.6.13-93250a118b43a85609ca27778784c161977024e6
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

hash-specific version of 6.6.x kernel in some tests was out of date; updated

**- How I did it**

`make`

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

updated hash for 6.6.x kernel in tests
