### PR TITLE
bump actions to v4 to avoid deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       id: go
 
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set path
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
@@ -79,7 +79,7 @@ jobs:
         GOPATH: ${{runner.workspace}}
 
     - name: Upload binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linuxkit-${{matrix.target.suffix}}
         path: |
@@ -93,14 +93,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up binfmt
       # Only register arm64 as we are on amd64 already. s390x is not reliable
       run: docker run --privileged --rm tonistiigi/binfmt --install arm64
 
     - name: Download linuxkit
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: linuxkit-amd64-linux
         path: bin
@@ -112,7 +112,7 @@ jobs:
         /usr/local/bin/linuxkit version
 
     - name: Cache Packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.linuxkit/cache/
         key: ${{ runner.os }}-linuxkit-${{ github.sha }}
@@ -160,7 +160,7 @@ jobs:
         shard: [1/10,2/10,3/10,4/10,5/10,6/10,7/10,8/10,9/10,10/10]
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Pre-Requisites
       run: |
@@ -170,7 +170,7 @@ jobs:
 
     - name: Restore RTF From Cache
       id: cache-rtf
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: bin
         key: rtf-${{hashFiles('Makefile')}}
@@ -184,7 +184,7 @@ jobs:
         sudo ln -s $(pwd)/bin/rtf /usr/local/bin/rtf
 
     - name: Download linuxkit
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: linuxkit-amd64-linux
         path: bin
@@ -196,7 +196,7 @@ jobs:
         /usr/local/bin/linuxkit version
 
     - name: Restore Package Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.linuxkit/cache/
         key: ${{ runner.os }}-linuxkit-${{ github.sha }}
@@ -215,7 +215,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Pre-Requisites
       run: |
@@ -225,7 +225,7 @@ jobs:
 
     - name: Restore RTF From Cache
       id: cache-rtf
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: bin
         key: rtf-${{hashFiles('Makefile')}}
@@ -239,7 +239,7 @@ jobs:
         sudo ln -s $(pwd)/bin/rtf /usr/local/bin/rtf
 
     - name: Download linuxkit
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: linuxkit-amd64-linux
         path: bin
@@ -251,7 +251,7 @@ jobs:
         /usr/local/bin/linuxkit version
 
     - name: Restore Package Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.linuxkit/cache/
         key: ${{ runner.os }}-linuxkit-${{ github.sha }}
@@ -271,7 +271,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Pre-Requisites
       run: |
@@ -281,13 +281,13 @@ jobs:
 
     - name: Restore RTF From Cache
       id: cache-rtf
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: bin
         key: rtf-${{hashFiles('Makefile')}}
 
     - name: Restore Package Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.linuxkit/cache/
         key: ${{ runner.os }}-linuxkit-${{ github.sha }}
@@ -303,7 +303,7 @@ jobs:
         sudo ln -s $(pwd)/bin/rtf /usr/local/bin/rtf
 
     - name: Download linuxkit
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: linuxkit-amd64-linux
         path: bin
@@ -327,7 +327,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Pre-Requisites
       run: |
@@ -337,7 +337,7 @@ jobs:
 
     - name: Restore RTF From Cache
       id: cache-rtf
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: bin
         key: rtf-${{hashFiles('Makefile')}}
@@ -351,7 +351,7 @@ jobs:
         sudo ln -s $(pwd)/bin/rtf /usr/local/bin/rtf
 
     - name: Download linuxkit
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: linuxkit-amd64-linux
         path: bin
@@ -363,7 +363,7 @@ jobs:
         /usr/local/bin/linuxkit version
 
     - name: Restore Package Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.linuxkit/cache/
         key: ${{ runner.os }}-linuxkit-${{ github.sha }}
@@ -383,7 +383,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Pre-Requisites
       run: |
@@ -393,7 +393,7 @@ jobs:
 
     - name: Restore RTF From Cache
       id: cache-rtf
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: bin
         key: rtf-${{hashFiles('Makefile')}}
@@ -407,7 +407,7 @@ jobs:
         sudo ln -s $(pwd)/bin/rtf /usr/local/bin/rtf
 
     - name: Download linuxkit
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: linuxkit-amd64-linux
         path: bin
@@ -419,7 +419,7 @@ jobs:
         /usr/local/bin/linuxkit version
 
     - name: Restore Package Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.linuxkit/cache/
         key: ${{ runner.os }}-linuxkit-${{ github.sha }}

--- a/.github/workflows/package_release.yml
+++ b/.github/workflows/package_release.yml
@@ -15,7 +15,7 @@ jobs:
         go-version: 1.21.5
       id: go
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Ensure bin/ directory
       run: mkdir -p bin
     - name: Install linuxkit

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Ensure bin/ directory
       run: mkdir -p bin
     - name: Download linuxkit
@@ -45,7 +45,7 @@ jobs:
         sudo ln -s $(pwd)/bin/${{ env.linuxkit_file }} /usr/local/bin/linuxkit
         /usr/local/bin/linuxkit version
     - name: Restore Package Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.linuxkit/cache/
         key: ${{ runner.os }}-linuxkit-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       id: go
 
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set path
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Bumped several GitHub actions from v3 to v4, because of deprecation:

* actions/checkout
* actions/cache
* actions/upload-artifact
* actions/download-artifact

**- How I did it**

Changed them

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update versions of actions
