### PR TITLE
add support for specifying additional certificates

### DIFF
--- a/src/cmd/linuxkit/cmd.go
+++ b/src/cmd/linuxkit/cmd.go
@@ -49,6 +49,7 @@ func newCmd() *cobra.Command {
 		flagVerbose     int
 		flagVerboseName = "verbose"
 		mirrorsRaw      []string
+		certFiles       []string
 	)
 	cmd := &cobra.Command{
 		Use:               "linuxkit",
@@ -87,6 +88,18 @@ func newCmd() *cobra.Command {
 				}
 			}
 
+			for _, f := range certFiles {
+				if f == "" {
+					continue
+				}
+				cert, err := os.ReadFile(f)
+				if err != nil {
+					return fmt.Errorf("failed to read certificate file %q: %w", f, err)
+				}
+				// Add the certificate file to the registry
+				registry.AddCert(cert)
+			}
+
 			// Set up logging
 			return util.SetupLogging(flagQuiet, flagVerbose, cmd.Flag(flagVerboseName).Changed)
 		},
@@ -103,6 +116,7 @@ func newCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(&cacheDir, "cache", defaultLinuxkitCache(), fmt.Sprintf("Directory for caching and finding cached image, overrides env var %s", envVarCacheDir))
 	cmd.PersistentFlags().StringArrayVar(&mirrorsRaw, "mirror", nil, "Mirror to use for pulling images, format is <registry>=<mirror>, e.g. docker.io=http://mymirror.io, or just http://mymirror.io for all not otherwise specified; must include protocol. Can be provided multiple times.")
+	cmd.PersistentFlags().StringArrayVar(&certFiles, "cert-file", nil, "Path to certificate files to use for pulling images, can be provided multiple times. Will augment system-provided certs.")
 	cmd.PersistentFlags().BoolVarP(&flagQuiet, "quiet", "q", false, "Quiet execution")
 	cmd.PersistentFlags().IntVarP(&flagVerbose, flagVerboseName, "v", 1, "Verbosity of logging: 0 = quiet, 1 = info, 2 = debug, 3 = trace. Default is info. Setting it explicitly will create structured logging lines.")
 

--- a/src/cmd/linuxkit/pkg.go
+++ b/src/cmd/linuxkit/pkg.go
@@ -33,6 +33,14 @@ func pkgCmd() *cobra.Command {
 		Short: "package building and pushing",
 		Long:  `Package building and pushing.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if parent := cmd.Parent(); parent != nil {
+				if parent.PersistentPreRunE != nil {
+					if err := parent.PersistentPreRunE(parent, args); err != nil {
+						return err
+					}
+				}
+			}
+
 			pkglibConfig = pkglib.PkglibConfig{
 				BuildYML:   buildYML,
 				Hash:       hash,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added ability to specify paths to cert files to use, in addition to system certs, when interacting with OCI registries

**- How I did it**
Added a persistent CLI flag and added to Transport

**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Support for additional certs
