### PR TITLE
fix build when pulling from non-default registry

### DIFF
--- a/src/cmd/linuxkit/registry/remote.go
+++ b/src/cmd/linuxkit/registry/remote.go
@@ -291,7 +291,7 @@ func (r *Remote) rewriteRepositoryBase(repo name.Repository) (string, []name.Opt
 
 	// No rewrite needed
 	if mirror == "" || mirror == originalRegistry {
-		return repo.RepositoryStr(), nil, nil
+		return fmt.Sprintf("%s/%s", repo.RegistryStr(), repo.RepositoryStr()), nil, nil
 	}
 
 	// get mirror protocol and separate host+path


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed problem wherein `lkt build` when pulling from non-Docker Hub (default) sometimes stripped the registry name. For example:

```yaml
init:
- registry.mylocal.com/linuxkit/init:foo
```

Would try to get `linuxkit/init:foo` if there is no mirror, as it stripped out the `registry.mylocal.com`

**- How I did it**

Fixed the resolution


**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Better handling of other registries
