### PR TITLE
cmd: allow more than one config yaml for build

### DIFF
--- a/src/cmd/linuxkit/build.go
+++ b/src/cmd/linuxkit/build.go
@@ -68,7 +68,7 @@ func buildCmd() *cobra.Command {
 The generated image can be in one of multiple formats which can be run on various platforms.
 `,
 		Example: `  linuxkit build [options] <file>[.yml]`,
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if name == "" && outputFile == "" {
 				conf := args[len(args)-1]


### PR DESCRIPTION
according to the documentation the following command is valid: `linuxkit build equinixmetal.yml equinixmetal.arm64.yml` (docs/platform-equinixmetal.md)

So, make it valid.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Allow running `linuxkit build equinixmetal.yml equinixmetal.arm64.yml`  as described in the documentation.

**- How I did it**

Just changed the cobra-args checker.

**- How to verify it**

`> linuxkit build --dry-run platform-equinixmetal.yml platform-equinixmetal.arm64.yml | grep cmdline`

should output `ttyAMA0`

while 

`> linuxkit build --dry-run platform-equinixmetal.yml | grep cmdline`

should output `ttyS1`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Allow more than one yaml config for build command


**- A picture of a cute animal (not mandatory but encouraged)**

https://memory-alpha.fandom.com/wiki/Mellanoid_slime_worm
