### PR TITLE
always tee test linuxkit run to tty, so if it gets stuck, we see why

### DIFF
--- a/test/cases/000_build/020_binds/test.sh
+++ b/test/cases/000_build/020_binds/test.sh
@@ -20,7 +20,7 @@ trap clean_up EXIT
 # Test code goes here
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK},size=32M ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK},size=32M ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/000_build/070_volumes/000_rw_on_rw/test.sh
+++ b/test/cases/000_build/070_volumes/000_rw_on_rw/test.sh
@@ -19,7 +19,7 @@ trap clean_up EXIT
 # Test code goes here
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/000_build/070_volumes/001_ro_on_ro/test.sh
+++ b/test/cases/000_build/070_volumes/001_ro_on_ro/test.sh
@@ -19,7 +19,7 @@ trap clean_up EXIT
 # Test code goes here
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/000_build/070_volumes/003_ro_on_rw/test.sh
+++ b/test/cases/000_build/070_volumes/003_ro_on_rw/test.sh
@@ -19,7 +19,7 @@ trap clean_up EXIT
 # Test code goes here
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/000_build/070_volumes/004_blank/test.sh
+++ b/test/cases/000_build/070_volumes/004_blank/test.sh
@@ -19,7 +19,7 @@ trap clean_up EXIT
 # Test code goes here
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/000_build/070_volumes/005_image/test.sh
+++ b/test/cases/000_build/070_volumes/005_image/test.sh
@@ -19,7 +19,7 @@ trap clean_up EXIT
 # Test code goes here
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/000_build/070_volumes/006_mount_types/test.sh
+++ b/test/cases/000_build/070_volumes/006_mount_types/test.sh
@@ -19,7 +19,7 @@ trap clean_up EXIT
 # Test code goes here
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/020_kernel/011_config_5.4.x/test.sh
+++ b/test/cases/020_kernel/011_config_5.4.x/test.sh
@@ -18,7 +18,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/013_config_5.10.x/test.sh
+++ b/test/cases/020_kernel/013_config_5.10.x/test.sh
@@ -18,7 +18,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/016_config_5.15.x/test.sh
+++ b/test/cases/020_kernel/016_config_5.15.x/test.sh
@@ -18,7 +18,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/019_config_6.6.x/test.sh
+++ b/test/cases/020_kernel/019_config_6.6.x/test.sh
@@ -18,7 +18,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/111_kmod_5.4.x/test.sh
+++ b/test/cases/020_kernel/111_kmod_5.4.x/test.sh
@@ -25,7 +25,7 @@ docker build -t ${IMAGE_NAME} .
 
 # Build and run a LinuxKit image with kernel module (and test script)
 linuxkit build --docker --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}" | grep -q "Hello LinuxKit"
 
 exit 0

--- a/test/cases/020_kernel/113_kmod_5.10.x/test.sh
+++ b/test/cases/020_kernel/113_kmod_5.10.x/test.sh
@@ -25,7 +25,7 @@ docker build -t ${IMAGE_NAME} .
 
 # Build and run a LinuxKit image with kernel module (and test script)
 linuxkit build --docker --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}" | grep -q "Hello LinuxKit"
 
 exit 0

--- a/test/cases/020_kernel/116_kmod_5.15.x/test.sh
+++ b/test/cases/020_kernel/116_kmod_5.15.x/test.sh
@@ -25,7 +25,7 @@ docker build -t ${IMAGE_NAME} .
 
 # Build and run a LinuxKit image with kernel module (and test script)
 linuxkit build --docker --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}" | grep -q "Hello LinuxKit"
 
 exit 0

--- a/test/cases/020_kernel/119_kmod_6.6.x/test.sh
+++ b/test/cases/020_kernel/119_kmod_6.6.x/test.sh
@@ -25,7 +25,7 @@ docker build -t ${IMAGE_NAME} .
 
 # Build and run a LinuxKit image with kernel module (and test script)
 linuxkit build --docker --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}" | grep -q "Hello LinuxKit"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/030_echo-udp-ipv4-short-1con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/030_echo-udp-ipv4-short-1con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/031_echo-udp-ipv4-short-10con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/031_echo-udp-ipv4-short-10con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/035_echo-udp-ipv4-long-1con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/035_echo-udp-ipv4-long-1con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/036_echo-udp-ipv4-long-10con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/036_echo-udp-ipv4-long-10con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/040_echo-udp-ipv6-short-1con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/040_echo-udp-ipv6-short-1con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/041_echo-udp-ipv6-short-10con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/041_echo-udp-ipv6-short-10con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/045_echo-udp-ipv6-long-1con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/045_echo-udp-ipv6-long-1con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/046_echo-udp-ipv6-long-10con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/046_echo-udp-ipv6-long-10con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi/test.sh
+++ b/test/cases/020_kernel/200_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/010_echo-short-1con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/010_echo-short-1con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/010_echo-short-1con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/010_echo-short-1con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/011_echo-short-10con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/011_echo-short-10con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/011_echo-short-10con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/011_echo-short-10con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/012_echo-short-5con-multi-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/012_echo-short-5con-multi-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/012_echo-short-5con-multi/test.sh
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/012_echo-short-5con-multi/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/015_echo-long-1con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/015_echo-long-1con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/015_echo-long-1con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/015_echo-long-1con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/016_echo-long-10con-single-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/016_echo-long-10con-single-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/016_echo-long-10con-single/test.sh
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/016_echo-long-10con-single/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/017_echo-long-5con-multi-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/017_echo-long-5con-multi-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/017_echo-long-5con-multi/test.sh
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/017_echo-long-5con-multi/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/100_mix/010_veth-unix-domain-echo/test.sh
+++ b/test/cases/020_kernel/200_namespace/100_mix/010_veth-unix-domain-echo/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/100_mix/011_veth-unix-domain-echo-reverse/test.sh
+++ b/test/cases/020_kernel/200_namespace/100_mix/011_veth-unix-domain-echo-reverse/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/100_mix/012_veth-ipv4-echo/test.sh
+++ b/test/cases/020_kernel/200_namespace/100_mix/012_veth-ipv4-echo/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/100_mix/013_veth-ipv6-echo/test.sh
+++ b/test/cases/020_kernel/200_namespace/100_mix/013_veth-ipv6-echo/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/100_mix/014_veth-tcp-echo/test.sh
+++ b/test/cases/020_kernel/200_namespace/100_mix/014_veth-tcp-echo/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/100_mix/015_veth-udp-echo/test.sh
+++ b/test/cases/020_kernel/200_namespace/100_mix/015_veth-udp-echo/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/020_kernel/200_namespace/100_mix/020_unix-domain-echo/test.sh
+++ b/test/cases/020_kernel/200_namespace/100_mix/020_unix-domain-echo/test.sh
@@ -17,7 +17,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} ../../common.yml test.yml
-RESULT="$(linuxkit run -cpus 2 ${NAME})"
+RESULT="$(linuxkitrun -cpus 2 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/030_security/010_ports/test.sh
+++ b/test/cases/030_security/010_ports/test.sh
@@ -19,6 +19,6 @@ trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
 linuxkit run qemu --kernel "${NAME}"
-#RESULT=$(linuxkit run qemu --kernel "${NAME}")
+#RESULT=$(linuxkitrun qemu --kernel "${NAME}")
 #echo "${RESULT}" | grep -q "PASSED"
 exit 0

--- a/test/cases/040_packages/002_bcc/test.sh
+++ b/test/cases/040_packages/002_bcc/test.sh
@@ -17,7 +17,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/002_binfmt/test.sh
+++ b/test/cases/040_packages/002_binfmt/test.sh
@@ -17,7 +17,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/002_bpftrace/test.sh
+++ b/test/cases/040_packages/002_bpftrace/test.sh
@@ -17,7 +17,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/003_ca-certificates/test.sh
+++ b/test/cases/040_packages/003_ca-certificates/test.sh
@@ -17,7 +17,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run $NAME)"
+RESULT="$(linuxkitrun $NAME)"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/003_cgroupv2/test.sh
+++ b/test/cases/040_packages/003_cgroupv2/test.sh
@@ -18,7 +18,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run --mem 3072 ${NAME})"
+RESULT="$(linuxkitrun --mem 3072 ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/040_packages/003_containerd/test.sh
+++ b/test/cases/040_packages/003_containerd/test.sh
@@ -18,7 +18,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run --mem 3072 --disk size=2G ${NAME})"
+RESULT="$(linuxkitrun --mem 3072 --disk size=2G ${NAME})"
 echo "${RESULT}" | grep -q "suite PASSED"
 
 exit 0

--- a/test/cases/040_packages/004_dhcpcd/test.sh
+++ b/test/cases/040_packages/004_dhcpcd/test.sh
@@ -18,7 +18,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run $NAME)"
+RESULT="$(linuxkitrun $NAME)"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/004_dm-crypt/000_simple/test.sh
+++ b/test/cases/040_packages/004_dm-crypt/000_simple/test.sh
@@ -19,7 +19,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK},size=32M ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK},size=32M ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/004_dm-crypt/001_luks/test.sh
+++ b/test/cases/040_packages/004_dm-crypt/001_luks/test.sh
@@ -19,7 +19,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK},size=20M ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK},size=20M ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/004_dm-crypt/002_key/test.sh
+++ b/test/cases/040_packages/004_dm-crypt/002_key/test.sh
@@ -19,7 +19,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK},size=32M ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK},size=32M ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/005_extend/000_ext4/test.sh
+++ b/test/cases/040_packages/005_extend/000_ext4/test.sh
@@ -25,7 +25,7 @@ linuxkit run --disk file="${DISK}",format=raw,size=256M "${NAME_CREATE}"
 # osx takes issue with bs=1M
 dd if=/dev/zero bs=1048576 count=256 >> "${DISK}"
 linuxkit build --format kernel+initrd --name ${NAME_EXTEND} test.yml
-RESULT="$(linuxkit run --disk file=${DISK} ${NAME_EXTEND})"
+RESULT="$(linuxkitrun --disk file=${DISK} ${NAME_EXTEND})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/005_extend/001_btrfs/test.sh
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.sh
@@ -25,7 +25,7 @@ linuxkit run --disk file="${DISK}",format=raw,size=256M "${NAME_CREATE}"
 # osx takes issue with bs=1M
 dd if=/dev/zero bs=1048576 count=256 >> "${DISK}"
 linuxkit build --format kernel+initrd --name ${NAME_EXTEND} test.yml
-RESULT="$(linuxkit run --disk file=${DISK} ${NAME_EXTEND})"
+RESULT="$(linuxkitrun --disk file=${DISK} ${NAME_EXTEND})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/005_extend/002_xfs/test.sh
+++ b/test/cases/040_packages/005_extend/002_xfs/test.sh
@@ -25,7 +25,7 @@ linuxkit run --disk file="${DISK}",format=raw,size=512M "${NAME_CREATE}"
 # osx takes issue with bs=1M
 dd if=/dev/zero bs=1048576 count=256 >> "${DISK}"
 linuxkit build --name "${NAME_EXTEND}" --format kernel+initrd test.yml
-RESULT="$(linuxkit run --disk file=${DISK} ${NAME_EXTEND})"
+RESULT="$(linuxkitrun --disk file=${DISK} ${NAME_EXTEND})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/005_extend/003_gpt/test.sh
+++ b/test/cases/040_packages/005_extend/003_gpt/test.sh
@@ -25,7 +25,7 @@ linuxkit run --disk file="${DISK}",format=raw,size=256M "${NAME_CREATE}"
 # osx takes issue with bs=1M
 dd if=/dev/zero bs=1048576 count=256 >> "${DISK}"
 linuxkit build --format kernel+initrd --name ${NAME_EXTEND} test.yml
-RESULT="$(linuxkit run --disk file=${DISK} ${NAME_EXTEND})"
+RESULT="$(linuxkitrun --disk file=${DISK} ${NAME_EXTEND})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/006_format_mount/000_auto/test.sh
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.sh
@@ -18,7 +18,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK},size=512M ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK},size=512M ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.sh
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.sh
@@ -18,7 +18,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK},size=512M ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK},size=512M ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.sh
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.sh
@@ -26,7 +26,7 @@ fi
 
 sed -e "s,@DEVICE@,${DEVICE},g" test.yml.in > test.yml
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK},size=512M ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK},size=512M ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.sh
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.sh
@@ -19,7 +19,7 @@ trap clean_up EXIT
 
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK},size=512M ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK},size=512M ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.sh
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.sh
@@ -18,7 +18,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK},size=512M ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK},size=512M ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.sh
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.sh
@@ -20,7 +20,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK1},size=512M --disk file=${DISK2},size=512M ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK1},size=512M --disk file=${DISK2},size=512M ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/006_format_mount/006_gpt/test.sh
+++ b/test/cases/040_packages/006_format_mount/006_gpt/test.sh
@@ -18,7 +18,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK},size=512M ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK},size=512M ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.sh
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.sh
@@ -19,7 +19,7 @@ clean_up() {
 trap clean_up EXIT
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK1},size=512M --disk file=${DISK2},size=512M ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK1},size=512M --disk file=${DISK2},size=512M ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/009_init_containerd/test.sh
+++ b/test/cases/040_packages/009_init_containerd/test.sh
@@ -17,7 +17,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run $NAME)"
+RESULT="$(linuxkitrun $NAME)"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/011_kmsg/test.sh
+++ b/test/cases/040_packages/011_kmsg/test.sh
@@ -17,7 +17,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/012_logwrite/test.sh
+++ b/test/cases/040_packages/012_logwrite/test.sh
@@ -17,7 +17,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/012_losetup/test.sh
+++ b/test/cases/040_packages/012_losetup/test.sh
@@ -18,7 +18,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run $NAME)"
+RESULT="$(linuxkitrun $NAME)"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/013_metadata/000_cidata/test.sh
+++ b/test/cases/040_packages/013_metadata/000_cidata/test.sh
@@ -25,7 +25,7 @@ ISOFILE=/tmp/cidata.iso
 docker run -i --rm -v $(pwd)/geniso.sh:/geniso.sh:ro alpine:3.13 /geniso.sh > ${ISOFILE}
 
 linuxkit build --format kernel+initrd --name ${NAME} test.yml
-RESULT="$(linuxkit run --disk file=${DISK},size=32M --disk file=${ISOFILE} ${NAME})"
+RESULT="$(linuxkitrun --disk file=${DISK},size=32M --disk file=${ISOFILE} ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/019_sysctl/test.sh
+++ b/test/cases/040_packages/019_sysctl/test.sh
@@ -18,7 +18,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/040_packages/023_wireguard/test.sh
+++ b/test/cases/040_packages/023_wireguard/test.sh
@@ -18,7 +18,7 @@ trap clean_up EXIT
 
 # Test code goes here
 linuxkit build --format kernel+initrd --name "${NAME}" test.yml
-RESULT="$(linuxkit run ${NAME})"
+RESULT="$(linuxkitrun ${NAME})"
 echo "${RESULT}"
 echo "${RESULT}" | grep -q "suite PASSED"
 

--- a/test/cases/_lib/lib.sh
+++ b/test/cases/_lib/lib.sh
@@ -12,3 +12,8 @@ LINUXKIT_TMPDIR="${RT_PROJECT_ROOT}/_tmp"
 
 # FIXME: Should source the rtf/lib/lib.sh instead
 RT_CANCEL=253
+
+# command to run `linuxkit run` that includes streaming to stderr, so you never miss logs
+linuxkitrun() {
+  linuxkit run $@ | tee /dev/stderr
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Created a function in tests `lib.sh` called `linuxkitrun()`, which takes the arguments and then passes the output to stdout and to `/dev/tty`. This ensures that if a run gets stuck, we see the output in logs, rather than thinking something is broken.

**- How I did it**

Search and replace

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
linuxkit run output teed to ttty in addition to vars
