### PR TITLE
Fix raw efi build image size calculation

### DIFF
--- a/src/cmd/linuxkit/moby/build/images.yaml
+++ b/src/cmd/linuxkit/moby/build/images.yaml
@@ -3,7 +3,7 @@
  iso-efi:        linuxkit/mkimage-iso-efi:4bff02040897e4177a2220038f4a5a08cd556afd
  iso-efi-initrd: linuxkit/mkimage-iso-efi-initrd:6d087ae7aa61fe6d840e314dcb2d6b7b2a5db1b8
  raw-bios:       linuxkit/mkimage-raw-bios:c64318cfc28b39010b05c7cd48673f397c45c8df
- raw-efi:        linuxkit/mkimage-raw-efi:8bc9d4afbbd5b01488a8c699b3db721484a9eda1
+ raw-efi:        linuxkit/mkimage-raw-efi:6d9a9ff0a575f8ba5fcd5bf25feac89d0aa343d0
  squashfs:       linuxkit/mkimage-squashfs:d9de62071bed575377e35e944004bcb23c50afab
  gcp:            linuxkit/mkimage-gcp:035c2c2b4b958060c0b6bdd41d9cbc886a335098
  qcow2-efi:      linuxkit/mkimage-qcow2-efi:64e1921dc6074d55d0fa95c2beddef7d153d3eca

--- a/tools/mkimage-raw-efi/make-efi
+++ b/tools/mkimage-raw-efi/make-efi
@@ -55,30 +55,42 @@ menuentry 'LinuxKit ISO Image' {
 }
 EOF
 
-#
+# FAT filesystem config
+FAT_SIZE=32
+SECTOR_SIZE=512
+SECTORS_PER_CLUSTER=8
+# these always include the Boot Sector and FS Information Sector (sector 0 and 1) among others for FAT32
+RESERVED_SECTORS=32
+
 # calculate sizes
 KERNEL_FILE_SIZE=$(stat -c %s "$KERNEL")
 INITRD_FILE_SIZE=$(stat -c %s "$INITRD")
 EFI_FILE_SIZE=$(stat -c %s "$BOOTFILE")
-# minimum headroom needed in ESP, in bytes
-# 511KiB headroom seems to be enough
-ESP_HEADROOM=$(( 1024 * 1024 ))
+GRUB_FILE_SIZE=$(stat -c %s EFI/BOOT/grub.cfg)
 
 # this is the minimum size of our EFI System Partition
-ESP_FILE_SIZE=$(( $KERNEL_FILE_SIZE + $INITRD_FILE_SIZE + $EFI_FILE_SIZE + $ESP_HEADROOM ))
+ESP_DATA_SIZE=$(( $KERNEL_FILE_SIZE + $INITRD_FILE_SIZE + $EFI_FILE_SIZE + $GRUB_FILE_SIZE ))
+ESP_DATA_SECTORS=$(( $ESP_DATA_SIZE / $SECTOR_SIZE ))
+
+# File Allocation Table Sectors = (clusters + 2) * bytes per cluster / sector size
+FILE_ALLOCATION_TABLE_SECTORS=$(( ( $ESP_DATA_SECTORS / $SECTORS_PER_CLUSTER + 2 ) * ( $FAT_SIZE / 8 ) / $SECTOR_SIZE ))
+
+# there are two file allocation tables hence 2 * $FILE_ALLOCATION_TABLE_SECTORS
+FAT_OVERHEAD_SECTORS=$(( $RESERVED_SECTORS + ( 2 * $FILE_ALLOCATION_TABLE_SECTORS ) ))
+FAT_OVERHEAD_SIZE=$(( $FAT_OVERHEAD_SECTORS * $SECTOR_SIZE ))
 
 # (x+1024)/1024*1024 rounds up to multiple of 1024KB, or 2048 sectors
 # some firmwares get confused if the partitions are not aligned on 2048 blocks
 # we will round up to the nearest multiple of 2048 blocks
 # since each block is 512 bytes, we want the size to be a multiple of
 # 2048 blocks * 512 bytes = 1048576 bytes = 1024KB
-ESP_FILE_SIZE_KB=$(( ( ( ($ESP_FILE_SIZE+1024-1) / 1024 ) + 1024-1) / 1024 * 1024 ))
+ESP_FILE_SIZE_KB=$(( ( ( ($ESP_DATA_SIZE + $FAT_OVERHEAD_SIZE + 1024 - 1) / 1024 ) + 1024 - 1) / 1024 * 1024 ))
 # and for sectors
-ESP_FILE_SIZE_SECTORS=$(( $ESP_FILE_SIZE_KB * 2 ))
+ESP_FILE_SIZE_SECTORS=$(( $ESP_FILE_SIZE_KB * 1024 / $SECTOR_SIZE ))
 
 # create a raw disk with an EFI boot partition
 # Stuff it into a FAT filesystem, making it as small as possible.
-mkfs.vfat -v -C $ESP_FILE $(( $ESP_FILE_SIZE_KB )) > /dev/null
+mkfs.vfat -v -F $FAT_SIZE -S $SECTOR_SIZE -s $SECTORS_PER_CLUSTER -R $RESERVED_SECTORS -C $ESP_FILE $(( $ESP_FILE_SIZE_KB )) > /dev/null
 echo "mtools_skip_check=1" >> /etc/mtools.conf && \
 mmd -i $ESP_FILE ::/EFI
 mmd -i $ESP_FILE ::/EFI/BOOT


### PR DESCRIPTION
fixes #4095

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Adjusted the calculations in the raw-efi build script.

**- How I did it**
Looked into the FAT design (https://en.wikipedia.org/wiki/Design_of_the_FAT_file_system) and `mkfs.fat` source code (https://github.com/dosfstools/dosfstools/blob/master/src/mkfs.fat.c).

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
I think the problem for the too small image size is the growing File Allocation Table. The current assumption of 511 KiB of headroom is only true for images with a size of around 250 MB.
This is still only an approximation of the total size an no guarantee that it will work under all circumstances as the calculations in https://github.com/dosfstools/dosfstools/blob/master/src/mkfs.fat.c are quite convoluted/complex.


**- A picture of a cute animal (not mandatory but encouraged)**
