### PR TITLE
internal restructure to use explicit platform instead of implicit arch in cache

### DIFF
--- a/src/cmd/linuxkit/cache/find.go
+++ b/src/cmd/linuxkit/cache/find.go
@@ -8,6 +8,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/match"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // matchPlatformsOSArch because match.Platforms rejects it if the provided
@@ -46,7 +47,7 @@ func matchAllAnnotations(annotations map[string]string) match.Matcher {
 	}
 }
 
-func (p *Provider) findImage(imageName, architecture string) (v1.Image, error) {
+func (p *Provider) findImage(imageName string, platform imagespec.Platform) (v1.Image, error) {
 	root, err := p.FindRoot(imageName)
 	if err != nil {
 		return nil, err
@@ -58,7 +59,7 @@ func (p *Provider) findImage(imageName, architecture string) (v1.Image, error) {
 	ii, err := root.ImageIndex()
 	if err == nil {
 		// we have the index, get the manifest that represents the manifest for the desired architecture
-		platform := v1.Platform{OS: "linux", Architecture: architecture}
+		platform := v1.Platform{OS: platform.OS, Architecture: platform.Architecture}
 		images, err := partial.FindImages(ii, matchPlatformsOSArch(platform))
 		if err != nil || len(images) < 1 {
 			return nil, fmt.Errorf("error retrieving image %s for platform %v from cache: %v", imageName, platform, err)

--- a/src/cmd/linuxkit/cache/indexsource.go
+++ b/src/cmd/linuxkit/cache/indexsource.go
@@ -1,0 +1,162 @@
+package cache
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/containerd/containerd/reference"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/spec"
+	lktspec "github.com/linuxkit/linuxkit/src/cmd/linuxkit/spec"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// IndexSource a source for an image in the OCI distribution cache.
+// Implements a spec.ImageSource.
+type IndexSource struct {
+	ref        *reference.Spec
+	provider   *Provider
+	descriptor *v1.Descriptor
+	platforms  []imagespec.Platform
+}
+
+// NewIndexSource return an IndexSource for a specific ref in the given
+// cache directory.
+func (p *Provider) NewIndexSource(ref *reference.Spec, descriptor *v1.Descriptor, platforms []imagespec.Platform) lktspec.IndexSource {
+	return IndexSource{
+		ref:        ref,
+		provider:   p,
+		descriptor: descriptor,
+		platforms:  platforms,
+	}
+}
+
+// Config return the imagespec.ImageConfig for the given source. Resolves to the
+// architecture, if necessary.
+func (c IndexSource) Image(platform imagespec.Platform) (spec.ImageSource, error) {
+	imageName := c.ref.String()
+	index, err := c.provider.findIndex(imageName)
+	if err != nil {
+		return nil, err
+	}
+	manifests, err := index.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+	for _, manifest := range manifests.Manifests {
+		if manifest.Platform != nil && manifest.Platform.Architecture == platform.Architecture && manifest.Platform.OS == platform.OS {
+			return c.provider.NewSource(c.ref, &platform, &manifest), nil
+		}
+	}
+	return nil, fmt.Errorf("no manifest found for platform %q", platform)
+}
+
+// OCITarReader return an io.ReadCloser to read the image as a v1 tarball whose contents match OCI v1 layout spec
+func (c IndexSource) OCITarReader(overrideName string) (io.ReadCloser, error) {
+	imageName := c.ref.String()
+	saveName := imageName
+	if overrideName != "" {
+		saveName = overrideName
+	}
+	refName, err := name.ParseReference(saveName)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing image name: %v", err)
+	}
+	// get a reference to the image
+	index, err := c.provider.findIndex(c.ref.String())
+	if err != nil {
+		return nil, err
+	}
+	// convert the writer to a reader
+	r, w := io.Pipe()
+	go func() {
+		defer w.Close()
+		tw := tar.NewWriter(w)
+		defer tw.Close()
+		if err := writeLayoutHeader(tw); err != nil {
+			_ = w.CloseWithError(err)
+			return
+		}
+
+		manifests, err := index.IndexManifest()
+		if err != nil {
+			_ = w.CloseWithError(err)
+			return
+		}
+		// for each manifest, write the manifest blob, then go through each manifest and find the image for it
+		// and write its blobs
+		for _, manifest := range manifests.Manifests {
+			// if we restricted this image source to certain platforms, we should only write those
+			if len(c.platforms) > 0 {
+				found := false
+				for _, platform := range c.platforms {
+					if platform.Architecture == manifest.Platform.Architecture && platform.OS == manifest.Platform.OS &&
+						(platform.Variant == "" || platform.Variant == manifest.Platform.Variant) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue
+				}
+			}
+			switch manifest.MediaType {
+			case types.OCIManifestSchema1, types.DockerManifestSchema2:
+				// this is an image manifest
+				image, err := index.Image(manifest.Digest)
+				if err != nil {
+					_ = w.CloseWithError(err)
+					return
+				}
+				if err := writeLayoutImage(tw, image); err != nil {
+					_ = w.CloseWithError(err)
+					return
+				}
+			}
+		}
+
+		// write the index directly as a blob
+		indexSize, err := index.Size()
+		if err != nil {
+			_ = w.CloseWithError(err)
+			return
+		}
+		indexDigest, err := index.Digest()
+		if err != nil {
+			_ = w.CloseWithError(err)
+			return
+		}
+		indexBytes, err := index.RawManifest()
+		if err != nil {
+			_ = w.CloseWithError(err)
+			return
+		}
+		if err := writeLayoutBlob(tw, indexDigest.Hex, indexSize, bytes.NewReader(indexBytes)); err != nil {
+			_ = w.CloseWithError(err)
+			return
+		}
+
+		desc := v1.Descriptor{
+			MediaType: types.OCIImageIndex,
+			Size:      indexSize,
+			Digest:    indexDigest,
+			Annotations: map[string]string{
+				imagespec.AnnotationRefName: refName.String(),
+			},
+		}
+		if err := writeLayoutIndex(tw, desc); err != nil {
+			_ = w.CloseWithError(err)
+			return
+		}
+	}()
+	return r, nil
+}
+
+// Descriptor return the descriptor of the index.
+func (c IndexSource) Descriptor() *v1.Descriptor {
+	return c.descriptor
+}

--- a/src/cmd/linuxkit/cache/layout.go
+++ b/src/cmd/linuxkit/cache/layout.go
@@ -1,0 +1,145 @@
+package cache
+
+import (
+	"archive/tar"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+)
+
+func writeLayoutHeader(tw *tar.Writer) error {
+	// layout file
+	layoutFileBytes := []byte(layoutFile)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "oci-layout",
+		Mode:     0644,
+		Size:     int64(len(layoutFileBytes)),
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		return err
+	}
+	if _, err := tw.Write(layoutFileBytes); err != nil {
+		return err
+	}
+
+	// make blobs directory
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "blobs/",
+		Mode:     0755,
+		Typeflag: tar.TypeDir,
+	}); err != nil {
+		return err
+	}
+	// make blobs/sha256 directory
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "blobs/sha256/",
+		Mode:     0755,
+		Typeflag: tar.TypeDir,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeLayoutImage(tw *tar.Writer, image v1.Image) error {
+	// write config, each layer, manifest, saving the digest for each
+	manifest, err := image.Manifest()
+	if err != nil {
+		return err
+	}
+	configDesc := manifest.Config
+	configBytes, err := image.RawConfigFile()
+	if err != nil {
+		return err
+	}
+	if err := writeLayoutBlob(tw, configDesc.Digest.Hex, configDesc.Size, bytes.NewReader(configBytes)); err != nil {
+		return err
+	}
+
+	layers, err := image.Layers()
+	if err != nil {
+		return err
+	}
+	for _, layer := range layers {
+		blob, err := layer.Compressed()
+		if err != nil {
+			return err
+		}
+		defer blob.Close()
+		blobDigest, err := layer.Digest()
+		if err != nil {
+			return err
+		}
+		blobSize, err := layer.Size()
+		if err != nil {
+			return err
+		}
+		if err := writeLayoutBlob(tw, blobDigest.Hex, blobSize, blob); err != nil {
+			return err
+		}
+	}
+	// write the manifest
+	manifestSize, err := image.Size()
+	if err != nil {
+		return err
+	}
+	manifestDigest, err := image.Digest()
+	if err != nil {
+		return err
+	}
+	manifestBytes, err := image.RawManifest()
+	if err != nil {
+		return err
+	}
+	if err := writeLayoutBlob(tw, manifestDigest.Hex, manifestSize, bytes.NewReader(manifestBytes)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeLayoutBlob(tw *tar.Writer, digest string, size int64, blob io.Reader) error {
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     fmt.Sprintf("blobs/sha256/%s", digest),
+		Mode:     0644,
+		Size:     size,
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		return err
+	}
+	if _, err := io.Copy(tw, blob); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeLayoutIndex(tw *tar.Writer, desc v1.Descriptor) error {
+	ii := empty.Index
+
+	index, err := ii.IndexManifest()
+	if err != nil {
+		return err
+	}
+
+	index.Manifests = append(index.Manifests, desc)
+
+	rawIndex, err := json.MarshalIndent(index, "", "   ")
+	if err != nil {
+		return err
+	}
+	// write the index
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "index.json",
+		Mode: 0644,
+		Size: int64(len(rawIndex)),
+	}); err != nil {
+		return err
+	}
+	if _, err := tw.Write(rawIndex); err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/cmd/linuxkit/cache/platform.go
+++ b/src/cmd/linuxkit/cache/platform.go
@@ -1,0 +1,33 @@
+package cache
+
+import (
+	"fmt"
+	"strings"
+
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func platformString(p imagespec.Platform) string {
+	parts := []string{p.OS, p.Architecture}
+	if p.Variant != "" {
+		parts = append(parts, p.Variant)
+	}
+	return strings.Join(parts, "/")
+}
+
+func platformMessageGenerator(platforms []imagespec.Platform) string {
+	var platformMessage string
+	switch {
+	case len(platforms) == 0:
+		platformMessage = "all platforms"
+	case len(platforms) == 1:
+		platformMessage = fmt.Sprintf("platform %s", platformString(platforms[0]))
+	default:
+		var platStrings []string
+		for _, p := range platforms {
+			platStrings = append(platStrings, platformString(p))
+		}
+		platformMessage = fmt.Sprintf("platforms %s", strings.Join(platStrings, ","))
+	}
+	return platformMessage
+}

--- a/src/cmd/linuxkit/cache_export.go
+++ b/src/cmd/linuxkit/cache_export.go
@@ -4,17 +4,20 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/containerd/containerd/reference"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	cachepkg "github.com/linuxkit/linuxkit/src/cmd/linuxkit/cache"
 	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/util"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 func cacheExportCmd() *cobra.Command {
 	var (
-		arch       string
+		platform   string
 		outputFile string
 		format     string
 		tagName    string
@@ -42,7 +45,16 @@ func cacheExportCmd() *cobra.Command {
 				log.Fatalf("unable to find image named %s: %v", name, err)
 			}
 
-			src := p.NewSource(&ref, arch, desc)
+			plat, err := v1.ParsePlatform(platform)
+			if err != nil {
+				log.Fatalf("invalid platform %s: %v", platform, err)
+			}
+			platspec := imagespec.Platform{
+				Architecture: plat.Architecture,
+				OS:           plat.OS,
+				Variant:      plat.Variant,
+			}
+			src := p.NewSource(&ref, &platspec, desc)
 			var reader io.ReadCloser
 			switch format {
 			case "docker":
@@ -88,7 +100,7 @@ func cacheExportCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&arch, "arch", runtime.GOARCH, "Architecture to resolve an index to an image, if the provided image name is an index")
+	cmd.Flags().StringVar(&platform, "platform", strings.Join([]string{"linux", runtime.GOARCH}, "/"), "Platform to resolve an index to an image, if the provided image name is an index")
 	cmd.Flags().StringVar(&outputFile, "outfile", "", "Path to file to save output, '-' for stdout")
 	cmd.Flags().StringVar(&format, "format", "oci", "export format, one of 'oci' (OCI tar), 'docker' (docker tar), 'filesystem'")
 	cmd.Flags().StringVar(&tagName, "name", "", "override the provided image name in the exported tar file; useful only for format=oci")

--- a/src/cmd/linuxkit/moby/build/images.go
+++ b/src/cmd/linuxkit/moby/build/images.go
@@ -5,20 +5,23 @@ import (
 	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/cache"
 	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/docker"
 	lktspec "github.com/linuxkit/linuxkit/src/cmd/linuxkit/spec"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// imagePull pull an image from the OCI registry to the cache.
-// If the image root already is in the cache, use it, unless
-// the option pull is set to true.
-// if alwaysPull, then do not even bother reading locally
-func imagePull(ref *reference.Spec, alwaysPull bool, cacheDir string, dockerCache bool, architecture string) (lktspec.ImageSource, error) {
+// imageSource given an image ref, get a handle on the image so it can be used as a source for its configuration
+// and layers. If the image root already is in the cache, use it.
+// If not in cache, pull it down from the OCI registry.
+// Optionally can look in docker image cache first, before falling back to linuxkit cache and OCI registry.
+// Optionally can be told to alwaysPull, in which case it always pulls from the OCI registry.
+// Always works for a single architecture, as we are referencing a specific image.
+func imageSource(ref *reference.Spec, alwaysPull bool, cacheDir string, dockerCache bool, platform imagespec.Platform) (lktspec.ImageSource, error) {
 	// several possibilities:
 	// - alwaysPull: try to pull it down from the registry to linuxkit cache, then fail
 	// - !alwaysPull && dockerCache: try to read it from docker, then try linuxkit cache, then try to pull from registry, then fail
 	// - !alwaysPull && !dockerCache: try linuxkit cache, then try to pull from registry, then fail
 	// first, try docker, if that is available
 	if !alwaysPull && dockerCache {
-		if err := docker.HasImage(ref, architecture); err == nil {
+		if err := docker.HasImage(ref, platform.Architecture); err == nil {
 			return docker.NewSource(ref), nil
 		}
 		// docker is not required, so any error - image not available, no docker, whatever - just gets ignored
@@ -31,5 +34,44 @@ func imagePull(ref *reference.Spec, alwaysPull bool, cacheDir string, dockerCach
 	}
 
 	// if we made it here, we either did not have the image, or it was incomplete
-	return c.ImagePull(ref, ref.String(), architecture, alwaysPull)
+	if err := c.ImagePull(ref, []imagespec.Platform{platform}, alwaysPull); err != nil {
+		return nil, err
+	}
+	desc, err := c.FindDescriptor(ref)
+	if err != nil {
+		return nil, err
+	}
+	return c.NewSource(
+		ref,
+		&platform,
+		desc,
+	), nil
+}
+
+// indexSource given an image ref, get a handle on the index so it can be used as a source for its underlying images.
+// If the index root already is in the cache, use it.
+// If not in cache, pull it down from the OCI registry.
+// Optionally can look in docker image cache first, before falling back to linuxkit cache and OCI registry.
+// Optionally can be told to alwaysPull, in which case it always pulls from the OCI registry.
+// Can provide architectures to list which ones to limit, or leave empty for all available.
+func indexSource(ref *reference.Spec, alwaysPull bool, cacheDir string, platforms []imagespec.Platform) (lktspec.IndexSource, error) {
+	// get a reference to the local cache; we either will find the ref there or will pull to it
+	c, err := cache.NewProvider(cacheDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// if we made it here, we either did not have the image, or it was incomplete
+	if err := c.ImagePull(ref, platforms, alwaysPull); err != nil {
+		return nil, err
+	}
+	desc, err := c.FindDescriptor(ref)
+	if err != nil {
+		return nil, err
+	}
+	return c.NewIndexSource(
+		ref,
+		desc,
+		platforms,
+	), nil
 }

--- a/src/cmd/linuxkit/moby/config.go
+++ b/src/cmd/linuxkit/moby/config.go
@@ -76,10 +76,12 @@ type File struct {
 
 // Volume is the type of a volume specification
 type Volume struct {
-	Name     string `yaml:"name" json:"name"`
-	Image    string `yaml:"image,omitempty" json:"image,omitempty"`
-	ReadOnly bool   `yaml:"readonly,omitempty" json:"readonly,omitempty"`
-	ref      *reference.Spec
+	Name      string   `yaml:"name" json:"name"`
+	Image     string   `yaml:"image,omitempty" json:"image,omitempty"`
+	ReadOnly  bool     `yaml:"readonly,omitempty" json:"readonly,omitempty"`
+	Format    string   `yaml:"format,omitempty" json:"format,omitempty"`
+	Platforms []string `yaml:"platforms,omitempty" json:"platforms,omitempty"`
+	ref       *reference.Spec
 }
 
 func (v Volume) ImageRef() *reference.Spec {

--- a/src/cmd/linuxkit/spec/cache.go
+++ b/src/cmd/linuxkit/spec/cache.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/reference"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // CacheProvider interface for a provide of a cache.
@@ -19,7 +20,7 @@ type CacheProvider interface {
 	// ImagePull takes an image name and pulls it from a registry to the cache. It should be
 	// efficient and only write missing blobs, based on their content hash. If the ref already
 	// exists in the cache, it should not pull anything, unless alwaysPull is set to true.
-	ImagePull(ref *reference.Spec, trustedRef, architecture string, alwaysPull bool) (ImageSource, error)
+	ImagePull(ref *reference.Spec, platform []imagespec.Platform, alwaysPull bool) error
 	// ImageInCache takes an image name and checks if it exists in the cache, including checking that the given
 	// architecture is complete. Like ImagePull, it should be efficient and only write missing blobs, based on
 	// their content hash.
@@ -30,20 +31,20 @@ type CacheProvider interface {
 	// Cache implementation determines whether it should pull missing blobs from a remote registry.
 	// If the provided reference already exists and it is an index, updates the manifests in the
 	// existing index.
-	IndexWrite(ref *reference.Spec, descriptors ...v1.Descriptor) (ImageSource, error)
+	IndexWrite(ref *reference.Spec, descriptors ...v1.Descriptor) error
 	// ImageLoad takes an OCI format image tar stream in the io.Reader and writes it to the cache. It should be
 	// efficient and only write missing blobs, based on their content hash.
 	ImageLoad(r io.Reader) ([]v1.Descriptor, error)
 	// DescriptorWrite writes a descriptor to the cache index; it validates that it has a name
 	// and replaces any existing one
-	DescriptorWrite(ref *reference.Spec, descriptors v1.Descriptor) (ImageSource, error)
+	DescriptorWrite(ref *reference.Spec, descriptors v1.Descriptor) error
 	// Push an image along with a multi-arch index from local cache to remote registry.
 	// name is the name as referenced in the local cache, remoteName is the name to give it remotely.
 	// If remoteName is empty, it is the same as name.
 	// if withManifest defined will push a multi-arch manifest
 	Push(name, remoteName string, withManifest, override bool) error
 	// NewSource return an ImageSource for a specific ref and architecture in the cache.
-	NewSource(ref *reference.Spec, architecture string, descriptor *v1.Descriptor) ImageSource
+	NewSource(ref *reference.Spec, platform *imagespec.Platform, descriptor *v1.Descriptor) ImageSource
 	// GetContent returns an io.Reader to the provided content as is, given a specific digest. It is
 	// up to the caller to validate it.
 	GetContent(hash v1.Hash) (io.ReadCloser, error)

--- a/src/cmd/linuxkit/spec/image.go
+++ b/src/cmd/linuxkit/spec/image.go
@@ -10,16 +10,27 @@ import (
 // ImageSource interface to an image. It can have its config read, and a its containers
 // can be read via an io.ReadCloser tar stream.
 type ImageSource interface {
+	// Descriptor get the v1.Descriptor of the image
+	Descriptor() *v1.Descriptor
 	// Config get the config for the image
 	Config() (imagespec.ImageConfig, error)
 	// TarReader get the flattened filesystem of the image as a tar stream
 	TarReader() (io.ReadCloser, error)
-	// Descriptor get the v1.Descriptor of the image
-	Descriptor() *v1.Descriptor
 	// V1TarReader get the image as v1 tarball, also compatible with `docker load`. If name arg is not "", override name of image in tarfile from default of image.
 	V1TarReader(overrideName string) (io.ReadCloser, error)
 	// OCITarReader get the image as an OCI tarball, also compatible with `docker load`. If name arg is not "", override name of image in tarfile from default of image.
 	OCITarReader(overrideName string) (io.ReadCloser, error)
 	// SBoM get the sbom for the image, if any is available
 	SBoMs() ([]io.ReadCloser, error)
+}
+
+// IndexSource interface to an image. It can have its config read, and a its containers
+// can be read via an io.ReadCloser tar stream.
+type IndexSource interface {
+	// Descriptor get the v1.Descriptor of the index
+	Descriptor() *v1.Descriptor
+	// Image get image for a specific architecture
+	Image(platform imagespec.Platform) (ImageSource, error)
+	// OCITarReader get the image as an OCI tarball, also compatible with `docker load`. If name arg is not "", override name of image in tarfile from default of image.
+	OCITarReader(overrideName string) (io.ReadCloser, error)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Internally, we used arch to define images we wanted, implicitly assuming OS always was `linux`. While mostly correct - this is _linuxkit_ - it makes the internal tools less useful, as you cannot pull down or check other platforms in images. That will become useful in future volume definitions. There is a follow-on PR ready for it, but I separated the "no functionality, all internal" changes from the "new functionality" changes.

**- How I did it**

Restructured internal cache commands and all references.

**- How to verify it**

CI.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Internal changes to support cache on multiple platforms, not just OS=linux
