### PR TITLE
Fix update component too broad match

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -69,8 +69,8 @@ SPACE := $(eval) $(eval)
 PERIOD := .
 # series - convert a version to a series, e.g. 6.6.13 -> 6.6.x
 series = $(word 1,$(subst ., ,$(1))).$(word 2,$(subst ., ,$(1))).x
-# serieswildcard - convert a version with or without a hash to a wildcard, e.g. 6.6.13-anbcd -> 6.6.-*
-serieswildcard = $(word 1,$(subst ., ,$(1))).$(word 2,$(subst ., ,$(1))).[0-9]+-[0-9a-f]+.*
+# serieswithhash - convert a version with or without a hash to a series with a hash, e.g. 6.6.13-anbcd -> 6.6.x-[0-9a-f]+
+serieswithhash = $(word 1,$(subst ., ,$(1))).$(word 2,$(subst ., ,$(1))).[0-9]+-[0-9a-f]+
 
 # word 1 is the release, word 2 is the tool
 RELEASESEP := PART
@@ -195,7 +195,7 @@ tag-debugkernel-%:
 # will update hash for same semver and/or patch version
 update-kernel-hash-yaml-%:
 	$(eval NEWTAG=$(shell $(MAKE) tag-plainkernel-$*))
-	$(eval OLDTAG=$(call serieswildcard,$(NEWTAG)))
+	$(eval OLDTAG=$(call serieswithhash,$(NEWTAG)))
 	@cd $(REPO_ROOT) && ./scripts/update-component-sha.sh --hash "$(OLDTAG)" "$(NEWTAG)"
 
 # find and replace any usage of the normal kernel with semver for most recent series

--- a/scripts/update-component-sha.sh
+++ b/scripts/update-component-sha.sh
@@ -69,7 +69,7 @@ case "${mode}" in
         fi
         old=$1
         new=$2
-        git grep -E -l "\b($old)([[:space:]].*)?$" -- '*.yml' '*.yaml' '*.yml.in' '*.yaml.in' '*/Dockerfile' '*/Makefile' | grep -v /vendor/ | while read -r file; do sed -ri.bak -e "s,$old,$new,g" "$file"; done
+        git grep -E -l "\b($old)([[:space:]]|$)?" -- '*.yml' '*.yaml' '*.yml.in' '*.yaml.in' '*/Dockerfile' '*/Makefile' | grep -v /vendor/ | while read -r file; do sed -ri.bak -e "s,($old)([[:space:]]|$)?,$new\2,g" "$file"; done
         ;;
 --image)
 	if [ $# -lt 1 ] ; then

--- a/test/cases/020_kernel/019_config_6.6.x/test.yml
+++ b/test/cases/020_kernel/019_config_6.6.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:6.6.13-93250a118b43a85609ca27778784c161977024e6
+  image: linuxkit/kernel:6.6.13-ad4d0da9e582d714cf61c8d99468cc7c1109bce5
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04

--- a/test/cases/020_kernel/119_kmod_6.6.x/Dockerfile
+++ b/test/cases/020_kernel/119_kmod_6.6.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:6.6.13-93250a118b43a85609ca27778784c161977024e6 AS ksrc
+FROM linuxkit/kernel:6.6.13-ad4d0da9e582d714cf61c8d99468cc7c1109bce5 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/kernel:6.6.13-builder AS build

--- a/test/cases/020_kernel/119_kmod_6.6.x/test.yml
+++ b/test/cases/020_kernel/119_kmod_6.6.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:6.6.13-93250a118b43a85609ca27778784c161977024e6
+  image: linuxkit/kernel:6.6.13-ad4d0da9e582d714cf61c8d99468cc7c1109bce5
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Final fix of `update-component-sha.sh` and `kernel/Makefile`, so that they handle all of the edge cases correctly.

**- How I did it**

Slowly and painfully

**- How to verify it**

I ran multiple replace commands, each worked exactly as expected

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
More update-component-sha.sh fixes for kernel
