### PR TITLE
moby: check architecture for docker image

### DIFF
--- a/src/cmd/linuxkit/docker/cmd.go
+++ b/src/cmd/linuxkit/docker/cmd.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -51,13 +52,19 @@ func createClient() (*client.Client, error) {
 }
 
 // HasImage check if the provided ref is available in the docker cache.
-func HasImage(ref *reference.Spec) error {
+func HasImage(ref *reference.Spec, architecture string) error {
 	log.Debugf("docker inspect image: %s", ref)
 	cli, err := Client()
 	if err != nil {
 		return err
 	}
-	_, err = InspectImage(cli, ref)
+	imageInspect, err := InspectImage(cli, ref)
+	if err != nil {
+		return err
+	}
+	if imageInspect.Architecture != "" && imageInspect.Architecture != architecture {
+		return fmt.Errorf("image not found for right architecture (%s != %s)", imageInspect.Architecture, architecture)
+	}
 
 	return err
 }

--- a/src/cmd/linuxkit/moby/build/images.go
+++ b/src/cmd/linuxkit/moby/build/images.go
@@ -18,7 +18,7 @@ func imagePull(ref *reference.Spec, alwaysPull bool, cacheDir string, dockerCach
 	// - !alwaysPull && !dockerCache: try linuxkit cache, then try to pull from registry, then fail
 	// first, try docker, if that is available
 	if !alwaysPull && dockerCache {
-		if err := docker.HasImage(ref); err == nil {
+		if err := docker.HasImage(ref, architecture); err == nil {
 			return docker.NewSource(ref), nil
 		}
 		// docker is not required, so any error - image not available, no docker, whatever - just gets ignored


### PR DESCRIPTION
Fixes that under certain cases the container image is already in the local docker registry, but with the wrong architecture; in this case just pretend it is not there and let the caller decide if they want to build it

**- What I did**

Check that linuxkit does accidentaly take a docker image with the wrong architecture.

**- How I did it**

Check architecture before taking it.

**- How to verify it**

https://github.com/lf-edge/eve/pull/4150 - enable DockerCache and run `make test`

**- A picture of a cute animal (not mandatory but encouraged)**

https://media2.giphy.com/media/4Ho5aPCXJEzOqcwddj/giphy.webp?cid=ecf05e47j41oybtdpecws1b12gvms2d2wdg82uciccnty2bd&ep=v1_gifs_search&rid=giphy.webp&ct=g
