### PR TITLE
ensured dumpFollow of logread includes 'follow' behaviour

### DIFF
--- a/pkg/memlogd/cmd/logread/main.go
+++ b/pkg/memlogd/cmd/logread/main.go
@@ -41,6 +41,11 @@ func main() {
 	flag.BoolVar(&follow, "f", false, "follow log buffer")
 	flag.Parse()
 
+	if dumpFollow {
+		// StreamLogs() has seperate 'dump' and 'follow' flags, since 'dumpFollow' includes 'follow' we set that too
+		follow = true
+	}
+
 	c, err := StreamLogs(socketPath, follow, dumpFollow)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**- What I did**

Ensured setting `dumpFollow` in memlogd `logread` actually `follow`s as well. closes #4048 

**- How I did it**

included logic: if `dumpFollow` flag is set set the `follow` flag too

**- How to verify it**

1. build memlogd container: `cd pkgs/memlogd && docker build -t logreadedit .`
2. build another container with the following dockerfile
```dockerfile
FROM linuxkit/memlogd:v1.0.0-amd64 AS memlogd-1.0
FROM logreadedit AS memlogd-edit

FROM alpine:3.19    

COPY --from=memlogd-1.0 /usr/bin/memlogd /usr/bin/memlogd
COPY --from=memlogd-1.0 /usr/bin/logread /usr/bin/logread-1.0
COPY --from=memlogd-edit /usr/bin/logread /usr/bin/logread-edit
```
3. start that container interactively: `docker run -it logreadtest /bin/sh`
4. perform the following operations
```shell
memlogd &

# note that the following command returns you directly to the cli - demonstrating the bug
logread-1.0 -F

# note the the following command waits for further logs - demonstrating the fix
logread-edit -F
```

**- Description for the changelog**

Ensured setting `dumpFollow` in memlogd `logread` actually `follow`s as well.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/linuxkit/linuxkit/assets/46323623/ef208f80-5a8b-4530-87eb-4235b127abf6)

