### PR TITLE
separate release builds of macOS CGO from others

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
   create:
 
 jobs:
-  build:
-    name: Build all targets
+  build-all:
+    name: Build all targets expect macOS
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
@@ -26,10 +26,67 @@ jobs:
 
     - name: Build
       run: |
-        make build-all-targets
+        make build-targets-all
       env:
         GOPATH: ${{runner.workspace}}
 
+    - uses: actions/upload-artifact@v4
+      with:
+        name: release-targets-except-cgo
+        path: bin/
+  
+  # separate macos build because macos needs CGO, and it is very hard to cross-compile that
+  build-macos:
+    name: Build macOS target
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: macos-latest
+    steps:
+
+    - name: Set up Go 1.122
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.22.3
+      id: go
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set path
+      run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      env:
+         GOPATH: ${{runner.workspace}}
+
+    - name: Build
+      run: |
+        make build-target-macos
+      env:
+        GOPATH: ${{runner.workspace}}
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: release-targets-macos
+        path: bin/
+    
+  release-artifacts:
+    needs: [build-all, build-macos]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with:
+        name: release-targets-except-cgo
+        path: bintmp/release-targets-except-cgo
+    - uses: actions/download-artifact@v4
+      with:
+        name: release-targets-macos
+        path: bintmp/release-targets-macos
+    - name: Combine Artifacts
+      run: |
+        mkdir -p bin/
+        cp bintmp/*/* bin/
+    - name: Checksum Artifacts
+      run: |
+        make checksum-targets
     - name: GitHub Release
       uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
       env:

--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,8 @@ endif
 		./scripts/update-component-sha.sh --image $${img}$(image); \
 	done
 
-.PHONY: build-all-targets
-build-all-targets: bin
-	$(MAKE) GOOS=darwin GOARCH=arm64 LOCAL_TARGET=$(CURDIR)/bin/linuxkit-darwin-arm64 local-build
-	file bin/linuxkit-darwin-arm64
+.PHONY: build-targets-all
+build-targets-all: bin
 	$(MAKE) GOOS=darwin GOARCH=amd64 LOCAL_TARGET=$(CURDIR)/bin/linuxkit-darwin-amd64 local-build
 	file bin/linuxkit-darwin-amd64
 	$(MAKE) GOOS=linux GOARCH=arm64 LOCAL_TARGET=$(CURDIR)/bin/linuxkit-linux-arm64 local-build
@@ -133,4 +131,10 @@ build-all-targets: bin
 	file bin/linuxkit-linux-s390x
 	$(MAKE) GOOS=windows GOARCH=amd64 LOCAL_TARGET=$(CURDIR)/bin/linuxkit-windows-amd64.exe local-build
 	file bin/linuxkit-windows-amd64.exe
+
+build-target-macos: bin
+	$(MAKE) GOOS=darwin GOARCH=arm64 LOCAL_TARGET=$(CURDIR)/bin/linuxkit-darwin-arm64 local-build
+	file bin/linuxkit-darwin-arm64
+
+checksum-targets: bin
 	cd bin && openssl sha256 -r linuxkit-* | tr -d '*' > checksums.txt


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

The final release workflow - on tags starting with `v*` - builds all of the versions of linuxkit. These all work well via cross-compilation, except for macOS. macOS needs CGO, which is very messy in cross-compilation.

GitHub Actions support macOS runners, so this uses a macOS runner to build macOS linuxkit, then combines all of the binaries into a single directory and then creates the release.

**- How I did it**

Changed Makefile targets and `release.yml`.

**- How to verify it**

CI and then cut a release, which I will do.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Native compilation for macOS in pipelines.
