### PR TITLE
Fix cache import from stdin

### DIFF
--- a/src/cmd/linuxkit/Makefile
+++ b/src/cmd/linuxkit/Makefile
@@ -117,7 +117,7 @@ sign:
 
 install:
 	cp -R ./bin/* $(PREFIX)/bin
-	
+
 .PHONY: clean
 clean:
 	rm -rf bin *.log *-kernel *-cmdline *-state *.img *.iso *.gz *.qcow2 *.vhd *.vmx *.vmdk *.tar *.raw

--- a/src/cmd/linuxkit/cache_import.go
+++ b/src/cmd/linuxkit/cache_import.go
@@ -10,15 +10,12 @@ import (
 )
 
 func cacheImportCmd() *cobra.Command {
-	var (
-		inputFile string
-	)
 	cmd := &cobra.Command{
 		Use:   "import",
 		Short: "import individual images to the linuxkit cache",
 		Long: `Import individual images from tar file to the linuxkit cache.
 		Can provide the file on the command-line or via stdin with filename '-'.
-		
+
 		Example:
 		linuxkit cache import myimage.tar
 		cat myimage.tar | linuxkit cache import -
@@ -27,8 +24,7 @@ func cacheImportCmd() *cobra.Command {
 		`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			paths := args
-			infile := paths[0]
+			infile := args[0]
 
 			p, err := cachepkg.NewProvider(cacheDir)
 			if err != nil {
@@ -36,7 +32,7 @@ func cacheImportCmd() *cobra.Command {
 			}
 
 			var reader io.ReadCloser
-			if inputFile == "-" {
+			if infile == "-" {
 				reader = os.Stdin
 			} else {
 				f, err := os.Open(infile)

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -730,7 +730,7 @@ func (p Pkg) buildArch(ctx context.Context, d DockerRunner, c spec.CacheProvider
 	}
 
 	if bo.dryRun {
-		return []registry.Descriptor{registry.Descriptor{}}, nil
+		return []registry.Descriptor{{}}, nil
 	}
 
 	// find the child manifests


### PR DESCRIPTION
**- What I did**

Fixed a bug in the `linuxkit cache import` command where it was failing when trying to import from stdin. The command was incorrectly treating the dash "-" (which conventionally represents stdin in Unix tools) as a regular filename instead of recognizing it as the stdin indicator.

**- How I did it**

Modified the stdin handling logic in `src/cmd/linuxkit/cache_import.go` to properly detect when "-" is passed as the input argument and route it to stdin processing instead of file processing. Also fixed Go formatting issues in `pkglib/build.go` that were preventing the `make local-check` target from passing.

**- How to verify it**

Try importing a docker image from stdin like
```bash
docker image save <image:tag> | linuxkit cache import -
```
it should not throw an error like
```
FATA[0000] unable to open -: open -: no such file or directory
```

**- Description for the changelog**

Fix linuxkit cache import command to properly handle stdin input when using "-" argument