### PR TITLE
fix registry auth

### DIFF
--- a/src/cmd/linuxkit/pkg.go
+++ b/src/cmd/linuxkit/pkg.go
@@ -101,6 +101,6 @@ func pkgCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&dirty, "force-dirty", false, "Force the pkg(s) to be considered dirty")
 	cmd.PersistentFlags().BoolVar(&devMode, "dev", false, "Force org and hash to $USER and \"dev\" respectively")
 
-	cmd.PersistentFlags().StringSliceVar(&registryCreds, "registry-creds", nil, "Registry auths to use for building images, format is <registry>=<username>:<password> OR <registry>=<registry-token>. If no username is provided, it is treated as a registry token. <registry> must be a URL, e.g. 'https://index.docker.io/'. May be provided as many times as desired. Will override anything in your default.")
+	cmd.PersistentFlags().StringSliceVar(&registryCreds, "registry-creds", nil, "Registry auths to use for building images, format is <registry>=<username>:<password> OR <registry>=<registry-token-base64>; do NOT forget to base64 encode it. If no username is provided, it is treated as a registry token. <registry> must be a URL, e.g. 'https://index.docker.io/'. May be provided as many times as desired. Will override anything in your default.")
 	return cmd
 }

--- a/src/cmd/linuxkit/pkglib/docker.go
+++ b/src/cmd/linuxkit/pkglib/docker.go
@@ -593,10 +593,13 @@ func (dr *dockerRunnerImpl) build(ctx context.Context, tag, pkg, dockerContext, 
 		cf = configfile.New("custom")
 		// merge imageBuildOpts.RegistryAuths into dockercfg
 		for registry, auth := range imageBuildOpts.RegistryAuths {
-			bareRegistry := strings.TrimPrefix(registry, "https://")
-			bareRegistry = strings.TrimPrefix(bareRegistry, "http://")
-			cf.AuthConfigs[bareRegistry] = dockerconfigtypes.AuthConfig{
-				ServerAddress: bareRegistry,
+			// special case for docker.io
+			registryWithoutScheme := strings.TrimPrefix(registry, "https://")
+			registryWithoutScheme = strings.TrimPrefix(registryWithoutScheme, "http://")
+			if registryWithoutScheme == "docker.io" || registryWithoutScheme == "index.docker.io" || registryWithoutScheme == "registry-1.docker.io" {
+				registry = "https://index.docker.io/v1/"
+			}
+			cf.AuthConfigs[registry] = dockerconfigtypes.AuthConfig{
 				Username:      auth.Username,
 				Password:      auth.Password,
 				RegistryToken: auth.RegistryToken,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed how linuxkit asks buildkit to do auth, when explicit credentials are provided using CLI. Also, handle the special use case of `docker.io`.

Does not affect inserting creds from `docker login`.

**- How I did it**
With difficulty, until Tonis Tiigi explained the special case.

**- How to verify it**
CI, plus tests I ran.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Handle docker.io registry-creds correctly.
