### PR TITLE
simplify sharding in package tests for CI; increase to 12 shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,14 @@ jobs:
     runs-on: ${{ matrix.target.runner }}
     steps:
 
-    - name: Set up Go 1.22
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.22.3
-      id: go
-
     - name: Check out code
       uses: actions/checkout@v4
+
+    - name: Set up Go based on go.mod
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'src/cmd/linuxkit/go.mod'
+      id: go
 
     - name: Set path
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
@@ -156,25 +156,32 @@ jobs:
   
   gen_package_test_matrix:
     name: Generate Package Test Matrix
+    needs: [ build_packages, build ]
     runs-on: ubuntu-latest
     outputs:
       shard_list: ${{ steps.mk.outputs.list }}
-      total: ${{ steps.mk.outputs.total }}
     steps:
     - name: Generate Test Matrix
       id: mk
       shell: bash
       run: |
           set -x
-          N="${{ env.TOTAL_SHARDS}}"
+          N="${{ env.TOTAL_SHARDS }}"
           # Priority: repo var SHARDS → event-based default (PR=6, else 10)
           if [ -n "${{ vars.SHARDS }}" ]; then
             N="${{ vars.SHARDS }}"
           fi
 
-          # Build JSON array [1,2,...,N]
-          echo "list=[$(seq -s, 1 "$N")]" >> "$GITHUB_OUTPUT"
-          echo "total=$N" >> "$GITHUB_OUTPUT"
+          # Build JSON array ["1/N","2/N",...,"N/N"]
+          shards=""
+          for i in $(seq 1 "$N"); do
+            if [ -z "$shards" ]; then
+              shards="\"$i/$N\""
+            else
+              shards="$shards,\"$i/$N\""
+            fi
+          done
+          echo "list=[$shards]" >> "$GITHUB_OUTPUT"
 
   test_packages:
     name: Packages Tests
@@ -183,7 +190,6 @@ jobs:
     strategy:
       matrix:
         shard: ${{ fromJson(needs.gen_package_test_matrix.outputs.shard_list) }}
-        totalShards: ${{ needs.gen_package_test_matrix.outputs.total }}
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -233,7 +239,7 @@ jobs:
         linuxkit cache ls
       
     - name: Run Tests
-      run: make test TEST_SUITE=linuxkit.packages TEST_SHARD=${{ matrix.shard }}/${{ matrix.totalShards }}
+      run: make test TEST_SUITE=linuxkit.packages TEST_SHARD=${{ matrix.shard }}
 
   test_kernel:
     name: Kernel Tests

--- a/.github/workflows/package_release.yml
+++ b/.github/workflows/package_release.yml
@@ -9,13 +9,13 @@ jobs:
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/pkg-v')
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.22
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.22.3
-      id: go
     - name: Check out code
       uses: actions/checkout@v4
+    - name: Set up Go based on go.mod
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'src/cmd/linuxkit/go.mod'
+      id: go
     - name: Ensure bin/ directory
       run: mkdir -p bin
     - name: Install linuxkit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.122
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.22.3
-      id: go
-
     - name: Check out code
       uses: actions/checkout@v4
+    - name: Set up Go based on go.mod
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'src/cmd/linuxkit/go.mod'
+      id: go
+
 
     - name: Set path
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
@@ -42,14 +42,14 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - name: Set up Go 1.122
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.22.3
-      id: go
-
     - name: Check out code
       uses: actions/checkout@v4
+    - name: Set up Go based on go.mod
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'src/cmd/linuxkit/go.mod'
+      id: go
+
 
     - name: Set path
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH

--- a/src/cmd/linuxkit/go.mod
+++ b/src/cmd/linuxkit/go.mod
@@ -1,8 +1,6 @@
 module github.com/linuxkit/linuxkit/src/cmd/linuxkit
 
-go 1.23.0
-
-toolchain go1.24.2
+go 1.24.2
 
 require (
 	github.com/Azure/azure-sdk-for-go v56.3.0+incompatible


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Increased the number of shards for package tests from 10 to 12.

Also simplified the shard listing.

**- How I did it**
Changed a single ci.yml

**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
12 shards for testing
