### PR TITLE
actions: publish should occur after successful run

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   packages:
+    if: >
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success'
     env:
       linuxkit_file: linuxkit-amd64-linux
     name: Publish Changed Packages


### PR DESCRIPTION
**- What I did**
Updates the publish action to run only if the build is successful

