### PR TITLE
check lock when reading cache provider index

### DIFF
--- a/src/cmd/linuxkit/cache/find.go
+++ b/src/cmd/linuxkit/cache/find.go
@@ -83,7 +83,7 @@ func (p *Provider) findIndex(imageName string) (v1.ImageIndex, error) {
 
 // FindDescriptor get the first descriptor pointed to by the image reference, whether tagged or digested
 func (p *Provider) FindDescriptor(ref *reference.Spec) (*v1.Descriptor, error) {
-	index, err := p.cache.ImageIndex()
+	index, err := p.Index()
 	// if there is no root index, we are broken
 	if err != nil {
 		return nil, fmt.Errorf("invalid image cache: %v", err)

--- a/src/cmd/linuxkit/cache/image.go
+++ b/src/cmd/linuxkit/cache/image.go
@@ -14,7 +14,7 @@ func ListImages(dir string) (map[string]string, error) {
 }
 
 func (p *Provider) List() (map[string]string, error) {
-	ii, err := p.cache.ImageIndex()
+	ii, err := p.Index()
 	if err != nil {
 		return nil, err
 	}

--- a/src/cmd/linuxkit/cache/resolvabledescriptor.go
+++ b/src/cmd/linuxkit/cache/resolvabledescriptor.go
@@ -51,7 +51,7 @@ func (l layoutIndex) Digest() (v1.Hash, error) {
 // a given imageName.
 func (p *Provider) FindRoot(imageName string) (ResolvableDescriptor, error) {
 	matcher := match.Name(imageName)
-	rootIndex, err := p.cache.ImageIndex()
+	rootIndex, err := p.Index()
 	// of there is no root index, we are broken
 	if err != nil {
 		return nil, fmt.Errorf("invalid image cache: %v", err)

--- a/src/cmd/linuxkit/cache/write.go
+++ b/src/cmd/linuxkit/cache/write.go
@@ -239,7 +239,7 @@ func (p *Provider) IndexWrite(ref *reference.Spec, descriptors ...v1.Descriptor)
 		return errors.New("cannot create index without any manifests")
 	}
 
-	ii, err := p.cache.ImageIndex()
+	ii, err := p.Index()
 	if err != nil {
 		return fmt.Errorf("unable to get root index: %v", err)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
We already lock the index before writing to it. However, the write is not atomic; the underlying ggcr library writes it in place. That means that some other thread or process reading it can get a corrupt file if it is mid-write. It would be nice if we could make the writes atomic, but ggcr does not support it.

Instead, we use the same lock everywhere that we read the cache root index. That turns out to be only in three places, so I added a function `cache.Provider.Index()` which gets the root index, and that uses the lock.

**- How I did it**
As described above.

**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
lock when reading cache root index.
