### PR TITLE
Enable riscv64 default

### DIFF
--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -46,7 +46,7 @@ services:
       - /etc/docker/daemon.json:/etc/docker/daemon.json
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
   - name: cadvisor
-    image: linuxkit/cadvisor:b4a75f3e296ebbeac3a008eee74f8dd2305e595e
+    image: linuxkit/cadvisor:8dfefe0f9593ba21aca5d08fadac16de907d470d
 files:
   - path: var/lib/docker
     directory: true

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -75,7 +75,7 @@ services:
     command: ["/vpnkit-forwarder", "-vsockPort", "62373"]
   # Monitor for image deletes and invoke a TRIM on the container filesystem
   - name: trim-after-delete
-    image: linuxkit/trim-after-delete:7d183e3da081e1c6cd08392f27630fafe069654d
+    image: linuxkit/trim-after-delete:fe73247abd4ab7584a75e95083543af97fe90d4d
   # When the host resumes from sleep, force a clock resync
   - name: host-timesync-daemon
     image: linuxkit/host-timesync-daemon:548bfe9d35c930ee42d6c0485bb4bf25d2729bad

--- a/examples/platform-equinixmetal.yml
+++ b/examples/platform-equinixmetal.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/runc:667e7ea2c426a2460ca21e3da065a57dbb3369c9
   - linuxkit/containerd:0854538eb4dedbb45521357633ccb69eef123f54
   - linuxkit/ca-certificates:7b32a26ca9c275d3ef32b11fe2a83dbd2aee2fdb
-  - linuxkit/firmware:d8d2cc5258da630d5b858ebe1fc96886b9281e9e
+  - linuxkit/firmware:bfc7802f909c4b760de5dd2bc02a7f52e86b78f7
 onboot:
   - name: rngd1
     image: linuxkit/rngd:1a18f2149e42a0a1cb9e7d37608a494342c26032

--- a/examples/platform-hetzner.yml
+++ b/examples/platform-hetzner.yml
@@ -7,7 +7,7 @@ init:
   - linuxkit/runc:667e7ea2c426a2460ca21e3da065a57dbb3369c9
   - linuxkit/containerd:0854538eb4dedbb45521357633ccb69eef123f54
   - linuxkit/ca-certificates:7b32a26ca9c275d3ef32b11fe2a83dbd2aee2fdb
-  - linuxkit/firmware:d8d2cc5258da630d5b858ebe1fc96886b9281e9e
+  - linuxkit/firmware:bfc7802f909c4b760de5dd2bc02a7f52e86b78f7
 onboot:
   - name: rngd1
     image: linuxkit/rngd:1a18f2149e42a0a1cb9e7d37608a494342c26032

--- a/examples/volumes.yml
+++ b/examples/volumes.yml
@@ -39,7 +39,7 @@ services:
 volumes:
 - name: blank   # blank volume
 - name: alpine  # populated volume
-  image: alpine:3.19
+  image: alpine:3.21
 files:
   - path: etc/linuxkit-config
     metadata: yaml

--- a/pkg/cadvisor/Dockerfile
+++ b/pkg/cadvisor/Dockerfile
@@ -7,7 +7,7 @@ RUN [ $(uname -m) = aarch64 ] && apk add --no-cache gcc || true
 ENV GOPATH=/go PATH=$PATH:/go/bin
 ENV GITBASE=github.com/google
 ENV GITREPO=github.com/google/cadvisor
-ENV COMMIT=v0.36.0
+ENV COMMIT=v0.51.0
 
 ADD /static.patch /tmp/
 
@@ -18,7 +18,7 @@ RUN mkdir -p /go/src/${GITBASE} \
     && git checkout ${COMMIT} \
     && patch -p1 build/build.sh </tmp/static.patch \
     && make build \
-    && mv cadvisor /usr/bin/
+    && mv _output/cadvisor /usr/bin/
 
 
 FROM linuxkit/alpine:35b33c6b03c40e51046c3b053dd131a68a26c37a AS mirror

--- a/pkg/cadvisor/build.yml
+++ b/pkg/cadvisor/build.yml
@@ -3,6 +3,7 @@ network: true
 arches:
   - amd64
   - arm64
+  - riscv64
 config:
   pid: host
   binds:

--- a/pkg/cadvisor/static.patch
+++ b/pkg/cadvisor/static.patch
@@ -1,6 +1,6 @@
 --- build/build.sh.orig	2017-11-16 16:29:18.281342577 +0000
 +++ build/build.sh	2017-11-16 16:29:55.534787421 +0000
-@@ -44,6 +44,7 @@
+@@ -47,6 +47,7 @@
    -X ${repo_path}/version.BuildDate${ldseparator}${BUILD_DATE}
    -X ${repo_path}/version.GoVersion${ldseparator}${go_version}"
  

--- a/pkg/firmware-all/build.yml
+++ b/pkg/firmware-all/build.yml
@@ -3,3 +3,4 @@ network: true
 arches:
   - amd64
   - arm64
+  - riscv64

--- a/pkg/firmware/build.yml
+++ b/pkg/firmware/build.yml
@@ -3,3 +3,5 @@ network: true
 arches:
   - amd64
   - arm64
+  - riscv64
+  

--- a/pkg/trim-after-delete/build.yml
+++ b/pkg/trim-after-delete/build.yml
@@ -2,6 +2,7 @@ image: trim-after-delete
 arches:
   - amd64
   - arm64
+  - riscv64
 config:
   binds:
     - /var/run:/var/run

--- a/src/cmd/linuxkit/cache/push.go
+++ b/src/cmd/linuxkit/cache/push.go
@@ -17,7 +17,7 @@ import (
 // If remoteName is empty, it is the same as name.
 // If withArchSpecificTags is true, it will push all arch-specific images in the index, each as
 // their own tag with the same name as the index, but with the architecture appended, e.g.
-// image:foo will have image:foo-amd64, image:foo-arm64, etc.
+// image:foo will have image:foo-amd64, image:foo-arm64, image:foo-riscv64, etc.
 func (p *Provider) Push(name, remoteName string, withArchSpecificTags, override bool) error {
 	var (
 		err     error

--- a/src/cmd/linuxkit/moby/build/images.yaml
+++ b/src/cmd/linuxkit/moby/build/images.yaml
@@ -5,9 +5,9 @@
  raw-bios:       linuxkit/mkimage-raw-bios:a11bbe671863a75c68c58e9454d3246ab406567c
  raw-efi:        linuxkit/mkimage-raw-efi:60415b45ea87afd47bb61ef5409b1320882d7e56
  squashfs:       linuxkit/mkimage-squashfs:3433e24dbecc28d1b70469bc36d91c152355841c
- gcp:            linuxkit/mkimage-gcp:035c2c2b4b958060c0b6bdd41d9cbc886a335098
+ gcp:            linuxkit/mkimage-gcp:7f220881aed6336708b62afea9820e436b573cea
  qcow2-efi:      linuxkit/mkimage-qcow2-efi:203809755424fb601f63700f13f17dc65cef69b5
- vhd:            linuxkit/mkimage-vhd:91bcc7a6475f46a3d5d84cf6161f07c583dd9c21
- dynamic-vhd:    linuxkit/mkimage-dynamic-vhd:b755f8ff82c8631d18decaebb09867e7b88c2533
- vmdk:           linuxkit/mkimage-vmdk:20a370a55bd8d58c2ae9d634c297a955bb006efd
+ vhd:            linuxkit/mkimage-vhd:c6f7696575081986bdda9a6b48ead70498e2aeee
+ dynamic-vhd:    linuxkit/mkimage-dynamic-vhd:f76ac6c6803e9e25d09f22f7fe431e5386885a85
+ vmdk:           linuxkit/mkimage-vmdk:e2f2973907ca1ad412344cebd11bfa6d47dd6099
  rpi3:           linuxkit/mkimage-rpi3:4de9c144e4766bf283620371601c91638164b686

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -60,7 +60,7 @@ type PkglibConfig struct {
 func NewPkgInfo() pkgInfo {
 	return pkgInfo{
 		Org:          "linuxkit",
-		Arches:       []string{"amd64", "arm64"},
+		Arches:       []string{"amd64", "arm64", "riscv64"},
 		Tag:          "{{.Hash}}",
 		GitRepo:      "https://github.com/linuxkit/linuxkit",
 		Network:      false,

--- a/src/cmd/linuxkit/run_qemu.go
+++ b/src/cmd/linuxkit/run_qemu.go
@@ -70,6 +70,8 @@ func init() {
 		defaultArch = "x86_64"
 	case "s390x":
 		defaultArch = "s390x"
+	case "riscv64":
+		defaultArch = "riscv64"
 	}
 	switch {
 	case runtime.GOARCH == "s390x":
@@ -475,6 +477,8 @@ func buildQemuCmdline(config QemuConfig) (QemuConfig, []string) {
 		goArch = "arm64"
 	case "x86_64":
 		goArch = "amd64"
+	case "riscv64":
+		goArch = "riscv64"
 	default:
 		log.Fatalf("%s is an unsupported architecture.", config.Arch)
 	}

--- a/src/cmd/linuxkit/util/arch.go
+++ b/src/cmd/linuxkit/util/arch.go
@@ -20,6 +20,8 @@ func GoArch(in string) (string, error) {
 		return "amd64", nil
 	case "aarch64", "arm64":
 		return "arm64", nil
+	case "riscv64":
+		return "riscv64", nil
 	}
 	return "", fmt.Errorf("unknown arch %q", in)
 }

--- a/test/cases/000_build/055_dockerfiles/000_missing_in_yml/Dockerfile
+++ b/test/cases/000_build/055_dockerfiles/000_missing_in_yml/Dockerfile
@@ -1,1 +1,1 @@
-FROM alpine:3.19
+FROM alpine:3.21

--- a/test/cases/000_build/055_dockerfiles/001_missing_in_yml_found_cli/Dockerfile
+++ b/test/cases/000_build/055_dockerfiles/001_missing_in_yml_found_cli/Dockerfile
@@ -1,1 +1,1 @@
-FROM alpine:3.19
+FROM alpine:3.21

--- a/test/cases/000_build/055_dockerfiles/002_found_in_yml_missing_cli/Dockerfile
+++ b/test/cases/000_build/055_dockerfiles/002_found_in_yml_missing_cli/Dockerfile
@@ -1,1 +1,1 @@
-FROM alpine:3.19
+FROM alpine:3.21

--- a/test/cases/000_build/055_dockerfiles/003_default/Dockerfile
+++ b/test/cases/000_build/055_dockerfiles/003_default/Dockerfile
@@ -1,1 +1,1 @@
-FROM alpine:3.19
+FROM alpine:3.21

--- a/test/cases/000_build/056_build_args/000_build_arg_yaml/build.yml
+++ b/test/cases/000_build/056_build_args/000_build_arg_yaml/build.yml
@@ -1,4 +1,4 @@
 org: linuxkit
 image: image-in-build-args
 buildArgs:
-- IMAGE=alpine:3.19
+- IMAGE=alpine:3.21

--- a/test/cases/000_build/056_build_args/001_build_arg_cli/build-args
+++ b/test/cases/000_build/056_build_args/001_build_arg_cli/build-args
@@ -1,1 +1,1 @@
-IMAGE=alpine:3.19
+IMAGE=alpine:3.21

--- a/test/cases/000_build/056_build_args/002_build_arg_cli_over_yaml/build-args
+++ b/test/cases/000_build/056_build_args/002_build_arg_cli_over_yaml/build-args
@@ -1,1 +1,1 @@
-IMAGE=alpine:3.19
+IMAGE=alpine:3.21

--- a/test/cases/000_build/070_volumes/005_image/test.yml
+++ b/test/cases/000_build/070_volumes/005_image/test.yml
@@ -16,7 +16,7 @@ onboot:
     command: ["/bin/sh", "/poweroff.sh", "10"]
 volumes:
   - name: vola
-    image: alpine:3.19
+    image: alpine:3.21
 files:
   - path: check.sh
     source: ./check.sh

--- a/test/cases/000_build/070_volumes/006_mount_types/test.yml
+++ b/test/cases/000_build/070_volumes/006_mount_types/test.yml
@@ -31,7 +31,7 @@ onboot:
     command: ["/bin/sh", "/poweroff.sh", "10"]
 volumes:
   - name: vola
-    image: alpine:3.19
+    image: alpine:3.21
 files:
   - path: check.sh
     source: ./check.sh

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/mount:cb8caa72248f7082fc2074ce843d53cdc15df04a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
-    image: alpine:3.19
+    image: alpine:3.21
     binds:
       - /var/lib/docker:/var/lib/docker
     command: ["touch", "/var/lib/docker/bar"]

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -12,7 +12,7 @@ onboot:
     image: linuxkit/mount:cb8caa72248f7082fc2074ce843d53cdc15df04a
     command: ["/usr/bin/mountie", "/var/lib/docker"]
   - name: test
-    image: alpine:3.19
+    image: alpine:3.21
     binds:
       - /var/lib/docker:/var/lib/docker
       - /check.sh:/check.sh

--- a/tools/guestfs/Dockerfile
+++ b/tools/guestfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim as base
+FROM debian:trixie-slim as base
 
 ARG TARGETARCH
 
@@ -11,6 +11,9 @@ ENV SYSLINUX="syslinux"
 
 FROM base as syslinux-arm64
 ENV SYSLINUX_arm64="syslinux-common"
+
+FROM base as syslinux-riscv64
+ENV SYSLINUX_riscv64="syslinux-common"
 
 FROM syslinux-${TARGETARCH} as syslinux
 RUN apt-get update && \

--- a/tools/guestfs/build.yml
+++ b/tools/guestfs/build.yml
@@ -3,3 +3,4 @@ network: true
 arches:
   - arm64
   - amd64
+  - riscv64

--- a/tools/mkimage-dynamic-vhd/Dockerfile
+++ b/tools/mkimage-dynamic-vhd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/guestfs:f85d370f7a3b0749063213c2dd451020e3a631ab
+FROM linuxkit/guestfs:8efdfac678bd6c621d3ccf916d70707ae09470f9
 
 COPY . .
 

--- a/tools/mkimage-dynamic-vhd/build.yml
+++ b/tools/mkimage-dynamic-vhd/build.yml
@@ -2,3 +2,4 @@ image: mkimage-dynamic-vhd
 arches:
   - amd64
   - arm64
+  - riscv64

--- a/tools/mkimage-gcp/Dockerfile
+++ b/tools/mkimage-gcp/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/guestfs:f85d370f7a3b0749063213c2dd451020e3a631ab
+FROM linuxkit/guestfs:8efdfac678bd6c621d3ccf916d70707ae09470f9
 
 COPY . .
 

--- a/tools/mkimage-iso-efi-initrd/build.yml
+++ b/tools/mkimage-iso-efi-initrd/build.yml
@@ -3,3 +3,4 @@ network: true
 arches:
   - amd64
   - arm64
+  - riscv64

--- a/tools/mkimage-iso-efi/build.yml
+++ b/tools/mkimage-iso-efi/build.yml
@@ -3,3 +3,4 @@ network: true
 arches:
   - amd64
   - arm64
+  - riscv64

--- a/tools/mkimage-raw-efi/build.yml
+++ b/tools/mkimage-raw-efi/build.yml
@@ -3,3 +3,4 @@ network: true
 arches:
   - amd64
   - arm64
+  - riscv64

--- a/tools/mkimage-vhd/Dockerfile
+++ b/tools/mkimage-vhd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/guestfs:f85d370f7a3b0749063213c2dd451020e3a631ab
+FROM linuxkit/guestfs:8efdfac678bd6c621d3ccf916d70707ae09470f9
 
 COPY . .
 

--- a/tools/mkimage-vhd/build.yml
+++ b/tools/mkimage-vhd/build.yml
@@ -2,3 +2,4 @@ image: mkimage-vhd
 arches:
   - amd64
   - arm64
+  - riscv64

--- a/tools/mkimage-vmdk/Dockerfile
+++ b/tools/mkimage-vmdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/guestfs:f85d370f7a3b0749063213c2dd451020e3a631ab
+FROM linuxkit/guestfs:8efdfac678bd6c621d3ccf916d70707ae09470f9
 
 COPY . .
 

--- a/tools/mkimage-vmdk/build.yml
+++ b/tools/mkimage-vmdk/build.yml
@@ -2,3 +2,4 @@ image: mkimage-vmdk
 arches:
   - amd64
   - arm64
+  - riscv64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes #3673 

**- What I did**

- Added riscv64 builds to remaining packages that need it
- make riscv64 a default build platform for `linuxkit build`

**- How I did it**

- leverage the kernels added in previous builds
- add riscv64 to list of default platforms in `lkt build`
- add riscv64 to remaining packages that support it, including many of the build tools
- build and push out packages

**- How to verify it**

CI in general. I also built multiple images for riscv64

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
riscv64 build support

**- Notes **

I imagine some weird nits will show up, like some missing package, or something that should support but doesn't. Overall, though, it appears to be working fine. People with access to riscv64 platforms can test it further.