### PR TITLE
Enable CONFIG_AMT in 6.6.x

### DIFF
--- a/kernel/6.6.x/config-x86_64
+++ b/kernel/6.6.x/config-x86_64
@@ -2264,7 +2264,7 @@ CONFIG_VXLAN=y
 CONFIG_GENEVE=m
 # CONFIG_BAREUDP is not set
 # CONFIG_GTP is not set
-# CONFIG_AMT is not set
+CONFIG_AMT=y
 # CONFIG_MACSEC is not set
 # CONFIG_NETCONSOLE is not set
 CONFIG_TUN=y


### PR DESCRIPTION
Automatic Multicast Tunneling (RFC7450) in Linux is quite mature now, and of importance for IPTV workflows

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
