### PR TITLE
feat: add riscv64 as supported arch

### DIFF
--- a/src/cmd/linuxkit/util/arch.go
+++ b/src/cmd/linuxkit/util/arch.go
@@ -9,6 +9,8 @@ func MArch(in string) (string, error) {
 		return "x86_64", nil
 	case "aarch64", "arm64":
 		return "aarch64", nil
+	case "riscv64":
+		return "riscv64", nil
 	}
 	return "", fmt.Errorf("unknown arch %q", in)
 }


### PR DESCRIPTION
**- What I did**
kernel+squashfs flow didn't work for riscv64, which was due to it missing in MArch function

**- How I did it**
Added riscv64

**- How to verify it**
Run minimal.yml with -arch riscv64

**- Description for the changelog**
Fixed bug preventing kernel+squashfs to work for riscv64 target
