### PR TITLE
pkglib/build: make dockerRunner public

### DIFF
--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -319,10 +319,10 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 
 	d := bo.runner
 	switch {
-	case bo.dryRun:
-		d = newDockerDryRunner()
+	case d == nil && bo.dryRun:
+		d = NewDockerDryRunner()
 	case d == nil:
-		d = newDockerRunner(p.cache)
+		d = NewDockerRunner(p.cache)
 	}
 
 	c := bo.cacheProvider

--- a/src/cmd/linuxkit/pkglib/build_test.go
+++ b/src/cmd/linuxkit/pkglib/build_test.go
@@ -40,23 +40,23 @@ type buildLog struct {
 	platform      string
 }
 
-func (d *dockerMocker) tag(ref, tag string) error {
+func (d *dockerMocker) Tag(ref, tag string) error {
 	if !d.enableTag {
 		return errors.New("tags not allowed")
 	}
 	d.images[tag] = d.images[ref]
 	return nil
 }
-func (d *dockerMocker) contextSupportCheck() error {
+func (d *dockerMocker) ContextSupportCheck() error {
 	if d.supportContexts {
 		return nil
 	}
 	return errors.New("contexts not supported")
 }
-func (d *dockerMocker) builder(_ context.Context, _, _, _, _ string, _ bool) (*buildkitClient.Client, error) {
+func (d *dockerMocker) Builder(_ context.Context, _, _, _, _ string, _ bool) (*buildkitClient.Client, error) {
 	return nil, fmt.Errorf("not implemented")
 }
-func (d *dockerMocker) build(ctx context.Context, tag, pkg, dockerContext, builderImage, builderConfigPath, platform string, builderRestart, preCacheImages bool, c spec.CacheProvider, r io.Reader, stdout io.Writer, sbomScan bool, sbomScannerImage, progress string, imageBuildOpts spec.ImageBuildOptions) error {
+func (d *dockerMocker) Build(ctx context.Context, tag, pkg, dockerContext, builderImage, builderConfigPath, platform string, builderRestart, preCacheImages bool, c spec.CacheProvider, r io.Reader, stdout io.Writer, sbomScan bool, sbomScannerImage, progress string, imageBuildOpts spec.ImageBuildOptions) error {
 	if !d.enableBuild {
 		return errors.New("build disabled")
 	}
@@ -201,7 +201,7 @@ func (d *dockerMocker) build(ctx context.Context, tag, pkg, dockerContext, build
 	}
 	return nil
 }
-func (d *dockerMocker) save(tgt string, refs ...string) error {
+func (d *dockerMocker) Save(tgt string, refs ...string) error {
 	var b []byte
 	for _, ref := range refs {
 		if data, ok := d.images[ref]; ok {
@@ -212,7 +212,7 @@ func (d *dockerMocker) save(tgt string, refs ...string) error {
 	}
 	return os.WriteFile(tgt, b, 0666)
 }
-func (d *dockerMocker) load(src io.Reader) error {
+func (d *dockerMocker) Load(src io.Reader) error {
 	b, err := io.ReadAll(src)
 	if err != nil {
 		return err
@@ -220,7 +220,7 @@ func (d *dockerMocker) load(src io.Reader) error {
 	d.images[d.fixedReadName] = b
 	return nil
 }
-func (d *dockerMocker) pull(img string) (bool, error) {
+func (d *dockerMocker) Pull(img string) (bool, error) {
 	if d.enablePull {
 		b := make([]byte, 256)
 		_, _ = rand.Read(b)

--- a/src/cmd/linuxkit/pkglib/depends.go
+++ b/src/cmd/linuxkit/pkglib/depends.go
@@ -87,7 +87,7 @@ func newDockerDepends(pkgPath string, pi *pkgInfo) (dockerDepends, error) {
 }
 
 // Do ensures that any dependencies the package has declared are met.
-func (dd dockerDepends) Do(d dockerRunner) error {
+func (dd dockerDepends) Do(d DockerRunner) error {
 	if len(dd.images) == 0 {
 		return nil
 	}
@@ -107,7 +107,7 @@ func (dd dockerDepends) Do(d dockerRunner) error {
 	var refs []string
 
 	for _, s := range dd.images {
-		if ok, err := d.pull(s.String()); !ok || err != nil {
+		if ok, err := d.Pull(s.String()); !ok || err != nil {
 			if err != nil {
 				return err
 			}
@@ -119,14 +119,14 @@ func (dd dockerDepends) Do(d dockerRunner) error {
 			bn := filepath.Base(s.Locator) + "@" + s.Digest().String()
 			path := filepath.Join(dd.path, bn+".tar")
 			fmt.Printf("Adding %q as dependency\n", bn)
-			if err := d.save(path, s.String()); err != nil {
+			if err := d.Save(path, s.String()); err != nil {
 				return err
 			}
 		}
 	}
 
 	if !dd.dir {
-		if err := d.save(dd.path, refs...); err != nil {
+		if err := d.Save(dd.path, refs...); err != nil {
 			return err
 		}
 	}

--- a/src/cmd/linuxkit/pkglib/docker.go
+++ b/src/cmd/linuxkit/pkglib/docker.go
@@ -18,12 +18,12 @@ import (
 	_ "github.com/moby/buildkit/client/connhelper/ssh"
 )
 
-type dockerRunner interface {
-	tag(ref, tag string) error
-	build(ctx context.Context, tag, pkg, dockerContext, builderImage, builderConfigPath, platform string, restart, preCacheImages bool, c spec.CacheProvider, r io.Reader, stdout io.Writer, sbomScan bool, sbomScannerImage, platformType string, imageBuildOpts spec.ImageBuildOptions) error
-	save(tgt string, refs ...string) error
-	load(src io.Reader) error
-	pull(img string) (bool, error)
-	contextSupportCheck() error
-	builder(ctx context.Context, dockerContext, builderImage, builderConfigPath, platform string, restart bool) (*buildkitClient.Client, error)
+type DockerRunner interface {
+	Tag(ref, tag string) error
+	Build(ctx context.Context, tag, pkg, dockerContext, builderImage, builderConfigPath, platform string, restart, preCacheImages bool, c spec.CacheProvider, r io.Reader, stdout io.Writer, sbomScan bool, sbomScannerImage, platformType string, imageBuildOpts spec.ImageBuildOptions) error
+	Save(tgt string, refs ...string) error
+	Load(src io.Reader) error
+	Pull(img string) (bool, error)
+	ContextSupportCheck() error
+	Builder(ctx context.Context, dockerContext, builderImage, builderConfigPath, platform string, restart bool) (*buildkitClient.Client, error)
 }

--- a/src/cmd/linuxkit/pkglib/dockerdryrun.go
+++ b/src/cmd/linuxkit/pkglib/dockerdryrun.go
@@ -25,11 +25,11 @@ import (
 type dockerDryRunnerImpl struct {
 }
 
-func newDockerDryRunner() dockerRunner {
+func newDockerDryRunner() DockerRunner {
 	return &dockerDryRunnerImpl{}
 }
 
-func (dr *dockerDryRunnerImpl) contextSupportCheck() error {
+func (dr *dockerDryRunnerImpl) ContextSupportCheck() error {
 	return nil
 }
 
@@ -46,19 +46,19 @@ func (dr *dockerDryRunnerImpl) contextSupportCheck() error {
 // 1. if dockerContext is provided, try to create a builder with that context; if it succeeds, we are done; if not, return an error.
 // 2. try to find an existing named runner with the pattern; if it succeeds, we are done; if not, try next.
 // 3. try to create a generic builder using the default context named "linuxkit".
-func (dr *dockerDryRunnerImpl) builder(ctx context.Context, dockerContext, builderImage, builderConfigPath, platform string, restart bool) (*buildkitClient.Client, error) {
+func (dr *dockerDryRunnerImpl) Builder(ctx context.Context, dockerContext, builderImage, builderConfigPath, platform string, restart bool) (*buildkitClient.Client, error) {
 	return nil, nil
 }
 
-func (dr *dockerDryRunnerImpl) pull(img string) (bool, error) {
+func (dr *dockerDryRunnerImpl) Pull(img string) (bool, error) {
 	return false, errors.New("not implemented")
 }
 
-func (dr *dockerDryRunnerImpl) tag(ref, tag string) error {
+func (dr *dockerDryRunnerImpl) Tag(ref, tag string) error {
 	return errors.New("not implemented")
 }
 
-func (dr *dockerDryRunnerImpl) build(ctx context.Context, tag, pkg, dockerContext, builderImage, builderConfigPath, platform string, restart, preCacheImages bool, c spec.CacheProvider, stdin io.Reader, stdout io.Writer, sbomScan bool, sbomScannerImage, progressType string, imageBuildOpts spec.ImageBuildOptions) error {
+func (dr *dockerDryRunnerImpl) Build(ctx context.Context, tag, pkg, dockerContext, builderImage, builderConfigPath, platform string, restart, preCacheImages bool, c spec.CacheProvider, stdin io.Reader, stdout io.Writer, sbomScan bool, sbomScannerImage, progressType string, imageBuildOpts spec.ImageBuildOptions) error {
 	// build args
 	var buildArgs []string
 	for k, v := range imageBuildOpts.BuildArgs {
@@ -85,10 +85,10 @@ func (dr *dockerDryRunnerImpl) build(ctx context.Context, tag, pkg, dockerContex
 	return nil
 }
 
-func (dr *dockerDryRunnerImpl) save(tgt string, refs ...string) error {
+func (dr *dockerDryRunnerImpl) Save(tgt string, refs ...string) error {
 	return errors.New("not implemented")
 }
 
-func (dr *dockerDryRunnerImpl) load(src io.Reader) error {
+func (dr *dockerDryRunnerImpl) Load(src io.Reader) error {
 	return errors.New("not implemented")
 }

--- a/src/cmd/linuxkit/pkglib/dockerdryrun.go
+++ b/src/cmd/linuxkit/pkglib/dockerdryrun.go
@@ -25,7 +25,7 @@ import (
 type dockerDryRunnerImpl struct {
 }
 
-func newDockerDryRunner() DockerRunner {
+func NewDockerDryRunner() DockerRunner {
 	return &dockerDryRunnerImpl{}
 }
 

--- a/src/cmd/linuxkit/pkglib/dockerimpl.go
+++ b/src/cmd/linuxkit/pkglib/dockerimpl.go
@@ -70,7 +70,7 @@ type dockerRunnerImpl struct {
 	cache bool
 }
 
-func newDockerRunner(cache bool) DockerRunner {
+func NewDockerRunner(cache bool) DockerRunner {
 	return &dockerRunnerImpl{cache: cache}
 }
 

--- a/src/cmd/linuxkit/pkglib/utils.go
+++ b/src/cmd/linuxkit/pkglib/utils.go
@@ -98,7 +98,7 @@ func getClientForPlatform(ctx context.Context, buildersMap map[string]string, bu
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse platform: %s", err)
 	}
-	dr := newDockerRunner(false)
+	dr := NewDockerRunner(false)
 	builderName := getBuilderForPlatform(p.Architecture, buildersMap)
 	client, err := dr.Builder(ctx, builderName, builderImage, builderConfigPath, platform, false)
 	if err != nil {

--- a/src/cmd/linuxkit/pkglib/utils.go
+++ b/src/cmd/linuxkit/pkglib/utils.go
@@ -100,7 +100,7 @@ func getClientForPlatform(ctx context.Context, buildersMap map[string]string, bu
 	}
 	dr := newDockerRunner(false)
 	builderName := getBuilderForPlatform(p.Architecture, buildersMap)
-	client, err := dr.builder(ctx, builderName, builderImage, builderConfigPath, platform, false)
+	client, err := dr.Builder(ctx, builderName, builderImage, builderConfigPath, platform, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to ensure builder container: %v", err)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

there is already a public method "WithBuildDocker", so it makes sense that the parameter definition is public as well so that a user of this method can actually use it

also allow dry-run with specific docker-runner


**- How I did it**

**- How to verify it**

no new feature was implemented, everything should work as before

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
make `dockerRunner` public
untangle `dockerRunner` and `DryRun`


**- A picture of a cute animal (not mandatory but encouraged)**

<img width="1024" height="1536" alt="ChatGPT Image Sep 12, 2025, 02_23_49 PM" src="https://github.com/user-attachments/assets/ec9fa6b3-e6f0-4791-a099-1f4161669989" />
(ChatGPT was very lazy today ...)