### PR TITLE
do full releases, not draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,10 +88,10 @@ jobs:
       run: |
         make checksum-targets
     - name: GitHub Release
-      uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        draft: true
+        draft: false
         files: bin/*
         generate_release_notes: true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
For reasons lost in the mists of time, when we cut a tag, it generates a draft release, which then requires someone to remember to go and change it to a regular release. This makes it not be draft.

**- How I did it**
Updated the version of the create-gh-release action to v2, and change `draft: true` to `draft: false`.

**- How to verify it**
CI on next release.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
All releases are real.
