### PR TITLE
properly save linuxkit version

### DIFF
--- a/src/cmd/linuxkit/Makefile
+++ b/src/cmd/linuxkit/Makefile
@@ -1,5 +1,24 @@
-VERSION?="v0.0-dev"
+# determine the version we save in the build binary
+# we always include the git commit.
+# the version is the current semver if it this commit matches the tag,
+# else it is the following: <tag>-<commits since tag>-<short commit hash>
+# if the git tree is dirty, append "-dirty"
+# most recent commit
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
+# whether or not it is dirty, i.e. has uncommitted changes
+GIT_DIRTY=$(shell git update-index -q --refresh && git diff-index --quiet HEAD -- . || echo "-dirty")
+# most recent tag, might or might not point to GIT_COMMIT
+GIT_TAG=$(shell git describe --tags --match="v*")
+# include the possible "-dirty" suffix
+VERSION=$(GIT_TAG)$(GIT_DIRTY)
+
+report:
+	@echo "VERSION: $(VERSION)"
+	@echo "GIT_COMMIT: $(GIT_COMMIT)"
+	@echo "GIT_DIRTY: $(GIT_DIRTY)"
+	@echo "GIT_TAG: $(GIT_TAG)"
+	@echo "VERSION: $(VERSION)"
+
 GO_COMPILE?=linuxkit/go-compile:c97703655e8510b7257ffc57f25e40337b0f0813
 export GO_FLAGS=-mod=vendor
 

--- a/src/cmd/linuxkit/version.go
+++ b/src/cmd/linuxkit/version.go
@@ -10,11 +10,22 @@ import (
 )
 
 func versionCmd() *cobra.Command {
+	var short, commit bool
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "report the version of linuxkit",
-		Long:  `Report the version of linuxkit.`,
+		Long: `Report the version of linuxkit.
+		Run with option --short to print just the version number.
+		Run with option --commit to print just the git commit.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if short {
+				fmt.Println(version.Version)
+				return nil
+			}
+			if commit {
+				fmt.Println(version.GitCommit)
+				return nil
+			}
 			fmt.Printf("%s version %s\n", filepath.Base(os.Args[0]), version.Version)
 			if version.GitCommit != "" {
 				fmt.Printf("commit: %s\n", version.GitCommit)
@@ -22,6 +33,8 @@ func versionCmd() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&short, "short", false, "print just the version number")
+	cmd.Flags().BoolVar(&commit, "commit", false, "print just the commit")
 
 	return cmd
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

The version for the `linuxkit` binary was consistently giving `v0.8+` from something hard-coded into the Makefile.

This changes the `src/cmd/Makefile` so it calculates the version. The version will be almost the equivalent of `git describe --tags`.

* If the most recent tag of semver pattern `v*` points to the HEAD commit, then version is injected as `vX.Y.Z` (the semver)
* If the most recent tag points to an earlier commit, then version is injected as `vX.Y.Z-<count>-<shorthash>`, i.e. the equivalent of `git describe --tags`
* In all cases, if there are uncommitted changes, append `-dirty`

**- How I did it**

Changes to `src/cmd/linuxkit/Makefile`

**- How to verify it**

CI obviously, although this should affect nothing in CI. Build it with various commits and run `linuxkit version` and see.

After the change:

```sh
$ linuxkit version
linuxkit version v1.2.0-92-ga7c8ed81f
commit: a7c8ed81f14cf5c11b6fbd50004ce1b1af6e2d26
```

That is _much_ better, and will be helpful in downloaded binaries from GitHub releases.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Proper versions included in linuxkit
