### PR TITLE
option to pull down required images from  to the cache, so that build…

### DIFF
--- a/src/cmd/linuxkit/pkg_build.go
+++ b/src/cmd/linuxkit/pkg_build.go
@@ -43,6 +43,7 @@ func pkgBuildCmd() *cobra.Command {
 		builderImage   string
 		builderConfig  string
 		builderRestart bool
+		preCacheImages bool
 		release        string
 		nobuild        bool
 		manifest       bool
@@ -80,6 +81,9 @@ func pkgBuildCmd() *cobra.Command {
 			}
 			if ignoreCache {
 				opts = append(opts, pkglib.WithBuildIgnoreCache())
+			}
+			if preCacheImages {
+				opts = append(opts, pkglib.WithPreCacheImages())
 			}
 			if pull {
 				opts = append(opts, pkglib.WithBuildPull())
@@ -283,6 +287,7 @@ func pkgBuildCmd() *cobra.Command {
 	cmd.Flags().StringVar(&builderImage, "builder-image", defaultBuilderImage, "buildkit builder container image to use")
 	cmd.Flags().StringVar(&builderConfig, "builder-config", "", "path to buildkit builder config.toml file to use, overrides the default config.toml in the builder image. When provided, copied over into builder, along with all certs. Use paths for certificates relative to your local host, they will be adjusted on copying into the container. USE WITH CAUTION")
 	cmd.Flags().BoolVar(&builderRestart, "builder-restart", false, "force restarting builder, even if container with correct name and image exists")
+	cmd.Flags().BoolVar(&preCacheImages, "precache-images", false, "download all referenced images in the Dockerfile to the linuxkit cache before building, thus referencing the local cache instead of pulling from the registry; this is useful for handling mirrors and special connections")
 	cmd.Flags().Var(&cacheDir, "cache", fmt.Sprintf("Directory for caching and finding cached image, overrides env var %s", envVarCacheDir))
 	cmd.Flags().StringVar(&release, "release", "", "Release the given version")
 	cmd.Flags().BoolVar(&nobuild, "nobuild", false, "Skip building the image before pushing, conflicts with -force")

--- a/src/cmd/linuxkit/pkglib/build_test.go
+++ b/src/cmd/linuxkit/pkglib/build_test.go
@@ -56,7 +56,7 @@ func (d *dockerMocker) contextSupportCheck() error {
 func (d *dockerMocker) builder(_ context.Context, _, _, _, _ string, _ bool) (*buildkitClient.Client, error) {
 	return nil, fmt.Errorf("not implemented")
 }
-func (d *dockerMocker) build(ctx context.Context, tag, pkg, dockerContext, builderImage, builderConfigPath, platform string, builderRestart bool, c spec.CacheProvider, r io.Reader, stdout io.Writer, sbomScan bool, sbomScannerImage, progress string, imageBuildOpts spec.ImageBuildOptions) error {
+func (d *dockerMocker) build(ctx context.Context, tag, pkg, dockerContext, builderImage, builderConfigPath, platform string, builderRestart, preCacheImages bool, c spec.CacheProvider, r io.Reader, stdout io.Writer, sbomScan bool, sbomScannerImage, progress string, imageBuildOpts spec.ImageBuildOptions) error {
 	if !d.enableBuild {
 		return errors.New("build disabled")
 	}


### PR DESCRIPTION
…kit never gets them over the network

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When you run `lkt pkg build`, it an image from a `FROM` line in the Dockerfile already is in the cache, then lkt points buildkit to the local copy, rather than having it pull from the remote. This has existed for a long time, to serve two purposes:

1. The ability to chain builds locally. E.g. I build one image, and then use it for another, when the first has not been pushed to a remote registry.
2. Saving remote pulls if you repeatedly build a local image.

In addition, you always could do `lkt cache pull` to pull an image, if you wanted. If you did that before `pkg build`, then a referenced image would be read from local cache.

This PR combines those two.

When `lkt pkg build` parses a Dockerfile right before passing it to buildkit, if it finds a reference that is not in the local cache, and the new `--pre-cache-images` option is set, then lkt will pull down the image to local cache. This means a larger cache, but more importantly, it means that buildkit always will read images just from local cache.

This can have an impact on network and registry usage. But it also lets you configure mirrors and such (see #4148) through the `lkt` client, without needing to configure buildkit specially.

**- How I did it**

* added a CLI flag to `pkg build`
* added cache pulling when needed

**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
support for pre-caching images before pkg build
