### PR TITLE
bump runc to v1.3.0 and containerd to v2.1.4

### DIFF
--- a/examples/addbinds.yml
+++ b/examples/addbinds.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/containerd-debug.yml
+++ b/examples/containerd-debug.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,8 +4,8 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:e39447f4ca312f9ca256e7737a6bec59bd36aec9 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
   - linuxkit/memlogd:c5521cc1bb602f8b6343c071e05da596523a4196

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 onboot:
   - name: dhcpcd

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 services:
   - name: getty

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/platform-aws.yml
+++ b/examples/platform-aws.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/platform-azure.yml
+++ b/examples/platform-azure.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/platform-equinixmetal.yml
+++ b/examples/platform-equinixmetal.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
   - linuxkit/firmware:c9c7d24ecc626db5d293d31ffaaed0a7ffa776e6

--- a/examples/platform-gcp.yml
+++ b/examples/platform-gcp.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/platform-hetzner.yml
+++ b/examples/platform-hetzner.yml
@@ -3,8 +3,8 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
   - linuxkit/firmware:c9c7d24ecc626db5d293d31ffaaed0a7ffa776e6

--- a/examples/platform-rt-for-vmware.yml
+++ b/examples/platform-rt-for-vmware.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/platform-scaleway.yml
+++ b/examples/platform-scaleway.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/platform-vmware.yml
+++ b/examples/platform-vmware.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/platform-vultr.yml
+++ b/examples/platform-vultr.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,8 +4,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 onboot:
   - name: dhcpcd

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/static-ip.yml
+++ b/examples/static-ip.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 onboot:
   - name: ip

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/volumes.yml
+++ b/examples/volumes.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 onboot:
   - name: dhcpcd

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 onboot:
   - name: dhcpcd

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -4,7 +4,7 @@ FROM linuxkit/alpine:6090baae063eb5023c9601966e88df831f789a70 as alpine
 RUN apk add tzdata binutils
 RUN mkdir -p /etc/init.d && ln -s /usr/bin/service /etc/init.d/020-containerd
 
-FROM linuxkit/containerd-dev:0de800928578cd1915c68ed4834175df5b641db1 as containerd-dev
+FROM linuxkit/containerd-dev:1a4eee3fc0d683667c9115256f035f792f681f30 as containerd-dev
 
 FROM scratch
 ENTRYPOINT []

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile to build linuxkit/init for linuxkit
-FROM linuxkit/containerd-dev:0de800928578cd1915c68ed4834175df5b641db1 AS containerd-dev
+FROM linuxkit/containerd-dev:1a4eee3fc0d683667c9115256f035f792f681f30 AS containerd-dev
 FROM linuxkit/alpine:6090baae063eb5023c9601966e88df831f789a70 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 

--- a/pkg/runc/Dockerfile
+++ b/pkg/runc/Dockerfile
@@ -13,7 +13,7 @@ RUN \
   make \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin GO111MODULE=off
-ENV RUNC_COMMIT=v1.1.12
+ENV RUNC_COMMIT=v1.3.0
 RUN mkdir -p $GOPATH/src/github.com/opencontainers && \
   cd $GOPATH/src/github.com/opencontainers && \
   git clone https://github.com/opencontainers/runc.git

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,8 +2,8 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 onboot:
   - name: dhcpcd

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
   - samoht/fdd

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 onboot:
   - name: sysctl

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,8 +2,8 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/src/cmd/linuxkit/moby/build/mkimage.yaml
+++ b/src/cmd/linuxkit/moby/build/mkimage.yaml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:c7e3baf460c6609e2fbaf3381bc660ec4c7e6828

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4681273eeea47c26d980958656e60fe70d49e318

--- a/test/cases/000_build/001_tarheaders/test.yml
+++ b/test/cases/000_build/001_tarheaders/test.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 
 onboot:

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 
 onboot:

--- a/test/cases/000_build/020_binds/test.yml
+++ b/test/cases/000_build/020_binds/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: mount
     image: linuxkit/mount:54906e884b21aca02bf5ecae65f3741b89d8c4e6

--- a/test/cases/000_build/050_sbom/test.yml
+++ b/test/cases/000_build/050_sbom/test.yml
@@ -3,8 +3,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 
 onboot:

--- a/test/cases/000_build/060_input_tar/000_build/test1.yml
+++ b/test/cases/000_build/060_input_tar/000_build/test1.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 onboot:
   - name: sysctl

--- a/test/cases/000_build/060_input_tar/000_build/test2.yml
+++ b/test/cases/000_build/060_input_tar/000_build/test2.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/test/cases/000_build/060_input_tar/010_same_filename/test.yml
+++ b/test/cases/000_build/060_input_tar/010_same_filename/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 onboot:
   - name: sysctl

--- a/test/cases/000_build/070_volumes/000_rw_on_rw/test.yml
+++ b/test/cases/000_build/070_volumes/000_rw_on_rw/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: test1
     image: alpine:3.20

--- a/test/cases/000_build/070_volumes/001_ro_on_ro/test.yml
+++ b/test/cases/000_build/070_volumes/001_ro_on_ro/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: test
     image: alpine:3.20

--- a/test/cases/000_build/070_volumes/002_rw_on_ro/test.yml
+++ b/test/cases/000_build/070_volumes/002_rw_on_ro/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: test
     image: alpine:3.20

--- a/test/cases/000_build/070_volumes/003_ro_on_rw/test.yml
+++ b/test/cases/000_build/070_volumes/003_ro_on_rw/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: test1
     image: alpine:3.20

--- a/test/cases/000_build/070_volumes/004_blank/test.yml
+++ b/test/cases/000_build/070_volumes/004_blank/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: test
     image: alpine:3.20

--- a/test/cases/000_build/070_volumes/005_image/test.yml
+++ b/test/cases/000_build/070_volumes/005_image/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: test
     image: alpine:3.20

--- a/test/cases/000_build/070_volumes/006_mount_types/test.yml
+++ b/test/cases/000_build/070_volumes/006_mount_types/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: testbinds
     image: alpine:3.20

--- a/test/cases/000_build/080_mirrors/test.yml
+++ b/test/cases/000_build/080_mirrors/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4681273eeea47c26d980958656e60fe70d49e318

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 services:
   - name: acpid

--- a/test/cases/010_platforms/110_gcp/000_run/test.yml
+++ b/test/cases/010_platforms/110_gcp/000_run/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/020_kernel/011_config_5.4.x/test.yml
+++ b/test/cases/020_kernel/011_config_5.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.172-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:0064f2f1465ecab4063e940e331c65ba0863d259

--- a/test/cases/020_kernel/013_config_5.10.x/test.yml
+++ b/test/cases/020_kernel/013_config_5.10.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:0064f2f1465ecab4063e940e331c65ba0863d259

--- a/test/cases/020_kernel/016_config_5.15.x/test.yml
+++ b/test/cases/020_kernel/016_config_5.15.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.15.27-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:0064f2f1465ecab4063e940e331c65ba0863d259

--- a/test/cases/020_kernel/019_config_6.6.x/test.yml
+++ b/test/cases/020_kernel/019_config_6.6.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71-819af9d59279506dd2994e7aea1cbbaaebfdb0a2
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: check-kernel-config
     image: linuxkit/test-kernel-config:0064f2f1465ecab4063e940e331c65ba0863d259

--- a/test/cases/020_kernel/111_kmod_5.4.x/test.yml
+++ b/test/cases/020_kernel/111_kmod_5.4.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.4.172-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/113_kmod_5.10.x/test.yml
+++ b/test/cases/020_kernel/113_kmod_5.10.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.10.104-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/116_kmod_5.15.x/test.yml
+++ b/test/cases/020_kernel/116_kmod_5.15.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:5.15.27-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/119_kmod_6.6.x/test.yml
+++ b/test/cases/020_kernel/119_kmod_6.6.x/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71-819af9d59279506dd2994e7aea1cbbaaebfdb0a2
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: check
     image: kmod-test

--- a/test/cases/020_kernel/200_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/010_echo-tcp-ipv4-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/011_echo-tcp-ipv4-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/012_echo-tcp-ipv4-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/015_echo-tcp-ipv4-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/016_echo-tcp-ipv4-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/017_echo-tcp-ipv4-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/020_echo-tcp-ipv6-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/021_echo-tcp-ipv6-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/022_echo-tcp-ipv6-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/025_echo-tcp-ipv6-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/026_echo-tcp-ipv6-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/027_echo-tcp-ipv6-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "tcp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/030_echo-udp-ipv4-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/030_echo-udp-ipv4-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/031_echo-udp-ipv4-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/031_echo-udp-ipv4-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/032_echo-udp-ipv4-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/035_echo-udp-ipv4-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/035_echo-udp-ipv4-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/036_echo-udp-ipv4-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/036_echo-udp-ipv4-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/037_echo-udp-ipv4-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "4", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/040_echo-udp-ipv6-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/040_echo-udp-ipv6-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/041_echo-udp-ipv6-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/041_echo-udp-ipv6-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/042_echo-udp-ipv6-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/045_echo-udp-ipv6-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/045_echo-udp-ipv6-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/046_echo-udp-ipv6-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/046_echo-udp-ipv6-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/200_namespace/010_veth/047_echo-udp-ipv6-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-ip", "6", "-p", "udp", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/010_echo-short-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/010_echo-short-1con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/010_echo-short-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/011_echo-short-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/011_echo-short-10con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/011_echo-short-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/012_echo-short-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/012_echo-short-5con-multi/test.yml
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/012_echo-short-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-s", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/015_echo-long-1con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1", "-r"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/015_echo-long-1con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/015_echo-long-1con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "1"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/016_echo-long-10con-single-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/016_echo-long-10con-single/test.yml
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/016_echo-long-10con-single/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "1", "-l", "5", "-i", "15", "-p", "unix", "-c", "10"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/017_echo-long-5con-multi-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/050_unix-domain/017_echo-long-5con-multi/test.yml
+++ b/test/cases/020_kernel/200_namespace/050_unix-domain/017_echo-long-5con-multi/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "5", "-l", "5", "-i", "15", "-p", "unix", "-c", "5"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/100_mix/010_veth-unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/200_namespace/100_mix/010_veth-unix-domain-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "mix"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/100_mix/011_veth-unix-domain-echo-reverse/test.yml
+++ b/test/cases/020_kernel/200_namespace/100_mix/011_veth-unix-domain-echo-reverse/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-reverse"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/100_mix/012_veth-ipv4-echo/test.yml
+++ b/test/cases/020_kernel/200_namespace/100_mix/012_veth-ipv4-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv4"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/100_mix/013_veth-ipv6-echo/test.yml
+++ b/test/cases/020_kernel/200_namespace/100_mix/013_veth-ipv6-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-ipv6"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/100_mix/014_veth-tcp-echo/test.yml
+++ b/test/cases/020_kernel/200_namespace/100_mix/014_veth-tcp-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-tcp"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/100_mix/015_veth-udp-echo/test.yml
+++ b/test/cases/020_kernel/200_namespace/100_mix/015_veth-udp-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-udp"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/100_mix/020_unix-domain-echo/test.yml
+++ b/test/cases/020_kernel/200_namespace/100_mix/020_unix-domain-echo/test.yml
@@ -1,6 +1,6 @@
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:c495734d799c451d3b73b1902f0c41e2731c74dd
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-unix"]
     mounts: # for runc
     - type: cgroup

--- a/test/cases/020_kernel/200_namespace/common.yml
+++ b/test/cases/020_kernel/200_namespace/common.yml
@@ -2,5 +2,5 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: test
     image: alpine:3.13

--- a/test/cases/040_packages/001_dummy/test.yml
+++ b/test/cases/040_packages/001_dummy/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: dummy
     image: linuxkit/dummy:5366c71e4c814259c8d8fe940cb6457a4e4129f8

--- a/test/cases/040_packages/002_bcc/test.yml
+++ b/test/cases/040_packages/002_bcc/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/kernel-bcc:5.4.113
 onboot:
   - name: check-bcc

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: binfmt
     image: linuxkit/binfmt:0dbbe9b1394561d693fe593aab3ec83d992b20d1

--- a/test/cases/040_packages/002_bpftrace/test.yml
+++ b/test/cases/040_packages/002_bpftrace/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/bpftrace:f7714e57ea5d5b82cc12c5ab2faf7d65c6fa7145
 onboot:
   - name: bpftrace-test

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:
   - name: test

--- a/test/cases/040_packages/003_cgroupv2/test.yml
+++ b/test/cases/040_packages/003_cgroupv2/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "linuxkit.unified_cgroup_hierarchy=1 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: test
     image: alpine:3.13

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:
@@ -18,6 +18,6 @@ onboot:
     image: linuxkit/mount:54906e884b21aca02bf5ecae65f3741b89d8c4e6
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:e38495a761b664e277648df88f0e5700f7f3785f
+    image: linuxkit/test-containerd:498f54d551169437a60b0d2ff98c5df212ee1db4
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:4681273eeea47c26d980958656e60fe70d49e318

--- a/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: dm-crypt
     image: linuxkit/dm-crypt:f5966a7f10705cf259ca80c30e087764b87cbd26

--- a/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: dm-crypt
     image: linuxkit/dm-crypt:f5966a7f10705cf259ca80c30e087764b87cbd26

--- a/test/cases/040_packages/004_dm-crypt/002_key/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/002_key/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: dm-crypt
     image: linuxkit/dm-crypt:f5966a7f10705cf259ca80c30e087764b87cbd26

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: format
     image: linuxkit/format:512d4fb6cd40c1d90a4aa8335d1bd167fa34a10e

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: extend
     image: linuxkit/extend:48c3e4cddfdd164b913e824eff4d7548405c8a76

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:c2d61d0989a54b0d41b8622304fb0f1f00e173e3

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:c2d61d0989a54b0d41b8622304fb0f1f00e173e3

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: format
     image: linuxkit/format:512d4fb6cd40c1d90a4aa8335d1bd167fa34a10e

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: extend
     image: linuxkit/extend:48c3e4cddfdd164b913e824eff4d7548405c8a76

--- a/test/cases/040_packages/005_extend/003_gpt/test-create.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test-create.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: format
     image: linuxkit/format:512d4fb6cd40c1d90a4aa8335d1bd167fa34a10e

--- a/test/cases/040_packages/005_extend/003_gpt/test.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: extend
     image: linuxkit/extend:48c3e4cddfdd164b913e824eff4d7548405c8a76

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: format
     image: linuxkit/format:512d4fb6cd40c1d90a4aa8335d1bd167fa34a10e

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: format
     image: linuxkit/format:512d4fb6cd40c1d90a4aa8335d1bd167fa34a10e

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: format
     image: linuxkit/format:512d4fb6cd40c1d90a4aa8335d1bd167fa34a10e

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: modprobe
     image: linuxkit/modprobe:c2d61d0989a54b0d41b8622304fb0f1f00e173e3

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: format
     image: linuxkit/format:512d4fb6cd40c1d90a4aa8335d1bd167fa34a10e

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: format
     image: linuxkit/format:512d4fb6cd40c1d90a4aa8335d1bd167fa34a10e

--- a/test/cases/040_packages/006_format_mount/006_gpt/test.yml
+++ b/test/cases/040_packages/006_format_mount/006_gpt/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: format
     image: linuxkit/format:512d4fb6cd40c1d90a4aa8335d1bd167fa34a10e

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: format
     image: linuxkit/format:512d4fb6cd40c1d90a4aa8335d1bd167fa34a10e

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/test/cases/040_packages/009_init_containerd/test.yml
+++ b/test/cases/040_packages/009_init_containerd/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 services:

--- a/test/cases/040_packages/011_kmsg/test.yml
+++ b/test/cases/040_packages/011_kmsg/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
   - linuxkit/memlogd:c5521cc1bb602f8b6343c071e05da596523a4196

--- a/test/cases/040_packages/012_logwrite/test.yml
+++ b/test/cases/040_packages/012_logwrite/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
   - linuxkit/memlogd:c5521cc1bb602f8b6343c071e05da596523a4196

--- a/test/cases/040_packages/012_losetup/test.yml
+++ b/test/cases/040_packages/012_losetup/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: losetup
     image: linuxkit/losetup:2b71926debfd2ca482e694bec4ad85ddeebb63aa

--- a/test/cases/040_packages/013_metadata/000_cidata/test.yml
+++ b/test/cases/040_packages/013_metadata/000_cidata/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: metadata
     image: linuxkit/metadata:db835ad616084adb6b474e7fd804928fd1d5dd5f

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: mkimage
     image: linuxkit/mkimage:c7e3baf460c6609e2fbaf3381bc660ec4c7e6828

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: poweroff
     image: linuxkit/poweroff:533800608f90bf05e2b39c899f2f1cbe7421b8e7

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:2fad4cdf96faa97bf7888696b8c3ca00f98137af

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
   - linuxkit/ca-certificates:a4f15fe71bb0ad7560ff78f48504dd2af500a442
 onboot:

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,8 +2,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 onboot:
   - name: ltp

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,8 +4,8 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
   - linuxkit/containerd:838b745e38e43309393675ce3cf04bee9047eb91
 onboot:
   - name: dhcpcd

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd-dev:0de800928578cd1915c68ed4834175df5b641db1 as containerd-dev
+FROM linuxkit/containerd-dev:1a4eee3fc0d683667c9115256f035f792f681f30 as containerd-dev
 FROM linuxkit/alpine:35b33c6b03c40e51046c3b053dd131a68a26c37a AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,11 +3,11 @@ kernel:
   image: linuxkit/kernel:6.6.71
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:e2c6a1afb6750ea766c7386c7f2115f6e28fda4d
-  - linuxkit/runc:c0d2d13905def9c220e1b61e3c4397e172dbfc2c
+  - linuxkit/init:680da6e6f79bb8236a095147d532cd2160e23c9f
+  - linuxkit/runc:2dfee46421e963d6c0d946137e46fe36fa606d29
 onboot:
   - name: test-ns
-    image: linuxkit/test-ns:f21567d611ffed8d39bbcb2c81d39965d8812815
+    image: linuxkit/test-ns:ebaa9a41f675f54c03a02c1f5bcadcf322515c42-dirty-c0f6961
     command: ["/bin/sh", "/runp-runc-net.sh", "mix-unix"]
     # command: ["/bin/sh", "/runc-net.sh", "-l", "5", "-i", "2", "-c", "5", "-p", "unix", "-ip", "6"]
     mounts: # for runc

--- a/tools/containerd-dev/Dockerfile
+++ b/tools/containerd-dev/Dockerfile
@@ -6,11 +6,7 @@ FROM linuxkit/alpine:6090baae063eb5023c9601966e88df831f789a70 as builder
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
 
-# this commit is post-v2.0.3 and includes the fix for the blkdiscard issue
-# which is necessary for the root tests to pass when running on Alpine.
-# Once it is in semver, likely v2.0.4, we can switch to that.
-# See PR https://github.com/containerd/containerd/pull/11330
-ENV CONTAINERD_COMMIT=f35b7dae5f1f4f1277e4c39b89acb0a8ea669c48
+ENV CONTAINERD_COMMIT=v2.1.4
 ENV GOPATH=/go
 RUN apk add go git
 RUN mkdir -p $GOPATH/src/github.com/containerd && \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Bump runc and containerd

**- How I did it**
Updated the version of each in their source images, then use update-container-sha to update dependencies. Repeat until everything downstream updated.

**- How to verify it**
CI. I updated all of the tests.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
runc v1.3.0 and containerd v2.1.4

