### PR TITLE
 pkglib/git: remove trailing spaces of GOPKGVERSION

### DIFF
--- a/src/cmd/linuxkit/pkglib/git.go
+++ b/src/cmd/linuxkit/pkglib/git.go
@@ -242,5 +242,8 @@ func (g git) goPkgVersion() (string, error) {
 		}
 		version = fmt.Sprintf("%s-%s", lastSemver, dateCommit)
 	}
+
+	version = strings.TrimSpace(version)
+
 	return version, nil
 }


### PR DESCRIPTION
this makes `--dry-run` inconvenient as it includes a newline

**- What I did**

trimming all whitespaces around the GOPKGVERSION

**- How I did it**

**- How to verify it**

Run
```
~/src/linuxkit/src/cmd/linuxkit/linuxkit pkg build --platforms linux/amd64 --force --dry-run pkg/pillar
```
 check that after `--build-arg=GOPKGVERSION=v0.0.0-20250828163257-a2e7a9467df0` there is no newline


**- Description for the changelog**

Fix trailing newline after GOPKGVERSION

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="1536" height="1024" alt="ChatGPT Image Aug 28, 2025, 04_47_16 PM" src="https://github.com/user-attachments/assets/5491effb-3318-4ad1-a939-170a1af0a7d1" />
