### PR TITLE
support --tag in build.yml for packages

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -50,6 +50,7 @@ A package source consists of a directory containing at least two files:
 
 - `image` _(string)_: *(mandatory)* The name of the image to build
 - `org` _(string)_: The hub/registry organisation to which this package belongs
+- `tag` _(string)_: The tag to use for the image, can be fixed string or template (default: `{{.Hash}}`)
 - `dockerfile` _(string)_: The dockerfile to use to build this package, must be in this directory or below (default: `Dockerfile`)
 - `arches` _(list of string)_: The architectures which this package should be built for (valid entries are `GOARCH` names)
 - `extra-sources` _(list of strings)_: Additional sources for the package outside the package directory. The format is `src:dst`, where `src` can be relative to the package directory and `dst` is the destination in the build context. This is useful for sharing files, such as vendored go code, between packages.

--- a/src/cmd/linuxkit/buildtemplate.go
+++ b/src/cmd/linuxkit/buildtemplate.go
@@ -22,12 +22,13 @@ func createPackageResolver(baseDir string) spec.PackageResolver {
 			pkgValue = pkgTmpl
 		case strings.HasPrefix(pkgTmpl, templateFlag+templatePkg):
 			pkgPath := strings.TrimPrefix(pkgTmpl, templateFlag+templatePkg)
+			piBase := pkglib.NewPkgInfo()
 
 			var pkgs []pkglib.Pkg
 			pkgConfig := pkglib.PkglibConfig{
 				BuildYML:   defaultPkgBuildYML,
 				HashCommit: defaultPkgCommit,
-				Tag:        defaultPkgTag,
+				Tag:        piBase.Tag,
 			}
 			pkgs, err = pkglib.NewFromConfig(pkgConfig, path.Join(baseDir, pkgPath))
 			if err != nil {

--- a/src/cmd/linuxkit/const.go
+++ b/src/cmd/linuxkit/const.go
@@ -3,5 +3,4 @@ package main
 const (
 	defaultPkgBuildYML = "build.yml"
 	defaultPkgCommit   = "HEAD"
-	defaultPkgTag      = "{{.Hash}}"
 )

--- a/src/cmd/linuxkit/pkg.go
+++ b/src/cmd/linuxkit/pkg.go
@@ -37,7 +37,6 @@ func pkgCmd() *cobra.Command {
 				HashPath:   hashPath,
 				Dirty:      dirty,
 				Dev:        devMode,
-				Tag:        tag,
 			}
 			if cmd.Flags().Changed("disable-cache") && cmd.Flags().Changed("enable-cache") {
 				return errors.New("cannot set but disable-cache and enable-cache")
@@ -65,6 +64,9 @@ func pkgCmd() *cobra.Command {
 			if cmd.Flags().Changed("org") {
 				pkglibConfig.Org = &argOrg
 			}
+			if cmd.Flags().Changed("tag") {
+				pkglibConfig.Tag = tag
+			}
 
 			return nil
 		},
@@ -88,7 +90,7 @@ func pkgCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&argOrg, "org", piBase.Org, "Override the hub org")
 	cmd.PersistentFlags().StringVar(&buildYML, "build-yml", defaultPkgBuildYML, "Override the name of the yml file")
 	cmd.PersistentFlags().StringVar(&hash, "hash", "", "Override the image hash (default is to query git for the package's tree-sh)")
-	cmd.PersistentFlags().StringVar(&tag, "tag", defaultPkgTag, "Override the tag using fixed strings and/or text templates. Acceptable are .Hash for the hash")
+	cmd.PersistentFlags().StringVar(&tag, "tag", piBase.Tag, "Override the tag using fixed strings and/or text templates. Acceptable are .Hash for the hash")
 	cmd.PersistentFlags().StringVar(&hashCommit, "hash-commit", defaultPkgCommit, "Override the git commit to use for the hash")
 	cmd.PersistentFlags().StringVar(&hashPath, "hash-path", "", "Override the directory to use for the image hash, must be a parent of the package dir (default is to use the package dir)")
 	cmd.PersistentFlags().BoolVar(&dirty, "force-dirty", false, "Force the pkg(s) to be considered dirty")

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -20,6 +20,7 @@ import (
 type pkgInfo struct {
 	Image        string            `yaml:"image"`
 	Org          string            `yaml:"org"`
+	Tag          string            `yaml:"tag,omitempty"` // default to {{.Hash}}
 	Dockerfile   string            `yaml:"dockerfile"`
 	Arches       []string          `yaml:"arches"`
 	ExtraSources []string          `yaml:"extra-sources"`
@@ -60,6 +61,7 @@ func NewPkgInfo() pkgInfo {
 	return pkgInfo{
 		Org:          "linuxkit",
 		Arches:       []string{"amd64", "arm64"},
+		Tag:          "{{.Hash}}",
 		GitRepo:      "https://github.com/linuxkit/linuxkit",
 		Network:      false,
 		DisableCache: false,
@@ -257,9 +259,16 @@ func NewFromConfig(cfg PkglibConfig, args ...string) ([]Pkg, error) {
 				}
 			}
 		}
+		tagTmpl := pi.Tag
+		if cfg.Tag != "" {
+			tagTmpl = cfg.Tag
+		}
+		if tagTmpl == "" {
+			tagTmpl = "{{.Hash}}"
+		}
 
 		// calculate the tag to use based on the template and the pkgHash
-		tmpl, err := template.New("tag").Parse(cfg.Tag)
+		tmpl, err := template.New("tag").Parse(tagTmpl)
 		if err != nil {
 			return nil, fmt.Errorf("invalid tag template: %v", err)
 		}

--- a/test/cases/000_build/057_pkg_tag/000_tag_yaml/Dockerfile
+++ b/test/cases/000_build/057_pkg_tag/000_tag_yaml/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.20

--- a/test/cases/000_build/057_pkg_tag/000_tag_yaml/build.yml
+++ b/test/cases/000_build/057_pkg_tag/000_tag_yaml/build.yml
@@ -1,0 +1,3 @@
+org: linuxkit
+image: image-with-tag
+tag: file

--- a/test/cases/000_build/057_pkg_tag/000_tag_yaml/test.sh
+++ b/test/cases/000_build/057_pkg_tag/000_tag_yaml/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# SUMMARY: Check that tar output format build is reproducible
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+linuxkit pkg build --force .
+
+# just run docker image inspect; if it does not exist, it will error out
+linuxkit cache ls 2>&1 | grep 'linuxkit/image-with-tag:file'
+
+exit 0

--- a/test/cases/000_build/057_pkg_tag/001_tag_cli/Dockerfile
+++ b/test/cases/000_build/057_pkg_tag/001_tag_cli/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.20

--- a/test/cases/000_build/057_pkg_tag/001_tag_cli/build.yml
+++ b/test/cases/000_build/057_pkg_tag/001_tag_cli/build.yml
@@ -1,0 +1,2 @@
+org: linuxkit
+image: image-with-tag

--- a/test/cases/000_build/057_pkg_tag/001_tag_cli/test.sh
+++ b/test/cases/000_build/057_pkg_tag/001_tag_cli/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# SUMMARY: Check that tar output format build is reproducible
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+linuxkit pkg build --force --tag cli .
+
+# just run docker image inspect; if it does not exist, it will error out
+linuxkit cache ls 2>&1 | grep 'linuxkit/image-with-tag:cli'
+
+exit 0

--- a/test/cases/000_build/057_pkg_tag/002_tag_cli_over_yaml/Dockerfile
+++ b/test/cases/000_build/057_pkg_tag/002_tag_cli_over_yaml/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.20

--- a/test/cases/000_build/057_pkg_tag/002_tag_cli_over_yaml/build.yml
+++ b/test/cases/000_build/057_pkg_tag/002_tag_cli_over_yaml/build.yml
@@ -1,0 +1,3 @@
+org: linuxkit
+image: image-with-tag
+tag: file-new

--- a/test/cases/000_build/057_pkg_tag/002_tag_cli_over_yaml/test.sh
+++ b/test/cases/000_build/057_pkg_tag/002_tag_cli_over_yaml/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SUMMARY: Check that tar output format build is reproducible
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+linuxkit pkg build --force --tag cli .
+
+# just run docker image inspect; if it does not exist, it will error out
+linuxkit cache ls 2>&1 | grep 'linuxkit/image-with-tag:cli'
+
+# specifically, the `file` tag should not exist, so check that it does not exist
+if linuxkit cache ls 2>&1 | grep 'linuxkit/image-with-tag:file-new'; then
+    echo "ERROR: image with tag 'file-new' should not exist"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added support for tag template in `build.yaml`. We already support `--tag <template>` in CLI, so add it to `build.yaml` as well.

**- How I did it**
Extended the definition of `pkgInfo` so it also includes `Tag`, which then will cause it to read it.

Of course, updated docs and added tests.

**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Support for tag templates in build.yml
