### PR TITLE
explicitly use GITHUB_TOKEN for actions script

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,7 @@ jobs:
     - name: Download linuxkit
       uses: actions/github-script@v3.1.0
       with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           var artifacts = await github.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Explicitly pass the GITHUB_TOKEN to action-script, because it seems to fail without it.

**- How I did it**

Added a single line to yaml file

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Explicit token
