### PR TITLE
Add zfs kernel module package

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -102,7 +102,7 @@ KERNEL_HIGHEST=$(shell echo $(KERNELS) | tr ' ' '\n' | sort -V | tail -n 1)
 
 
 # we build all tools across all platforms and kernels that we build
-TOOLS=bcc perf
+TOOLS=bcc perf zfs
 
 # kernel versions used for kconfig
 KERNEL_VERSIONS=$(call uniq,$(foreach l,$(KERNELS),$(word 1,$(subst -, ,$(l)))))

--- a/kernel/common/Dockerfile.zfs
+++ b/kernel/common/Dockerfile.zfs
@@ -1,16 +1,43 @@
-ARG IMAGE
 ARG BUILD_IMAGE
+ARG KERNEL_VERSION
+ARG PKG_HASH
 
-FROM ${IMAGE} AS ksrc
+FROM linuxkit/kernel:${KERNEL_VERSION}-${PKG_HASH} AS ksrc
 
 FROM ${BUILD_IMAGE} AS build
+
+ARG ZFS_VERSION=2.2.9
+
+# Kernel headers
+COPY --from=ksrc /kernel-dev.tar /
+RUN tar xf kernel-dev.tar
+
+# Also extract the kernel modules
+COPY --from=ksrc /kernel.tar /
+RUN tar xf kernel.tar
+
+# Also extract the kernel source
+COPY --from=ksrc /linux.tar.xz /linux.tar.xz
+RUN tar xf linux.tar.xz -C /usr/src
+
+# Fix kernel source tree and add config
+RUN cp -r /usr/src/linux-headers-*/.config /usr/src/linux
+RUN cp -r /usr/src/linux-headers-*/* /usr/src/linux
+
 RUN apk add \
     attr-dev \
     autoconf \
     automake \
+    bash \
+    bison \
     build-base \
+    elfutils-dev \
     file \
+    flex \
     git \
+    gmp-dev \
+    installkernel \
+    kmod \
     libtirpc-dev \
     libtool \
     mpc1-dev \
@@ -19,29 +46,21 @@ RUN apk add \
     util-linux-dev \
     zlib-dev
 
-COPY --from=ksrc /kernel-dev.tar /
-RUN tar xf kernel-dev.tar
-
-# Also extract the kernel modules
-COPY --from=ksrc /kernel.tar /
-RUN tar xf kernel.tar
-
-# SPL is part of the ZFS repo since 0.8.0 (https://github.com/zfsonlinux/zfs/releases/tag/zfs-0.8.0)
-ENV VERSION=0.8.1
+RUN git config --global url.https://.insteadOf git://
 
 ENV ZFS_REPO=https://github.com/zfsonlinux/zfs.git
-ENV ZFS_COMMIT=zfs-${VERSION}
+ENV ZFS_COMMIT=zfs-${ZFS_VERSION}
 RUN git clone ${ZFS_REPO} && \
     cd zfs && \
     git checkout ${ZFS_COMMIT}
 
-WORKDIR /zfs
-RUN ./autogen.sh && \
-    ./configure && \
+RUN ( cd zfs && \
+    ./autogen.sh && \
+    ./configure --with-linux=/usr/src/linux && \
     ./scripts/make_gitrev.sh && \
     cd module && \
     make -j "$(getconf _NPROCESSORS_ONLN)" && \
-    make install
+    make install )
 
 # Run depmod against the new module directory.
 RUN cd /lib/modules && \

--- a/kernel/common/build-zfs.yml
+++ b/kernel/common/build-zfs.yml
@@ -1,0 +1,3 @@
+image: kernel-zfs
+network: true
+dockerfile: common/Dockerfile.zfs

--- a/test/cases/040_packages/027_zfs/Dockerfile
+++ b/test/cases/040_packages/027_zfs/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.20
+RUN apk add --no-cache zfs kmod util-linux
+COPY check.sh /check.sh
+ENTRYPOINT ["/bin/sh", "/check.sh"]

--- a/test/cases/040_packages/027_zfs/check.sh
+++ b/test/cases/040_packages/027_zfs/check.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+failed() {
+	printf "zfs test suite FAILED\n"
+	exit 1
+}
+
+modprobe zfs || failed
+dmesg | grep -qi "ZFS:" || failed
+
+IMG=/tmp/zfs-test.img
+dd if=/dev/zero of="$IMG" bs=1M count=64 >/dev/null 2>&1 || failed
+zpool create -m legacy ziptest "$IMG" || failed
+zpool list ziptest | grep -q ziptest || failed
+zfs list ziptest | grep -q ziptest || failed
+zpool destroy ziptest || failed
+rm -f "$IMG"
+
+printf "zfs test suite PASSED\n"

--- a/test/cases/040_packages/027_zfs/test.sh
+++ b/test/cases/040_packages/027_zfs/test.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# SUMMARY: Check that the zfs kernel module package works
+# LABELS: skip
+# REPEAT:
+
+set -e
+
+# Source libraries. Uncomment if needed/defined
+#. "${RT_LIB}"
+. "${RT_PROJECT_ROOT}/_lib/lib.sh"
+NAME=zfs
+
+clean_up() {
+	docker rmi zfs-check-test || true
+	rm -rf ${NAME}-*
+}
+trap clean_up EXIT
+
+# Requires linuxkit/kernel-zfs:test-local to already exist in the local
+# docker image store (build it from kernel/common/build-zfs.yml). Not
+# pulled from any registry, so this test is skipped by default.
+docker build -t zfs-check-test .
+linuxkit build --docker --format kernel+initrd --name "${NAME}" test.yml
+RESULT="$(linuxkitrun ${NAME})"
+echo "${RESULT}"
+echo "${RESULT}" | grep -q "suite PASSED"
+
+exit 0

--- a/test/cases/040_packages/027_zfs/test.yml
+++ b/test/cases/040_packages/027_zfs/test.yml
@@ -1,0 +1,22 @@
+kernel:
+  image: linuxkit/kernel:6.12.59
+  cmdline: "console=ttyS0 console=ttyAMA0"
+init:
+  - linuxkit/init:b5506cc74a6812dc40982cacfd2f4328f8a4b12a
+  - linuxkit/runc:9442aa234715e751a16144f1d4ae3fd1a00fd492
+  - linuxkit/kernel-zfs:test-local
+onboot:
+  - name: check-zfs
+    image: zfs-check-test
+    binds:
+      - /dev:/dev
+      - /lib/modules:/lib/modules
+      - /tmp:/tmp
+    devices:
+      - path: all
+        type: a
+    capabilities:
+      - all
+  - name: poweroff
+    image: linuxkit/poweroff:4059858a555bed90c2280fa9b060b7a8f8de6d45
+    command: ["/bin/sh", "/poweroff.sh", "10"]


### PR DESCRIPTION
**- What I did**

Added a ZFS kernel module package ([ZFS 2.2.9](https://github.com/zfsonlinux/zfs.git)) built against a given kernel's headers, wired into the same per-kernel-series tool-build mechanism already used by `perf` and `bcc`.

**- How I did it**

`kernel/common/Dockerfile.zfs` existed but was orphaned (still ZFS 0.8.1, using the old `ARG IMAGE` convention, and not referenced by any current build target since the `perf`/`bcc` tool-build refactor). I rewrote it to:
- ZFS 2.2.9, with the fuller Alpine dependency list and `--with-linux=/usr/src/linux` kernel-source extraction needed to build against current kernels
- The current `ARG BUILD_IMAGE`/`ARG KERNEL_VERSION`/`ARG PKG_HASH` + `FROM linuxkit/kernel:${KERNEL_VERSION}-${PKG_HASH}` convention shared with `Dockerfile.perf`/`Dockerfile.bcc`

Added `kernel/common/build-zfs.yml` (same shape as `build-perf.yml`/`build-bcc.yml`) and added `zfs` to `kernel/Makefile`'s `TOOLS` list, so `make build-<version>` builds it for every supported kernel series automatically.

**- How to verify it**

\`\`\`
cd kernel
make buildtool-6.12.59PARTzfs
make buildtool-6.6.71PARTzfs
\`\`\`
I build-tested both currently non-deprecated series (6.12.59 and 6.6.71) directly via `docker build --build-arg KERNEL_VERSION=... --build-arg PKG_HASH=... -f kernel/common/Dockerfile.zfs kernel/common` against the real published `linuxkit/kernel` images, and confirmed `spl.ko`/`zfs.ko` are present in `/lib/modules/<version>-linuxkit/extra/` in both resulting images.

**- Description for the changelog**

Add a ZFS (2.2.9) kernel module package, buildable per supported kernel series alongside `perf`/`bcc`.

**- A picture of a cute animal (not mandatory but encouraged)**

🦭