### PR TITLE
fix kernel tools build.yml files to reflect correct dockerfiles

### DIFF
--- a/kernel/Dockerfile.bcc
+++ b/kernel/Dockerfile.bcc
@@ -1,6 +1,8 @@
 ARG BUILD_IMAGE
+ARG KERNEL_VERSION
+ARG PKG_HASH
 
-FROM ${KERNEL_VERSION}-${HASH} as ksrc
+FROM linuxkit/kernel:${KERNEL_VERSION}-${PKG_HASH} as ksrc
 
 FROM ${BUILD_IMAGE} AS build
 RUN apk update && apk upgrade -a && \

--- a/kernel/Dockerfile.perf
+++ b/kernel/Dockerfile.perf
@@ -1,8 +1,10 @@
 # This Dockerfile extracts the source code and headers from a kernel package,
 # builds the perf utility, and places it into a scratch image
 ARG BUILD_IMAGE
+ARG KERNEL_VERSION
+ARG PKG_HASH
 
-FROM ${KERNEL_VERSION}-${HASH} AS ksrc
+FROM linuxkit/kernel:${KERNEL_VERSION}-${PKG_HASH} as ksrc
 
 FROM ${BUILD_IMAGE} AS build
 RUN apk add \

--- a/kernel/build-bcc.yml
+++ b/kernel/build-bcc.yml
@@ -1,2 +1,3 @@
 image: kernel-bcc
 network: true
+dockerfile: Dockerfile.bcc

--- a/kernel/build-perf.yml
+++ b/kernel/build-perf.yml
@@ -1,2 +1,3 @@
 image: kernel-perf
 network: true
+dockerfile: Dockerfile.perf

--- a/test/cases/020_kernel/019_config_6.6.x/test.yml
+++ b/test/cases/020_kernel/019_config_6.6.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:6.6.13-e274bc71d6552570c922d2fca6c6481d1f9f045a
+  image: linuxkit/kernel:6.6.13-44a5293614ca7c7674013e928cb11dcdbba73ba8
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04

--- a/test/cases/020_kernel/119_kmod_6.6.x/Dockerfile
+++ b/test/cases/020_kernel/119_kmod_6.6.x/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:6.6.13-e274bc71d6552570c922d2fca6c6481d1f9f045a AS ksrc
+FROM linuxkit/kernel:6.6.13-44a5293614ca7c7674013e928cb11dcdbba73ba8 AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/kernel:6.6.13-builder AS build

--- a/test/cases/020_kernel/119_kmod_6.6.x/test.yml
+++ b/test/cases/020_kernel/119_kmod_6.6.x/test.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:6.6.13-e274bc71d6552570c922d2fca6c6481d1f9f045a
+  image: linuxkit/kernel:6.6.13-44a5293614ca7c7674013e928cb11dcdbba73ba8
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
   - linuxkit/init:07d37c3ae7fad5ddcb54c8dc65774ae050851f04


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

The build for perf and bcc were reinstalling the kernel, rather than leveraging it to build the tools. This fixes it.

**- How I did it**

Changed the build.yaml and Dockerfile.perf / Dockerfile.bcc

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Correctly build perf and bcc kernel tools
