### PR TITLE
update debian for binfmt

### DIFF
--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -17,7 +17,7 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:7345172dbf4d436c861adfc27150af474194289b
   - name: binfmt
-    image: linuxkit/binfmt:ce9509ccfa25002227ccd7ed8dd48d6947854427
+    image: linuxkit/binfmt:9d2a7ee581dabee65ea6866763d9a1dbbea2f271
   # Format and mount the disk image in /var/lib/docker
   - name: format
     image: linuxkit/format:3fb088f60ed73ba4a15be41e44654b74112fd3f9

--- a/pkg/binfmt/Dockerfile
+++ b/pkg/binfmt/Dockerfile
@@ -1,5 +1,5 @@
 # Use Debian testing Qemu 4.2.0 until https://bugs.alpinelinux.org/issues/8131 is resolved.
-FROM debian@sha256:d828cca5497a2519da9c6d42372066895fa28a69f1e8a46a38ce8f750bd2adf0 AS qemu
+FROM debian@sha256:731dd1380d6a8d170a695dbeb17fe0eade0e1c29f654cf0a3a07f372191c3f4b AS qemu
 RUN apt-get update && apt-get install -y qemu-user-static && \
     mv /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64 && \
     mv /usr/bin/qemu-arm-static /usr/bin/qemu-arm && \

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -6,7 +6,7 @@ init:
   - linuxkit/runc:667e7ea2c426a2460ca21e3da065a57dbb3369c9
 onboot:
   - name: binfmt
-    image: linuxkit/binfmt:ce9509ccfa25002227ccd7ed8dd48d6947854427
+    image: linuxkit/binfmt:9d2a7ee581dabee65ea6866763d9a1dbbea2f271
   - name: test
     image: alpine:3.13
     binds:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #4157

**- What I did**
Updated the hash for debian to get qemu-*-static utils for `pkg/binfmt`

**- How I did it**
1. See on the issue that `debian:bookworm` works
2. Get hash of `debian:bookworm` as `debian@sha256:731dd1380d6a8d170a695dbeb17fe0eade0e1c29f654cf0a3a07f372191c3f4b`
3. Update `pkg/binfmt/Dockerfile`
4. Run `lkt pkg push pkg/binfmt`
5. Run `./scripts/update-component-sha.sh --pkg ./pkg/binfmt`
6. commit and push

**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Updated debian source of qemu user utils for `binfmt`

