### PR TITLE
add support for input-tar

### DIFF
--- a/src/cmd/linuxkit/moby/config.go
+++ b/src/cmd/linuxkit/moby/config.go
@@ -1,6 +1,7 @@
 package moby
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"sort"
@@ -60,6 +61,27 @@ type Image struct {
 	Name        string `yaml:"name" json:"name"`
 	Image       string `yaml:"image" json:"image"`
 	ImageConfig `yaml:",inline"`
+}
+
+// Equal check if another Image is functionally equal to this one.
+// Takes the easy path by marshaling both into yaml and then comparing the yaml.
+// There may be a more efficient way to do this, but this is simplest.
+func (i *Image) Equal(o *Image) bool {
+	// if we are going to compare, we must canonicalized both image names
+	i0 := i
+	i0.Image = util.ReferenceExpand(i.Image)
+	iy, err := yaml.Marshal(i0)
+	if err != nil {
+		return false
+	}
+
+	o0 := o
+	o0.Image = util.ReferenceExpand(o.Image)
+	oy, err := yaml.Marshal(o)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(iy, oy)
 }
 
 // ImageConfig is the configuration part of Image, it is the subset

--- a/src/cmd/linuxkit/moby/opts.go
+++ b/src/cmd/linuxkit/moby/opts.go
@@ -9,4 +9,5 @@ type BuildOpts struct {
 	DockerCache      bool
 	Arch             string
 	SbomGenerator    *SbomGenerator
+	InputTar         string
 }

--- a/test/cases/000_build/010_reproducible/004_input_tar/test.sh
+++ b/test/cases/000_build/010_reproducible/004_input_tar/test.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# SUMMARY: Check that tar output format build is reproducible after leveraging input tar
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+NAME=check
+
+clean_up() {
+	rm -f ${NAME}*
+}
+
+trap clean_up EXIT
+
+# do not include the sbom, because the SBoM unique IDs per file/package are *not* deterministic,
+# (currently based upon syft), and thus will make the file non-reproducible
+linuxkit build --no-sbom --format tar --o "${NAME}-1.tar" ../test.yml
+linuxkit build --no-sbom --format tar --input-tar "${NAME}-1.tar" --o "${NAME}-2.tar" ../test.yml
+
+diff -q "${NAME}-1.tar" "${NAME}-2.tar" || exit 1
+
+exit 0

--- a/test/cases/000_build/060_input_tar/README.md
+++ b/test/cases/000_build/060_input_tar/README.md
@@ -1,0 +1,18 @@
+# testing --input-tar
+
+This test works by building two tar files, and checking logs.
+This only works because we use verbose logs.
+
+The two files - `test1.yml` and `test2.yml` are identical, except for some changed lines.
+
+The test script - `test.sh` - builds an image from `test1.yml`, then uses its output
+as `--input-tar` for building from `test2.yml`. It then checks the output logs to make sure
+that expected sections are copied over, and unexpected ones are not.
+
+**Note:** If you make any changes to either test file, mark here and in `test.sh` so we know what has changed.
+
+Changes:
+
+- added one entry in `init`
+- changed the command in `onboot[1]`
+- removed `services[1]`, which causes `services[2]` to become `services[1]`, and thus should not be copied either, as order may matter.

--- a/test/cases/000_build/060_input_tar/test.sh
+++ b/test/cases/000_build/060_input_tar/test.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# SUMMARY: Check that tar output format build is reproducible after leveraging input tar
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+NAME=check
+
+clean_up() {
+	rm -f ${NAME}-*.tar
+}
+
+trap clean_up EXIT
+
+logfile=$(mktemp)
+
+# do not include the sbom, because the SBoM unique IDs per file/package are *not* deterministic,
+# (currently based upon syft), and thus will make the file non-reproducible
+linuxkit build --no-sbom --format tar --o "${NAME}-1.tar" ./test1.yml
+linuxkit build -v --no-sbom --format tar --input-tar "${NAME}-1.tar" --o "${NAME}-2.tar" ./test2.yml 2>&1 | tee ${logfile}
+
+# the logfile should indicate which parts were copied and which not
+# we only know this because we built the test2.yml manually
+
+# should have 3 entries copied from init, but not a 4th
+errors=""
+grep -q "Copy init\[0\]" ${logfile} || errors="${errors}\nmissing Copy init[0]"
+grep -q "Copy init\[1\]" ${logfile} || errors="${errors}\nmissing Copy init[1]"
+grep -q "Copy init\[2\]" ${logfile} || errors="${errors}\nmissing Copy init[2]"
+grep -q "Copy init\[3\]" ${logfile} && errors="${errors}\nunexpected Copy init[3]"
+# should have one entry copied from onboot, but not a second
+grep -q "Copy onboot\[0\]" ${logfile} || errors="${errors}\nmissing Copy onboot[0]"
+grep -q "Copy onboot\[1\]" ${logfile} && errors="${errors}\nunexpected Copy onboot[1]"
+# should have one entry copied from services, but not a second or third
+grep -q "Copy services\[0\]" ${logfile} || errors="${errors}\nmissing Copy services[0]"
+grep -q "Copy services\[1\]" ${logfile} && errors="${errors}\nunexpected Copy services[1]"
+grep -q "Copy services\[2\]" ${logfile} && errors="${errors}\nunexpected Copy services[2]"
+
+if [ -n "${errors}" ]; then
+	echo "Errors: ${errors}"
+	echo "logfile: ${logfile}"
+	exit 1
+fi
+
+exit 0

--- a/test/cases/000_build/060_input_tar/test1.yml
+++ b/test/cases/000_build/060_input_tar/test1.yml
@@ -1,0 +1,37 @@
+kernel:
+  image: linuxkit/kernel:6.6.13
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+init:
+  - linuxkit/init:45a1ad5919f0b6acf0f0cf730e9434abfae11fe6
+  - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
+  - linuxkit/containerd:e7a92d9f3282039eac5fb1b07cac2b8664cbf0ad
+onboot:
+  - name: sysctl
+    image: linuxkit/sysctl:5a374e4bf3e5a7deeacff6571d0f30f7ea8f56db
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:e9e3580f2de00e73e7b316a007186d22fea056ee
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+onshutdown:
+  - name: shutdown
+    image: busybox:latest
+    command: ["/bin/echo", "so long and thanks for all the fish"]
+services:
+  - name: getty
+    image: linuxkit/getty:5d86a2ce2d890c14ab66b13638dcadf74f29218b
+    env:
+     - INSECURE=true
+  - name: rngd
+    image: linuxkit/rngd:cdb919e4aee49fed0bf6075f0a104037cba83c39
+  - name: nginx
+    image: nginx:1.19.5-alpine
+    capabilities:
+     - CAP_NET_BIND_SERVICE
+     - CAP_CHOWN
+     - CAP_SETUID
+     - CAP_SETGID
+     - CAP_DAC_OVERRIDE
+    binds:
+     - /etc/resolv.conf:/etc/resolv.conf
+files:
+  - path: etc/linuxkit-config
+    metadata: yaml

--- a/test/cases/000_build/060_input_tar/test2.yml
+++ b/test/cases/000_build/060_input_tar/test2.yml
@@ -1,0 +1,36 @@
+kernel:
+  image: linuxkit/kernel:6.6.13
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+init:
+  - linuxkit/init:45a1ad5919f0b6acf0f0cf730e9434abfae11fe6
+  - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
+  - linuxkit/containerd:e7a92d9f3282039eac5fb1b07cac2b8664cbf0ad
+  - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff
+onboot:
+  - name: sysctl
+    image: linuxkit/sysctl:5a374e4bf3e5a7deeacff6571d0f30f7ea8f56db
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:e9e3580f2de00e73e7b316a007186d22fea056ee
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1", "change"]
+onshutdown:
+  - name: shutdown
+    image: busybox:latest
+    command: ["/bin/echo", "so long and thanks for all the fish"]
+services:
+  - name: getty
+    image: linuxkit/getty:5d86a2ce2d890c14ab66b13638dcadf74f29218b
+    env:
+     - INSECURE=true
+  - name: nginx
+    image: nginx:1.19.5-alpine
+    capabilities:
+     - CAP_NET_BIND_SERVICE
+     - CAP_CHOWN
+     - CAP_SETUID
+     - CAP_SETGID
+     - CAP_DAC_OVERRIDE
+    binds:
+     - /etc/resolv.conf:/etc/resolv.conf
+files:
+  - path: etc/linuxkit-config
+    metadata: yaml


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add a new option called `--input-tar <in.tar>`. When it sees this option, it tries to read the `linuxkit.yml` build file (aka metadata) from `<in.tar>`.

If it does not find the metadata, it builds as normal.

If it finds the metadata, it compares it to the currently building image. For each one that is identical - image name, position in section (init, onboot, onshutdown, services), settings, etc. - it finds the files from the original tar and copies them over, rather than trying to find the image in the linuxkit cache and possibly pull it down. It uses the PAXRecords on the tar to read the files.

This is a performance speed-up. For example, building `linuxkit.yml` takes ~6 seconds on my test cloud VM, while using the input tar takes ~2 seconds. Since a large part of this is fixed overhead, longer builds show a much better improvement. I did one large build that normally takes ~1m08s, it did the build in 0m12s.

Most of this is due to finding the layers in the cache, gunzipping them, etc. It is just significantly faster to copy files from one tar stream to another, than to start gunzipping layers, applying them, etc. Obviously, if we can find a way to optimize that, even better.

If it cannot find the build yaml at the configured location, it falls back to regular build.

I included tests. These check both that only the appropriate sections are copied, and also that if nothing has changed, i.e. it just streams files, it is bitwise identical.

**- How I did it**

Took advantage of the PAXRecords headers and potential existence of metadata in the tar.

**- How to verify it**

CI, I added tests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Ability to create a new tar from an existing tar plus changes.
