### PR TITLE
bump containerd to v2.2.4 (CVE-2026-46680)

### DIFF
--- a/examples/addbinds.yml
+++ b/examples/addbinds.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/containerd-debug.yml
+++ b/examples/containerd-debug.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/dm-crypt-loop.yml
+++ b/examples/dm-crypt-loop.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/dm-crypt.yml
+++ b/examples/dm-crypt.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/docker-for-mac.yml
+++ b/examples/docker-for-mac.yml
@@ -4,9 +4,9 @@ kernel:
   cmdline: "console=ttyS0 page_poison=1"
 init:
   - linuxkit/vpnkit-expose-port:19c9fd4180d33c9b434fd73b1a3a7ab83cadbf30 # install vpnkit-expose-port and vpnkit-iptables-wrapper on host
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   # support metadata for optional config in /run/config

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/getty.yml
+++ b/examples/getty.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/hostmount-writeable-overlay.yml
+++ b/examples/hostmount-writeable-overlay.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/influxdb-os.yml
+++ b/examples/influxdb-os.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: dhcpcd

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
   - linuxkit/memlogd:19b0fdec83dded95e0a2f97a8ca6868f5e83c401
 onboot:

--- a/examples/minimal.yml
+++ b/examples/minimal.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:b87e9ececac55a65eaa592f4dd8b4e0c3009afdb

--- a/examples/node_exporter.yml
+++ b/examples/node_exporter.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 services:
   - name: getty
     image: linuxkit/getty:a86d74c8f89be8956330c3b115b0b1f2e09ef6e0

--- a/examples/openstack.yml
+++ b/examples/openstack.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/platform-aws.yml
+++ b/examples/platform-aws.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/platform-azure.yml
+++ b/examples/platform-azure.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/platform-equinixmetal.yml
+++ b/examples/platform-equinixmetal.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
   - linuxkit/firmware:68c2b29f28f2639020b9f8d55254d333498a30aa
 onboot:

--- a/examples/platform-gcp.yml
+++ b/examples/platform-gcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/platform-hetzner.yml
+++ b/examples/platform-hetzner.yml
@@ -3,9 +3,9 @@ kernel:
   cmdline: console=ttyS1
   ucode: intel-ucode.cpio
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
   - linuxkit/firmware:68c2b29f28f2639020b9f8d55254d333498a30aa
 onboot:

--- a/examples/platform-rt-for-vmware.yml
+++ b/examples/platform-rt-for-vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.6.71-rt
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/platform-scaleway.yml
+++ b/examples/platform-scaleway.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0 root=/dev/vda"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/platform-vmware.yml
+++ b/examples/platform-vmware.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/platform-vultr.yml
+++ b/examples/platform-vultr.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/redis-os.yml
+++ b/examples/redis-os.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:b87e9ececac55a65eaa592f4dd8b4e0c3009afdb

--- a/examples/sshd.yml
+++ b/examples/sshd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/static-ip.yml
+++ b/examples/static-ip.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 onboot:
   - name: ip
     image: linuxkit/ip:3c0676ee83a0dc739685be1253b8326f08581ef7

--- a/examples/swap.yml
+++ b/examples/swap.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/tpm.yml
+++ b/examples/tpm.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/volumes.yml
+++ b/examples/volumes.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/examples/vpnkit-forwarder.yml
+++ b/examples/vpnkit-forwarder.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:b87e9ececac55a65eaa592f4dd8b4e0c3009afdb

--- a/examples/vsudd-containerd.yml
+++ b/examples/vsudd-containerd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:b87e9ececac55a65eaa592f4dd8b4e0c3009afdb

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/linuxkit.yml
+++ b/linuxkit.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -4,7 +4,7 @@ FROM linuxkit/alpine:7f3944798557de5518a56e3437d7ed982701f224 as alpine
 RUN apk add tzdata binutils
 RUN mkdir -p /etc/init.d && ln -s /usr/bin/service /etc/init.d/020-containerd
 
-FROM linuxkit/containerd-dev:3cb13cb53e9901cd9e8a8c087e4599b9bdbe8931 as containerd-dev
+FROM linuxkit/containerd-dev:405449f30ba384a0f67ad1b75f78a501604f2e44 as containerd-dev
 
 FROM scratch
 ENTRYPOINT []

--- a/pkg/init/Dockerfile
+++ b/pkg/init/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile to build linuxkit/init for linuxkit
-FROM linuxkit/containerd-dev:3cb13cb53e9901cd9e8a8c087e4599b9bdbe8931 AS containerd-dev
+FROM linuxkit/containerd-dev:405449f30ba384a0f67ad1b75f78a501604f2e44 AS containerd-dev
 FROM linuxkit/alpine:7f3944798557de5518a56e3437d7ed982701f224 AS build
 RUN apk add --no-cache --initdb alpine-baselayout make gcc musl-dev git linux-headers
 

--- a/projects/clear-containers/clear-containers.yml
+++ b/projects/clear-containers/clear-containers.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel-clear-containers:4.9.x
   cmdline: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off quiet  cryptomgr.notests page_poison=on"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
 onboot:
   - name: sysctl
     image: mobylinux/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c

--- a/projects/compose/compose-dynamic.yml
+++ b/projects/compose/compose-dynamic.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/projects/compose/compose-static.yml
+++ b/projects/compose/compose-static.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/projects/ima-namespace/ima-namespace.yml
+++ b/projects/ima-namespace/ima-namespace.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel-ima:4.11.1-186dd3605ee7b23214850142f8f02b4679dbd148
   cmdline: "console=ttyS0 console=tty0 page_poison=1 ima_appraise=enforce_ns"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
   - linuxkit/ima-utils:dfeb3896fd29308b80ff9ba7fe5b8b767e40ca29
 onboot:

--- a/projects/landlock/landlock.yml
+++ b/projects/landlock/landlock.yml
@@ -2,7 +2,7 @@ kernel:
   image: mobylinux/kernel-landlock:4.9.x
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - mobylinux/runc:b0fb122e10dbb7e4e45115177a61a3f8d68c19a9
   - mobylinux/containerd:18eaf72f3f4f9a9f29ca1951f66df701f873060b
   - mobylinux/ca-certificates:eabc5a6e59f05aa91529d80e9a595b85b046f935

--- a/projects/memorizer/memorizer.yml
+++ b/projects/memorizer/memorizer.yml
@@ -2,9 +2,9 @@ kernel:
   image: "linuxkitprojects/kernel-memorizer:4.10_dbg"
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:b87e9ececac55a65eaa592f4dd8b4e0c3009afdb

--- a/projects/miragesdk/examples/fdd.yml
+++ b/projects/miragesdk/examples/fdd.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
   - samoht/fdd
 onboot:

--- a/projects/miragesdk/examples/mirage-dhcp.yml
+++ b/projects/miragesdk/examples/mirage-dhcp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:43ac1d39da329c3567fcb9689e5ca99de6d169b6

--- a/projects/okernel/examples/okernel_simple.yaml
+++ b/projects/okernel/examples/okernel_simple.yaml
@@ -2,9 +2,9 @@ kernel:
   image: okernel:latest
   cmdline: "console=tty0 page_poison=1"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/projects/shiftfs/shiftfs.yml
+++ b/projects/shiftfs/shiftfs.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkitprojects/kernel-shiftfs:4.11.4-881a041fc14bd95814cf140b5e98d97dd65160b5
   cmdline: "console=ttyS0 console=tty0 page_poison=1"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/src/cmd/linuxkit/moby/build/mkimage.yaml
+++ b/src/cmd/linuxkit/moby/build/mkimage.yaml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: mkimage

--- a/test/cases/000_build/000_formats/test.yml
+++ b/test/cases/000_build/000_formats/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: dhcpcd

--- a/test/cases/000_build/001_tarheaders/test.yml
+++ b/test/cases/000_build/001_tarheaders/test.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 
 onboot:
   - name: dhcpcd

--- a/test/cases/000_build/010_reproducible/test.yml
+++ b/test/cases/000_build/010_reproducible/test.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 
 onboot:
   - name: dhcpcd

--- a/test/cases/000_build/020_binds/test.yml
+++ b/test/cases/000_build/020_binds/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: mount

--- a/test/cases/000_build/050_sbom/test.yml
+++ b/test/cases/000_build/050_sbom/test.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 
 onboot:
   - name: package1

--- a/test/cases/000_build/060_input_tar/000_build/test1.yml
+++ b/test/cases/000_build/060_input_tar/000_build/test1.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:43ac1d39da329c3567fcb9689e5ca99de6d169b6

--- a/test/cases/000_build/060_input_tar/000_build/test2.yml
+++ b/test/cases/000_build/060_input_tar/000_build/test2.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/test/cases/000_build/060_input_tar/010_same_filename/test.yml
+++ b/test/cases/000_build/060_input_tar/010_same_filename/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:43ac1d39da329c3567fcb9689e5ca99de6d169b6

--- a/test/cases/000_build/070_volumes/000_rw_on_rw/test.yml
+++ b/test/cases/000_build/070_volumes/000_rw_on_rw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: test1

--- a/test/cases/000_build/070_volumes/001_ro_on_ro/test.yml
+++ b/test/cases/000_build/070_volumes/001_ro_on_ro/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: test

--- a/test/cases/000_build/070_volumes/002_rw_on_ro/test.yml
+++ b/test/cases/000_build/070_volumes/002_rw_on_ro/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: test

--- a/test/cases/000_build/070_volumes/003_ro_on_rw/test.yml
+++ b/test/cases/000_build/070_volumes/003_ro_on_rw/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: test1

--- a/test/cases/000_build/070_volumes/004_blank/test.yml
+++ b/test/cases/000_build/070_volumes/004_blank/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: test

--- a/test/cases/000_build/070_volumes/005_image/test.yml
+++ b/test/cases/000_build/070_volumes/005_image/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: test

--- a/test/cases/000_build/070_volumes/006_mount_types/test.yml
+++ b/test/cases/000_build/070_volumes/006_mount_types/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: testbinds

--- a/test/cases/000_build/080_mirrors/test.yml
+++ b/test/cases/000_build/080_mirrors/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: dhcpcd

--- a/test/cases/000_build/091_validate_linuxkit_yaml/linuxkit.yml
+++ b/test/cases/000_build/091_validate_linuxkit_yaml/linuxkit.yml
@@ -3,9 +3,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/000_qemu/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/000_qemu/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
+++ b/test/cases/010_platforms/000_qemu/010_run_iso/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/020_run_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/030_run_qcow_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
+++ b/test/cases/010_platforms/000_qemu/040_run_raw_bios/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
+++ b/test/cases/010_platforms/000_qemu/050_run_aws/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/060_run_raw_efi/test.yml
+++ b/test/cases/010_platforms/000_qemu/060_run_raw_efi/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/000_qemu/100_container/test.yml
+++ b/test/cases/010_platforms/000_qemu/100_container/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/000_run_kernel+initrd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/005_run_kernel+squashfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
+++ b/test/cases/010_platforms/010_hyperkit/010_acpi/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 services:
   - name: acpid
     image: linuxkit/acpid:dbd30b25903bf17042c22171b729f94c4bd3d98d

--- a/test/cases/010_platforms/110_gcp/000_run/test.yml
+++ b/test/cases/010_platforms/110_gcp/000_run/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/020_kernel/011_config_5.4.x/test.yml
+++ b/test/cases/020_kernel/011_config_5.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.4.172-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/013_config_5.10.x/test.yml
+++ b/test/cases/020_kernel/013_config_5.10.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.10.104-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/016_config_5.15.x/test.yml
+++ b/test/cases/020_kernel/016_config_5.15.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.15.27-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/019_config_6.6.x/test.yml
+++ b/test/cases/020_kernel/019_config_6.6.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.71-77b4563829536629b7d5768d4407453c26602d65
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/022_config_6.12.x/test.yml
+++ b/test/cases/020_kernel/022_config_6.12.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59-0ef72d722190ecfe0b3b37711f9a871a696e301a
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: check-kernel-config

--- a/test/cases/020_kernel/111_kmod_5.4.x/test.yml
+++ b/test/cases/020_kernel/111_kmod_5.4.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.4.172-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: check

--- a/test/cases/020_kernel/113_kmod_5.10.x/test.yml
+++ b/test/cases/020_kernel/113_kmod_5.10.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.10.104-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: check

--- a/test/cases/020_kernel/116_kmod_5.15.x/test.yml
+++ b/test/cases/020_kernel/116_kmod_5.15.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:5.15.27-9005a97e2b2cba68b4374092167b079a2874f66b
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: check

--- a/test/cases/020_kernel/119_kmod_6.6.x/test.yml
+++ b/test/cases/020_kernel/119_kmod_6.6.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.6.71-77b4563829536629b7d5768d4407453c26602d65
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: check

--- a/test/cases/020_kernel/122_kmod_6.12.x/test.yml
+++ b/test/cases/020_kernel/122_kmod_6.12.x/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59-0ef72d722190ecfe0b3b37711f9a871a696e301a
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: check

--- a/test/cases/020_kernel/200_namespace/common.yml
+++ b/test/cases/020_kernel/200_namespace/common.yml
@@ -2,5 +2,5 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492

--- a/test/cases/030_security/000_docker-bench/test.yml
+++ b/test/cases/030_security/000_docker-bench/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: sysctl

--- a/test/cases/030_security/010_ports/test.yml
+++ b/test/cases/030_security/010_ports/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 page_poison=1"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: test

--- a/test/cases/040_packages/001_dummy/test.yml
+++ b/test/cases/040_packages/001_dummy/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: dummy

--- a/test/cases/040_packages/002_bcc/test.yml
+++ b/test/cases/040_packages/002_bcc/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
   - linuxkit/kernel-bcc:5.4.113
 onboot:

--- a/test/cases/040_packages/002_binfmt/test.yml
+++ b/test/cases/040_packages/002_binfmt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: binfmt

--- a/test/cases/040_packages/002_bpftrace/test.yml
+++ b/test/cases/040_packages/002_bpftrace/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
   - linuxkit/bpftrace:d4641399bc9a9504f09d64b9817f83e34a4118fc
 onboot:

--- a/test/cases/040_packages/003_ca-certificates/test.yml
+++ b/test/cases/040_packages/003_ca-certificates/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:

--- a/test/cases/040_packages/003_cgroupv2/test.yml
+++ b/test/cases/040_packages/003_cgroupv2/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "linuxkit.unified_cgroup_hierarchy=1 console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: test

--- a/test/cases/040_packages/003_containerd/test.yml
+++ b/test/cases/040_packages/003_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: dhcpcd
@@ -18,6 +18,6 @@ onboot:
     image: linuxkit/mount:bd1c3bb45e48e68e47a9456d1669f7119f855184
     command: ["/usr/bin/mountie", "/var/lib"]
   - name: test
-    image: linuxkit/test-containerd:904a149157f8cdf8c2da7e47be7c0eecc5723cf3
+    image: linuxkit/test-containerd:2619efafb83003a2679b404ab5581c079e1cfd7a
   - name: poweroff
     image: linuxkit/poweroff:4059858a555bed90c2280fa9b060b7a8f8de6d45

--- a/test/cases/040_packages/004_dhcpcd/test.yml
+++ b/test/cases/040_packages/004_dhcpcd/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/000_simple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/001_luks/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/004_dm-crypt/002_key/test.yml
+++ b/test/cases/040_packages/004_dm-crypt/002_key/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: dm-crypt

--- a/test/cases/040_packages/005_extend/000_ext4/test-create.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/000_ext4/test.yml
+++ b/test/cases/040_packages/005_extend/000_ext4/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/001_btrfs/test.yml
+++ b/test/cases/040_packages/005_extend/001_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/005_extend/002_xfs/test-create.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/002_xfs/test.yml
+++ b/test/cases/040_packages/005_extend/002_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: extend

--- a/test/cases/040_packages/005_extend/003_gpt/test-create.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test-create.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: format

--- a/test/cases/040_packages/005_extend/003_gpt/test.yml
+++ b/test/cases/040_packages/005_extend/003_gpt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: extend

--- a/test/cases/040_packages/006_format_mount/000_auto/test.yml
+++ b/test/cases/040_packages/006_format_mount/000_auto/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/001_by_label/test.yml
+++ b/test/cases/040_packages/006_format_mount/001_by_label/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
+++ b/test/cases/040_packages/006_format_mount/002_by_name/test.yml.in
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/003_btrfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: modprobe

--- a/test/cases/040_packages/006_format_mount/004_xfs/test.yml
+++ b/test/cases/040_packages/006_format_mount/004_xfs/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
+++ b/test/cases/040_packages/006_format_mount/005_by_device_force/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/006_gpt/test.yml
+++ b/test/cases/040_packages/006_format_mount/006_gpt/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: format

--- a/test/cases/040_packages/006_format_mount/010_multiple/test.yml
+++ b/test/cases/040_packages/006_format_mount/010_multiple/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: format

--- a/test/cases/040_packages/007_getty-containerd/test.yml
+++ b/test/cases/040_packages/007_getty-containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: dhcpcd

--- a/test/cases/040_packages/009_init_containerd/test.yml
+++ b/test/cases/040_packages/009_init_containerd/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 services:
   - name: test

--- a/test/cases/040_packages/011_kmsg/test.yml
+++ b/test/cases/040_packages/011_kmsg/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
   - linuxkit/memlogd:19b0fdec83dded95e0a2f97a8ca6868f5e83c401
 services:

--- a/test/cases/040_packages/012_logwrite/test.yml
+++ b/test/cases/040_packages/012_logwrite/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
   - linuxkit/memlogd:19b0fdec83dded95e0a2f97a8ca6868f5e83c401
 services:

--- a/test/cases/040_packages/012_losetup/test.yml
+++ b/test/cases/040_packages/012_losetup/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: losetup

--- a/test/cases/040_packages/013_metadata/000_cidata/test.yml
+++ b/test/cases/040_packages/013_metadata/000_cidata/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: metadata

--- a/test/cases/040_packages/013_mkimage/mkimage.yml
+++ b/test/cases/040_packages/013_mkimage/mkimage.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: mkimage

--- a/test/cases/040_packages/013_mkimage/run.yml
+++ b/test/cases/040_packages/013_mkimage/run.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: poweroff

--- a/test/cases/040_packages/019_sysctl/test.yml
+++ b/test/cases/040_packages/019_sysctl/test.yml
@@ -2,7 +2,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: sysctl

--- a/test/cases/040_packages/023_wireguard/test.yml
+++ b/test/cases/040_packages/023_wireguard/test.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0 console=ttyAMA0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
   - linuxkit/ca-certificates:256f1950df59f2f209e9f0b81374177409eb11de
 onboot:
   - name: dhcpcd

--- a/test/hack/test-ltp.yml
+++ b/test/hack/test-ltp.yml
@@ -2,9 +2,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 onboot:
   - name: ltp
     image: linuxkit/test-ltp:0967388fb338867dddd3c1a72470a1a7cec5a0dd

--- a/test/hack/test.yml
+++ b/test/hack/test.yml
@@ -4,9 +4,9 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
-  - linuxkit/containerd:ba19f64efd3331a8fd0a33e00eabd14f6ee1780e
+  - linuxkit/containerd:eb5daf20704109ea58abb38d2b808e0c3a7e3717
 onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:b87e9ececac55a65eaa592f4dd8b4e0c3009afdb

--- a/test/pkg/containerd/Dockerfile
+++ b/test/pkg/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/containerd-dev:3cb13cb53e9901cd9e8a8c087e4599b9bdbe8931 as containerd-dev
+FROM linuxkit/containerd-dev:405449f30ba384a0f67ad1b75f78a501604f2e44 as containerd-dev
 FROM linuxkit/alpine:7f3944798557de5518a56e3437d7ed982701f224 AS mirror
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 # btrfs-progfs is required for btrfs test (mkfs.btrfs)

--- a/test/pkg/ns/template.yml
+++ b/test/pkg/ns/template.yml
@@ -3,7 +3,7 @@ kernel:
   image: linuxkit/kernel:6.12.59
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/init:1c3e4933ceabd7418b961d66d5d884bf0044ac64
   - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
 onboot:
   - name: test-ns

--- a/tools/containerd-dev/Dockerfile
+++ b/tools/containerd-dev/Dockerfile
@@ -6,7 +6,7 @@ FROM linuxkit/alpine:7f3944798557de5518a56e3437d7ed982701f224 as builder
 # `test/pkg/containerd/Dockerfile` when changing this.
 ENV CONTAINERD_REPO=https://github.com/containerd/containerd.git
 
-ENV CONTAINERD_COMMIT=v2.2.0
+ENV CONTAINERD_COMMIT=v2.2.4
 ENV GOPATH=/go
 RUN apk add go git
 RUN mkdir -p $GOPATH/src/github.com/containerd && \


### PR DESCRIPTION
**- What I did**

Bumped containerd from v2.2.0 to v2.2.4 in `tools/containerd-dev/Dockerfile`. This fixes [CVE-2026-46680](https://github.com/advisories/GHSA-fqw6-gf59-qr4w): an image whose `User` directive is a numeric string outside int32 range (e.g. `"9999999999"`) is treated as a username and resolved against the image's `/etc/passwd`. A crafted `/etc/passwd` mapping the same string to UID 0 then makes the container run as root, defeating Kubernetes `runAsNonRoot`. Fixed on the 2.2 line in v2.2.4.

**- How I did it**

1. `tools/containerd-dev/Dockerfile`: `CONTAINERD_COMMIT=v2.2.0` → `v2.2.4`.
2. Updated the `FROM linuxkit/containerd-dev:<hash>` line in `pkg/containerd/Dockerfile`, `pkg/init/Dockerfile`, and `test/pkg/containerd/Dockerfile` (the three consumers called out by the comment in `tools/containerd-dev/Dockerfile`).
3. Swept every example/test/project YAML that pins the resulting `linuxkit/containerd:<hash>`, `linuxkit/init:<hash>`, and `linuxkit/test-containerd:<hash>` tree hashes to the new values.

Mirrors the scope of the v2.2.0 bump (`2dd12173`, 2025-11-18).

**- How to verify it**

`make -C pkg build` will fail on this PR until the new `linuxkit/containerd-dev:405449f30ba384a0f67ad1b75f78a501604f2e44` image is published to Docker Hub. I don't have push access to the `linuxkit/` org, so a maintainer needs to build & push that image (and the dependent `linuxkit/containerd`, `linuxkit/init`, `linuxkit/test-containerd` tags) before CI can resolve the FROMs. Once the dev image is on Hub, CI should run cleanly.

**- Description for the changelog**

Update containerd to v2.2.4 (fixes CVE-2026-46680).