### PR TITLE
use canonical ref when looking in cache

### DIFF
--- a/src/cmd/linuxkit/cache/write.go
+++ b/src/cmd/linuxkit/cache/write.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	lktspec "github.com/linuxkit/linuxkit/src/cmd/linuxkit/spec"
+	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/util"
 	lktutil "github.com/linuxkit/linuxkit/src/cmd/linuxkit/util"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	log "github.com/sirupsen/logrus"
@@ -41,6 +42,12 @@ const (
 // Note that ImagePull does try ValidateImage first, so if the image is already in the cache, it will not
 // do any network activity at all.
 func (p *Provider) ImagePull(ref *reference.Spec, trustedRef, architecture string, alwaysPull bool) (lktspec.ImageSource, error) {
+	imageName := util.ReferenceExpand(ref.String())
+	canonicalRef, err := reference.Parse(imageName)
+	if err != nil {
+		return ImageSource{}, fmt.Errorf("invalid image name %s: %v", imageName, err)
+	}
+	ref = &canonicalRef
 	image := ref.String()
 	pullImageName := image
 	remoteOptions := []remote.Option{remote.WithAuthFromKeychain(authn.DefaultKeychain)}

--- a/src/cmd/linuxkit/util/reference.go
+++ b/src/cmd/linuxkit/util/reference.go
@@ -17,7 +17,9 @@ func ReferenceWithTag() ReferenceOption {
 	}
 }
 
-// ReferenceExpand expands "redis" to "docker.io/library/redis" so all images have a full domain
+// ReferenceExpand expands "redis" to "docker.io/library/redis" so all images have a full domain,
+// and similarly foo/bar to docker.io/foo/bar.
+// If the image does not have a tag, ":latest" is added.
 func ReferenceExpand(ref string, options ...ReferenceOption) string {
 	var opts refOpts
 	for _, opt := range options {
@@ -26,8 +28,11 @@ func ReferenceExpand(ref string, options ...ReferenceOption) string {
 	ret := ref
 
 	parts := strings.Split(ref, "/")
-	if len(parts) == 1 {
+	switch len(parts) {
+	case 1:
 		ret = "docker.io/library/" + ref
+	case 2:
+		ret = "docker.io/" + ref
 	}
 
 	if opts.withTag && !strings.Contains(ret, ":") {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

It should always canonicalize package names before reading from or writing to cache. However, it missed it reading in one place. So `foo/bar:abc` would fail to find, even though the canonical `docker.io/foo/bar:abc` _was_ there. This fixes it.

**- How I did it**

Changed the source.

**- How to verify it**

CI will catch all of this.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Better canonical names in cache
