### PR TITLE
add pkg remote-tag option to tag descriptors remotely without pulling…

### DIFF
--- a/src/cmd/linuxkit/pkg.go
+++ b/src/cmd/linuxkit/pkg.go
@@ -75,6 +75,7 @@ func pkgCmd() *cobra.Command {
 	cmd.AddCommand(pkgPushCmd())
 	cmd.AddCommand(pkgShowTagCmd())
 	cmd.AddCommand(pkgManifestCmd())
+	cmd.AddCommand(pkgRemoteTagCmd())
 
 	// These override fields in pkgInfo default below, bools are in both forms to allow user overrides in either direction.
 	// These will apply to all packages built.

--- a/src/cmd/linuxkit/pkg_remotetag.go
+++ b/src/cmd/linuxkit/pkg_remotetag.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	namepkg "github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/util"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func pkgRemoteTagCmd() *cobra.Command {
+	var release string
+	cmd := &cobra.Command{
+		Use:   "remote-tag",
+		Short: "tag a package in a remote registry with another tag",
+		Long: `Tag a package in a remote registry with another tag, without downloading or pulling.
+		Will simply tag using the identical descriptor.
+		First argument is "from" tag, second is "to" tag.
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			from := args[0]
+			to := args[1]
+			remoteOptions := []remote.Option{remote.WithAuthFromKeychain(authn.DefaultKeychain)}
+
+			fromFullname := util.ReferenceExpand(from, util.ReferenceWithTag())
+			toFullname := util.ReferenceExpand(to, util.ReferenceWithTag())
+			fromRef, err := namepkg.ParseReference(fromFullname)
+			if err != nil {
+				return err
+			}
+			toRef, err := namepkg.ParseReference(toFullname)
+			if err != nil {
+				return err
+			}
+			fromDesc, err := remote.Get(fromRef, remoteOptions...)
+			if err != nil {
+				return fmt.Errorf("error getting manifest for from image %s: %v", fromFullname, err)
+			}
+			toDesc, err := remote.Get(toRef, remoteOptions...)
+			if err == nil {
+				if toDesc.Digest == fromDesc.Digest {
+					log.Infof("image %s already exists in the registry, identical to %s, skipping", toFullname, fromFullname)
+					return nil
+				}
+				log.Infof("image %s already exists in the registry, but is different from %s, overwriting", toFullname, fromFullname)
+			}
+			toTag, err := namepkg.NewTag(toFullname)
+			if err != nil {
+				return err
+			}
+			if err := remote.Tag(toTag, fromDesc, remoteOptions...); err != nil {
+				return fmt.Errorf("error tagging image %s as %s: %v", fromFullname, toFullname, err)
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&release, "release", "", "Release the given version")
+
+	return cmd
+}


### PR DESCRIPTION
… and pushing

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added option `lkt pkg remote-tag <a> <b>`  to rename a tag remotely on a registry without pulling and pushing

**- How I did it**

Added the option

**- How to verify it**

Run it, I did.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Option to manage tags remotely
