### PR TITLE
Fix LinuxKit BCC and perf builds after per-series hashing change

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -178,7 +178,7 @@ buildtool-%:
 	$(eval KERNEL_VERSION=$(call toolkernel,$*))
 	$(eval KERNEL_SERIES=$(call series,$(KERNEL_VERSION)))
 	$(eval SERIES_HASH=$(call series_hash,$(KERNEL_SERIES)))
-	linuxkit pkg build . $(FORCE) --platforms $(BUILD_PLATFORM) --build-yml ./$(COMMON_DIR)/build-$(TOOL).yml --tag "$(KERNEL_VERSION)-$(SERIES_HASH)" --build-arg-file $(KERNEL_SERIES)/build-args
+	linuxkit pkg build . $(FORCE) --platforms $(BUILD_PLATFORM) --build-yml ./$(COMMON_DIR)/build-$(TOOL).yml --hash $(SERIES_HASH) --tag "$(KERNEL_VERSION)-$(SERIES_HASH)" --build-arg-file $(KERNEL_SERIES)/build-args
 
 pushtools-%: $(addprefix pushtool-%$(RELEASESEP),$(TOOLS));
 


### PR DESCRIPTION
**- What I did**

I am currently upgrading the dependencies of our cyber security product. The kernel tool build stopped working after upgrading LinuxKit.

I fixed the BCC and perf builds.

**- How I did it**

Commit `50025b884067d9913c18399ad074c6cec0c91468` (https://github.com/linuxkit/linuxkit/tree/50025b884067d9913c18399ad074c6cec0c91468) introduced per-series kernel hashes. BCC and perf still used the full kernel directory hash as far as I am concerned. They referenced a kernel image that did not exist.

I passed the series hash using `--hash`. The tool builds now reference the correct kernel image.

**- How to verify it**

Build the ARM64 kernels and tools:

```bash
make -C kernel ARCH=arm64 build
```

Verify that the kernel, BCC, and perf builds use the same hash.

**- Description for the changelog**

Fixed BCC and perf builds after the introduction of per-series kernel hashes.