### PR TITLE
pkg/extend fix panic for empty partition tables

### DIFF
--- a/pkg/extend/extend.go
+++ b/pkg/extend/extend.go
@@ -82,6 +82,11 @@ func extend(d, fsType string) error {
 		return fmt.Errorf("Unable to unmarshal partition table from sfdisk: %v", err)
 	}
 
+	if len(f.PartitionTable.Partitions) == 0 {
+		log.Printf("Disk %s has no partitions. Skipping", d)
+		return nil
+	}
+
 	if len(f.PartitionTable.Partitions) > 1 {
 		log.Printf("Disk %s has more than 1 partition. Skipping", d)
 		return nil

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:8b5af3365fc7d015db4e44113d93c7b1f8e2d2ab
 onboot:
   - name: extend
-    image: linuxkit/extend:9fa90cc4ba8c261b8eb5adacda71feb2f60d75e3
+    image: linuxkit/extend:4fe799316df0f29a6930a5363841057d7c55484b
   - name: mount
     image: linuxkit/mount:2a507ef30302693682f9f612289028df00c58ac5
     command: ["/usr/bin/mountie", "/var/lib/docker"]

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -9,7 +9,7 @@ onboot:
     image: linuxkit/modprobe:fad39ef443853ef02520052cdbf6acbeb4ec7799
     command: ["modprobe", "btrfs"]
   - name: extend
-    image: linuxkit/extend:9fa90cc4ba8c261b8eb5adacda71feb2f60d75e3
+    image: linuxkit/extend:4fe799316df0f29a6930a5363841057d7c55484b
     command: ["/usr/bin/extend", "-type", "btrfs"]
   - name: mount
     image: linuxkit/mount:2a507ef30302693682f9f612289028df00c58ac5

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:8b5af3365fc7d015db4e44113d93c7b1f8e2d2ab
 onboot:
   - name: extend
-    image: linuxkit/extend:9fa90cc4ba8c261b8eb5adacda71feb2f60d75e3
+    image: linuxkit/extend:4fe799316df0f29a6930a5363841057d7c55484b
     command: ["/usr/bin/extend", "-type", "xfs"]
   - name: mount
     image: linuxkit/mount:2a507ef30302693682f9f612289028df00c58ac5

--- a/test/cases/040_packages/005_extend/003_gpt/test.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:8b5af3365fc7d015db4e44113d93c7b1f8e2d2ab
 onboot:
   - name: extend
-    image: linuxkit/extend:9fa90cc4ba8c261b8eb5adacda71feb2f60d75e3
+    image: linuxkit/extend:4fe799316df0f29a6930a5363841057d7c55484b
   - name: mount
     image: linuxkit/mount:2a507ef30302693682f9f612289028df00c58ac5
     command: ["/usr/bin/mountie", "/var/lib/docker"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix a go panic when trying to resize a device with a partition table with 0 partitions.

**- How I did it**

Check the condition and return early.

**- How to verify it**

Create and mount a dummy device with an empty partition table and let `pkg/extend` try to resize the device.
The following error should no longer occur:
```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.extend({0xc000013880, 0xa}, {0x5341a3, 0x4})
        /<redacted>/linuxkit/pkg/extend/extend.go:93 +0x119c
main.autoextend({0x5341a3, 0x4})
        /<redacted>/linuxkit/pkg/extend/extend.go:60 +0x1b0
main.main()
        /<redacted>/linuxkit/pkg/extend/extend.go:333 +0x8e
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
