### PR TITLE
linuxkit/build: implement --modified-only option

### DIFF
--- a/src/cmd/linuxkit/moby/build.go
+++ b/src/cmd/linuxkit/moby/build.go
@@ -206,8 +206,10 @@ func Build(m Moby, w io.Writer, opts BuildOpts) error {
 		// first check if the existing one had it
 		//if config != nil && len(oldConfig.initRefs) > index+1 && oldConfig.initRefs[index].String() == image {
 		if oldConfig != nil && oldConfig.Kernel.ref != nil && oldConfig.Kernel.ref.String() == m.Kernel.ref.String() {
-			if err := extractPackageFilesFromTar(in, iw, m.Kernel.ref.String(), "kernel"); err != nil {
-				return err
+			if !opts.ModifiedOnly {
+				if err := extractPackageFilesFromTar(in, iw, m.Kernel.ref.String(), "kernel"); err != nil {
+					return err
+				}
 			}
 		} else {
 			// get kernel and initrd tarball and ucode cpio archive from container
@@ -231,8 +233,10 @@ func Build(m Moby, w io.Writer, opts BuildOpts) error {
 	apkTar := newAPKTarWriter(iw, "init")
 	for i, ii := range m.initRefs {
 		if oldConfig != nil && len(oldConfig.initRefs) > i && oldConfig.initRefs[i].String() == ii.String() {
-			if err := extractPackageFilesFromTar(in, apkTar, ii.String(), fmt.Sprintf("init[%d]", i)); err != nil {
-				return err
+			if !opts.ModifiedOnly {
+				if err := extractPackageFilesFromTar(in, apkTar, ii.String(), fmt.Sprintf("init[%d]", i)); err != nil {
+					return err
+				}
 			}
 		} else {
 			log.Infof("Process init image: %s", ii)
@@ -251,8 +255,10 @@ func Build(m Moby, w io.Writer, opts BuildOpts) error {
 	}
 	for i, image := range m.Onboot {
 		if oldConfig != nil && len(oldConfig.Onboot) > i && oldConfig.Onboot[i].Equal(image) {
-			if err := extractPackageFilesFromTar(in, iw, image.Image, fmt.Sprintf("onboot[%d]", i)); err != nil {
-				return err
+			if !opts.ModifiedOnly {
+				if err := extractPackageFilesFromTar(in, iw, image.Image, fmt.Sprintf("onboot[%d]", i)); err != nil {
+					return err
+				}
 			}
 		} else {
 			so := fmt.Sprintf("%03d", i)
@@ -267,8 +273,10 @@ func Build(m Moby, w io.Writer, opts BuildOpts) error {
 	}
 	for i, image := range m.Onshutdown {
 		if oldConfig != nil && len(oldConfig.Onshutdown) > i && oldConfig.Onshutdown[i].Equal(image) {
-			if err := extractPackageFilesFromTar(in, iw, image.Image, fmt.Sprintf("onshutdown[%d]", i)); err != nil {
-				return err
+			if !opts.ModifiedOnly {
+				if err := extractPackageFilesFromTar(in, iw, image.Image, fmt.Sprintf("onshutdown[%d]", i)); err != nil {
+					return err
+				}
 			}
 		} else {
 			so := fmt.Sprintf("%03d", i)
@@ -283,8 +291,10 @@ func Build(m Moby, w io.Writer, opts BuildOpts) error {
 	}
 	for i, image := range m.Services {
 		if oldConfig != nil && len(oldConfig.Services) > i && oldConfig.Services[i].Equal(image) {
-			if err := extractPackageFilesFromTar(in, iw, image.Image, fmt.Sprintf("services[%d]", i)); err != nil {
-				return err
+			if !opts.ModifiedOnly {
+				if err := extractPackageFilesFromTar(in, iw, image.Image, fmt.Sprintf("services[%d]", i)); err != nil {
+					return err
+				}
 			}
 		} else {
 			if err := outputImage(image, "services", i, "", m, idMap, dupMap, iw, opts); err != nil {

--- a/src/cmd/linuxkit/moby/opts.go
+++ b/src/cmd/linuxkit/moby/opts.go
@@ -10,4 +10,5 @@ type BuildOpts struct {
 	Arch             string
 	SbomGenerator    *SbomGenerator
 	InputTar         string
+	ModifiedOnly     bool
 }


### PR DESCRIPTION
This implements `--modified-only` option, which should complement recent `--input-tar` feature by generating resulting tarball with modified only files.

**- A picture of a cute animal (not mandatory but encouraged)**

Sure thing. Sad Hamster himself:

![](https://i.kym-cdn.com/entries/icons/original/000/048/516/Screenshot_2024-02-20_at_10.43.43_AM.jpg)
