### PR TITLE
cache push only overrides remote if explicit

### DIFF
--- a/src/cmd/linuxkit/cache_push.go
+++ b/src/cmd/linuxkit/cache_push.go
@@ -11,6 +11,7 @@ func cachePushCmd() *cobra.Command {
 	var (
 		remoteName           string
 		pushArchSpecificTags bool
+		override             bool
 	)
 	cmd := &cobra.Command{
 		Use:   "push",
@@ -29,7 +30,7 @@ func cachePushCmd() *cobra.Command {
 					log.Fatalf("unable to read a local cache: %v", err)
 				}
 
-				if err := p.Push(fullname, remoteName, pushArchSpecificTags); err != nil {
+				if err := p.Push(fullname, remoteName, pushArchSpecificTags, override); err != nil {
 					log.Fatalf("unable to push image named %s: %v", name, err)
 				}
 			}
@@ -38,5 +39,6 @@ func cachePushCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&remoteName, "remote-name", "", "Push it under a different name, e.g. push local image foo/bar:mine as baz/bee:yours. If blank, uses same local name.")
 	cmd.Flags().BoolVar(&pushArchSpecificTags, "with-arch-tags", false, "When the local reference is an index, add to the remote arch-specific tags for each arch in the index, each as their own tag with the same name as the index, but with the architecture appended, e.g. image:foo will have image:foo-amd64, image:foo-arm64, etc.")
+	cmd.Flags().BoolVar(&override, "override", false, "Even if the image already exists in the registry, push it again, overwriting the existing image.")
 	return cmd
 }

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -524,7 +524,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	}
 
 	// push the manifest
-	if err := c.Push(p.FullTag(), "", bo.manifest); err != nil {
+	if err := c.Push(p.FullTag(), "", bo.manifest, true); err != nil {
 		return err
 	}
 
@@ -546,7 +546,7 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 	if _, err := c.DescriptorWrite(&ref, *desc); err != nil {
 		return err
 	}
-	if err := c.Push(fullRelTag, "", bo.manifest); err != nil {
+	if err := c.Push(fullRelTag, "", bo.manifest, true); err != nil {
 		return err
 	}
 

--- a/src/cmd/linuxkit/pkglib/build_test.go
+++ b/src/cmd/linuxkit/pkglib/build_test.go
@@ -392,7 +392,7 @@ func (c *cacheMocker) IndexWrite(ref *reference.Spec, descriptors ...registry.De
 
 	return c.NewSource(ref, "", &desc), nil
 }
-func (c *cacheMocker) Push(name, remoteName string, withManifest bool) error {
+func (c *cacheMocker) Push(name, remoteName string, withManifest, override bool) error {
 	if !c.enablePush {
 		return errors.New("push disabled")
 	}

--- a/src/cmd/linuxkit/spec/cache.go
+++ b/src/cmd/linuxkit/spec/cache.go
@@ -41,7 +41,7 @@ type CacheProvider interface {
 	// name is the name as referenced in the local cache, remoteName is the name to give it remotely.
 	// If remoteName is empty, it is the same as name.
 	// if withManifest defined will push a multi-arch manifest
-	Push(name, remoteName string, withManifest bool) error
+	Push(name, remoteName string, withManifest, override bool) error
 	// NewSource return an ImageSource for a specific ref and architecture in the cache.
 	NewSource(ref *reference.Spec, architecture string, descriptor *v1.Descriptor) ImageSource
 	// GetContent returns an io.Reader to the provided content as is, given a specific digest. It is


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add option so `linuxkit cache push` only overrides remote if explicitly selected

**- How I did it**

In `cache_push.go`

**- How to verify it**

I did

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
cache push option to overrride
