### PR TITLE
support cmdline-driven debugging mode for runc

### DIFF
--- a/docs/cmdline.md
+++ b/docs/cmdline.md
@@ -1,0 +1,15 @@
+# Kernel command-line options
+
+The kernel command-line is a string of text that the kernel parses as it is starting up. It is passed by the boot loader
+to the kernel and specifies parameters that the kernel uses to configure the system. The command-line is a list of command-line
+options separated by spaces. The options are parsed by the kernel and can be used to enable or disable certain features.
+
+LinuxKit passes all command-line options to the kernel, which uses them in the usual way.
+
+There are several options that can be used to control the behaviour of linuxkit itself, or specifically packages
+within linuxkit. Unless standard Linux options exist, these all are prefaced with `linuxkit.`.
+
+| Option | Description |
+|---|---|
+| `linuxkit.runc_debug=1` | Start runc for `onboot` and `onshutdown` containers to run with `--debug`. Also sends output to the console, in addition to the normal output to logfiles. If not present or set to 0, default to usual mode. |
+| `linuxkit.unified_cgroup_hierarchy=0` | Start up cgroups v1. If not present or set to 1, default to cgroups v1. |

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -52,6 +52,9 @@ which should contain a `kernel` file that will be booted (eg a `bzImage` for `am
 called `kernel.tar` which is a tarball that is unpacked into the root, which should usually
 contain a kernel modules directory. `cmdline` specifies the kernel command line options if required.
 
+The contents of `cmdline` are passed to the kernel as-is. There are several special values that are
+used to control the behaviour of linuxkit packages. See [kernel command line options](../docs/cmdline.md).
+
 To override the names, you can specify the kernel image name with `binary: bzImage` and the tar image
 with `tar: kernel.tar` or the empty string or `none` if you do not want to use a tarball at all.
 

--- a/examples/addbinds.yml
+++ b/examples/addbinds.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/containerd-debug.yml
+++ b/examples/containerd-debug.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,7 +4,7 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:77e45e4681c78d59f1d8a48818260948d55f9d05 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 onboot:

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 services:

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/platform-aws.yml
+++ b/examples/platform-aws.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/platform-azure.yml
+++ b/examples/platform-azure.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/platform-equinixmetal.yml
+++ b/examples/platform-equinixmetal.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/platform-gcp.yml
+++ b/examples/platform-gcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/platform-hetzner.yml
+++ b/examples/platform-hetzner.yml
@@ -3,7 +3,7 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/platform-rt-for-vmware.yml
+++ b/examples/platform-rt-for-vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/platform-scaleway.yml
+++ b/examples/platform-scaleway.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/platform-vmware.yml
+++ b/examples/platform-vmware.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/platform-vultr.yml
+++ b/examples/platform-vultr.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 onboot:

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/static-ip.yml
+++ b/examples/static-ip.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 onboot:

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/volumes.yml
+++ b/examples/volumes.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 onboot:

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 onboot:

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,7 +2,7 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 onboot:

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 onboot:

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,7 +2,7 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/src/cmd/linuxkit/moby/build/mkimage.yaml
+++ b/src/cmd/linuxkit/moby/build/mkimage.yaml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: mkimage

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: dhcpcd

--- a/test/cases/000_build/001_tarheaders/test.yml
+++ b/test/cases/000_build/001_tarheaders/test.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 

--- a/test/cases/000_build/020_binds/test.yml
+++ b/test/cases/000_build/020_binds/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: mount

--- a/test/cases/000_build/050_sbom/test.yml
+++ b/test/cases/000_build/050_sbom/test.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 

--- a/test/cases/000_build/060_input_tar/000_build/test1.yml
+++ b/test/cases/000_build/060_input_tar/000_build/test1.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 onboot:

--- a/test/cases/000_build/060_input_tar/000_build/test2.yml
+++ b/test/cases/000_build/060_input_tar/000_build/test2.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/test/cases/000_build/060_input_tar/010_same_filename/test.yml
+++ b/test/cases/000_build/060_input_tar/010_same_filename/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 onboot:

--- a/test/cases/000_build/070_volumes/000_rw_on_rw/test.yml
+++ b/test/cases/000_build/070_volumes/000_rw_on_rw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: test1

--- a/test/cases/000_build/070_volumes/001_ro_on_ro/test.yml
+++ b/test/cases/000_build/070_volumes/001_ro_on_ro/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: test

--- a/test/cases/000_build/070_volumes/002_rw_on_ro/test.yml
+++ b/test/cases/000_build/070_volumes/002_rw_on_ro/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: test

--- a/test/cases/000_build/070_volumes/003_ro_on_rw/test.yml
+++ b/test/cases/000_build/070_volumes/003_ro_on_rw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: test1

--- a/test/cases/000_build/070_volumes/004_blank/test.yml
+++ b/test/cases/000_build/070_volumes/004_blank/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: test

--- a/test/cases/000_build/070_volumes/005_image/test.yml
+++ b/test/cases/000_build/070_volumes/005_image/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: test

--- a/test/cases/000_build/070_volumes/006_mount_types/test.yml
+++ b/test/cases/000_build/070_volumes/006_mount_types/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: testbinds

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 services:

--- a/test/cases/010_platforms/110_gcp/000_run/test.yml
+++ b/test/cases/010_platforms/110_gcp/000_run/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: poweroff

--- a/test/cases/020_kernel/011_config_5.4.x/test.yml
+++ b/test/cases/020_kernel/011_config_5.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.4.172-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/013_config_5.10.x/test.yml
+++ b/test/cases/020_kernel/013_config_5.10.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.10.104-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/016_config_5.15.x/test.yml
+++ b/test/cases/020_kernel/016_config_5.15.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.15.27-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/019_config_6.6.x/test.yml
+++ b/test/cases/020_kernel/019_config_6.6.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13-44a5293614ca7c7674013e928cb11dcdbba73ba8
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/111_kmod_5.4.x/test.yml
+++ b/test/cases/020_kernel/111_kmod_5.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.4.172-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: check

--- a/test/cases/020_kernel/113_kmod_5.10.x/test.yml
+++ b/test/cases/020_kernel/113_kmod_5.10.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.10.104-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: check

--- a/test/cases/020_kernel/116_kmod_5.15.x/test.yml
+++ b/test/cases/020_kernel/116_kmod_5.15.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.15.27-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: check

--- a/test/cases/020_kernel/119_kmod_6.6.x/test.yml
+++ b/test/cases/020_kernel/119_kmod_6.6.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13-44a5293614ca7c7674013e928cb11dcdbba73ba8
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: check

--- a/test/cases/020_kernel/200_namespace/common.yml
+++ b/test/cases/020_kernel/200_namespace/common.yml
@@ -2,5 +2,5 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: test

--- a/test/cases/040_packages/001_dummy/test.yml
+++ b/test/cases/040_packages/001_dummy/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: dummy

--- a/test/cases/040_packages/002_bcc/test.yml
+++ b/test/cases/040_packages/002_bcc/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/kernel-bcc:5.4.113
 onboot:

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/002_bpftrace/test.yml
+++ b/test/cases/040_packages/002_bpftrace/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/bpftrace:d9ddf9095bce44197aadb0119fe963cb9ebc4444
 onboot:

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff
 onboot:

--- a/test/cases/040_packages/003_cgroupv2/test.yml
+++ b/test/cases/040_packages/003_cgroupv2/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "linuxkit.unified_cgroup_hierarchy=1 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/004_dm-crypt/002_key/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/002_key/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/003_gpt/test-create.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/003_gpt/test.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/006_gpt/test.yml
+++ b/test/cases/040_packages/006_format_mount/006_gpt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/test/cases/040_packages/009_init_containerd/test.yml
+++ b/test/cases/040_packages/009_init_containerd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/test/cases/040_packages/011_kmsg/test.yml
+++ b/test/cases/040_packages/011_kmsg/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/test/cases/040_packages/012_logwrite/test.yml
+++ b/test/cases/040_packages/012_logwrite/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/test/cases/040_packages/012_losetup/test.yml
+++ b/test/cases/040_packages/012_losetup/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: losetup

--- a/test/cases/040_packages/013_metadata/000_cidata/test.yml
+++ b/test/cases/040_packages/013_metadata/000_cidata/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: metadata

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
   - linuxkit/ca-certificates:5aaa343474e5ac3ac01f8b917e82efb1063d80ff

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 onboot:

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,7 +4,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
   - linuxkit/containerd:39301e7312f13eedf19bd5d5551af7b37001d435
 onboot:

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:6.6.13
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:872d2e1be745f1acb948762562cf31c367303a3b
+  - linuxkit/init:6e9ce8698d65bca46d4a791656f86a8a80bffd75
   - linuxkit/runc:6062483d748609d505f2bcde4e52ee64a3329f5f
 onboot:
   - name: test-ns


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added an option to our `init`, wherein, if the kernel cmdline contains `linuxkit.runc_debug`, it will:

1. Run `runc --debug`
2. Send the output to both `os.Stdout`/`os.Stderr` in addition to the usual log files. 

This makes it easier to debug early boot time issues, especially if you cannot get to a shell later to inspect log files.

**- How I did it**

Added the option. Also documented.

**- How to verify it**

Run a test.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Ability to debug runc early via kernel cmdline