### PR TITLE
add support for pkg release tags

### DIFF
--- a/.github/workflows/package_release.yml
+++ b/.github/workflows/package_release.yml
@@ -1,0 +1,65 @@
+name: Release a tag
+
+on:
+  create:
+    tags:
+      - pkg-v*
+
+jobs:
+  build:
+    name: Release packages
+    runs-on: macos-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+    - name: Ensure bin/ directory
+      run: mkdir -p bin
+    - name: Download linuxkit
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+          });
+          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "${{ env.linuxkit_file }}"
+          })[0];
+          var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+          });
+          var fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/bin/${{ env.linuxkit_file }}.zip', Buffer.from(download.data));
+    - name: unzip linuxkit
+      run: cd bin && unzip ${{ env.linuxkit_file }}.zip
+    - name: Symlink Linuxkit
+      run: |
+        chmod ugo+x bin/${{ env.linuxkit_file }}
+        sudo ln -s $(pwd)/bin/${{ env.linuxkit_file }} /usr/local/bin/linuxkit
+        /usr/local/bin/linuxkit version
+    - name: Restore Package Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.linuxkit/cache/
+        key: ${{ runner.os }}-linuxkit-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-linuxkit-
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Publish Packages as Release
+      # this should only push changed ones:
+      #  - unchanged: already in the registry
+      #  - changed: already built and cached, so only will push
+      # Skip s390x as emulation is unreliable
+      run: |
+        RELEASE_TAG=${GITHUB_REF#refs/tags/pkg-}
+        echo "RELEASE_TAG=${RELEASE_TAG}"
+        [ -n "${RELEASE_TAG}" ] || { echo "Not a tag"; exit 1; }
+        make OPTIONS="--skip-platforms linux/s390x" -C pkg push PUSHOPTIONS="--nobuild --release ${RELEASE_TAG}"

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -378,3 +378,16 @@ ARG all_proxy
 
 LinuxKit does not judge between lower-cased or upper-cased variants of these options, e.g. `http_proxy` vs `HTTP_PROXY`,
 as `docker build` does not either. It just passes them through "as-is".
+
+## Releases
+
+Normally, whenever a package is updated, CI will build and push the package to Docker Hub by calling `linuxkit pkg push`.
+This automatically creates a tag based on the git tree hash of the package's directory.
+For example, the package in `./pkg/init` is tagged as `linuxkit/init:45a1ad5919f0b6acf0f0cf730e9434abfae11fe6`.
+
+In addition, you can release semver tags for packages by adding a tag to the git repository that begins with `pkg-` and is
+followed by a valid semver tag. For example, `pkg-v1.0.0`. This will cause CI to build and push the package to Docker Hub
+with the tag `v1.0.0`.
+
+Pure semver tags, like `v1.0.0`, are not used for package releases. They are used for the linuxkit project itself and to
+publish releases of the `linuxkit` binary.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added support for `pkg-v<semver>` tags which can be used to add release versions for packages. This leaves the existing standard semver tags for linuxkit itself.

And of course added it to the `packages.md` doc.

**- How I did it**

Added `package_release.yml`

**- How to verify it**
CI runs

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Releases of packages via tags
