### PR TITLE
util: allow pulling from local registry

### DIFF
--- a/src/cmd/linuxkit/util/reference.go
+++ b/src/cmd/linuxkit/util/reference.go
@@ -1,6 +1,8 @@
 package util
 
-import "strings"
+import (
+	"strings"
+)
 
 type refOpts struct {
 	withTag bool
@@ -21,16 +23,13 @@ func ReferenceExpand(ref string, options ...ReferenceOption) string {
 	for _, opt := range options {
 		opt(&opts)
 	}
-	var ret string
+	ret := ref
+
 	parts := strings.Split(ref, "/")
-	switch len(parts) {
-	case 1:
+	if len(parts) == 1 {
 		ret = "docker.io/library/" + ref
-	case 2:
-		ret = "docker.io/" + ref
-	default:
-		ret = ref
 	}
+
 	if opts.withTag && !strings.Contains(ret, ":") {
 		ret += ":latest"
 	}


### PR DESCRIPTION
before a command like
linuxkit cache pull 127.0.0.1:5000/pkgalpine

would result in trying to pull the following image: docker.io/127.0.0.1:5000/pkgalpine

and this is wrong

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Trying to fix pulling from a local registry.

**- How I did it**

Grumpily ;-)

**- How to verify it**

```
docker run -d -p 5000:5000 --name registry registry:latest
docker build -t localhost:5000/pkgalpine .
docker push localhost:5000/pkgalpine
linuxkit cache pull 127.0.0.1:5000/pkgalpine
```

**- Description for the changelog**
Allow pulling from local docker registry


**- A picture of a cute animal (not mandatory but encouraged)**

https://en.wikipedia.org/wiki/Bunk%C5%8D#/media/File:Sculpture_of_Brave_Dog_Bunchan_-_Otaru_-_Hokkaido_-_Japan_(47984518556).jpg
