### PR TITLE
env: move builder getenv out of cobra cmds

### DIFF
--- a/src/cmd/linuxkit/cmd.go
+++ b/src/cmd/linuxkit/cmd.go
@@ -43,6 +43,21 @@ func readConfig() {
 	}
 }
 
+func init() {
+	mirrorsEnv := make([]string, 0)
+	// prepend mirrors from env var so CLI flags take precedence (last SetProxy call wins)
+	if envMirrors := os.Getenv(envVarMirror); envMirrors != "" {
+		envList := strings.FieldsFunc(envMirrors, func(r rune) bool { return r == ',' || r == ' ' })
+		mirrorsEnv = append(envList, mirrorsEnv...)
+	}
+
+	err := convertProvidedMirrorsToMap(mirrorsEnv)
+
+	if err != nil {
+		panic(err)
+	}
+}
+
 func newCmd() *cobra.Command {
 	var (
 		flagQuiet       bool
@@ -58,40 +73,9 @@ func newCmd() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			readConfig()
 
-			// prepend mirrors from env var so CLI flags take precedence (last SetProxy call wins)
-			if envMirrors := os.Getenv(envVarMirror); envMirrors != "" {
-				envList := strings.FieldsFunc(envMirrors, func(r rune) bool { return r == ',' || r == ' ' })
-				mirrorsRaw = append(envList, mirrorsRaw...)
-			}
-
-			// convert the provided mirrors to a map
-			for _, m := range mirrorsRaw {
-				if m == "" {
-					continue
-				}
-				parts := strings.SplitN(m, "=", 2)
-				// if no equals sign, use the whole string as the mirror for all registries
-				// not otherwise specified
-				var key, value string
-				if len(parts) == 1 {
-					key = "*"
-					value = parts[0]
-				} else {
-					key = parts[0]
-					value = parts[1]
-				}
-				// value must start with http:// or https://
-				if !strings.HasPrefix(value, "http://") && !strings.HasPrefix(value, "https://") {
-					return fmt.Errorf("mirror %q must start with http:// or https://", value)
-				}
-				// special logic for docker.io because of its odd references
-				if key == "docker.io" || key == "docker.io/" {
-					for _, prefix := range []string{"docker.io", "index.docker.io", "registry-1.docker.io"} {
-						registry.SetProxy(prefix, value)
-					}
-				} else {
-					registry.SetProxy(key, value)
-				}
+			err := convertProvidedMirrorsToMap(mirrorsRaw)
+			if err != nil {
+				return err
 			}
 
 			for _, f := range certFiles {
@@ -127,4 +111,36 @@ func newCmd() *cobra.Command {
 	cmd.PersistentFlags().IntVarP(&flagVerbose, flagVerboseName, "v", 1, "Verbosity of logging: 0 = quiet, 1 = info, 2 = debug, 3 = trace. Default is info. Setting it explicitly will create structured logging lines.")
 
 	return cmd
+}
+
+func convertProvidedMirrorsToMap(mirrorsRaw []string) error {
+	for _, m := range mirrorsRaw {
+		if m == "" {
+			continue
+		}
+		parts := strings.SplitN(m, "=", 2)
+		// if no equals sign, use the whole string as the mirror for all registries
+		// not otherwise specified
+		var key, value string
+		if len(parts) == 1 {
+			key = "*"
+			value = parts[0]
+		} else {
+			key = parts[0]
+			value = parts[1]
+		}
+		// value must start with http:// or https://
+		if !strings.HasPrefix(value, "http://") && !strings.HasPrefix(value, "https://") {
+			return fmt.Errorf("mirror %q must start with http:// or https://", value)
+		}
+		// special logic for docker.io because of its odd references
+		if key == "docker.io" || key == "docker.io/" {
+			for _, prefix := range []string{"docker.io", "index.docker.io", "registry-1.docker.io"} {
+				registry.SetProxy(prefix, value)
+			}
+		} else {
+			registry.SetProxy(key, value)
+		}
+	}
+	return nil
 }

--- a/src/cmd/linuxkit/pkg.go
+++ b/src/cmd/linuxkit/pkg.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/pkglib"
 	"github.com/spf13/cobra"
@@ -76,8 +75,6 @@ func pkgCmd() *cobra.Command {
 			}
 			if cmd.Flags().Changed("org") {
 				pkglibConfig.Org = &argOrg
-			} else if org := os.Getenv(envVarPkgOrg); org != "" {
-				pkglibConfig.Org = &org
 			}
 			if cmd.Flags().Changed("tag") {
 				pkglibConfig.Tag = tag

--- a/src/cmd/linuxkit/pkg_build.go
+++ b/src/cmd/linuxkit/pkg_build.go
@@ -16,9 +16,6 @@ import (
 const (
 	buildersEnvVar      = "LINUXKIT_BUILDERS"
 	envVarCacheDir      = "LINUXKIT_CACHE"
-	envVarBuilderName   = "LINUXKIT_BUILDER_NAME"
-	envVarBuilderImage  = "LINUXKIT_BUILDER_IMAGE"
-	envVarBuilderConfig = "LINUXKIT_BUILDER_CONFIG"
 	envVarMirror        = "LINUXKIT_MIRROR"
 	envVarPkgOrg        = "LINUXKIT_PKG_ORG"
 	defaultBuilderImage = "moby/buildkit:v0.26.3"
@@ -45,9 +42,9 @@ func pkgBuildCmd() *cobra.Command {
 		platforms      string
 		skipPlatforms  string
 		builders       string
-		builderName    = flagOverEnvVarOverDefaultString{def: pkglib.DefaultBuilderName(), envVar: envVarBuilderName}
-		builderImage   = flagOverEnvVarOverDefaultString{def: defaultBuilderImage, envVar: envVarBuilderImage}
-		builderConfig  = flagOverEnvVarOverDefaultString{def: "", envVar: envVarBuilderConfig}
+		builderName    = flagOverEnvVarOverDefaultString{def: pkglib.DefaultBuilderName()}
+		builderImage   = flagOverEnvVarOverDefaultString{def: defaultBuilderImage}
+		builderConfig  = flagOverEnvVarOverDefaultString{def: ""}
 		builderRestart bool
 		preCacheImages bool
 		release        string
@@ -312,9 +309,9 @@ func pkgBuildCmd() *cobra.Command {
 	cmd.Flags().StringVar(&platforms, "platforms", "", "Which platforms to build for, defaults to all of those for which the package can be built")
 	cmd.Flags().StringVar(&skipPlatforms, "skip-platforms", "", "Platforms that should be skipped, even if present in build.yml")
 	cmd.Flags().StringVar(&builders, "builders", "", "Which builders to use for which platforms, e.g. linux/arm64=docker-context-arm64, overrides defaults and environment variables, see https://github.com/linuxkit/linuxkit/blob/master/docs/packages.md#Providing-native-builder-nodes")
-	cmd.Flags().Var(&builderName, "builder-name", fmt.Sprintf("Name of the buildkit builder container, default: %s, overrides env var %s", pkglib.DefaultBuilderName(), envVarBuilderName))
-	cmd.Flags().Var(&builderImage, "builder-image", fmt.Sprintf("buildkit builder container image to use, overrides env var %s", envVarBuilderImage))
-	cmd.Flags().Var(&builderConfig, "builder-config", fmt.Sprintf("path to buildkit builder config.toml file to use, overrides the default config.toml in the builder image. When provided, copied over into builder, along with all certs. Use paths for certificates relative to your local host, they will be adjusted on copying into the container. USE WITH CAUTION. Overrides env var %s", envVarBuilderConfig))
+	cmd.Flags().Var(&builderName, "builder-name", fmt.Sprintf("Name of the buildkit builder container, default: %s, overrides env var %s", pkglib.DefaultBuilderName(), pkglib.EnvVarBuilderName))
+	cmd.Flags().Var(&builderImage, "builder-image", fmt.Sprintf("buildkit builder container image to use, overrides env var %s", pkglib.EnvVarBuilderImage))
+	cmd.Flags().Var(&builderConfig, "builder-config", fmt.Sprintf("path to buildkit builder config.toml file to use, overrides the default config.toml in the builder image. When provided, copied over into builder, along with all certs. Use paths for certificates relative to your local host, they will be adjusted on copying into the container. USE WITH CAUTION. Overrides env var %s", pkglib.EnvVarBuilderConfig))
 	cmd.Flags().BoolVar(&builderRestart, "builder-restart", false, "force restarting builder, even if container with correct name and image exists")
 	cmd.Flags().BoolVar(&preCacheImages, "precache-images", false, "download all referenced images in the Dockerfile to the linuxkit cache before building, thus referencing the local cache instead of pulling from the registry; this is useful for handling mirrors and special connections")
 	cmd.Flags().Var(&cacheDir, "cache", fmt.Sprintf("Directory for caching and finding cached image, overrides env var %s", envVarCacheDir))

--- a/src/cmd/linuxkit/pkg_builder.go
+++ b/src/cmd/linuxkit/pkg_builder.go
@@ -13,7 +13,7 @@ import (
 func pkgBuilderCmd() *cobra.Command {
 	var (
 		builders          string
-		builderName       = flagOverEnvVarOverDefaultString{def: pkglib.DefaultBuilderName(), envVar: envVarBuilderName}
+		builderName       = flagOverEnvVarOverDefaultString{def: pkglib.DefaultBuilderName(), envVar: pkglib.EnvVarBuilderName}
 		platforms         string
 		builderImage      string
 		builderConfigPath string
@@ -62,7 +62,7 @@ func pkgBuilderCmd() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVar(&builders, "builders", "", "Which builders to use for which platforms, e.g. linux/arm64=docker-context-arm64, overrides defaults and environment variables, see https://github.com/linuxkit/linuxkit/blob/master/docs/packages.md#Providing-native-builder-nodes")
-	cmd.PersistentFlags().Var(&builderName, "builder-name", fmt.Sprintf("Name of the buildkit builder container, default: %s, overrides env var %s", pkglib.DefaultBuilderName(), envVarBuilderName))
+	cmd.PersistentFlags().Var(&builderName, "builder-name", fmt.Sprintf("Name of the buildkit builder container, default: %s, overrides env var %s", pkglib.DefaultBuilderName(), pkglib.EnvVarBuilderName))
 	cmd.PersistentFlags().StringVar(&platforms, "platforms", fmt.Sprintf("linux/%s", runtime.GOARCH), "Which platforms we built images for")
 	cmd.PersistentFlags().StringVar(&builderImage, "builder-image", defaultBuilderImage, "buildkit builder container image to use")
 	cmd.Flags().StringVar(&builderConfigPath, "builder-config", "", "path to buildkit builder config.toml file to use, overrides the default config.toml in the builder image; USE WITH CAUTION")

--- a/src/cmd/linuxkit/pkglib/build.go
+++ b/src/cmd/linuxkit/pkglib/build.go
@@ -23,6 +23,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const (
+	EnvVarBuilderName   = "LINUXKIT_BUILDER_NAME"
+	EnvVarBuilderImage  = "LINUXKIT_BUILDER_IMAGE"
+	EnvVarBuilderConfig = "LINUXKIT_BUILDER_CONFIG"
+)
+
 type buildOpts struct {
 	skipBuild        bool
 	force            bool
@@ -249,6 +255,32 @@ func (p Pkg) Build(bos ...BuildOpt) error {
 		if err := fn(&bo); err != nil {
 			return err
 		}
+	}
+
+	// override builder from env variables
+	for _, k := range []struct {
+		p   *string
+		env string
+	}{
+		{
+			p:   &bo.builderConfig.Name,
+			env: EnvVarBuilderName,
+		},
+		{
+			p:   &bo.builderConfig.Image,
+			env: EnvVarBuilderImage,
+		},
+		{
+			p:   &bo.builderConfig.ConfigPath,
+			env: EnvVarBuilderConfig,
+		},
+	} {
+		env := os.Getenv(k.env)
+		if env == "" {
+			continue
+		}
+
+		*k.p = env
 	}
 
 	writer := bo.writer

--- a/src/cmd/linuxkit/pkglib/pkglib.go
+++ b/src/cmd/linuxkit/pkglib/pkglib.go
@@ -16,6 +16,10 @@ import (
 	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/util"
 )
 
+const (
+	envVarPkgOrg = "LINUXKIT_PKG_ORG"
+)
+
 // Contains fields settable in the build.yml
 type pkgInfo struct {
 	Image        string            `yaml:"image"`
@@ -191,6 +195,12 @@ func NewFromConfig(cfg PkglibConfig, args ...string) ([]Pkg, error) {
 		}
 		if cfg.Network != nil {
 			pi.Network = *cfg.Network
+		}
+		if cfg.Org == nil {
+			env := os.Getenv(envVarPkgOrg)
+			if env != "" {
+				cfg.Org = &env
+			}
 		}
 		if cfg.Org != nil {
 			pi.Org = *cfg.Org


### PR DESCRIPTION
as it has been introduced in 666bbfdbd5c5ab3a0a5e96f738d5d70321190ad2

this makes it possible to profit from this change also when using linuxkit as a library (e.g. lf-edge/eve/bpftrace-compiler)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

move builder getenv out of cobra cmds

**- How I did it**

adding one `func init()` and changing some other funcs

**- How to verify it**

same as https://github.com/linuxkit/linuxkit/pull/4205

**- Description for the changelog**

move builder getenv out of cobra cmds

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="1024" height="1536" alt="ChatGPT Image Mar 12, 2026, 03_55_18 PM" src="https://github.com/user-attachments/assets/03eeacea-57de-4967-8da8-42ead0be1b77" />
