### PR TITLE
docs: Add instructions for OCI export from Docker

### DIFF
--- a/docs/image-cache.md
+++ b/docs/image-cache.md
@@ -59,3 +59,31 @@ is provided, it always will pull, independent of what is in the cache.
 
 The read process is smart enough to check each blob in the local cache before downloading
 it from a registry.
+
+## Imports from local Docker instance
+
+To import an image from your local Docker daemon into LinuxKit, you’ll need to ensure the image is exported in the [OCI image format](https://docs.docker.com/build/exporters/oci-docker/), which LinuxKit understands.
+
+This requires using a `docker-container` [buildx driver](https://docs.docker.com/build/builders/drivers/docker-container/), rather than the default.
+
+Set it up like so:
+
+```shell
+docker buildx create --driver docker-container --driver-opt image=moby/buildkit:latest --name=ocibuilder --bootstrap
+```
+
+Then build and export your image using the OCI format:
+
+```shell
+docker buildx build --builder=ocibuilder --output type=oci,name=foo . > foo.tar
+```
+
+You can now import it into LinuxKit with:
+
+```shell
+linuxkit cache import foo.tar
+```
+
+Note that this process, as described, will only produce images for the platform/architecture you're currently on. To produce multi-platform images requires extra docker build flags and external builder or QEMU support - see [here](https://docs.docker.com/build/building/multi-platform/).
+
+This workaround is only necessary when working with the local Docker daemon. If you’re pulling from Docker Hub or another registry, you don’t need to do any of this.


### PR DESCRIPTION
**- What I did**

Modified `docs/image-cache.md` to note how one can export from a local docker instance into linuxkit
closes #4126 

**- How I did it**

NA

**- How to verify it**

NA

**- Description for the changelog**

Add instructions for importing images from local docker instance

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/user-attachments/assets/2aa7a192-82a4-4392-b8b4-68140980e338)
