### PR TITLE
when comparing builder config files, ensure only compare post-processed

### DIFF
--- a/test/cases/040_packages/026_buildkit_config/.gitignore
+++ b/test/cases/040_packages/026_buildkit_config/.gitignore
@@ -1,0 +1,1 @@
+docker-config/

--- a/test/cases/040_packages/026_buildkit_config/Dockerfile
+++ b/test/cases/040_packages/026_buildkit_config/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.21
+RUN echo hi

--- a/test/cases/040_packages/026_buildkit_config/build.yml
+++ b/test/cases/040_packages/026_buildkit_config/build.yml
@@ -1,0 +1,2 @@
+org: linuxkit
+image: builder-config

--- a/test/cases/040_packages/026_buildkit_config/buildkitd-2.toml
+++ b/test/cases/040_packages/026_buildkit_config/buildkitd-2.toml
@@ -1,0 +1,18 @@
+# it does not matter what these contents are, as long as they are valid and can be processed
+# and are different than the ones in buildkitd.toml
+debug = true
+# trace = true
+insecure-entitlements = [ "network.host", "security.insecure" ]
+
+[worker.oci]
+  max-parallelism = 48
+[worker.oci.gcpulimits]
+  enabled = true
+
+[log]
+  # log formatter: json or text
+  format = "json"
+
+[registry."172.17.0.2:5001"]
+  insecure = true
+  http = true

--- a/test/cases/040_packages/026_buildkit_config/buildkitd.toml
+++ b/test/cases/040_packages/026_buildkit_config/buildkitd.toml
@@ -1,0 +1,17 @@
+# it does not matter what these contents are, as long as they are valid and can be processed
+debug = true
+# trace = true
+insecure-entitlements = [ "network.host", "security.insecure" ]
+
+[worker.oci]
+  max-parallelism = 56
+[worker.oci.gcpulimits]
+  enabled = false
+
+[log]
+  # log formatter: json or text
+  format = "text"
+
+[registry."172.17.0.2:5000"]
+  insecure = true
+  http = true

--- a/test/cases/040_packages/026_buildkit_config/test.sh
+++ b/test/cases/040_packages/026_buildkit_config/test.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# SUMMARY: Check that we can access a registry with auth
+# LABELS:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+
+clean_up() {
+	[ -n "${CACHEDIR}" ] && rm -rf "${CACHEDIR}"
+}
+trap clean_up EXIT
+
+# determine platform
+ARCH=$(uname -m)
+if [ "${ARCH}" = "x86_64" ]; then
+  ARCH="amd64"
+elif [ "${ARCH}" = "aarch64" ]; then
+  ARCH="arm64"
+fi
+PLATFORM="linux/${ARCH}"
+
+CACHEDIR=$(mktemp -d)
+
+# tests:
+# 1. build the local package with the custom buildkitd.toml - should succeed
+# 2. rebuild the local package with the same buildkitd.toml - should succeed without starting a new builder container
+# 3. rebuild the local package with the different buildkitd-2.toml - should succeed after starting a new builder container
+if ! linuxkit --verbose 3 --cache "${CACHEDIR}" pkg build --platforms "${PLATFORM}" \
+  --builder-config "$(pwd)/buildkitd.toml" --force \
+  .; then 
+  echo "Build 1 failed"
+  exit 1
+fi
+CID1=$(docker inspect linuxkit-builder --format '{{.ID}}')
+
+# get the containerd
+
+if ! linuxkit --verbose 3 --cache "${CACHEDIR}" pkg build --platforms "${PLATFORM}" \
+  --builder-config "$(pwd)/buildkitd.toml" --force \
+  .; then 
+  echo "Build 2 failed"
+  exit 1
+fi
+CID2=$(docker inspect linuxkit-builder --format '{{.ID}}')
+
+if ! linuxkit --verbose 3 --cache "${CACHEDIR}" pkg build --platforms "${PLATFORM}" \
+  --builder-config "$(pwd)/buildkitd-2.toml" --force \
+  .; then 
+  echo "Build 3 failed"
+  exit 1
+fi
+CID3=$(docker inspect linuxkit-builder --format '{{.ID}}')
+
+# CID1 and CID2 should match, CID3 should not
+echo "CID1: ${CID1}"
+echo "CID2: ${CID2}"
+echo "CID3: ${CID3}"
+
+if [ "${CID1}" = "${CID2}" ] && [ "${CID2}" != "${CID3}" ]; then
+  echo "Build 1 and 2 used the same builder container, but Build 3 used a different one"
+else
+  echo "Unexpected builder container behavior"
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Fixes #4171

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When the user passes a custom buildkitd.toml config to the builder, and a builder already exists, it is supposed to check it against the existing one. If it matches, reuse it; if not, start a new one.

The problem was that it was *always* starting a new one, even if it matches. This fixes it and adds tests:

* Fix a bug where it was reusing a `bytes.Buffer`, so it always would fail to match, as the buffer already had data in it
* Fix a bug to ensure that any pre-processing of the buildkitd.toml happens before comparison
* Add tests

For the pre-processing, the problem was the following. It would

1. See that there is a custom config
2. Retrieve the config from the existing container
3. Compare the configs
4. If they do not match, pre-process the locally-provided config to provide standard formatting via toml unmarshal/marshal, but more importantly to do any path translations, so that mounted certificates and such use the paths inside the container, rather than outside. This means that the final config toml by definition is different than the one we started with
5. Load the processed config toml into the container

The new process does the following:

1. See that there is a custom config
2. Retrieve the config from the existing container
3. pre-process the locally-provided config
4. Compare the processed config and the one in the container
5. If they do not match, start a new container and load the processed config toml into the container

This way, they match successfully

The test runs 3 builds:

1. With a custom config toml
2. Rerun with the same custom config toml
3. Rerun with a different custom config toml

After each build, it retrieves and saves the container ID for the builder container.

The first two should match, the last should be different.

**- How I did it**
Fixes in linuxkit binary, and a new test

**- How to verify it**
CI, which is why I added tests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed bugs and added tests for custom builder config toml