### PR TITLE
missing pipe in package_release workflow

### DIFF
--- a/.github/workflows/package_release.yml
+++ b/.github/workflows/package_release.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Ensure bin/ directory
       run: mkdir -p bin
     - name: Install linuxkit
-      run:
+      run: |
         go -C ./src/cmd/linuxkit build -o $(pwd)/bin/linuxkit 
         sudo mv bin/linuxkit /usr/local/bin/
     - name: Login to Docker Hub


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a missing `|` in an actions command

**- How I did it**

Typing

**- How to verify it**

CI
