### PR TITLE
add missing CRLF in log message

### DIFF
--- a/src/cmd/linuxkit/cache/push.go
+++ b/src/cmd/linuxkit/cache/push.go
@@ -66,7 +66,7 @@ func (p *Provider) Push(name, remoteName string, withArchSpecificTags, override 
 		}
 		desc, err := remote.Get(ref, remoteOptions...)
 		if err == nil && desc != nil && dig == desc.Digest {
-			fmt.Printf("%s image already available on remote registry, skipping push", remoteName)
+			fmt.Printf("%s image already available on remote registry, skipping push\n", remoteName)
 			return nil
 		}
 		log.Debugf("pushing image %s as %s", name, remoteName)
@@ -88,7 +88,7 @@ func (p *Provider) Push(name, remoteName string, withArchSpecificTags, override 
 		desc, err := remote.Get(ref, remoteOptions...)
 		if err == nil && desc != nil {
 			if dig == desc.Digest {
-				fmt.Printf("%s index already available on remote registry, skipping push", remoteName)
+				fmt.Printf("%s index already available on remote registry, skipping push\n", remoteName)
 				return nil
 			}
 			// we have a different index, need to cross-reference and only override relevant stuff


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added missing `"\n"` on 2 log line messages

**- How I did it**

Addined `"\n"`

**- How to verify it**
Run it. I did.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Separate log line messages that should be separate

