### PR TITLE
Improve support for third-party registry images

### DIFF
--- a/src/cmd/linuxkit/util/reference.go
+++ b/src/cmd/linuxkit/util/reference.go
@@ -32,7 +32,12 @@ func ReferenceExpand(ref string, options ...ReferenceOption) string {
 	case 1:
 		ret = "docker.io/library/" + ref
 	case 2:
-		ret = "docker.io/" + ref
+		// If the first part is not a domain, assume it is a DockerHub user/org.
+		// This logic is copied from moby:
+		// https://github.com/moby/moby/blob/e7347f8a8c2fd3d2abd34b638d6fc8c18b0278d1/registry/search.go#L148C29-L149C71
+		if !strings.Contains(parts[0], ".") && !strings.Contains(parts[0], ":") && parts[0] != "localhost" {
+			ret = "docker.io/" + ref
+		}
 	}
 
 	if opts.withTag && !strings.Contains(ret, ":") {

--- a/src/cmd/linuxkit/util/reference_test.go
+++ b/src/cmd/linuxkit/util/reference_test.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReferenceExpand(t *testing.T) {
+	tests := []struct {
+		name    string
+		ref     string
+		options []ReferenceOption
+		want    string
+	}{
+		{
+			"basic image name should expand to docker.io/library image",
+			"redis",
+			nil,
+			"docker.io/library/redis",
+		},
+		{
+			"image name with user/org should expand to docker.io image",
+			"foo/bar",
+			nil,
+			"docker.io/foo/bar",
+		},
+		{
+			"custom registry image name should not expand",
+			"myregistry.io/foo",
+			nil,
+			"myregistry.io/foo",
+		},
+		{
+			"image name with more than three parts should not expand",
+			"foo/bar/baz",
+			nil,
+			"foo/bar/baz",
+		},
+		{
+			"with tag should add latest if image does not have tag",
+			"redis",
+			[]ReferenceOption{ReferenceWithTag()},
+			"docker.io/library/redis:latest",
+		},
+		{
+			"with tag should not add latest if image already has tag",
+			"redis:alpine",
+			[]ReferenceOption{ReferenceWithTag()},
+			"docker.io/library/redis:alpine",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ReferenceExpand(tt.ref, tt.options...)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix `util.ReferenceExpand` to support image references from non-DockerHub remote registries.

**- How I did it**

If the first part of an image reference looks like a domain, we simply return it as is.

**- How to verify it**


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Improve support for image references from remote registries.

fixes #4045

**- A picture of a cute animal (not mandatory but encouraged)**

![PXL_20240420_190655037 PORTRAIT ORIGINAL](https://github.com/linuxkit/linuxkit/assets/247849/ffbacae7-f725-4848-b2d7-d09eac30ebee)
