### PR TITLE
additional volume support in building

### DIFF
--- a/src/cmd/linuxkit/moby/schema.go
+++ b/src/cmd/linuxkit/moby/schema.go
@@ -43,7 +43,9 @@ var schema = `
         "properties": {
           "name": {"type": "string"},
           "image": {"type": "string"},
-          "readonly": {"type": "boolean"}
+          "readonly": {"type": "boolean"},
+          "format": {"enum": ["oci","filesystem"]},
+          "platforms": {"$ref": "#/definitions/strings"}
         }
     },
     "volumes": {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added support for volumes as OCI v1 layout.

`volumes` section already has the ability to populate a volume with the contents of an OCI Image by merging it into a filesystem. Sometimes, you want to just have the image as is. This gives an option to lay it out in OCI v1 layout format, with all of the blobs and index.json. You also can choose which architectures to include.

This is useful if one of your processes is not _running_ a container - the `onboot`, `services`, etc. are excellent for that - but _working with_ a container image.

**- How I did it**
Added options to the `volumes` section, updated the schema, updated the doc.

**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Support for image-based volumes with OCI v1 layout rather than expanding filesystem
