### PR TITLE
remove linuxefi grub EFI handover to normal linux loading

### DIFF
--- a/src/cmd/linuxkit/moby/build/images.yaml
+++ b/src/cmd/linuxkit/moby/build/images.yaml
@@ -1,12 +1,12 @@
  iso:            linuxkit/mkimage-iso:08d19f8acf285bdce65dd4aea24f01d8adbedfbc
  iso-bios:       linuxkit/mkimage-iso-bios:96d5dac296345c308b8ad9e6cae7467e76ba8fd1
- iso-efi:        linuxkit/mkimage-iso-efi:cf2a3ff1dacfcacfb1f165abc210d9e33dc9d161
- iso-efi-initrd: linuxkit/mkimage-iso-efi-initrd:a9e61bc810ae9928bab92f41f6e810e5b4f6183a
+ iso-efi:        linuxkit/mkimage-iso-efi:8b538605a581db7523c021bf92a715d2054f609e
+ iso-efi-initrd: linuxkit/mkimage-iso-efi-initrd:d390030aae1069f3142523e9f433aad946838911
  raw-bios:       linuxkit/mkimage-raw-bios:4c21d66c81fd3641c62b9e80ddf5494000a1a442
- raw-efi:        linuxkit/mkimage-raw-efi:df0979572e8d0251a5cf55b6f73131868d036bb4
+ raw-efi:        linuxkit/mkimage-raw-efi:14b66a308b2047c59b0fe7c43996f73c653a9fcd
  squashfs:       linuxkit/mkimage-squashfs:a61fd76227ab4998d6c1ba17229cd8bd749e8f13
  gcp:            linuxkit/mkimage-gcp:035c2c2b4b958060c0b6bdd41d9cbc886a335098
- qcow2-efi:      linuxkit/mkimage-qcow2-efi:98a6e3e7b6eed965f879cd77c009c7c404d4457d
+ qcow2-efi:      linuxkit/mkimage-qcow2-efi:8b76f4118e6640db6f39196dc365529f401e7670
  vhd:            linuxkit/mkimage-vhd:91bcc7a6475f46a3d5d84cf6161f07c583dd9c21
  dynamic-vhd:    linuxkit/mkimage-dynamic-vhd:b755f8ff82c8631d18decaebb09867e7b88c2533
  vmdk:           linuxkit/mkimage-vmdk:20a370a55bd8d58c2ae9d634c297a955bb006efd

--- a/tools/grub-dev/Dockerfile
+++ b/tools/grub-dev/Dockerfile
@@ -40,7 +40,7 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN make install
 RUN case $(uname -m) in \
   x86_64) \
-    ./grub-mkimage -O x86_64-efi -d /grub-lib/grub/x86_64-efi -o /grub-lib/BOOTX64.EFI -p /EFI/BOOT ${GRUB_MODULES} linuxefi; \
+    ./grub-mkimage -O x86_64-efi -d /grub-lib/grub/x86_64-efi -o /grub-lib/BOOTX64.EFI -p /EFI/BOOT ${GRUB_MODULES}; \
     ;; \
   aarch64) \
     ./grub-mkimage -O arm64-efi -d /grub-lib/grub/arm64-efi -o /grub-lib/BOOTAA64.EFI -p /EFI/BOOT ${GRUB_MODULES}; \

--- a/tools/grub/Dockerfile
+++ b/tools/grub/Dockerfile
@@ -1,6 +1,6 @@
 # this is really hard to build. Do not change this version unless you must
-FROM --platform=linux/amd64 linuxkit/grub-dev:e94da02aac3a39fec34047051a40d367e61cd0a0 AS grub-build-amd64
-FROM --platform=linux/arm64 linuxkit/grub-dev:e94da02aac3a39fec34047051a40d367e61cd0a0 AS grub-build-arm64
+FROM --platform=linux/amd64 linuxkit/grub-dev:854df7920df18567e23940a1f9cf573980dcfe9b AS grub-build-amd64
+FROM --platform=linux/arm64 linuxkit/grub-dev:854df7920df18567e23940a1f9cf573980dcfe9b AS grub-build-arm64
 
 FROM scratch
 ENTRYPOINT []

--- a/tools/mkimage-iso-efi-initrd/Dockerfile
+++ b/tools/mkimage-iso-efi-initrd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/grub:292deb743d85eb79cbd5b163841db8ccd2500677 AS grub
+FROM linuxkit/grub:9b36ab2ca67e9cdc2faf008278cc4bb8f981350b AS grub
 
 FROM linuxkit/alpine:146f540f25cd92ec8ff0c5b0c98342a9a95e479e AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/

--- a/tools/mkimage-iso-efi-initrd/make-efi-initrd
+++ b/tools/mkimage-iso-efi-initrd/make-efi-initrd
@@ -7,13 +7,9 @@ ARCH=${TARGETARCH:-`uname -m`}
 case $ARCH in
 x86_64)
   BOOTFILE=BOOTX64.EFI
-  LINUX_ENTRY=linuxefi
-  INITRD_ENTRY=initrdefi
   ;;
 aarch64)
   BOOTFILE=BOOTAA64.EFI
-  LINUX_ENTRY=linux
-  INITRD_ENTRY=initrd
   ;;
 esac
 
@@ -35,8 +31,8 @@ cp /usr/local/share/$BOOTFILE .
 CFG="set timeout=0
 set gfxpayload=text
 menuentry 'LinuxKit ISO Image' {
-	$LINUX_ENTRY /kernel ${CMDLINE} text
-	$INITRD_ENTRY /initrd.img
+	linux /kernel ${CMDLINE} text
+	initrd /initrd.img
 }
 "
 

--- a/tools/mkimage-iso-efi/Dockerfile
+++ b/tools/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/grub:292deb743d85eb79cbd5b163841db8ccd2500677 AS grub
+FROM linuxkit/grub:9b36ab2ca67e9cdc2faf008278cc4bb8f981350b AS grub
 
 FROM linuxkit/alpine:146f540f25cd92ec8ff0c5b0c98342a9a95e479e AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/

--- a/tools/mkimage-iso-efi/make-efi
+++ b/tools/mkimage-iso-efi/make-efi
@@ -8,12 +8,10 @@ case $ARCH in
 x86_64)
   BOOTFILE=BOOTX64.EFI
   ROOTDEV=/dev/sr0
-  LINUX_ENTRY=linuxefi
   ;;
 aarch64)
   BOOTFILE=BOOTAA64.EFI
   ROOTDEV=/dev/vda
-  LINUX_ENTRY=linux
   ;;
 esac
 
@@ -38,7 +36,7 @@ cp /usr/local/share/$BOOTFILE .
 CFG="set timeout=0
 set gfxpayload=text
 menuentry 'LinuxKit ISO Image' {
-	$LINUX_ENTRY /boot/kernel ${CMDLINE} text
+	linux /boot/kernel ${CMDLINE} text
 }
 "
 

--- a/tools/mkimage-qcow2-efi/Dockerfile
+++ b/tools/mkimage-qcow2-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/grub:292deb743d85eb79cbd5b163841db8ccd2500677 AS grub
+FROM linuxkit/grub:9b36ab2ca67e9cdc2faf008278cc4bb8f981350b AS grub
 
 FROM linuxkit/alpine:146f540f25cd92ec8ff0c5b0c98342a9a95e479e AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/

--- a/tools/mkimage-qcow2-efi/make-efi
+++ b/tools/mkimage-qcow2-efi/make-efi
@@ -19,13 +19,9 @@ ARCH=${TARGETARCH:-`uname -m`}
 case $ARCH in
 x86_64)
   BOOTFILE=BOOTX64.EFI
-  LINUX_ENTRY=linuxefi
-  INITRD_ENTRY=initrdefi
   ;;
 aarch64)
   BOOTFILE=BOOTAA64.EFI
-  LINUX_ENTRY=linux
-  INITRD_ENTRY=initrd
   ;;
 esac
 
@@ -54,8 +50,8 @@ cat >> EFI/BOOT/grub.cfg <<EOF
 set timeout=0
 set gfxpayload=text
 menuentry 'LinuxKit ISO Image' {
-	$LINUX_ENTRY /kernel ${CMDLINE} text
-  $INITRD_ENTRY /initrd.img
+	linux /kernel ${CMDLINE} text
+  initrd /initrd.img
 }
 EOF
 

--- a/tools/mkimage-raw-efi/Dockerfile
+++ b/tools/mkimage-raw-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/grub:292deb743d85eb79cbd5b163841db8ccd2500677 AS grub
+FROM linuxkit/grub:9b36ab2ca67e9cdc2faf008278cc4bb8f981350b AS grub
 
 FROM linuxkit/alpine:146f540f25cd92ec8ff0c5b0c98342a9a95e479e AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/

--- a/tools/mkimage-raw-efi/make-efi
+++ b/tools/mkimage-raw-efi/make-efi
@@ -19,13 +19,9 @@ ARCH=${TARGETARCH:-`uname -m`}
 case $ARCH in
 x86_64)
   BOOTFILE=BOOTX64.EFI
-  LINUX_ENTRY=linuxefi
-  INITRD_ENTRY=initrdefi
   ;;
 aarch64)
   BOOTFILE=BOOTAA64.EFI
-  LINUX_ENTRY=linux
-  INITRD_ENTRY=initrd
   ;;
 esac
 
@@ -54,8 +50,8 @@ cat >> EFI/BOOT/grub.cfg <<EOF
 set timeout=0
 set gfxpayload=text
 menuentry 'LinuxKit ISO Image' {
-	$LINUX_ENTRY /kernel ${CMDLINE} text
-  $INITRD_ENTRY /initrd.img
+	linux /kernel ${CMDLINE} text
+  initrd /initrd.img
 }
 EOF
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes #4068 

**- What I did**

Removed any references to `linuxefi` and `initrdefi` when building EFI images for x86_64, as the EFI handover has been deprecated, per https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=cc3fdda2876e58a7e83e558ab51853cf106afb6a

**- How I did it**

1. Removed `linuxefi` module from `linuxkit/grub-dev`
2. Regenerated `linuxkit/grub`
3. Changed the grub config files in the various packages
4. Ran `scripts/update-component-sha.sh` for all of the above

**- How to verify it**

CI to ensure no regression, and build an image to check

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Removal of deprecated `linuxefi` call.
