### PR TITLE
ensure that new index does not break on missing lock file

### DIFF
--- a/src/cmd/linuxkit/cache/open.go
+++ b/src/cmd/linuxkit/cache/open.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -10,18 +11,28 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var (
+	newIndexLockFile = filepath.Join(os.TempDir(), "linuxkit-new-cache-index.lock")
+)
+
 // Get get or initialize the cache
 func Get(cache string) (layout.Path, error) {
 	// initialize the cache path if needed
 	p, err := layout.FromPath(cache)
 	if err != nil {
-		lock, err := util.Lock(filepath.Join(cache, indexFile))
+		if err := os.WriteFile(newIndexLockFile, []byte{}, 0644); err != nil {
+			return "", fmt.Errorf("unable to create lock file %s for writing descriptor for new cache %s: %v", newIndexLockFile, cache, err)
+		}
+		lock, err := util.Lock(newIndexLockFile)
 		if err != nil {
-			return "", fmt.Errorf("unable to lock cache index for writing descriptor for new cache: %v", err)
+			return "", fmt.Errorf("unable to retrieve lock for writing descriptor for new cache %s: %v", newIndexLockFile, err)
 		}
 		defer func() {
 			if err := lock.Unlock(); err != nil {
 				log.Errorf("unable to close lock for cache index after writing descriptor for new cache: %v", err)
+			}
+			if err := os.RemoveAll(newIndexLockFile); err != nil {
+				log.Errorf("unable to remove lock file %s after writing descriptor for new cache: %v", newIndexLockFile, err)
 			}
 		}()
 		p, err = layout.Write(cache, empty.Index)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Follow up to cache index locking. It worked, but fails on new cache because it tries to lock a non-existent file. Instead, it creates a different tmp file (consistent name) as a lock file, uses that, creates the proper `index.json`, and then releases the lock.

**- How I did it**
As described 

**- How to verify it**
CI. Also, I tried it manually.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Proper lock handling for new cache.
