### PR TITLE
add cache export format OCI

### DIFF
--- a/src/cmd/linuxkit/cache_export.go
+++ b/src/cmd/linuxkit/cache_export.go
@@ -45,12 +45,18 @@ func cacheExportCmd() *cobra.Command {
 			src := p.NewSource(&ref, arch, desc)
 			var reader io.ReadCloser
 			switch format {
-			case "oci":
+			case "docker":
 				fullTagName := fullname
 				if tagName != "" {
 					fullTagName = util.ReferenceExpand(tagName)
 				}
 				reader, err = src.V1TarReader(fullTagName)
+			case "oci":
+				fullTagName := fullname
+				if tagName != "" {
+					fullTagName = util.ReferenceExpand(tagName)
+				}
+				reader, err = src.OCITarReader(fullTagName)
 			case "filesystem":
 				reader, err = src.TarReader()
 			default:
@@ -84,7 +90,7 @@ func cacheExportCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&arch, "arch", runtime.GOARCH, "Architecture to resolve an index to an image, if the provided image name is an index")
 	cmd.Flags().StringVar(&outputFile, "outfile", "", "Path to file to save output, '-' for stdout")
-	cmd.Flags().StringVar(&format, "format", "oci", "export format, one of 'oci', 'filesystem'")
+	cmd.Flags().StringVar(&format, "format", "oci", "export format, one of 'oci' (OCI tar), 'docker' (docker tar), 'filesystem'")
 	cmd.Flags().StringVar(&tagName, "name", "", "override the provided image name in the exported tar file; useful only for format=oci")
 
 	return cmd

--- a/src/cmd/linuxkit/docker/source.go
+++ b/src/cmd/linuxkit/docker/source.go
@@ -86,6 +86,11 @@ func (d ImageSource) V1TarReader(overrideName string) (io.ReadCloser, error) {
 	return Save(saveName)
 }
 
+// OCITarReader return an io.ReadCloser to read the save of the image
+func (d ImageSource) OCITarReader(overrideName string) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("unsupported")
+}
+
 // Descriptor return the descriptor of the image.
 func (d ImageSource) Descriptor() *v1.Descriptor {
 	return nil

--- a/src/cmd/linuxkit/pkglib/build_test.go
+++ b/src/cmd/linuxkit/pkglib/build_test.go
@@ -494,6 +494,15 @@ func (c cacheMockerSource) V1TarReader(overrideName string) (io.ReadCloser, erro
 	_, _ = rand.Read(b)
 	return io.NopCloser(bytes.NewReader(b)), nil
 }
+func (c cacheMockerSource) OCITarReader(overrideName string) (io.ReadCloser, error) {
+	_, found := c.c.images[c.ref.String()]
+	if !found {
+		return nil, fmt.Errorf("no image found with ref: %s", c.ref.String())
+	}
+	b := make([]byte, 256)
+	_, _ = rand.Read(b)
+	return io.NopCloser(bytes.NewReader(b)), nil
+}
 func (c cacheMockerSource) Descriptor() *registry.Descriptor {
 	return c.descriptor
 }

--- a/src/cmd/linuxkit/spec/image.go
+++ b/src/cmd/linuxkit/spec/image.go
@@ -18,6 +18,8 @@ type ImageSource interface {
 	Descriptor() *v1.Descriptor
 	// V1TarReader get the image as v1 tarball, also compatible with `docker load`. If name arg is not "", override name of image in tarfile from default of image.
 	V1TarReader(overrideName string) (io.ReadCloser, error)
+	// OCITarReader get the image as an OCI tarball, also compatible with `docker load`. If name arg is not "", override name of image in tarfile from default of image.
+	OCITarReader(overrideName string) (io.ReadCloser, error)
 	// SBoM get the sbom for the image, if any is available
 	SBoMs() ([]io.ReadCloser, error)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed the `cache export` structure. It nominally supported 2 formats:

* oct
* filesystem

However, `oci` was not _really_ OCI v1 layout, but rather the docker tar format.

I changed it so that `oci` becomes a true OCI v1 layout, and added `docker` format for the docker tar

**- How I did it**

Changed `cache_export.go` to add an option, and added it to the image source

**- How to verify it**

CI, mainly to ensure no regressions. Doesn't matter, as nothing else is affected, but I also tested it manually.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
cache export formats
