### PR TITLE
add tag to args passed for package builds

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -272,6 +272,8 @@ When building packages, the following build-args automatically are set for you:
 * `SOURCE` - the source repository of the package
 * `REVISION` - the git commit that was used for the build
 * `GOPKGVERSION` - the go package version or pseudo-version per https://go.dev/ref/mod#glos-pseudo-version
+* `PKG_HASH` - the git tree hash of the package directory, e.g. `45a1ad5919f0b6acf0f0cf730e9434abfae11fe6`; tag part of `linuxkit pkg show-tag`
+* `PKG_IMAGE` - the name of the image that is being built, e.g. `linuxkit/init`; image name part of `linuxkit pkg show-tag`. Combine with `PKG_HASH` for the full tag.
 
 Note that the above are set **only** if you do not set them in `build.yaml`. Your settings _always_
 override these built-in ones.

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -431,6 +431,14 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 		if _, ok := imageBuildOpts.BuildArgs["GOPKGVERSION"]; !ok && goPkgVersion != "" {
 			imageBuildOpts.BuildArgs["GOPKGVERSION"] = &goPkgVersion
 		}
+		if _, ok := imageBuildOpts.BuildArgs["PKG_HASH"]; !ok && p.Hash() != "" {
+			ret := p.Hash()
+			imageBuildOpts.BuildArgs["PKG_HASH"] = &ret
+		}
+		if _, ok := imageBuildOpts.BuildArgs["PKG_IMAGE"]; !ok && p.Image() != "" {
+			ret := p.Image()
+			imageBuildOpts.BuildArgs["PKG_IMAGE"] = &ret
+		}
 
 		// build for each arch and save in the linuxkit cache
 		for _, platform := range platformsToBuild {

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -317,6 +317,11 @@ func (p Pkg) Tag() string {
 	return p.org + "/" + p.image + ":" + t
 }
 
+// Image returns the image name without the tag
+func (p Pkg) Image() string {
+	return p.org + "/" + p.image
+}
+
 // FullTag returns a reference expanded tag
 func (p Pkg) FullTag() string {
 	return util.ReferenceExpand(p.Tag())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added `PKG_HASH` and `PKG_IMAGE` build args when building packages, in addition to the existing ones `SOURCE`, `REVISION` and `GOPKGVERSION`. Added to docs as well.

**- How I did it**

Adding to the list of `imageBuildOpts.BuildArgs`

**- How to verify it**

I ran it and checked that they are there. And CI of course

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Build args to pass hash tag and image name.
